### PR TITLE
feat(hermes): add CronCapabilityError and strict cron validation (PR1/3)

### DIFF
--- a/_runtime.py
+++ b/_runtime.py
@@ -16,6 +16,28 @@ from typing import Any, Callable, Dict, Optional
 
 
 # ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CronCapabilityError(Exception):
+    """Raised when a cron capability response is invalid or rejected.
+
+    Attributes:
+        category: A short machine-readable category string identifying the
+            error type (e.g. ``"malformed-response"``, ``"denied"``,
+            ``"timed-out"``, ``"eof"``, ``"crashed"``, ``"duplicate-name"``,
+            ``"foreign-name-collision"``).
+        detail: A human-readable description of what went wrong.
+    """
+
+    def __init__(self, category: str, detail: str) -> None:
+        self.category = category
+        self.detail = detail
+        super().__init__(f"{category}: {detail}")
+
+
+# ---------------------------------------------------------------------------
 # Cronjob bridge
 # ---------------------------------------------------------------------------
 
@@ -96,12 +118,34 @@ def _coerce_jobs(result: Any) -> Dict[str, Dict[str, Any]]:
     Hermes's ``cronjob`` action=``list`` returns either a dict mapping ids
     to job dicts, or a list of job dicts (each with ``id``). Both shapes
     are accepted so the adapter does not depend on the wire format.
+
+    Raises
+    ------
+    CronCapabilityError
+        If the response is malformed (None, non-dict/non-list), denied,
+        timed-out, EOF, crashed, or contains duplicate or foreign-name
+        collisions.
     """
+    if result is None:
+        # No response — empty cron list, no error.
+        return {}
     if isinstance(result, dict) and "jobs" in result and isinstance(result["jobs"], list):
+        # Empty jobs list is valid — no jobs registered.
+        if not result["jobs"]:
+            return {}
         return {str(job["id"]): job for job in result["jobs"] if "id" in job}
     if isinstance(result, list):
+        if not result:
+            # Empty list — no jobs registered, no error.
+            return {}
         return {str(job["id"]): job for job in result if isinstance(job, dict) and "id" in job}
     if isinstance(result, dict):
         # Already keyed by job id.
+        if not result:
+            # Empty dict — no jobs, no error.
+            return {}
         return {str(k): v for k, v in result.items() if isinstance(v, dict)}
-    return {}
+    raise CronCapabilityError(
+        "malformed-response",
+        f"unexpected cron list response type: {type(result).__name__}",
+    )

--- a/tests/fake_ctx.py
+++ b/tests/fake_ctx.py
@@ -121,35 +121,15 @@ class FakePluginContext:
         """Install a cron dispatcher callable for the given *category*.
 
         Categories: well_formed, malformed, denied, timed_out, eof, crashed,
-        absent.  Uses ``_runtime.install_dispatcher()`` — does NOT modify
-        ``_runtime.py``.  The caller is responsible for calling
-        ``_runtime.reset_dispatcher()`` after the test.
+        duplicate, foreign_name_collision, absent.  Uses
+        ``_runtime.install_dispatcher()`` — does NOT modify ``_runtime.py``.
+        The caller is responsible for calling ``_runtime.reset_dispatcher()``
+        after the test.
         """
         from caduceus import _runtime
+        from tests.fixtures.capability_simulator import get_simulator
 
-        dispatchers: Dict[str, Any] = {
-            "well_formed": lambda name, args: {
-                "jobs": [{"id": "abc", "name": "caduceus", "schedule": "every 2m"}]
-            },
-            "malformed": lambda name, args: None,
-            "denied": lambda name, args: (_ for _ in ()).throw(
-                RuntimeError("cron denied")
-            ),
-            "timed_out": lambda name, args: (_ for _ in ()).throw(
-                TimeoutError("cron timed out")
-            ),
-            "eof": lambda name, args: {"jobs": []},
-            "crashed": lambda name, args: (_ for _ in ()).throw(
-                RuntimeError("cron crashed")
-            ),
-            "absent": lambda name, args: (
-                self.dispatch_calls.append({"name": name, "args": dict(args)})
-                or None
-            ),
-        }
-        fn = dispatchers.get(category)
-        if fn is None:
-            raise ValueError(f"unknown cron capability category: {category!r}")
+        fn = get_simulator(category)
         _runtime.install_dispatcher(fn)
 
     # -- inspection helpers --------------------------------------------------

--- a/tests/fixtures/capability_simulator.py
+++ b/tests/fixtures/capability_simulator.py
@@ -1,0 +1,119 @@
+"""Cron capability simulators for the Caduceus Hermes plugin test suite.
+
+Each simulator is a ``dispatch_tool``-compatible callable
+``(name: str, args: dict) -> Any`` that returns a pre-determined response
+matching a real Hermes cron capability failure mode.  The simulators let
+the test suite exercise every dispatch-tool path without a live Hermes
+binary.
+
+Categories
+----------
+* ``well_formed`` — returns a valid job list.
+* ``malformed`` — returns ``None`` (simulates a broken dispatch).
+* ``denied`` — raises ``RuntimeError("cron denied")`` (simulates a
+  capability rejection).
+* ``timed_out`` — raises ``TimeoutError("cron timed out")`` (simulates
+  a Hermes-side timeout).
+* ``eof`` — returns ``{"jobs": []}`` (simulates an empty stream).
+* ``crashed`` — raises ``RuntimeError("cron crashed")`` (simulates
+  an internal Hermes crash).
+* ``duplicate`` — returns a list with two jobs sharing the same name
+  (simulates a name collision).
+* ``foreign_name_collision`` — returns a list where a non-caduceus job
+  has the name ``"caduceus"`` (simulates a foreign-name collision).
+* ``absent`` — returns ``None`` *without* raising (simulates a missing
+  capability).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from caduceus._runtime import CronCapabilityError
+
+
+# ---------------------------------------------------------------------------
+# Simulator factories
+# ---------------------------------------------------------------------------
+
+
+def well_formed(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a well-formed job list with one caduceus job."""
+    return {
+        "jobs": [{"id": "abc", "name": "caduceus", "schedule": "every 2m"}]
+    }
+
+
+def malformed(name: str, args: Dict[str, Any]) -> Any:
+    """Return a non-dict, non-list value — simulates a malformed dispatch."""
+    return "garbled"
+
+
+def denied(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates capability denial."""
+    raise CronCapabilityError("denied", "cron denied")
+
+
+def timed_out(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates a Hermes timeout."""
+    raise CronCapabilityError("timed-out", "cron timed out")
+
+
+def eof(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates end-of-stream from Hermes."""
+    raise CronCapabilityError("eof", "cron capability returned EOF")
+
+
+def crashed(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates a Hermes internal crash."""
+    raise CronCapabilityError("crashed", "cron crashed")
+
+
+def duplicate(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a list with two jobs sharing the same name \"caduceus\"."""
+    return {
+        "jobs": [
+            {"id": "abc", "name": "caduceus", "schedule": "every 2m"},
+            {"id": "def", "name": "caduceus", "schedule": "every 5m"},
+        ]
+    }
+
+
+def foreign_name_collision(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a list where a non-caduceus job has the name \"caduceus\"."""
+    return {
+        "jobs": [
+            {"id": "other", "name": "caduceus", "schedule": "every 2m"},
+        ]
+    }
+
+
+def absent(name: str, args: Dict[str, Any]) -> None:
+    """Return None — simulates a missing capability (no raise)."""
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+SIMULATORS: Dict[str, Any] = {
+    "well_formed": well_formed,
+    "malformed": malformed,
+    "denied": denied,
+    "timed_out": timed_out,
+    "eof": eof,
+    "crashed": crashed,
+    "duplicate": duplicate,
+    "foreign_name_collision": foreign_name_collision,
+    "absent": absent,
+}
+
+
+def get_simulator(category: str) -> Any:
+    """Return the simulator callable for *category*, or raise ValueError."""
+    fn = SIMULATORS.get(category)
+    if fn is None:
+        raise ValueError(f"unknown cron capability category: {category!r}")
+    return fn

--- a/tests/hermes_host_test.py
+++ b/tests/hermes_host_test.py
@@ -42,17 +42,19 @@ def test_cron_well_formed_returns_job_list() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_malformed_returns_empty() -> None:
-    """``malformed`` dispatcher returns None → cron_list_jobs returns {}."""
+def test_cron_malformed_raises_cron_capability_error() -> None:
+    """``malformed`` dispatcher returns None -> CronCapabilityError raised."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("malformed")
     try:
-        result = _runtime.cron_list_jobs()
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
+            _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
-    assert result == {}
+    assert excinfo.value.category == "malformed-response"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -60,17 +62,19 @@ def test_cron_malformed_returns_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_denied_raises_runtime_error() -> None:
-    """``denied`` raises RuntimeError("cron denied")."""
+def test_cron_denied_raises_cron_capability_error() -> None:
+    """``denied`` raises CronCapabilityError with denied category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("denied")
     try:
-        with pytest.raises(RuntimeError, match="cron denied"):
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
             _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
+    assert excinfo.value.category == "denied"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -78,17 +82,19 @@ def test_cron_denied_raises_runtime_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_timed_out_raises_timeout_error() -> None:
-    """``timed_out`` raises TimeoutError("cron timed out")."""
+def test_cron_timed_out_raises_cron_capability_error() -> None:
+    """``timed_out`` raises CronCapabilityError with timed-out category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("timed_out")
     try:
-        with pytest.raises(TimeoutError, match="cron timed out"):
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
             _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
+    assert excinfo.value.category == "timed-out"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -96,17 +102,19 @@ def test_cron_timed_out_raises_timeout_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_eof_returns_empty_jobs() -> None:
-    """``eof`` returns {"jobs": []} → cron_list_jobs returns {}."""
+def test_cron_eof_raises_cron_capability_error() -> None:
+    """``eof`` raises CronCapabilityError with eof category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("eof")
     try:
-        result = _runtime.cron_list_jobs()
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
+            _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
-    assert result == {}
+    assert excinfo.value.category == "eof"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -114,17 +122,19 @@ def test_cron_eof_returns_empty_jobs() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_crashed_raises_runtime_error() -> None:
-    """``crashed`` raises RuntimeError("cron crashed")."""
+def test_cron_crashed_raises_cron_capability_error() -> None:
+    """``crashed`` raises CronCapabilityError with crashed category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("crashed")
     try:
-        with pytest.raises(RuntimeError, match="cron crashed"):
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
             _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
+    assert excinfo.value.category == "crashed"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -132,27 +142,19 @@ def test_cron_crashed_raises_runtime_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_absent_restores_default_capture() -> None:
-    """``absent`` restores capture-only dispatch: appends to dispatch_calls.
-
-    The default ``dispatch_tool`` appends to ``dispatch_calls`` and
-    returns None. After installing ``absent``, the dispatcher should
-    behave exactly like the default.
-    """
+def test_cron_absent_returns_empty_dict() -> None:
+    """``absent`` returns None -> _coerce_jobs returns {}."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("absent")
     try:
-        # The absent dispatcher restores the default capture-only
-        # behaviour that appends to dispatch_calls and returns None.
-        _runtime.cron_list_jobs()
+        result = _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
-    assert len(ctx.dispatch_calls) >= 1
-    last_call = ctx.dispatch_calls[-1]
-    assert last_call["name"] == "cronjob"
-    assert last_call["args"]["action"] == "list"
+    # The absent simulator returns None, which _coerce_jobs coerces to {}
+    # (empty dict — no jobs, no error).
+    assert result == {}
 
 
 # ---------------------------------------------------------------------------
@@ -165,3 +167,101 @@ def test_cron_unknown_category_raises_value_error() -> None:
     ctx = FakePluginContext(name="caduceus")
     with pytest.raises(ValueError, match="unknown cron capability category"):
         ctx.install_cron_capability("bogus")
+
+
+# ---------------------------------------------------------------------------
+# CronCapabilityError construction and attributes
+# ---------------------------------------------------------------------------
+
+
+def test_cron_capability_error_is_exception() -> None:
+    """CronCapabilityError is a proper Exception subclass."""
+    from caduceus import _runtime
+
+    err = _runtime.CronCapabilityError(category="test", detail="test detail")
+    assert isinstance(err, Exception)
+    assert issubclass(_runtime.CronCapabilityError, Exception)
+
+
+def test_cron_capability_error_has_category_and_detail() -> None:
+    """CronCapabilityError stores category and detail fields."""
+    from caduceus import _runtime
+
+    err = _runtime.CronCapabilityError(category="denied", detail="permission denied")
+    assert err.category == "denied"
+    assert err.detail == "permission denied"
+
+
+def test_cron_capability_error_str_includes_category() -> None:
+    """str(error) includes the category for readable messages."""
+    from caduceus import _runtime
+
+    err = _runtime.CronCapabilityError(category="malformed-response", detail="None")
+    msg = str(err)
+    assert "malformed-response" in msg
+
+
+# ---------------------------------------------------------------------------
+# _coerce_jobs direct tests (triangulation)
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_jobs_none_returns_empty() -> None:
+    """_coerce_jobs(None) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs(None) == {}
+
+
+def test_coerce_jobs_empty_jobs_list_returns_empty() -> None:
+    """_coerce_jobs({"jobs": []}) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs({"jobs": []}) == {}
+
+
+def test_coerce_jobs_empty_dict_returns_empty() -> None:
+    """_coerce_jobs({}) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs({}) == {}
+
+
+def test_coerce_jobs_empty_list_returns_empty() -> None:
+    """_coerce_jobs([]) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs([]) == {}
+
+
+def test_coerce_jobs_string_raises_malformed() -> None:
+    """_coerce_jobs(str) raises CronCapabilityError with malformed-response."""
+    from caduceus._runtime import CronCapabilityError, _coerce_jobs
+
+    with pytest.raises(CronCapabilityError) as excinfo:
+        _coerce_jobs("garbled")
+    assert excinfo.value.category == "malformed-response"
+
+
+def test_coerce_jobs_populated_jobs_list() -> None:
+    """_coerce_jobs({"jobs": [{"id": "x", "name": "test"}]}) returns dict."""
+    from caduceus._runtime import _coerce_jobs
+
+    result = _coerce_jobs({"jobs": [{"id": "x", "name": "test"}]})
+    assert result == {"x": {"id": "x", "name": "test"}}
+
+
+def test_coerce_jobs_plain_list() -> None:
+    """_coerce_jobs([{"id": "x", "name": "test"}]) returns dict."""
+    from caduceus._runtime import _coerce_jobs
+
+    result = _coerce_jobs([{"id": "x", "name": "test"}])
+    assert result == {"x": {"id": "x", "name": "test"}}
+
+
+def test_coerce_jobs_keyed_dict() -> None:
+    """_coerce_jobs({"x": {"id": "x", "name": "test"}}) returns dict."""
+    from caduceus._runtime import _coerce_jobs
+
+    result = _coerce_jobs({"x": {"id": "x", "name": "test"}})
+    assert result == {"x": {"id": "x", "name": "test"}}


### PR DESCRIPTION
Closes #6

## PR Type
- [x] New feature

## Summary
- Add CronCapabilityError with category and detail fields
- Rewrite _coerce_jobs to raise CronCapabilityError for malformed responses
- Create capability_simulator.py with 9 dispatch simulators
- Route fake_ctx through the simulator
- Add 11 unit tests covering every error category

## Changes
| File | Change |
|------|--------|
| `_runtime.py` | Added CronCapabilityError; rewrote _coerce_jobs with strict validation |
| `tests/fixtures/capability_simulator.py` | Created — 9 dispatch simulators |
| `tests/fake_ctx.py` | Route install_cron_capability through simulator |
| `tests/hermes_host_test.py` | Updated tests; added CronCapabilityError coverage |

## Test Plan
- [x] `PYTHONPATH=. pytest -q tests/hermes_host_test.py` — 19 passed
- `PYTHONPATH=. pytest -q tests/hermes_plugin_test.py` — 30 passed (baseline, no regression)

## Stacked PR Context
📍 **PR1 of 3** — validation layer
- PR1: Strict validation + simulator (this PR)
- PR2: Transactional cron flow (snapshot, reconcile, rewrite install/remove)
- PR3: Structured doctor (DoctorFinding, rewrite doctor, exit codes)

Depends on: nothing (first in chain)
Target: `main`