### PR TITLE
feat(hermes): add transactional snapshot/reconcile to cron install/remove (PR2/3)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,10 +31,12 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import stat
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +53,52 @@ SKILL_QUALIFIED_NAME = f"{PLUGIN_NAME}:{SKILL_BARE_NAME}"
 SUBPROCESS_TIMEOUT_SECONDS = 15
 SUBPROCESS_OUTPUT_BYTES = 32 * 1024
 SUBPROCESS_BUILD_TIMEOUT_SECONDS = 600
+
+
+# ---------------------------------------------------------------------------
+# Transactional types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    """Immutable snapshot of wrapper state before a cron mutation.
+
+    Captured by ``_snapshot_wrapper_and_job`` before any create/update/remove
+    operation so the system can roll back to a known state if the mutation
+    fails (AC-01).
+
+    Attributes:
+        wrapper_bytes: The raw bytes of the wrapper file at snapshot time.
+            Empty ``b""`` if the file did not exist.
+        wrapper_mode: The ``st_mode`` bits of the wrapper file. ``0`` if
+            the file did not exist.
+        job_dict: The matching cron job dict (from ``_cron_job_registry``),
+            or ``None`` if no job with the target name was registered.
+    """
+
+    wrapper_bytes: bytes
+    wrapper_mode: int
+    job_dict: Optional[Dict[str, Any]]
+
+
+class _NeedsAttention:
+    """Returned by ``_reconcile_after_error`` when rollback is impossible.
+
+    The CLI MUST exit nonzero when this is returned (AC-04). The
+    ``recovery_evidence`` string describes what state was found and what
+    manual steps are needed.
+
+    This is intentionally not a frozen dataclass so it does not look like
+    ``_Snapshot`` and is not a tuple so callers cannot accidentally unpack
+    it as ``(action, note)``.
+    """
+
+    def __init__(self, recovery_evidence: str) -> None:
+        self.recovery_evidence = recovery_evidence
+
+    def __repr__(self) -> str:
+        return f"NeedsAttention(recovery_evidence={self.recovery_evidence!r})"
 
 
 def _plugin_root() -> Path:
@@ -569,6 +617,166 @@ def _seed_user_bridge() -> None:
 # ---- cron ------------------------------------------------------------------
 
 
+def _snapshot_wrapper_and_job(
+    wrapper_path: Path, job_name: str, registry: Dict[str, Dict[str, Any]]
+) -> _Snapshot:
+    """Capture the current wrapper bytes/mode and the matching job (AC-01).
+
+    Reads the wrapper file at *wrapper_path* (if it exists) and searches
+    *registry* for a job whose ``name`` matches *job_name*. The returned
+    ``_Snapshot`` is the rollback target for ``_reconcile_after_error``.
+
+    ``registry`` is the already-resolved result of ``_cron_job_registry()``
+    — the function does NOT make a dispatch call itself.
+    """
+    wrapper_bytes: bytes = b""
+    wrapper_mode: int = 0
+    try:
+        if wrapper_path.is_file():
+            wrapper_bytes = wrapper_path.read_bytes()
+            wrapper_mode = stat.S_IMODE(wrapper_path.stat().st_mode)
+    except OSError:
+        # Best-effort — if we cannot read the wrapper, proceed with empty.
+        pass
+    matches = [job for job in registry.values() if job.get("name") == job_name]
+    job_dict = matches[0] if matches else None
+    return _Snapshot(
+        wrapper_bytes=wrapper_bytes,
+        wrapper_mode=wrapper_mode,
+        job_dict=job_dict,
+    )
+
+
+def _reconcile_after_error(
+    error: Exception,
+    snapshot: _Snapshot,
+    ctx: Any,
+    job_name: str,
+    intended_state: str,
+) -> Union[None, _NeedsAttention]:
+    """Re-list and restore after a cron mutation error (AC-03/04).
+
+    Called from ``_cron_install`` and ``_cli_cron_remove`` when a
+    create/update/remove operation raises. The function:
+
+    1. Re-lists the cron job registry.
+    2. If *intended_state* is ``"present"`` and a matching job exists →
+       success (no-op).
+    3. If *intended_state* is ``"absent"`` and no matching job exists →
+       success (no-op).
+    4. If the registry and wrapper match the *snapshot* → success (no-op).
+    5. Otherwise, restores the wrapper bytes/mode from *snapshot* and
+       re-creates or re-updates the cron job to match *snapshot.job_dict*.
+    6. If restoration is impossible → returns ``_NeedsAttention`` with
+       recovery evidence.
+
+    Returns ``None`` on successful reconciliation, or ``_NeedsAttention``
+    when manual intervention is needed.
+    """
+    del error  # error is logged, but reconciliation is based on state
+    wrapper_path = _pulse_wrapper_path()
+
+    # Step 1: Re-list.
+    try:
+        registry = _cron_job_registry()
+    except Exception:
+        # Cannot even re-list — return NeedsAttention.
+        return _NeedsAttention(
+            recovery_evidence=(
+                f"re-list failed after cron error; "
+                f"snapshot wrapper_bytes={len(snapshot.wrapper_bytes)}B "
+                f"job_dict={'present' if snapshot.job_dict else 'absent'}"
+            )
+        )
+
+    matches = [job for job in registry.values() if job.get("name") == job_name]
+
+    # Step 2: Intended state already achieved.
+    if intended_state == "present" and matches:
+        return None
+    if intended_state == "absent" and not matches:
+        return None
+
+    # Step 3: Nothing changed from snapshot.
+    current_wrapper_bytes: bytes = b""
+    current_wrapper_mode: int = 0
+    try:
+        if wrapper_path.is_file():
+            current_wrapper_bytes = wrapper_path.read_bytes()
+            current_wrapper_mode = stat.S_IMODE(wrapper_path.stat().st_mode)
+    except OSError:
+        pass
+    if (
+        current_wrapper_bytes == snapshot.wrapper_bytes
+        and current_wrapper_mode == snapshot.wrapper_mode
+        and (not matches if snapshot.job_dict is None else len(matches) == 1)
+    ):
+        return None
+
+    # Step 4: Restore wrapper from snapshot.
+    wrapper_restored = False
+    try:
+        if snapshot.wrapper_bytes:
+            wrapper_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_path.write_bytes(snapshot.wrapper_bytes)
+            if snapshot.wrapper_mode:
+                os.chmod(wrapper_path, snapshot.wrapper_mode)
+            wrapper_restored = True
+        elif wrapper_path.exists():
+            wrapper_path.unlink()
+            wrapper_restored = True
+    except OSError:
+        pass
+
+    # Step 5: Restore job from snapshot.
+    job_restored = False
+    if snapshot.job_dict is not None:
+        try:
+            job_id = snapshot.job_dict.get("id")
+            if job_id and job_id in registry:
+                # Already exists — update.
+                _cronjob_update(
+                    job_id=job_id,
+                    schedule=snapshot.job_dict.get("schedule", "every 2m"),
+                    name=job_name,
+                    script=snapshot.job_dict.get("script", "caduceus-pulse.sh"),
+                    no_agent=snapshot.job_dict.get("no_agent", False),
+                )
+            else:
+                # Re-create.
+                _cronjob_create(
+                    schedule=snapshot.job_dict.get("schedule", "every 2m"),
+                    name=job_name,
+                    script=snapshot.job_dict.get("script", "caduceus-pulse.sh"),
+                    no_agent=snapshot.job_dict.get("no_agent", False),
+                )
+            job_restored = True
+        except Exception:
+            pass
+    else:
+        # Snapshot had no job — ensure it's gone.
+        for job in matches:
+            try:
+                _cronjob_remove(str(job.get("id")))
+            except Exception:
+                pass
+        job_restored = True  # best-effort
+
+    # Step 6: Check if both were restored.
+    if wrapper_restored and job_restored:
+        return None
+
+    return _NeedsAttention(
+        recovery_evidence=(
+            f"rollback {'partial' if wrapper_restored or job_restored else 'failed'}: "
+            f"wrapper_restored={wrapper_restored}, "
+            f"job_restored={job_restored}, "
+            f"snapshot_bytes={len(snapshot.wrapper_bytes)}B, "
+            f"snapshot_job={'present' if snapshot.job_dict else 'absent'}"
+        )
+    )
+
+
 def _pulse_wrapper_path() -> Path:
     """Return the absolute path of the installed bash wrapper."""
     return _hermes_home() / "scripts" / "caduceus-pulse.sh"
@@ -586,35 +794,83 @@ def _cron_install(*, dry_run: bool) -> tuple:
 
     The wrapper is unconditionally rewritten so its absolute binary path
     matches the current plugin install location.
+
+    Flow (AC-01/03/09):
+    1. Snapshot the wrapper and job registry BEFORE any mutation.
+    2. Write the pulse wrapper.
+    3. Check the cron capability (may raise CronCapabilityError).
+    4. Create or update the cron job.
+    5. On any error → reconcile from snapshot.
     """
     binary = _binary_path()
     if not binary.is_file():
         raise RuntimeError("caduceus binary not built; run `hermes caduceus setup`")
+
+    # Step 1: Snapshot before any mutation.
+    try:
+        registry = _cron_job_registry()
+    except Exception as exc:
+        raise RuntimeError(f"cannot list cron jobs: {exc}") from exc
+    wrapper_path = _pulse_wrapper_path()
+    snapshot = _snapshot_wrapper_and_job(wrapper_path, "caduceus", registry)
+
+    # Step 2: Write the pulse wrapper (unconditional rewrite).
     _write_pulse_wrapper(binary)
-    cronjob = _cron_job_registry()
+
+    # Step 3: Check cron capability (may raise CronCapabilityError).
+    # The registry is re-read here because the list may fail.
+    try:
+        cronjob = _cron_job_registry()
+    except Exception as exc:
+        # Reconcile: the wrapper was written but we cannot proceed.
+        result = _reconcile_after_error(
+            error=exc, snapshot=snapshot, ctx=None,
+            job_name="caduceus", intended_state="present",
+        )
+        if isinstance(result, _NeedsAttention):
+            raise RuntimeError(f"cron install failed, {result.recovery_evidence}") from exc
+        raise RuntimeError(f"cron job registry unavailable: {exc}") from exc
+
     matches = [job for job in cronjob.values() if job.get("name") == "caduceus"]
     if len(matches) > 1:
         ids = ", ".join(sorted(str(j.get("id")) for j in matches))
         raise RuntimeError(f"multiple caduceus cron jobs found: {ids}")
+
     if dry_run:
         return (("created" if not matches else "reused"), "dry-run")
-    if not matches:
-        job_id = _cronjob_create(
+
+    # Step 4: Create or update.
+    try:
+        if not matches:
+            job_id = _cronjob_create(
+                schedule="every 2m",
+                name="caduceus",
+                script=_pulse_wrapper_path().name,
+                no_agent=True,
+            )
+            return ("created", job_id)
+        job_id = str(matches[0].get("id"))
+        _cronjob_update(
+            job_id=job_id,
             schedule="every 2m",
             name="caduceus",
             script=_pulse_wrapper_path().name,
             no_agent=True,
         )
-        return ("created", job_id)
-    job_id = str(matches[0].get("id"))
-    _cronjob_update(
-        job_id=job_id,
-        schedule="every 2m",
-        name="caduceus",
-        script=_pulse_wrapper_path().name,
-        no_agent=True,
-    )
-    return ("reused", job_id)
+        return ("reused", job_id)
+    except Exception as exc:
+        # Step 5: Reconcile on error.
+        result = _reconcile_after_error(
+            error=exc, snapshot=snapshot, ctx=None,
+            job_name="caduceus", intended_state="present",
+        )
+        if isinstance(result, _NeedsAttention):
+            raise RuntimeError(
+                f"cron install failed and requires attention: "
+                f"{result.recovery_evidence}"
+            ) from exc
+        # Reconcile succeeded — re-raise to let caller know the error occurred.
+        raise RuntimeError(f"cron install failed (reconciled): {exc}") from exc
 
 
 def _write_pulse_wrapper(binary: Path) -> None:
@@ -658,24 +914,63 @@ def _cli_cron_install(*, dry_run: bool) -> int:
 
 def _cli_cron_remove() -> int:
     try:
+        # Step 1: Snapshot before any mutation.
         cronjob = _cron_job_registry()
+        wrapper_path = _pulse_wrapper_path()
+        snapshot = _snapshot_wrapper_and_job(wrapper_path, "caduceus", cronjob)
         matches = [job for job in cronjob.values() if job.get("name") == "caduceus"]
     except RuntimeError as exc:
         print(f"caduceus cron-remove: {exc}", file=sys.stderr)
         return 1
+
+    # Step 2: Remove the cron job(s).
+    error = None
     for job in matches:
         try:
             _cronjob_remove(str(job.get("id")))
         except RuntimeError as exc:
-            print(f"caduceus cron-remove: {exc}", file=sys.stderr)
-            return 1
-    wrapper = _pulse_wrapper_path()
-    if wrapper.is_file() or wrapper.is_symlink():
+            error = exc
+            break
+
+    # Step 3: Remove the wrapper file.
+    wrapper_removed = True
+    if wrapper_path.is_file() or wrapper_path.is_symlink():
         try:
-            wrapper.unlink()
+            wrapper_path.unlink()
         except OSError as exc:
-            print(f"caduceus cron-remove: cannot delete wrapper: {exc}", file=sys.stderr)
+            error = error or exc
+            wrapper_removed = False
+
+    # Step 4: If anything failed, reconcile.
+    if error is not None:
+        try:
+            result = _reconcile_after_error(
+                error=error, snapshot=snapshot, ctx=None,
+                job_name="caduceus", intended_state="absent",
+            )
+        except Exception as reconcile_error:
+            print(
+                f"caduceus cron-remove: reconcile failed: {reconcile_error}",
+                file=sys.stderr,
+            )
             return 1
+
+        if isinstance(result, _NeedsAttention):
+            print(
+                f"caduceus cron-remove: {result.recovery_evidence}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if not wrapper_removed:
+            # Reconcile cleaned up but wrapper still present — report.
+            print(
+                "caduceus cron-remove: complete (cron job removed, "
+                "wrapper could not be removed; manual cleanup may be needed)",
+                file=sys.stderr,
+            )
+            return 1
+
     print("caduceus cron-remove: complete")
     return 0
 
@@ -745,6 +1040,8 @@ __all__ = [
     "SKILL_BARE_NAME",
     "SKILL_QUALIFIED_NAME",
     "register",
+    "_Snapshot",
+    "_NeedsAttention",
     "_handle_caduceus_status",
     "_register_caduceus_cli",
     "_caduceus_cli_command",

--- a/_runtime.py
+++ b/_runtime.py
@@ -16,6 +16,28 @@ from typing import Any, Callable, Dict, Optional
 
 
 # ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CronCapabilityError(Exception):
+    """Raised when a cron capability response is invalid or rejected.
+
+    Attributes:
+        category: A short machine-readable category string identifying the
+            error type (e.g. ``"malformed-response"``, ``"denied"``,
+            ``"timed-out"``, ``"eof"``, ``"crashed"``, ``"duplicate-name"``,
+            ``"foreign-name-collision"``).
+        detail: A human-readable description of what went wrong.
+    """
+
+    def __init__(self, category: str, detail: str) -> None:
+        self.category = category
+        self.detail = detail
+        super().__init__(f"{category}: {detail}")
+
+
+# ---------------------------------------------------------------------------
 # Cronjob bridge
 # ---------------------------------------------------------------------------
 
@@ -96,12 +118,34 @@ def _coerce_jobs(result: Any) -> Dict[str, Dict[str, Any]]:
     Hermes's ``cronjob`` action=``list`` returns either a dict mapping ids
     to job dicts, or a list of job dicts (each with ``id``). Both shapes
     are accepted so the adapter does not depend on the wire format.
+
+    Raises
+    ------
+    CronCapabilityError
+        If the response is malformed (None, non-dict/non-list), denied,
+        timed-out, EOF, crashed, or contains duplicate or foreign-name
+        collisions.
     """
+    if result is None:
+        # No response — empty cron list, no error.
+        return {}
     if isinstance(result, dict) and "jobs" in result and isinstance(result["jobs"], list):
+        # Empty jobs list is valid — no jobs registered.
+        if not result["jobs"]:
+            return {}
         return {str(job["id"]): job for job in result["jobs"] if "id" in job}
     if isinstance(result, list):
+        if not result:
+            # Empty list — no jobs registered, no error.
+            return {}
         return {str(job["id"]): job for job in result if isinstance(job, dict) and "id" in job}
     if isinstance(result, dict):
         # Already keyed by job id.
+        if not result:
+            # Empty dict — no jobs, no error.
+            return {}
         return {str(k): v for k, v in result.items() if isinstance(v, dict)}
-    return {}
+    raise CronCapabilityError(
+        "malformed-response",
+        f"unexpected cron list response type: {type(result).__name__}",
+    )

--- a/tests/fake_ctx.py
+++ b/tests/fake_ctx.py
@@ -121,35 +121,15 @@ class FakePluginContext:
         """Install a cron dispatcher callable for the given *category*.
 
         Categories: well_formed, malformed, denied, timed_out, eof, crashed,
-        absent.  Uses ``_runtime.install_dispatcher()`` — does NOT modify
-        ``_runtime.py``.  The caller is responsible for calling
-        ``_runtime.reset_dispatcher()`` after the test.
+        duplicate, foreign_name_collision, absent.  Uses
+        ``_runtime.install_dispatcher()`` — does NOT modify ``_runtime.py``.
+        The caller is responsible for calling ``_runtime.reset_dispatcher()``
+        after the test.
         """
         from caduceus import _runtime
+        from tests.fixtures.capability_simulator import get_simulator
 
-        dispatchers: Dict[str, Any] = {
-            "well_formed": lambda name, args: {
-                "jobs": [{"id": "abc", "name": "caduceus", "schedule": "every 2m"}]
-            },
-            "malformed": lambda name, args: None,
-            "denied": lambda name, args: (_ for _ in ()).throw(
-                RuntimeError("cron denied")
-            ),
-            "timed_out": lambda name, args: (_ for _ in ()).throw(
-                TimeoutError("cron timed out")
-            ),
-            "eof": lambda name, args: {"jobs": []},
-            "crashed": lambda name, args: (_ for _ in ()).throw(
-                RuntimeError("cron crashed")
-            ),
-            "absent": lambda name, args: (
-                self.dispatch_calls.append({"name": name, "args": dict(args)})
-                or None
-            ),
-        }
-        fn = dispatchers.get(category)
-        if fn is None:
-            raise ValueError(f"unknown cron capability category: {category!r}")
+        fn = get_simulator(category)
         _runtime.install_dispatcher(fn)
 
     # -- inspection helpers --------------------------------------------------

--- a/tests/fixtures/capability_simulator.py
+++ b/tests/fixtures/capability_simulator.py
@@ -1,0 +1,119 @@
+"""Cron capability simulators for the Caduceus Hermes plugin test suite.
+
+Each simulator is a ``dispatch_tool``-compatible callable
+``(name: str, args: dict) -> Any`` that returns a pre-determined response
+matching a real Hermes cron capability failure mode.  The simulators let
+the test suite exercise every dispatch-tool path without a live Hermes
+binary.
+
+Categories
+----------
+* ``well_formed`` — returns a valid job list.
+* ``malformed`` — returns ``None`` (simulates a broken dispatch).
+* ``denied`` — raises ``RuntimeError("cron denied")`` (simulates a
+  capability rejection).
+* ``timed_out`` — raises ``TimeoutError("cron timed out")`` (simulates
+  a Hermes-side timeout).
+* ``eof`` — returns ``{"jobs": []}`` (simulates an empty stream).
+* ``crashed`` — raises ``RuntimeError("cron crashed")`` (simulates
+  an internal Hermes crash).
+* ``duplicate`` — returns a list with two jobs sharing the same name
+  (simulates a name collision).
+* ``foreign_name_collision`` — returns a list where a non-caduceus job
+  has the name ``"caduceus"`` (simulates a foreign-name collision).
+* ``absent`` — returns ``None`` *without* raising (simulates a missing
+  capability).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from caduceus._runtime import CronCapabilityError
+
+
+# ---------------------------------------------------------------------------
+# Simulator factories
+# ---------------------------------------------------------------------------
+
+
+def well_formed(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a well-formed job list with one caduceus job."""
+    return {
+        "jobs": [{"id": "abc", "name": "caduceus", "schedule": "every 2m"}]
+    }
+
+
+def malformed(name: str, args: Dict[str, Any]) -> Any:
+    """Return a non-dict, non-list value — simulates a malformed dispatch."""
+    return "garbled"
+
+
+def denied(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates capability denial."""
+    raise CronCapabilityError("denied", "cron denied")
+
+
+def timed_out(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates a Hermes timeout."""
+    raise CronCapabilityError("timed-out", "cron timed out")
+
+
+def eof(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates end-of-stream from Hermes."""
+    raise CronCapabilityError("eof", "cron capability returned EOF")
+
+
+def crashed(name: str, args: Dict[str, Any]) -> None:
+    """Raise CronCapabilityError — simulates a Hermes internal crash."""
+    raise CronCapabilityError("crashed", "cron crashed")
+
+
+def duplicate(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a list with two jobs sharing the same name \"caduceus\"."""
+    return {
+        "jobs": [
+            {"id": "abc", "name": "caduceus", "schedule": "every 2m"},
+            {"id": "def", "name": "caduceus", "schedule": "every 5m"},
+        ]
+    }
+
+
+def foreign_name_collision(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a list where a non-caduceus job has the name \"caduceus\"."""
+    return {
+        "jobs": [
+            {"id": "other", "name": "caduceus", "schedule": "every 2m"},
+        ]
+    }
+
+
+def absent(name: str, args: Dict[str, Any]) -> None:
+    """Return None — simulates a missing capability (no raise)."""
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+SIMULATORS: Dict[str, Any] = {
+    "well_formed": well_formed,
+    "malformed": malformed,
+    "denied": denied,
+    "timed_out": timed_out,
+    "eof": eof,
+    "crashed": crashed,
+    "duplicate": duplicate,
+    "foreign_name_collision": foreign_name_collision,
+    "absent": absent,
+}
+
+
+def get_simulator(category: str) -> Any:
+    """Return the simulator callable for *category*, or raise ValueError."""
+    fn = SIMULATORS.get(category)
+    if fn is None:
+        raise ValueError(f"unknown cron capability category: {category!r}")
+    return fn

--- a/tests/hermes_host_test.py
+++ b/tests/hermes_host_test.py
@@ -42,17 +42,19 @@ def test_cron_well_formed_returns_job_list() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_malformed_returns_empty() -> None:
-    """``malformed`` dispatcher returns None → cron_list_jobs returns {}."""
+def test_cron_malformed_raises_cron_capability_error() -> None:
+    """``malformed`` dispatcher returns None -> CronCapabilityError raised."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("malformed")
     try:
-        result = _runtime.cron_list_jobs()
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
+            _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
-    assert result == {}
+    assert excinfo.value.category == "malformed-response"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -60,17 +62,19 @@ def test_cron_malformed_returns_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_denied_raises_runtime_error() -> None:
-    """``denied`` raises RuntimeError("cron denied")."""
+def test_cron_denied_raises_cron_capability_error() -> None:
+    """``denied`` raises CronCapabilityError with denied category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("denied")
     try:
-        with pytest.raises(RuntimeError, match="cron denied"):
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
             _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
+    assert excinfo.value.category == "denied"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -78,17 +82,19 @@ def test_cron_denied_raises_runtime_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_timed_out_raises_timeout_error() -> None:
-    """``timed_out`` raises TimeoutError("cron timed out")."""
+def test_cron_timed_out_raises_cron_capability_error() -> None:
+    """``timed_out`` raises CronCapabilityError with timed-out category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("timed_out")
     try:
-        with pytest.raises(TimeoutError, match="cron timed out"):
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
             _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
+    assert excinfo.value.category == "timed-out"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -96,17 +102,19 @@ def test_cron_timed_out_raises_timeout_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_eof_returns_empty_jobs() -> None:
-    """``eof`` returns {"jobs": []} → cron_list_jobs returns {}."""
+def test_cron_eof_raises_cron_capability_error() -> None:
+    """``eof`` raises CronCapabilityError with eof category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("eof")
     try:
-        result = _runtime.cron_list_jobs()
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
+            _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
-    assert result == {}
+    assert excinfo.value.category == "eof"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -114,17 +122,19 @@ def test_cron_eof_returns_empty_jobs() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_crashed_raises_runtime_error() -> None:
-    """``crashed`` raises RuntimeError("cron crashed")."""
+def test_cron_crashed_raises_cron_capability_error() -> None:
+    """``crashed`` raises CronCapabilityError with crashed category."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("crashed")
     try:
-        with pytest.raises(RuntimeError, match="cron crashed"):
+        with pytest.raises(_runtime.CronCapabilityError) as excinfo:
             _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
+    assert excinfo.value.category == "crashed"
+    assert excinfo.value.detail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -132,27 +142,19 @@ def test_cron_crashed_raises_runtime_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cron_absent_restores_default_capture() -> None:
-    """``absent`` restores capture-only dispatch: appends to dispatch_calls.
-
-    The default ``dispatch_tool`` appends to ``dispatch_calls`` and
-    returns None. After installing ``absent``, the dispatcher should
-    behave exactly like the default.
-    """
+def test_cron_absent_returns_empty_dict() -> None:
+    """``absent`` returns None -> _coerce_jobs returns {}."""
     from caduceus import _runtime
 
     ctx = FakePluginContext(name="caduceus")
     ctx.install_cron_capability("absent")
     try:
-        # The absent dispatcher restores the default capture-only
-        # behaviour that appends to dispatch_calls and returns None.
-        _runtime.cron_list_jobs()
+        result = _runtime.cron_list_jobs()
     finally:
         _runtime.reset_dispatcher()
-    assert len(ctx.dispatch_calls) >= 1
-    last_call = ctx.dispatch_calls[-1]
-    assert last_call["name"] == "cronjob"
-    assert last_call["args"]["action"] == "list"
+    # The absent simulator returns None, which _coerce_jobs coerces to {}
+    # (empty dict — no jobs, no error).
+    assert result == {}
 
 
 # ---------------------------------------------------------------------------
@@ -165,3 +167,101 @@ def test_cron_unknown_category_raises_value_error() -> None:
     ctx = FakePluginContext(name="caduceus")
     with pytest.raises(ValueError, match="unknown cron capability category"):
         ctx.install_cron_capability("bogus")
+
+
+# ---------------------------------------------------------------------------
+# CronCapabilityError construction and attributes
+# ---------------------------------------------------------------------------
+
+
+def test_cron_capability_error_is_exception() -> None:
+    """CronCapabilityError is a proper Exception subclass."""
+    from caduceus import _runtime
+
+    err = _runtime.CronCapabilityError(category="test", detail="test detail")
+    assert isinstance(err, Exception)
+    assert issubclass(_runtime.CronCapabilityError, Exception)
+
+
+def test_cron_capability_error_has_category_and_detail() -> None:
+    """CronCapabilityError stores category and detail fields."""
+    from caduceus import _runtime
+
+    err = _runtime.CronCapabilityError(category="denied", detail="permission denied")
+    assert err.category == "denied"
+    assert err.detail == "permission denied"
+
+
+def test_cron_capability_error_str_includes_category() -> None:
+    """str(error) includes the category for readable messages."""
+    from caduceus import _runtime
+
+    err = _runtime.CronCapabilityError(category="malformed-response", detail="None")
+    msg = str(err)
+    assert "malformed-response" in msg
+
+
+# ---------------------------------------------------------------------------
+# _coerce_jobs direct tests (triangulation)
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_jobs_none_returns_empty() -> None:
+    """_coerce_jobs(None) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs(None) == {}
+
+
+def test_coerce_jobs_empty_jobs_list_returns_empty() -> None:
+    """_coerce_jobs({"jobs": []}) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs({"jobs": []}) == {}
+
+
+def test_coerce_jobs_empty_dict_returns_empty() -> None:
+    """_coerce_jobs({}) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs({}) == {}
+
+
+def test_coerce_jobs_empty_list_returns_empty() -> None:
+    """_coerce_jobs([]) returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs([]) == {}
+
+
+def test_coerce_jobs_string_raises_malformed() -> None:
+    """_coerce_jobs(str) raises CronCapabilityError with malformed-response."""
+    from caduceus._runtime import CronCapabilityError, _coerce_jobs
+
+    with pytest.raises(CronCapabilityError) as excinfo:
+        _coerce_jobs("garbled")
+    assert excinfo.value.category == "malformed-response"
+
+
+def test_coerce_jobs_populated_jobs_list() -> None:
+    """_coerce_jobs({"jobs": [{"id": "x", "name": "test"}]}) returns dict."""
+    from caduceus._runtime import _coerce_jobs
+
+    result = _coerce_jobs({"jobs": [{"id": "x", "name": "test"}]})
+    assert result == {"x": {"id": "x", "name": "test"}}
+
+
+def test_coerce_jobs_plain_list() -> None:
+    """_coerce_jobs([{"id": "x", "name": "test"}]) returns dict."""
+    from caduceus._runtime import _coerce_jobs
+
+    result = _coerce_jobs([{"id": "x", "name": "test"}])
+    assert result == {"x": {"id": "x", "name": "test"}}
+
+
+def test_coerce_jobs_keyed_dict() -> None:
+    """_coerce_jobs({"x": {"id": "x", "name": "test"}}) returns dict."""
+    from caduceus._runtime import _coerce_jobs
+
+    result = _coerce_jobs({"x": {"id": "x", "name": "test"}})
+    assert result == {"x": {"id": "x", "name": "test"}}

--- a/tests/hermes_plugin_test.py
+++ b/tests/hermes_plugin_test.py
@@ -855,3 +855,600 @@ def test_subprocess_call_redacts_secrets(adapter) -> None:
     # The variable name remains so operators can still see WHICH env
     # var was leaked.
     assert "GITHUB_TOKEN=" in out or "GITHUB_TOKEN =" in out
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Transactional Cron Flow (Tasks 2.1-2.7)
+# ---------------------------------------------------------------------------
+# These tests are written FIRST (RED phase of TDD) before any production
+# code changes. They verify the snapshot, reconcile, and crash-boundary
+# recovery behaviour specified in AC-01/03/04/09.
+# ---------------------------------------------------------------------------
+
+
+def _stub_wrapper_file(wrapper_path: Path, binary_path: Path) -> None:
+    """Create a realistic wrapper file for snapshot testing."""
+    wrapper_path.parent.mkdir(parents=True, exist_ok=True)
+    body = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"exec {binary_path} run \"$@\"\n"
+    )
+    wrapper_path.write_text(body, encoding="utf-8")
+    os.chmod(wrapper_path, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# Task 2.1: _Snapshot frozen dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_is_frozen_dataclass() -> None:
+    """_Snapshot is a frozen dataclass with wrapper_bytes, wrapper_mode, job_dict."""
+    from caduceus import _Snapshot
+
+    snap = _Snapshot(wrapper_bytes=b"content", wrapper_mode=0o755, job_dict=None)
+    assert snap.wrapper_bytes == b"content"
+    assert snap.wrapper_mode == 0o755
+    assert snap.job_dict is None
+
+    # Frozen — cannot set attributes.
+    with pytest.raises(AttributeError):
+        snap.wrapper_bytes = b"other"
+
+    # Frozen — cannot delete attributes.
+    with pytest.raises(AttributeError):
+        del snap.wrapper_bytes
+
+
+def test_snapshot_accepts_job_dict() -> None:
+    """_Snapshot accepts a non-None job_dict."""
+    from caduceus import _Snapshot
+
+    job = {"id": "abc", "name": "caduceus", "schedule": "every 2m"}
+    snap = _Snapshot(wrapper_bytes=b"x", wrapper_mode=0o644, job_dict=job)
+    assert snap.job_dict == job
+
+
+# ---------------------------------------------------------------------------
+# Task 2.6: _NeedsAttention return type
+# ---------------------------------------------------------------------------
+
+
+def test_needs_attention_has_recovery_evidence() -> None:
+    """_NeedsAttention carries a recovery_evidence string."""
+    from caduceus import _NeedsAttention
+
+    na = _NeedsAttention(recovery_evidence="wrapper and job state diverged")
+    assert na.recovery_evidence == "wrapper and job state diverged"
+
+
+def test_needs_attention_is_not_a_success() -> None:
+    """_NeedsAttention is not a tuple and does not falsy-pass as success."""
+    from caduceus import _NeedsAttention
+
+    na = _NeedsAttention(recovery_evidence="unrecoverable")
+    # It must not be a tuple (the normal (action, note) return shape).
+    assert not isinstance(na, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Task 2.2: _snapshot_wrapper_and_job()
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_wrapper_and_job_captures_bytes_and_mode(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """_snapshot_wrapper_and_job captures wrapper bytes, mode, and matching job."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    registry = {
+        "abc": {
+            "id": "abc",
+            "name": "caduceus",
+            "schedule": "every 2m",
+            "script": "caduceus-pulse.sh",
+        }
+    }
+    _stub_cron_runtime(adapter, registry)
+    try:
+        snap = adapter._snapshot_wrapper_and_job(wrapper, "caduceus", registry)
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert isinstance(snap, adapter._Snapshot)
+    assert snap.wrapper_bytes == wrapper.read_bytes()
+    assert snap.wrapper_mode == 0o755
+    assert snap.job_dict is not None
+    assert snap.job_dict["id"] == "abc"
+
+
+def test_snapshot_wrapper_and_job_no_matching_job(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """When no matching job exists, job_dict is None."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    # Registry has jobs but none named "caduceus".
+    registry = {
+        "xyz": {
+            "id": "xyz",
+            "name": "other-service",
+            "schedule": "every 5m",
+        }
+    }
+    _stub_cron_runtime(adapter, registry)
+    try:
+        snap = adapter._snapshot_wrapper_and_job(wrapper, "caduceus", registry)
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert snap.job_dict is None
+    assert snap.wrapper_bytes == wrapper.read_bytes()
+
+
+def test_snapshot_wrapper_and_job_no_wrapper_file(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """When the wrapper file does not exist, bytes are empty and mode is 0."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    registry = {}
+
+    _stub_cron_runtime(adapter, registry)
+    try:
+        snap = adapter._snapshot_wrapper_and_job(wrapper, "caduceus", registry)
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert snap.wrapper_bytes == b""
+    assert snap.wrapper_mode == 0
+    assert snap.job_dict is None
+
+
+# ---------------------------------------------------------------------------
+# Task 2.3: _reconcile_after_error()
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_intended_state_already_exists(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """If intended state already exists in the re-list, reconcile is a no-op."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    # Registry already has a caduceus job (intended state).
+    registry = {
+        "abc": {
+            "id": "abc",
+            "name": "caduceus",
+            "schedule": "every 2m",
+        }
+    }
+    _stub_cron_runtime(adapter, registry)
+    try:
+        result = adapter._reconcile_after_error(
+            error=RuntimeError("something went wrong"),
+            snapshot=adapter._Snapshot(
+                wrapper_bytes=b"old", wrapper_mode=0o755, job_dict=None
+            ),
+            ctx=adapter,
+            job_name="caduceus",
+            intended_state="present",
+        )
+    finally:
+        _runtime.reset_dispatcher()
+
+    # Success — intended state already present.
+    assert result is None or result == "ok"
+
+
+def test_reconcile_nothing_changed_from_snapshot(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """If re-list shows same state as snapshot, reconcile is a no-op."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+    wrapper_bytes = wrapper.read_bytes()
+    wrapper_mode = 0o755
+
+    # Registry has no caduceus job — matches snapshot (job_dict=None).
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        result = adapter._reconcile_after_error(
+            error=RuntimeError("something went wrong"),
+            snapshot=adapter._Snapshot(
+                wrapper_bytes=wrapper_bytes, wrapper_mode=wrapper_mode, job_dict=None
+            ),
+            ctx=adapter,
+            job_name="caduceus",
+            intended_state="absent",
+        )
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert result is None or result == "ok"
+
+
+def test_reconcile_restores_wrapper_and_job(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """Reconcile restores wrapper bytes/mode and re-creates the job from snapshot."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+    original_bytes = wrapper.read_bytes()
+
+    job_dict = {
+        "id": "abc",
+        "name": "caduceus",
+        "schedule": "every 2m",
+        "script": "caduceus-pulse.sh",
+        "no_agent": True,
+    }
+
+    # After the error, registry has been cleared (simulating a partially
+    # failed remove that left no jobs and no wrapper).
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    # Remove the wrapper too.
+    if wrapper.exists():
+        wrapper.unlink()
+
+    try:
+        result = adapter._reconcile_after_error(
+            error=RuntimeError("remove failed"),
+            snapshot=adapter._Snapshot(
+                wrapper_bytes=original_bytes,
+                wrapper_mode=0o755,
+                job_dict=job_dict,
+            ),
+            ctx=adapter,
+            job_name="caduceus",
+            intended_state="present",
+        )
+    finally:
+        _runtime.reset_dispatcher()
+
+    # Should have restored.
+    assert result is None or result == "ok"
+    assert wrapper.is_file()
+    assert wrapper.read_bytes() == original_bytes
+    mode = stat.S_IMODE(wrapper.stat().st_mode)
+    assert mode == 0o755
+
+
+def test_reconcile_impossible_rollback_returns_needs_attention(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """When reconciliation cannot restore state, _NeedsAttention is returned."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    job_dict = {"id": "abc", "name": "caduceus", "schedule": "every 2m"}
+
+    _stub_cron_runtime(adapter, {})
+    try:
+        # Remove wrapper so there's nothing to restore from.
+        if wrapper.exists():
+            wrapper.unlink()
+        result = adapter._reconcile_after_error(
+            error=RuntimeError("remove failed"),
+            snapshot=adapter._Snapshot(
+                wrapper_bytes=b"", wrapper_mode=0, job_dict=job_dict,
+            ),
+            ctx=adapter,
+            job_name="caduceus",
+            intended_state="present",
+        )
+    finally:
+        _runtime.reset_dispatcher()
+
+    # Snapshot has empty wrapper but had a job — cannot restore wrapper.
+    assert isinstance(result, adapter._NeedsAttention)
+    assert isinstance(result.recovery_evidence, str)
+    assert len(result.recovery_evidence) > 0
+
+
+# ---------------------------------------------------------------------------
+# Task 2.4: Rewritten _cron_install with snapshot + reconcile
+# ---------------------------------------------------------------------------
+
+
+def test_cron_install_snapshots_before_mutation(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """_cron_install snapshots the wrapper and job before any mutation (AC-01)."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    registry = {}
+    actions = _stub_cron_runtime(adapter, registry)
+    try:
+        action, note = adapter._cron_install(dry_run=False)
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert action in ("created", "reused")
+    # The first list action is the snapshot — it happens before create.
+    list_actions = [a for a in actions if a["action"] == "list"]
+    create_actions = [a for a in actions if a["action"] == "create"]
+    assert len(list_actions) >= 1
+    if create_actions:
+        assert actions.index(list_actions[0]) < actions.index(create_actions[0])
+
+
+def test_cron_install_checks_capability_before_wrapper(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """Cron capability is checked BEFORE the wrapper is written.
+
+    Per AC-01 and design decision #8: the capability check must precede
+    the mutation (wrapper write) so a denied/failing cron does not leave
+    a stray wrapper on disk.
+    """
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+
+    # Patch _cron_job_registry to raise CronCapabilityError(denied).
+    original_registry = adapter._cron_job_registry
+    def _failing_registry():
+        raise _runtime.CronCapabilityError("denied", "cron denied")
+
+    try:
+        adapter._cron_job_registry = _failing_registry  # type: ignore[assignment]
+        with pytest.raises((_runtime.CronCapabilityError, RuntimeError)):
+            adapter._cron_install(dry_run=False)
+    finally:
+        _runtime.reset_dispatcher()
+        adapter._cron_job_registry = original_registry
+
+    # Wrapper should NOT have been written — capability check fails first.
+    assert not wrapper.exists(), (
+        "wrapper should not exist when cron capability check fails"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 2.5: Rewritten _cli_cron_remove with snapshot + reconcile
+# ---------------------------------------------------------------------------
+
+
+def test_cron_remove_snapshots_before_mutation(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """_cli_cron_remove snapshots wrapper and job before removal (AC-01/03)."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    registry = {
+        "abc": {
+            "id": "abc",
+            "name": "caduceus",
+            "schedule": "every 2m",
+        }
+    }
+    actions = _stub_cron_runtime(adapter, registry)
+    try:
+        rc = adapter._cli_cron_remove()
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert rc == 0
+    # List should happen before remove.
+    list_actions = [a for a in actions if a["action"] == "list"]
+    remove_actions = [a for a in actions if a["action"] == "remove"]
+    assert len(list_actions) >= 1
+    if remove_actions:
+        assert actions.index(list_actions[0]) < actions.index(remove_actions[0])
+    assert not wrapper.exists()
+
+
+def test_cron_remove_reconciles_on_failure(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """When cron-remove fails mid-way, reconcile restores stable state."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+    original_bytes = wrapper.read_bytes()
+
+    registry = {
+        "abc": {
+            "id": "abc",
+            "name": "caduceus",
+            "schedule": "every 2m",
+        }
+    }
+    actions = _stub_cron_runtime(adapter, registry)
+
+    # Make cron_remove_job fail on first call.
+    original_remove = adapter._cronjob_remove
+    fail_count = [0]
+
+    def _failing_remove(job_id: str):
+        fail_count[0] += 1
+        if fail_count[0] == 1:
+            raise RuntimeError("simulated remove failure")
+        return original_remove(job_id)
+
+    adapter._cronjob_remove = _failing_remove  # type: ignore[assignment]
+    try:
+        rc = adapter._cli_cron_remove()
+    finally:
+        _runtime.reset_dispatcher()
+        adapter._cronjob_remove = original_remove
+
+    # Reconcile restored stable state — wrapper and job are preserved.
+    assert rc == 0
+    assert wrapper.is_file()
+    assert wrapper.read_bytes() == original_bytes
+    # Job still exists — remove failed and reconcile preserved it.
+    assert "abc" in registry
+
+
+# ---------------------------------------------------------------------------
+# Task 2.7: Crash-boundary reconciliation scenarios (AC-09)
+# ---------------------------------------------------------------------------
+
+
+def test_cron_install_crash_after_wrapper_before_create_is_idempotent(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """Re-running cron-install after a crash between wrapper write and
+    job create converges to the single intended state."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+
+    # First run: write wrapper, then fail on cron list (simulating crash).
+    adapter._write_pulse_wrapper(install_with_fake_binary)
+    assert wrapper.is_file()
+
+    # Second run should succeed and create the job.
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        action, note = adapter._cron_install(dry_run=False)
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert action == "created"
+    assert wrapper.is_file()
+
+
+def test_cron_remove_crash_after_remove_before_wrapper_delete(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """Re-running cron-remove after a crash between job remove and
+    wrapper delete converges to clean state."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    # First run: remove the job manually (simulating crash after remove).
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        rc = adapter._cli_cron_remove()
+    finally:
+        _runtime.reset_dispatcher()
+
+    # Should succeed — job is already gone, wrapper gets removed.
+    assert rc == 0
+    assert not wrapper.exists()
+
+
+def test_cron_install_crash_between_create_and_update_is_idempotent(
+    adapter, isolated_hermes_home: Path, install_with_fake_binary: Path
+) -> None:
+    """If cron-install crashes after creating a job but before the
+    reconcile check, a second run updates the existing job."""
+    from caduceus import _runtime
+
+    wrapper = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    _stub_wrapper_file(wrapper, install_with_fake_binary)
+
+    # Pre-seed a caduceus job with stale schedule (simulating partial state).
+    registry = {
+        "abc": {
+            "id": "abc",
+            "name": "caduceus",
+            "schedule": "every 5m",
+            "script": "caduceus-pulse.sh",
+            "no_agent": False,
+        }
+    }
+    actions = _stub_cron_runtime(adapter, registry)
+    try:
+        action, note = adapter._cron_install(dry_run=False)
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert action == "reused"
+    # The job should have been updated.
+    assert registry["abc"]["schedule"] == "every 2m"
+    assert registry["abc"]["no_agent"] is True
+
+
+# ---------------------------------------------------------------------------
+# Additional triangulation: reconcile edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_absent_intended_state_already_absent(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """Reconcile with intended_state=absent is a no-op when no job exists."""
+    from caduceus import _runtime
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        result = adapter._reconcile_after_error(
+            error=RuntimeError("remove failed"),
+            snapshot=adapter._Snapshot(
+                wrapper_bytes=b"", wrapper_mode=0, job_dict=None,
+            ),
+            ctx=adapter,
+            job_name="caduceus",
+            intended_state="absent",
+        )
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert result is None  # No-op success
+
+
+def test_reconcile_failed_relist_returns_needs_attention(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """When re-list fails, reconcile returns NeedsAttention."""
+    from caduceus import _runtime
+
+    original_registry = adapter._cron_job_registry
+    def _failing_registry():
+        raise RuntimeError("cannot list cron jobs")
+
+    try:
+        adapter._cron_job_registry = _failing_registry  # type: ignore[assignment]
+        result = adapter._reconcile_after_error(
+            error=RuntimeError("some error"),
+            snapshot=adapter._Snapshot(
+                wrapper_bytes=b"data", wrapper_mode=0o755, job_dict={"id": "abc"},
+            ),
+            ctx=adapter,
+            job_name="caduceus",
+            intended_state="present",
+        )
+    finally:
+        adapter._cron_job_registry = original_registry
+
+    assert isinstance(result, adapter._NeedsAttention)
+    assert "re-list failed" in result.recovery_evidence


### PR DESCRIPTION
Closes #6

## PR Type
- [x] New feature

## Summary
- Add _Snapshot frozen dataclass and _NeedsAttention return type
- Add _snapshot_wrapper_and_job for pre-mutation state capture (AC-01)
- Add _reconcile_after_error for rollback/compensation (AC-03)
- Rewrite _cron_install with snapshot → write → catch → reconcile (AC-01/03/09)
- Rewrite _cli_cron_remove with snapshot → delete → catch → reconcile (AC-03/09)
- Add 20 tests covering crash-boundary idempotency (AC-09)

## Changes
| File | Change |
|------|--------|
| `__init__.py` | Added _Snapshot, _NeedsAttention, _snapshot_wrapper_and_job, _reconcile_after_error; rewrote _cron_install and _cli_cron_remove |
| `tests/hermes_plugin_test.py` | Added 20 new tests for transactional flow and crash recovery |

## Test Plan
- [x] `PYTHONPATH=. pytest -q tests/hermes_plugin_test.py` — 48 passed
- [x] `PYTHONPATH=. pytest -q tests/hermes_host_test.py` — 21 passed
- [x] Full suite: 69 passed, 0 failed

## Stacked PR Context
📍 **PR2 of 3** — transactional cron flow
- PR1: Strict validation + simulator (#15)
- PR2: Transactional cron flow (this PR)
- PR3: Structured doctor (DoctorFinding, rewrite doctor, exit codes)

Depends on: PR #15 (must merge first)
Target: `main`