### PR TITLE
feat(hermes): add structured doctor with 3 exit codes (PR3/3)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,9 +34,10 @@ import shlex
 import stat
 import subprocess
 import sys
+from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +100,27 @@ class _NeedsAttention:
 
     def __repr__(self) -> str:
         return f"NeedsAttention(recovery_evidence={self.recovery_evidence!r})"
+
+
+# ---------------------------------------------------------------------------
+# Doctor types
+# ---------------------------------------------------------------------------
+
+
+_DoctorFinding = namedtuple(
+    "_DoctorFinding",
+    ["category", "status", "detail", "next_action"],
+)
+"""Structured doctor finding.
+
+Attributes:
+    category: One of ``"host-capability-unavailable"``, ``"gateway-inactive"``,
+        ``"config-incomplete"``, ``"daemon-defect"``.
+    status: ``"ok"`` or ``"fail"``.
+    detail: Human-readable description of the finding.
+    next_action: What the operator should do to fix the issue, or empty
+        string if status is ``"ok"``.
+"""
 
 
 def _plugin_root() -> Path:
@@ -481,45 +503,176 @@ def _atomic_install_binary(src: Path, dst: Path) -> None:
 # ---- doctor / status -------------------------------------------------------
 
 
-def _cli_doctor() -> int:
-    """Print whether the binary, bridge, cron wrapper, and cron job look healthy.
-
-    The doctor output is deliberately self-explanatory: every line names
-    the file path or cron job identifier, the next action to take when
-    something is wrong, and the lifecycle facts operators routinely
-    forget (gateway requirement, plugin-skill opt-in nature, etc.).
-    """
-    binary_ok = _binary_path().is_file()
-    bridge_path = _user_bridge_path()
-    bridge_ok = bridge_path.is_file() and not bridge_path.is_symlink()
-    wrapper = _pulse_wrapper_path()
-    wrapper_ok = wrapper.is_file() and not wrapper.is_symlink()
-    cron_ok = False
-    cron_detail = "not found"
-    try:
-        cron_ok, cron_detail = _cron_job_state(name="caduceus")
-    except RuntimeError as exc:
-        cron_detail = str(exc)
-    print(f"binary present : {'yes' if binary_ok else 'no'} ({_binary_path()})")
-    print(f"bridge present : {'yes' if bridge_ok else 'no'} ({bridge_path})")
-    print(f"cron wrapper   : {'yes' if wrapper_ok else 'no'} ({wrapper})")
-    print(f"cron job       : {'yes' if cron_ok else 'no'} ({cron_detail})")
-    print(f"plugin skill   : opt-in (caduceus:caduceus — explicit skill_view only)")
-    print(f"plugin layout  : standalone (no tools/hooks; explicit setup required)")
-    if binary_ok and bridge_ok and wrapper_ok and cron_ok:
-        print(
-            "gateway req    : the Hermes gateway (or a configured managed cron "
-            "provider) must be running for the cron job to fire"
+def _doctor_check_binary() -> _DoctorFinding:
+    """Check that the caduceus binary is present at the expected path (AC-05)."""
+    binary = _binary_path()
+    if binary.is_file():
+        return _DoctorFinding(
+            category="host-capability-unavailable",
+            status="ok",
+            detail=f"binary present at {binary}",
+            next_action="",
         )
-    print()
-    print("lifecycle:")
-    print("  install     : hermes plugins install barkley-assistant/caduceus --enable")
-    print("  build       : hermes caduceus setup")
-    print("  schedule    : hermes caduceus cron-install")
-    print("  inspect     : hermes caduceus status   |   /caduceus-status")
-    print("  source up   : hermes plugins update caduceus   then   hermes caduceus setup")
-    print("  uninstall   : hermes caduceus cron-remove   then   hermes plugins remove caduceus")
-    return 0 if (binary_ok and bridge_ok) else 1
+    return _DoctorFinding(
+        category="host-capability-unavailable",
+        status="fail",
+        detail=f"binary not found at {binary}",
+        next_action="run `hermes caduceus setup` to build and install the binary",
+    )
+
+
+def _doctor_check_bridge_harness() -> _DoctorFinding:
+    """Check that the configured worker_command path is executable (AC-10).
+
+    Checks ``os.X_OK`` on the bridge path. Does NOT execute the script.
+    """
+    bridge = _user_bridge_path()
+    if not bridge.is_file():
+        # Not necessarily a defect — the bridge may not have been seeded yet.
+        # But if the path exists and is not executable, that's a problem.
+        return _DoctorFinding(
+            category="host-capability-unavailable",
+            status="ok",
+            detail=f"bridge harness at {bridge} (not yet created)",
+            next_action="",
+        )
+    if os.access(bridge, os.X_OK):
+        return _DoctorFinding(
+            category="host-capability-unavailable",
+            status="ok",
+            detail=f"bridge harness at {bridge} is executable",
+            next_action="",
+        )
+    return _DoctorFinding(
+        category="host-capability-unavailable",
+        status="fail",
+        detail=f"bridge harness at {bridge} is not executable (mode {oct(stat.S_IMODE(bridge.stat().st_mode))})",
+        next_action=f"run `chmod +x {bridge}` to make it executable",
+    )
+
+
+def _doctor_check_provider_secret() -> _DoctorFinding:
+    """Check that the provider secret name is configured (AC-10).
+
+    Checks for the presence of a secret-name in the environment or config.
+    Does NOT read the secret value and does NOT make network calls.
+    """
+    # The provider secret name is expected in the environment.
+    # Caduceus's daemon config uses CADUCEUS_GITHUB_TOKEN or GITHUB_TOKEN.
+    # The secret *name* (not value) is checked here.
+    for secret_name in ("CADUCEUS_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+        if os.environ.get(secret_name):
+            return _DoctorFinding(
+                category="config-incomplete",
+                status="ok",
+                detail=f"provider secret name {secret_name} is configured",
+                next_action="",
+            )
+    # No secret name found — the operator may need to configure one.
+    return _DoctorFinding(
+        category="config-incomplete",
+        status="fail",
+        detail="no provider secret token configured (checked CADUCEUS_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN)",
+        next_action="set one of CADUCEUS_GITHUB_TOKEN, GITHUB_TOKEN, or GH_TOKEN in the environment",
+    )
+
+
+def _doctor_check_cron_capability(ctx: Any) -> _DoctorFinding:
+    """Check that cron capability is available via a bounded round-trip (AC-05).
+
+    Performs a single ``cronjob list`` call via the runtime dispatcher.
+    If the dispatcher is not installed or the call fails, the finding
+    reports a failure.
+    """
+    del ctx  # ctx is not needed — we use the runtime dispatcher directly
+    try:
+        from . import _runtime as rt  # type: ignore[import-not-found]
+
+        if rt._DISPATCHER is None:
+            return _DoctorFinding(
+                category="host-capability-unavailable",
+                status="fail",
+                detail="cron dispatcher not installed (adapter not registered with Hermes)",
+                next_action="run `hermes plugins install barkley-assistant/caduceus --enable` to register the adapter",
+            )
+        _cron_job_registry()
+        return _DoctorFinding(
+            category="host-capability-unavailable",
+            status="ok",
+            detail="cron capability is available (cronjob list succeeded)",
+            next_action="",
+        )
+    except Exception as exc:
+        return _DoctorFinding(
+            category="host-capability-unavailable",
+            status="fail",
+            detail=f"cron capability check failed: {exc}",
+            next_action="ensure the Hermes gateway is running and cron is enabled",
+        )
+
+
+def _doctor_check_gateway() -> _DoctorFinding:
+    """Check that the Hermes gateway delivery is reachable (AC-05).
+
+    This is a best-effort check — the gateway may not be running in
+    the current environment. The finding always returns a result without
+    making a network call.
+    """
+    # The gateway is an external Hermes process. Without a live Hermes
+    # context, we cannot probe it directly. We check for the presence of
+    # the Hermes CLI which is a prerequisite for gateway operation.
+    hermes_home = _hermes_home()
+    if hermes_home.is_dir():
+        return _DoctorFinding(
+            category="gateway-inactive",
+            status="ok",
+            detail=f"Hermes home at {hermes_home} exists",
+            next_action="",
+        )
+    return _DoctorFinding(
+        category="gateway-inactive",
+        status="fail",
+        detail=f"Hermes home at {hermes_home} not found",
+        next_action="ensure Hermes is installed and configured",
+    )
+
+
+def _cli_doctor() -> int:
+    """Run all doctor checks and print a structured report (AC-06/07/08/11).
+
+    Each check is independent — a failure in one does NOT short-circuit
+    the others. Exit codes:
+        0: all checks healthy
+        1: Caduceus config/runtime defects (``daemon-defect``, ``config-incomplete``)
+        2: host capability / external prerequisite (``host-capability-unavailable``,
+           ``gateway-inactive``)
+
+    Exit 2 takes precedence over exit 1 because prerequisites block everything.
+    """
+    checks = [
+        ("Binary", _doctor_check_binary()),
+        ("Bridge Harness", _doctor_check_bridge_harness()),
+        ("Provider Secret", _doctor_check_provider_secret()),
+        ("Cron Capability", _doctor_check_cron_capability(ctx=None)),
+        ("Gateway", _doctor_check_gateway()),
+    ]
+
+    max_severity = 0  # 0 = ok, 1 = config/runtime, 2 = prerequisite
+    for name, finding in checks:
+        status_mark = "OK" if finding.status == "ok" else "FAIL"
+        print(f"[{status_mark}] {name}")
+        print(f"       category   : {finding.category}")
+        print(f"       detail     : {finding.detail}")
+        if finding.next_action:
+            print(f"       next action: {finding.next_action}")
+        print()
+        if finding.status != "ok":
+            if finding.category in ("host-capability-unavailable", "gateway-inactive"):
+                max_severity = max(max_severity, 2)
+            else:
+                max_severity = max(max_severity, 1)
+
+    return max_severity
 
 
 def _cli_status() -> int:
@@ -877,15 +1030,12 @@ def _write_pulse_wrapper(binary: Path) -> None:
     """Atomically write the ``caduceus-pulse.sh`` wrapper.
 
     The wrapper contains the absolute installed binary path and uses
-    ``exec`` so the cron process replaces its shell with the daemon. This
-    matches the contract's "exec <binary> run" requirement.
+    ``exec`` so the cron process replaces its shell with the daemon.
     """
     path = _pulse_wrapper_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     body = (
         "#!/usr/bin/env bash\n"
-        "# Generated by `hermes caduceus cron-install`. Do not edit by hand;\n"
-        "# rerun that command after moving the plugin.\n"
         "set -euo pipefail\n"
         f"exec {binary} run \"$@\"\n"
     )
@@ -1042,6 +1192,7 @@ __all__ = [
     "register",
     "_Snapshot",
     "_NeedsAttention",
+    "_DoctorFinding",
     "_handle_caduceus_status",
     "_register_caduceus_cli",
     "_caduceus_cli_command",

--- a/plugin-assets/caduceus-pulse.sh
+++ b/plugin-assets/caduceus-pulse.sh
@@ -1,31 +1,13 @@
 #!/usr/bin/env bash
-# Caduceus pulse wrapper — TEMPLATE installed by `hermes caduceus cron-install`.
+# Caduceus pulse wrapper — template used by `hermes caduceus cron-install`.
 #
-# This file lives in the plugin's plugin-assets/ directory and is used by
-# setup/cron-install as a content reference. The actually-installed
-# wrapper at `$HERMES_HOME/scripts/caduceus-pulse.sh` is generated
-# dynamically by the adapter (it embeds the absolute binary path of the
-# installed daemon and uses `exec` so the cron process is replaced by
-# the daemon, not forked from a shell).
+# This file lives in the plugin's plugin-assets/ directory. The actual
+# installed wrapper at `$HERMES_HOME/scripts/caduceus-pulse.sh` is
+# generated dynamically by the adapter with the absolute binary path of
+# the installed daemon.
 #
-# Do not run this template directly. Always use `hermes caduceus
-# cron-install` (or the equivalent direct invocation of the adapter's
-# CLI) to install the runtime copy.
-#
-# Notes for the operator:
-#   * The runtime wrapper is owned by the Hermes install, not by this
-#     repo. `hermes caduceus cron-remove` removes it idempotently.
-#   * `exec <absolute-binary-path> run` replaces the shell process with
-#     the daemon so the cron process tree has no shell ancestor — that
-#     keeps the worker supervisor's session/timeout plan intact.
-#   * The wrapper does not pass any environment variables of its own;
-#     the daemon re-reads its config via the normal resolution chain.
-#   * The Hermes gateway (or a configured managed cron provider) must
-#     be running for this script to fire on schedule.
+# Do not run this template directly. Use `hermes caduceus cron-install`
+# to install the runtime copy.
 set -euo pipefail
 
-# Two lines so users see exactly what would run:
-#   exec <absolute-binary-path> run
-# Adapter replaces the entire body with the real installed binary path
-# during cron-install.
 exec caduceus run "$@"

--- a/tests/hermes_plugin_test.py
+++ b/tests/hermes_plugin_test.py
@@ -1426,6 +1426,388 @@ def test_reconcile_absent_intended_state_already_absent(
     assert result is None  # No-op success
 
 
+# ---------------------------------------------------------------------------
+# Phase 3: Structured Doctor (Tasks 3.1-3.4)
+# ---------------------------------------------------------------------------
+# Tests written FIRST (RED phase) before any production code changes.
+# They verify the _DoctorFinding namedtuple, five doctor check functions,
+# structured _cli_doctor with 3 exit codes, and cleanup of AC-12.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Task 3.1: _DoctorFinding namedtuple
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_finding_is_namedtuple() -> None:
+    """_DoctorFinding is a namedtuple with category, status, detail, next_action."""
+    from collections import namedtuple
+    from caduceus import _DoctorFinding
+
+    assert isinstance(_DoctorFinding, type)
+    assert issubclass(_DoctorFinding, tuple)
+    # Namedtuples have _fields.
+    assert _DoctorFinding._fields == ("category", "status", "detail", "next_action")
+
+
+def test_doctor_finding_holds_values() -> None:
+    """_DoctorFinding stores category, status, detail, next_action."""
+    from caduceus import _DoctorFinding
+
+    f = _DoctorFinding(
+        category="host-capability-unavailable",
+        status="fail",
+        detail="/path/to/binary not found",
+        next_action="run `hermes caduceus setup` to build the binary",
+    )
+    assert f.category == "host-capability-unavailable"
+    assert f.status == "fail"
+    assert f.detail == "/path/to/binary not found"
+    assert f.next_action == "run `hermes caduceus setup` to build the binary"
+
+
+def test_doctor_finding_accepts_ok_status() -> None:
+    """_DoctorFinding accepts status='ok'."""
+    from caduceus import _DoctorFinding
+
+    f = _DoctorFinding(
+        category="config-incomplete",
+        status="ok",
+        detail="all config present",
+        next_action="",
+    )
+    assert f.status == "ok"
+    assert f.next_action == ""
+
+
+def test_doctor_finding_is_immutable() -> None:
+    """_DoctorFinding is a namedtuple — fields cannot be reassigned."""
+    from caduceus import _DoctorFinding
+
+    f = _DoctorFinding(
+        category="gateway-inactive",
+        status="fail",
+        detail="gateway not reachable",
+        next_action="run `hermes gateway restart`",
+    )
+    with pytest.raises(AttributeError):
+        f.status = "ok"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Task 3.2: Doctor check functions
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_check_binary_present(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """_doctor_check_binary returns ok when binary exists."""
+    finding = adapter._doctor_check_binary()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "ok"
+    assert str(install_with_fake_binary) in finding.detail
+
+
+def test_doctor_check_binary_missing(adapter) -> None:
+    """_doctor_check_binary returns fail when binary is missing."""
+    finding = adapter._doctor_check_binary()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "fail"
+    assert "not found" in finding.detail.lower() or "missing" in finding.detail.lower()
+    assert "setup" in finding.next_action.lower()
+
+
+def test_doctor_check_bridge_harness_executable(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """_doctor_check_bridge_harness returns ok when bridge is executable."""
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+    finding = adapter._doctor_check_bridge_harness()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "ok"
+    assert str(bridge) in finding.detail
+
+
+def test_doctor_check_bridge_harness_not_executable(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """_doctor_check_bridge_harness returns fail when bridge lacks execute bit."""
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o644)  # Not executable
+    finding = adapter._doctor_check_bridge_harness()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "fail"
+    assert "chmod" in finding.next_action.lower() or "+x" in finding.next_action.lower()
+
+
+def test_doctor_check_provider_secret_present(
+    adapter, install_plugin: Path
+) -> None:
+    """_doctor_check_provider_secret returns ok when secret name is configured."""
+    finding = adapter._doctor_check_provider_secret()
+    # Without a config to inspect, we expect a sensible default.
+    assert finding.category in ("config-incomplete", "host-capability-unavailable")
+    assert finding.status in ("ok", "fail")
+
+
+def test_doctor_check_cron_capability_ok(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """_doctor_check_cron_capability returns ok when cron lists without error."""
+    from caduceus import _runtime
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        finding = adapter._doctor_check_cron_capability(ctx=adapter)
+    finally:
+        _runtime.reset_dispatcher()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "ok"
+
+
+def test_doctor_check_cron_capability_fails(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """_doctor_check_cron_capability returns fail when cron list raises."""
+    from caduceus import _runtime
+
+    original_registry = adapter._cron_job_registry
+    def _failing_registry():
+        raise RuntimeError("cron unavailable")
+
+    try:
+        adapter._cron_job_registry = _failing_registry  # type: ignore[assignment]
+        finding = adapter._doctor_check_cron_capability(ctx=adapter)
+    finally:
+        adapter._cron_job_registry = original_registry
+    assert finding.status == "fail"
+    assert "cron" in finding.detail.lower()
+
+
+def test_doctor_check_gateway_returns_finding(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """_doctor_check_gateway returns a _DoctorFinding (ok or fail)."""
+    finding = adapter._doctor_check_gateway()
+    assert isinstance(finding, tuple)
+    assert finding.category == "gateway-inactive"
+    assert finding.status in ("ok", "fail")
+
+
+# ---------------------------------------------------------------------------
+# Task 3.3: Rewritten _cli_doctor
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_exit_0_when_all_healthy(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, monkeypatch
+) -> None:
+    """_cli_doctor returns 0 when all checks pass (AC-06)."""
+    from caduceus import _runtime
+
+    # Set up healthy environment: binary exists, bridge is executable,
+    # cron works, and provider secret is configured.
+    monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        rc = adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+    assert rc == 0
+
+
+def test_doctor_exit_1_for_config_defect(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path
+) -> None:
+    """_cli_doctor returns 1 for config-incomplete or daemon-defect (AC-08)."""
+    from caduceus import _runtime
+
+    # Binary present, bridge executable, cron works — but provider secret
+    # is missing (config-incomplete).
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+
+    # Make provider secret check return fail (config-incomplete).
+    original_secret = adapter._doctor_check_provider_secret
+    def _failing_secret():
+        from caduceus import _DoctorFinding
+        return _DoctorFinding(
+            category="config-incomplete",
+            status="fail",
+            detail="provider secret not configured",
+            next_action="set HERMES_PROVIDER_SECRET in environment",
+        )
+
+    try:
+        adapter._doctor_check_provider_secret = _failing_secret  # type: ignore[assignment]
+        rc = adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+        adapter._doctor_check_provider_secret = original_secret
+    assert rc == 1
+
+
+def test_doctor_exit_2_for_missing_binary(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """_cli_doctor returns 2 for host-capability-unavailable (AC-11)."""
+    from caduceus import _runtime
+
+    # No binary installed — exit 2.
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        rc = adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+    assert rc == 2
+
+
+def test_doctor_exit_2_takes_precedence_over_exit_1(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """When both exit-1 and exit-2 failures exist, exit 2 wins (design #9)."""
+    from caduceus import _runtime
+
+    # Binary missing (exit 2) AND config defect (exit 1) — exit 2 wins.
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    original_secret = adapter._doctor_check_provider_secret
+    def _failing_secret():
+        from caduceus import _DoctorFinding
+        return _DoctorFinding(
+            category="config-incomplete",
+            status="fail",
+            detail="provider secret not configured",
+            next_action="set HERMES_PROVIDER_SECRET in environment",
+        )
+
+    try:
+        adapter._doctor_check_provider_secret = _failing_secret  # type: ignore[assignment]
+        rc = adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+        adapter._doctor_check_provider_secret = original_secret
+    assert rc == 2
+
+
+def test_doctor_prints_structured_report(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, capsys: pytest.CaptureFixture, monkeypatch
+) -> None:
+    """_cli_doctor prints each finding with status, detail, next_action (AC-07)."""
+    from caduceus import _runtime
+
+    monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        rc = adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    # Each finding category should appear in the output.
+    assert "binary" in captured.out.lower() or "Binary" in captured.out
+    assert "cron" in captured.out.lower() or "Cron" in captured.out
+    assert "bridge" in captured.out.lower() or "Bridge" in captured.out
+    assert "ok" in captured.out.lower() or "OK" in captured.out
+
+
+def test_doctor_prints_failures_on_exit_2(
+    adapter, capsys: pytest.CaptureFixture
+) -> None:
+    """_cli_doctor prints failure details when exiting 2."""
+    from caduceus import _runtime
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        rc = adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    # Should show what failed.
+    assert "fail" in captured.out.lower() or "FAIL" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Task 3.5: AC-12 cleanup tests
+# ---------------------------------------------------------------------------
+
+
+def test_write_pulse_wrapper_no_misleading_comments(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path
+) -> None:
+    """_write_pulse_wrapper no longer has misleading comments (AC-12)."""
+    # We check the body content the adapter generates.
+    # Get the source of the function.
+    import inspect
+    source = inspect.getsource(adapter._write_pulse_wrapper)
+    # The body string should not contain "Generated by" (the old comment
+    # was misleading — it's generated at runtime with the installed path).
+    # Actually AC-12 says REMOVE misleading comments, so let's verify
+    # the body is clean.
+    assert "Do not edit by hand" not in source
+    # The wrapper should still contain the exec line and set -euo pipefail.
+    body = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"exec {install_with_fake_binary} run \"$@\"\n"
+    )
+    # The generated wrapper should match a clean structure.
+    adapter._write_pulse_wrapper(install_with_fake_binary)
+    wrapper_path = isolated_hermes_home / "scripts" / "caduceus-pulse.sh"
+    assert wrapper_path.is_file()
+    text = wrapper_path.read_text(encoding="utf-8")
+    assert text == body
+
+
+def test_pulse_template_has_strict_shell_and_accurate_comments(
+    plugin_root: Path
+) -> None:
+    """caduceus-pulse.sh has strict shell and accurate comments (AC-12)."""
+    template = plugin_root / "plugin-assets" / "caduceus-pulse.sh"
+    text = template.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    # Must have strict shell settings.
+    assert "set -euo pipefail" in text
+    # Must NOT have misleading or dev-only comments.
+    assert "FIXME" not in text
+    assert "TODO" not in text
+    assert "pending" not in text.lower()
+    assert "dev-only" not in text.lower()
+    # Must accurately describe what the file is.
+    assert "template" in text.lower() or "Template" in text
+
+
 def test_reconcile_failed_relist_returns_needs_attention(
     adapter, isolated_hermes_home: Path
 ) -> None:


### PR DESCRIPTION
Closes #6

## PR Type
- [x] New feature

## Summary
- Add _DoctorFinding namedtuple with structured findings
- Add 5 independent doctor checks (binary, bridge, secret, cron, gateway)
- Rewrite _cli_doctor with 3 exit codes (0 healthy, 1 daemon/config, 2 host prerequisite)
- Add 20 doctor tests covering all exit scenarios
- AC-12 cleanup: fix pulse wrapper comments and caduceus-pulse.sh

## Changes
| File | Change |
|------|--------|
| `__init__.py` | Added _DoctorFinding, 5 doctor checks, rewritten _cli_doctor with structured exit codes |
| `tests/hermes_plugin_test.py` | Added 20 doctor tests across 4 groups |
| `plugin-assets/caduceus-pulse.sh` | AC-12 cleanup: strict shell + accurate comments |

## Test Plan
- [x] `PYTHONPATH=. pytest -q tests/hermes_plugin_test.py` — 68 passed
- [x] `PYTHONPATH=. pytest -q tests/hermes_host_test.py` — 21 passed
- [x] Full suite: 89 passed, 0 failed

## Stacked PR Context
📍 **PR3 of 3** — structured doctor
- PR1: Strict validation + simulator (#15)
- PR2: Transactional cron flow (#16)
- PR3: Structured doctor (this PR)

Depends on: PR #16 (must merge first)
Target: `main`