### PR TITLE
fix(cli): rewrite doctor findings for operator legibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -673,16 +673,6 @@ def _doctor_check_hermes_home() -> _DoctorFinding:
     )
 
 
-def _is_ci() -> bool:
-    """Return True when running on a CI / automated host.
-
-    Detected by the presence of the ``CI`` or ``GITHUB_ACTIONS``
-    environment variables, both common on GitHub Actions and other
-    hosted runners.
-    """
-    return bool(os.environ.get("CI")) or bool(os.environ.get("GITHUB_ACTIONS"))
-
-
 def _cli_doctor(verbose: bool = False) -> int:
     """Run all doctor checks and print a structured report (AC-06/07/08/11).
 
@@ -696,8 +686,11 @@ def _cli_doctor(verbose: bool = False) -> int:
     Exit 2 takes precedence over exit 1 because prerequisites block everything.
 
     ``--verbose`` prints the internal detail string and the structured
-    category on FAIL lines, but is suppressed on CI hosts so CI logs
-    stay operator-only.
+    category on FAIL lines. The verbose flag is always honoured when
+    the operator passes it — operators running ``--verbose`` from a CI
+    shell (e.g. for debugging) get the internal detail. CI log hygiene
+    is achieved by the default output being operator-only (verbose=False
+    is the default), not by overriding an explicit verbose flag.
     """
     checks = [
         ("Binary", _doctor_check_binary()),
@@ -707,7 +700,7 @@ def _cli_doctor(verbose: bool = False) -> int:
         ("Hermes Home", _doctor_check_hermes_home()),
     ]
 
-    effective_verbose = verbose and not _is_ci()
+    effective_verbose = verbose
     max_severity = 0  # 0 = ok, 1 = config/runtime, 2 = prerequisite
     for name, finding in checks:
         status_mark = "OK" if finding.status == "ok" else "FAIL"

--- a/__init__.py
+++ b/__init__.py
@@ -109,7 +109,8 @@ class _NeedsAttention:
 
 _DoctorFinding = namedtuple(
     "_DoctorFinding",
-    ["category", "status", "detail", "next_action"],
+    ["category", "status", "detail", "next_action", "internal_detail"],
+    defaults=("",),
 )
 """Structured doctor finding.
 
@@ -117,9 +118,12 @@ Attributes:
     category: One of ``"host-capability-unavailable"``, ``"gateway-inactive"``,
         ``"config-incomplete"``, ``"daemon-defect"``.
     status: ``"ok"`` or ``"fail"``.
-    detail: Human-readable description of the finding.
+    detail: Human-readable operator-facing description of the finding.
     next_action: What the operator should do to fix the issue, or empty
         string if status is ``"ok"``.
+    internal_detail: Internal diagnostic for ``--verbose`` output, never
+        shown by default. May include structured categories such as
+        ``"malformed-response"`` because it is not operator-facing.
 """
 
 
@@ -357,9 +361,14 @@ def _register_caduceus_cli(subparser: Any) -> None:
         help="Print the actions without running them.",
     )
 
-    subs.add_parser(
+    doctor = subs.add_parser(
         "doctor",
         help="Verify the binary, bridge, and cron job are healthy.",
+    )
+    doctor.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print internal detail and structured category (human debugging only).",
     )
 
     subs.add_parser(
@@ -390,7 +399,7 @@ def _caduceus_cli_command(args: Any) -> int:
     if sub == "setup":
         return _cli_setup(dry_run=getattr(args, "dry_run", False))
     if sub == "doctor":
-        return _cli_doctor()
+        return _cli_doctor(verbose=getattr(args, "verbose", False))
     if sub == "status":
         return _cli_status()
     if sub == "cron-install":
@@ -510,14 +519,16 @@ def _doctor_check_binary() -> _DoctorFinding:
         return _DoctorFinding(
             category="host-capability-unavailable",
             status="ok",
-            detail=f"binary present at {binary}",
+            detail=f"caduceus binary present at {binary}",
             next_action="",
+            internal_detail="",
         )
     return _DoctorFinding(
         category="host-capability-unavailable",
         status="fail",
-        detail=f"binary not found at {binary}",
+        detail=f"caduceus binary not found at {binary} (run setup to build it)",
         next_action="run `hermes caduceus setup` to build and install the binary",
+        internal_detail="",
     )
 
 
@@ -533,21 +544,24 @@ def _doctor_check_bridge_harness() -> _DoctorFinding:
         return _DoctorFinding(
             category="host-capability-unavailable",
             status="ok",
-            detail=f"bridge harness at {bridge} (not yet created)",
+            detail=f"worker bridge not yet seeded at {bridge} (external prerequisite)",
             next_action="",
+            internal_detail=f"bridge harness at {bridge} (not yet created)",
         )
     if os.access(bridge, os.X_OK):
         return _DoctorFinding(
             category="host-capability-unavailable",
             status="ok",
-            detail=f"bridge harness at {bridge} is executable",
+            detail=f"worker bridge at {bridge} is executable",
             next_action="",
+            internal_detail="",
         )
     return _DoctorFinding(
         category="host-capability-unavailable",
         status="fail",
-        detail=f"bridge harness at {bridge} is not executable (mode {oct(stat.S_IMODE(bridge.stat().st_mode))})",
+        detail=f"worker bridge at {bridge} is not executable (mode {oct(stat.S_IMODE(bridge.stat().st_mode))})",
         next_action=f"run `chmod +x {bridge}` to make it executable",
+        internal_detail="",
     )
 
 
@@ -560,84 +574,116 @@ def _doctor_check_provider_secret() -> _DoctorFinding:
     # The provider secret name is expected in the environment.
     # Caduceus's daemon config uses CADUCEUS_GITHUB_TOKEN or GITHUB_TOKEN.
     # The secret *name* (not value) is checked here.
+    checked = "CADUCEUS_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN"
     for secret_name in ("CADUCEUS_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
         if os.environ.get(secret_name):
             return _DoctorFinding(
                 category="config-incomplete",
                 status="ok",
-                detail=f"provider secret name {secret_name} is configured",
+                detail=f"provider secret name {secret_name} is configured (no value read)",
                 next_action="",
+                internal_detail="",
             )
     # No secret name found — the operator may need to configure one.
     return _DoctorFinding(
         category="config-incomplete",
         status="fail",
-        detail="no provider secret token configured (checked CADUCEUS_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN)",
+        detail=f"no provider secret name configured (checked {checked})",
         next_action="set one of CADUCEUS_GITHUB_TOKEN, GITHUB_TOKEN, or GH_TOKEN in the environment",
+        internal_detail="",
     )
 
 
 def _doctor_check_cron_capability(ctx: Any) -> _DoctorFinding:
     """Check that cron capability is available via a bounded round-trip (AC-05).
 
-    Performs a single ``cronjob list`` call via the runtime dispatcher.
-    If the dispatcher is not installed or the call fails, the finding
-    reports a failure.
+    Performs a single ``cronjob list`` call via the runtime dispatcher,
+    then distinguishes five outcomes: dispatcher absent, no Caduceus job,
+    one or more Caduceus jobs, malformed payload, and every other error.
     """
     del ctx  # ctx is not needed — we use the runtime dispatcher directly
-    try:
-        from . import _runtime as rt  # type: ignore[import-not-found]
+    from . import _runtime as rt  # type: ignore[import-not-found]
 
-        if rt._DISPATCHER is None:
-            return _DoctorFinding(
-                category="host-capability-unavailable",
-                status="fail",
-                detail="cron dispatcher not installed (adapter not registered with Hermes)",
-                next_action="run `hermes plugins install barkley-assistant/caduceus --enable` to register the adapter",
-            )
-        _cron_job_registry()
-        return _DoctorFinding(
-            category="host-capability-unavailable",
-            status="ok",
-            detail="cron capability is available (cronjob list succeeded)",
-            next_action="",
-        )
-    except Exception as exc:
+    if rt._DISPATCHER is None:
         return _DoctorFinding(
             category="host-capability-unavailable",
             status="fail",
-            detail=f"cron capability check failed: {exc}",
-            next_action="ensure the Hermes gateway is running and cron is enabled",
+            detail="Caduceus adapter is not installed; cannot reach the cron subsystem",
+            next_action="run `hermes plugins install barkley-assistant/caduceus --enable` to register the adapter, then re-check",
+            internal_detail="cron dispatcher not installed (adapter not registered with Hermes)",
         )
+    try:
+        jobs = rt.cron_list_jobs()
+    except rt.CronCapabilityError as exc:
+        if exc.category == "malformed-response":
+            return _DoctorFinding(
+                category="host-capability-unavailable",
+                status="fail",
+                detail="Hermes returned an unexpected payload shape for the cron list",
+                next_action="run `hermes plugins install --enable` to refresh the adapter, then re-check",
+                internal_detail=str(exc),
+            )
+        return _DoctorFinding(
+            category="host-capability-unavailable",
+            status="fail",
+            detail=f"cron list call raised an exception: {exc.category}",
+            next_action="run `hermes caduceus cron-install` to register the 2-minute job (or re-run `hermes plugins install --enable` if the adapter was reinstalled)",
+            internal_detail=f"cron list call raised: {exc.category}: {exc.detail}",
+        )
+    caduceus_jobs = [job for job in jobs.values() if job.get("name") == "caduceus"]
+    if caduceus_jobs:
+        noun = "job" if len(caduceus_jobs) == 1 else "jobs"
+        return _DoctorFinding(
+            category="host-capability-unavailable",
+            status="ok",
+            detail=f"{len(caduceus_jobs)} Caduceus cron {noun} registered (external prerequisite, exercised)",
+            next_action="",
+            internal_detail="cron capability is available (cronjob list succeeded)",
+        )
+    return _DoctorFinding(
+        category="host-capability-unavailable",
+        status="ok",
+        detail="no Caduceus cron job registered yet (external prerequisite, not exercised)",
+        next_action="run `hermes caduceus cron-install` to register the 2-minute job",
+        internal_detail="cron list returned 0 Caduceus jobs",
+    )
 
 
-def _doctor_check_gateway() -> _DoctorFinding:
-    """Check that the Hermes gateway delivery is reachable (AC-05).
+def _doctor_check_hermes_home() -> _DoctorFinding:
+    """Check that the Hermes home directory exists on disk (AC-05).
 
-    This is a best-effort check — the gateway may not be running in
-    the current environment. The finding always returns a result without
-    making a network call.
+    This is a prerequisite check, not an active probe of the Hermes
+    gateway. It confirms a well-known directory the Hermes CLI owns.
     """
-    # The gateway is an external Hermes process. Without a live Hermes
-    # context, we cannot probe it directly. We check for the presence of
-    # the Hermes CLI which is a prerequisite for gateway operation.
     hermes_home = _hermes_home()
     if hermes_home.is_dir():
         return _DoctorFinding(
             category="gateway-inactive",
             status="ok",
-            detail=f"Hermes home at {hermes_home} exists",
+            detail=f"Hermes home at {hermes_home} exists (external prerequisite)",
             next_action="",
+            internal_detail="",
         )
     return _DoctorFinding(
         category="gateway-inactive",
         status="fail",
         detail=f"Hermes home at {hermes_home} not found",
-        next_action="ensure Hermes is installed and configured",
+        next_action="install Hermes and ensure the home directory is initialised",
+        internal_detail="",
     )
 
 
-def _cli_doctor() -> int:
+def _is_ci() -> bool:
+    """Return True when running on a CI / automated host.
+
+    Detected by the presence of the ``CI`` or ``GITHUB_ACTIONS``
+    environment variables, both common on GitHub Actions and other
+    hosted runners.
+    """
+    return bool(os.environ.get("CI")) or bool(os.environ.get("GITHUB_ACTIONS"))
+
+
+def _cli_doctor(verbose: bool = False) -> int:
     """Run all doctor checks and print a structured report (AC-06/07/08/11).
 
     Each check is independent — a failure in one does NOT short-circuit
@@ -648,23 +694,31 @@ def _cli_doctor() -> int:
            ``gateway-inactive``)
 
     Exit 2 takes precedence over exit 1 because prerequisites block everything.
+
+    ``--verbose`` prints the internal detail string and the structured
+    category on FAIL lines, but is suppressed on CI hosts so CI logs
+    stay operator-only.
     """
     checks = [
         ("Binary", _doctor_check_binary()),
         ("Bridge Harness", _doctor_check_bridge_harness()),
         ("Provider Secret", _doctor_check_provider_secret()),
         ("Cron Capability", _doctor_check_cron_capability(ctx=None)),
-        ("Gateway", _doctor_check_gateway()),
+        ("Hermes Home", _doctor_check_hermes_home()),
     ]
 
+    effective_verbose = verbose and not _is_ci()
     max_severity = 0  # 0 = ok, 1 = config/runtime, 2 = prerequisite
     for name, finding in checks:
         status_mark = "OK" if finding.status == "ok" else "FAIL"
-        print(f"[{status_mark}] {name}")
-        print(f"       category   : {finding.category}")
-        print(f"       detail     : {finding.detail}")
+        print(f"[{status_mark}] {name} — {finding.detail}")
         if finding.next_action:
             print(f"       next action: {finding.next_action}")
+        if effective_verbose:
+            internal = finding.internal_detail or finding.detail
+            print(f"       detail:      {internal}")
+            if finding.status != "ok":
+                print(f"       category:    {finding.category}")
         print()
         if finding.status != "ok":
             if finding.category in ("host-capability-unavailable", "gateway-inactive"):

--- a/tests/plugin/test_doctor_checks.py
+++ b/tests/plugin/test_doctor_checks.py
@@ -42,7 +42,8 @@ def test_doctor_check_binary_missing(adapter) -> None:
     assert finding.category == "host-capability-unavailable"
     assert finding.status == "fail"
     assert "not found" in finding.detail.lower() or "missing" in finding.detail.lower()
-    assert "setup" in finding.next_action.lower()
+    assert "run setup to build it" in finding.detail
+    assert "hermes caduceus setup" in finding.next_action
 
 
 
@@ -59,6 +60,7 @@ def test_doctor_check_bridge_harness_executable(
     assert finding.category == "host-capability-unavailable"
     assert finding.status == "ok"
     assert str(bridge) in finding.detail
+    assert "worker bridge" in finding.detail.lower()
 
 
 
@@ -74,27 +76,78 @@ def test_doctor_check_bridge_harness_not_executable(
     finding = adapter._doctor_check_bridge_harness()
     assert finding.category == "host-capability-unavailable"
     assert finding.status == "fail"
+    assert "worker bridge" in finding.detail.lower()
     assert "chmod" in finding.next_action.lower() or "+x" in finding.next_action.lower()
 
 
 
 
+def test_doctor_check_bridge_harness_not_yet_seeded(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """A missing bridge is OK but framed as an external prerequisite."""
+    finding = adapter._doctor_check_bridge_harness()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "ok"
+    assert "worker bridge not yet seeded" in finding.detail.lower()
+    assert "external prerequisite" in finding.detail.lower()
+
+
+
+
 def test_doctor_check_provider_secret_present(
-    adapter, install_plugin: Path
+    adapter, install_plugin: Path, monkeypatch
 ) -> None:
     """_doctor_check_provider_secret returns ok when secret name is configured."""
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test-secret-name")
     finding = adapter._doctor_check_provider_secret()
-    # Without a config to inspect, we expect a sensible default.
-    assert finding.category in ("config-incomplete", "host-capability-unavailable")
-    assert finding.status in ("ok", "fail")
+    assert finding.category == "config-incomplete"
+    assert finding.status == "ok"
+    assert "provider secret name GITHUB_TOKEN is configured" in finding.detail
+    assert "no value read" in finding.detail
 
 
 
 
-def test_doctor_check_cron_capability_ok(
+def test_doctor_check_provider_secret_missing(adapter) -> None:
+    """_doctor_check_provider_secret returns fail when no secret name is set."""
+    for var in ("CADUCEUS_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+        os.environ.pop(var, None)
+    finding = adapter._doctor_check_provider_secret()
+    assert finding.category == "config-incomplete"
+    assert finding.status == "fail"
+    assert "no provider secret name configured" in finding.detail.lower()
+    assert finding.next_action.startswith("set one of")
+
+
+
+
+def test_doctor_check_cron_capability_ok_with_jobs(
     adapter, install_with_fake_binary: Path
 ) -> None:
-    """_doctor_check_cron_capability returns ok when cron lists without error."""
+    """_doctor_check_cron_capability returns ok with caduceus job count."""
+    from caduceus import _runtime
+
+    registry = {
+        "job-1": {"id": "job-1", "name": "caduceus", "schedule": "every 2m"},
+    }
+    _stub_cron_runtime(adapter, registry)
+    try:
+        finding = adapter._doctor_check_cron_capability(ctx=adapter)
+    finally:
+        _runtime.reset_dispatcher()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "ok"
+    assert "1 Caduceus cron job registered" in finding.detail
+    assert "external prerequisite, exercised" in finding.detail
+
+
+
+
+def test_doctor_check_cron_capability_no_caduceus_job(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """A reachable cron subsystem with no caduceus job is a prerequisite."""
     from caduceus import _runtime
 
     registry = {}
@@ -105,36 +158,35 @@ def test_doctor_check_cron_capability_ok(
         _runtime.reset_dispatcher()
     assert finding.category == "host-capability-unavailable"
     assert finding.status == "ok"
+    assert "no Caduceus cron job registered yet" in finding.detail
+    assert "external prerequisite, not exercised" in finding.detail
+    assert "hermes caduceus cron-install" in finding.next_action
 
 
 
 
-def test_doctor_check_cron_capability_fails(
+def test_doctor_check_cron_capability_dispatcher_not_installed(
     adapter, install_with_fake_binary: Path
 ) -> None:
-    """_doctor_check_cron_capability returns fail when cron list raises."""
+    """Missing dispatcher points at plugin install, not gateway state."""
     from caduceus import _runtime
 
-    original_registry = adapter._cron_job_registry
-    def _failing_registry():
-        raise RuntimeError("cron unavailable")
-
-    try:
-        adapter._cron_job_registry = _failing_registry  # type: ignore[assignment]
-        finding = adapter._doctor_check_cron_capability(ctx=adapter)
-    finally:
-        adapter._cron_job_registry = original_registry
+    _runtime.reset_dispatcher()
+    finding = adapter._doctor_check_cron_capability(ctx=adapter)
+    # reset_dispatcher leaves _DISPATCHER None; no restore needed.
     assert finding.status == "fail"
-    assert "cron" in finding.detail.lower()
+    assert "adapter is not installed" in finding.detail.lower()
+    assert "gateway is running" not in finding.next_action.lower()
+    assert "hermes plugins install" in finding.next_action
 
 
 
 
-def test_doctor_check_gateway_returns_finding(
+def test_doctor_check_gateway_renamed_to_hermes_home(
     adapter, install_with_fake_binary: Path
 ) -> None:
-    """_doctor_check_gateway returns a _DoctorFinding (ok or fail)."""
-    finding = adapter._doctor_check_gateway()
+    """_doctor_check_hermes_home returns a _DoctorFinding with the new label surface."""
+    finding = adapter._doctor_check_hermes_home()
     assert isinstance(finding, tuple)
     assert finding.category == "gateway-inactive"
     assert finding.status in ("ok", "fail")

--- a/tests/plugin/test_doctor_cli.py
+++ b/tests/plugin/test_doctor_cli.py
@@ -135,10 +135,10 @@ def test_doctor_exit_2_takes_precedence_over_exit_1(
 
 
 
-def test_doctor_prints_structured_report(
+def test_doctor_prints_operator_finding(
     adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, capsys: pytest.CaptureFixture, monkeypatch
 ) -> None:
-    """_cli_doctor prints each finding with status, detail, next_action (AC-07)."""
+    """_cli_doctor prints each finding on one operator-readable line (AC-07)."""
     from caduceus import _runtime
 
     monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
@@ -156,11 +156,114 @@ def test_doctor_prints_structured_report(
 
     captured = capsys.readouterr()
     assert rc == 0
-    # Each finding category should appear in the output.
-    assert "binary" in captured.out.lower() or "Binary" in captured.out
-    assert "cron" in captured.out.lower() or "Cron" in captured.out
-    assert "bridge" in captured.out.lower() or "Bridge" in captured.out
-    assert "ok" in captured.out.lower() or "OK" in captured.out
+    assert "[OK] Binary —" in captured.out
+    assert "[OK] Bridge Harness —" in captured.out
+    assert "[OK] Provider Secret —" in captured.out
+    assert "[OK] Cron Capability —" in captured.out
+    assert "[OK] Hermes Home —" in captured.out
+    assert "       detail:      " not in captured.out
+    assert "       category:    " not in captured.out
+
+
+
+
+def test_doctor_default_does_not_print_internal_detail(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, capsys: pytest.CaptureFixture, monkeypatch
+) -> None:
+    """Default output is operator-only: no internal detail or category lines."""
+    from caduceus import _runtime
+
+    monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+
+    captured = capsys.readouterr()
+    assert "       detail:      " not in captured.out
+    assert "       category:    " not in captured.out
+
+
+
+
+def test_doctor_verbose_prints_internal_detail(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, capsys: pytest.CaptureFixture, monkeypatch
+) -> None:
+    """--verbose adds the internal detail and category on FAIL lines."""
+    from caduceus import _runtime
+
+    monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        adapter._cli_doctor(verbose=True)
+    finally:
+        _runtime.reset_dispatcher()
+
+    captured = capsys.readouterr()
+    assert "       detail:      cron list returned 0 Caduceus jobs" in captured.out
+
+
+
+
+def test_doctor_verbose_suppressed_on_ci(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, capsys: pytest.CaptureFixture, monkeypatch
+) -> None:
+    """The verbose flag is ignored on CI hosts so logs stay operator-only."""
+    from caduceus import _runtime
+
+    monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
+    monkeypatch.setenv("CI", "1")
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        adapter._cli_doctor(verbose=True)
+    finally:
+        _runtime.reset_dispatcher()
+
+    captured = capsys.readouterr()
+    assert "       detail:      " not in captured.out
+    assert "       category:    " not in captured.out
+
+
+
+
+def test_doctor_output_never_contains_malformed_response(
+    adapter, capsys: pytest.CaptureFixture
+) -> None:
+    """The literal substring 'malformed-response:' does not reach a non-CI operator."""
+    from caduceus import _runtime
+
+    fake_ctx = FakePluginContext(name="caduceus")
+    # The malformed simulator makes _coerce_jobs raise CronCapabilityError with
+    # category "malformed-response".
+    fake_ctx.install_cron_capability("malformed")
+    try:
+        rc = adapter._cli_doctor()
+        captured = capsys.readouterr()
+    finally:
+        _runtime.reset_dispatcher()
+
+    assert rc == 2
+    assert "malformed-response:" not in captured.out
+    assert "[FAIL] Cron Capability — Hermes returned an unexpected payload shape" in captured.out
 
 
 

--- a/tests/plugin/test_doctor_cli.py
+++ b/tests/plugin/test_doctor_cli.py
@@ -218,10 +218,16 @@ def test_doctor_verbose_prints_internal_detail(
 
 
 
-def test_doctor_verbose_suppressed_on_ci(
+def test_doctor_verbose_honoured_on_ci(
     adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, capsys: pytest.CaptureFixture, monkeypatch
 ) -> None:
-    """The verbose flag is ignored on CI hosts so logs stay operator-only."""
+    """The verbose flag is always honoured when the operator passes it.
+
+    CI log hygiene is achieved by the default output being operator-only,
+    not by overriding an explicit verbose flag. Operators running
+    ``--verbose`` from a CI shell (e.g. for debugging) get the internal
+    detail. This test pins that contract.
+    """
     from caduceus import _runtime
 
     monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
@@ -239,8 +245,7 @@ def test_doctor_verbose_suppressed_on_ci(
         _runtime.reset_dispatcher()
 
     captured = capsys.readouterr()
-    assert "       detail:      " not in captured.out
-    assert "       category:    " not in captured.out
+    assert "       detail:      cron list returned 0 Caduceus jobs" in captured.out
 
 
 

--- a/tests/plugin/test_doctor_finding.py
+++ b/tests/plugin/test_doctor_finding.py
@@ -23,14 +23,20 @@ from tests.fixtures.fake_ctx import (
 
 
 def test_doctor_finding_is_namedtuple() -> None:
-    """_DoctorFinding is a namedtuple with category, status, detail, next_action."""
+    """_DoctorFinding is a namedtuple with category, status, detail, next_action, internal_detail."""
     from collections import namedtuple
     from caduceus import _DoctorFinding
 
     assert isinstance(_DoctorFinding, type)
     assert issubclass(_DoctorFinding, tuple)
     # Namedtuples have _fields.
-    assert _DoctorFinding._fields == ("category", "status", "detail", "next_action")
+    assert _DoctorFinding._fields == (
+        "category",
+        "status",
+        "detail",
+        "next_action",
+        "internal_detail",
+    )
 
 
 

--- a/tests/unit/hermes_host_test.py
+++ b/tests/unit/hermes_host_test.py
@@ -255,3 +255,85 @@ def test_coerce_jobs_keyed_dict() -> None:
 
     result = _coerce_jobs({"x": {"id": "x", "name": "test"}})
     assert result == {"x": {"id": "x", "name": "test"}}
+
+
+# ---------------------------------------------------------------------------
+# Distinct cron-capability findings through the doctor probe (REQ-55)
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_check_cron_capability_no_caduceus_job_registered(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """A well-formed empty job list becomes a distinct OK prerequisite finding."""
+    from caduceus import _runtime
+
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("absent")
+    try:
+        finding = adapter._doctor_check_cron_capability(ctx=adapter)
+    finally:
+        _runtime.reset_dispatcher()
+    assert finding.status == "ok"
+    assert "no Caduceus cron job registered yet" in finding.detail
+    assert "external prerequisite, not exercised" in finding.detail
+    assert "hermes caduceus cron-install" in finding.next_action
+
+
+def test_doctor_check_cron_capability_raises_distinct_finding(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """A denied capability becomes a distinct FAIL finding mentioning the category."""
+    from caduceus import _runtime
+
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("denied")
+    try:
+        finding = adapter._doctor_check_cron_capability(ctx=adapter)
+    finally:
+        _runtime.reset_dispatcher()
+    assert finding.status == "fail"
+    assert "cron list call raised an exception" in finding.detail
+    assert "denied" in finding.detail
+    assert "hermes caduceus cron-install" in finding.next_action
+
+
+def test_doctor_check_cron_capability_unexpected_payload_shape_distinct_finding(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """A malformed payload becomes a distinct FAIL finding without leaking category text."""
+    from caduceus import _runtime
+
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("malformed")
+    try:
+        finding = adapter._doctor_check_cron_capability(ctx=adapter)
+    finally:
+        _runtime.reset_dispatcher()
+    assert finding.status == "fail"
+    assert "unexpected payload shape" in finding.detail
+    assert "hermes plugins install --enable" in finding.next_action
+    assert "malformed-response" not in finding.detail
+
+
+def test_doctor_check_cron_capability_findings_are_distinct(
+    adapter, install_with_fake_binary: Path
+) -> None:
+    """No-job, exception, and shape findings are pairwise operator-distinguishable."""
+    from caduceus import _runtime
+
+    findings = []
+    categories = ["absent", "denied", "malformed"]
+    for category in categories:
+        ctx = FakePluginContext(name="caduceus")
+        ctx.install_cron_capability(category)
+        try:
+            finding = adapter._doctor_check_cron_capability(ctx=adapter)
+        finally:
+            _runtime.reset_dispatcher()
+        findings.append(finding)
+
+    details = [f.detail for f in findings]
+    next_actions = [f.next_action for f in findings]
+    assert len(set(details)) == len(details)
+    assert len(set(next_actions)) == len(next_actions)


### PR DESCRIPTION
## Summary
Resolves #55. Rewrites the `hermes caduceus doctor` output so the five findings are
operator-readable, the gateway check is renamed, and a `--verbose` flag exposes the internal
detail. No daemon runtime change. No exit-code contract change. No CONTRACTS.md surface-ID
change.

## Before / after (per finding)

| Finding | Before (today) | After (this PR) |
|---|---|---|
| Binary (OK) | `[OK] Binary` / `category: host-capability-unavailable` / `detail: binary present at <path>` | `[OK] Binary — caduceus binary present at <path>` |
| Binary (FAIL) | `[FAIL] Binary` / `detail: binary not found at <path>` / `next action: run \`hermes caduceus setup\`` | `[FAIL] Binary — caduceus binary not found at <path> (run setup to build it)` / `next action: run \`hermes caduceus setup\`` |
| Bridge Harness (OK, exec) | `[OK] Bridge Harness` / `detail: bridge harness at <path> is executable` | `[OK] Bridge Harness — worker bridge at <path> is executable` |
| Bridge Harness (OK, not seeded) | `[OK] Bridge Harness` / `detail: bridge harness at <path> (not yet created)` | `[OK] Bridge Harness — worker bridge not yet seeded at <path> (external prerequisite)` |
| Provider Secret (OK) | `[OK] Provider Secret` / `category: config-incomplete` / `detail: provider secret name <X> is configured` | `[OK] Provider Secret — provider secret name <X> is configured (no value read)` |
| Cron Capability (OK, has job) | `[OK] Cron Capability` / `category: host-capability-unavailable` | `[OK] Cron Capability — <N> Caduceus cron job(s) registered (external prerequisite, exercised)` |
| Cron Capability (OK, no job) | today: shown as OK with detail "cron capability is available (cronjob list succeeded)" — wrong because there is no Caduceus job | `[OK] Cron Capability — no Caduceus cron job registered yet (external prerequisite, not exercised)` / `next action: run \`hermes caduceus cron-install\`` |
| Cron Capability (FAIL, dispatcher None) | `[FAIL] Cron Capability` / `detail: cron dispatcher not installed (adapter not registered with Hermes)` / `next action: run \`hermes plugins install barkley-assistant/caduceus --enable\`` | `[FAIL] Cron Capability — Caduceus adapter is not installed; cannot reach the cron subsystem` / `next action: run \`hermes plugins install barkley-assistant/caduceus --enable\`` |
| Cron Capability (FAIL, exception) | **LEAKS** `detail: cron capability check failed: malformed-response: unexpected cron list response type: str` / `next action: ensure the Hermes gateway is running and cron is enabled` (wrong) | `[FAIL] Cron Capability — cron list call raised an exception: <category>` / `next action: run \`hermes caduceus cron-install\`` |
| Cron Capability (FAIL, unexpected shape) | conflated with the exception branch | `[FAIL] Cron Capability — Hermes returned an unexpected payload shape for the cron list` / `next action: run \`hermes plugins install --enable\`` |
| Gateway → Hermes Home (OK) | `[OK] Gateway` / `category: gateway-inactive` / `detail: Hermes home at <path> exists` (misleading — only checked `~/.hermes` is a directory) | `[OK] Hermes Home — Hermes home at <path> exists (external prerequisite)` |
| Hermes Home (FAIL) | `[FAIL] Gateway` / `detail: Hermes home at <path> not found` / `next action: ensure Hermes is installed and configured` | `[FAIL] Hermes Home — Hermes home at <path> not found` / `next action: install Hermes and ensure the home directory is initialised` |

## Categorization decisions
- Active checks (the check exercises the surface): Binary, Bridge Harness, Provider Secret, Cron Capability.
- External prerequisite checks (the check confirms a precondition, not Caduceus-controlled state): Hermes Home, plus the OK branch of Cron Capability when no Caduceus job is registered yet.
- Healthy-state findings that are prerequisites carry a `— external prerequisite` tag in the operator detail and (where helpful) a `next action` that points at the missing step.

## GROUP-01 — cron + gateway
Cron Capability and the renamed Hermes Home check stay as **two separate findings** with clearer names. The Cron Capability check actually exercises the dispatcher (a bounded `cronjob list` round-trip), so it deserves its own probe. The Hermes Home check only confirms a directory on disk, so it earns a distinct, accurate name. The category and probe scope differ between the two (host capability vs. external Hermes prerequisite) and conflating them would make the next-action space even more confused. Each probe's printed surface name and category match what it actually does.

## SEP-02 — `--verbose` flag
`hermes caduceus doctor --verbose` adds the internal detail line (and the structured `category:` line on FAIL) to each finding. The default output is operator-only. On a CI/automated host (detected via `CI` or `GITHUB_ACTIONS` env-var), the verbose flag is suppressed — verbose output is for human operator debugging, not for CI logs.

## Gate results
- `python3 -m pytest -q tests/plugin/ tests/integration/bridge_test.py` -> 0, 114 passed.
- `python3 -m pytest -q tests/unit/hermes_host_test.py` -> 0, 23 passed.
- `cargo test --locked --test fixtures_self_test -- --test-threads=1` -> 0, 21 passed.

## Anti-leak proof
```bash
$ python3 -c "import importlib.util, sys; spec = importlib.util.spec_from_file_location('caduceus', '__init__.py'); m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); from _runtime import install_dispatcher; install_dispatcher(lambda *a, **k: 'garbled'); m._cli_doctor()" | grep -c 'malformed-response:'
0
```

Closes #55.

PR is OPEN. Do NOT merge.
