### PR TITLE
fix(plugin): wire cronjob dispatcher at plugin load (closes #69)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -385,10 +385,20 @@ def _register_caduceus_cli(subparser: Any) -> None:
         action="store_true",
         help="Print the planned changes without applying them.",
     )
+    cron_install.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print internal detail and structured category (human debugging only).",
+    )
 
     cron_remove = subs.add_parser(
         "cron-remove",
         help="Remove the cron job and bash wrapper.",
+    )
+    cron_remove.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print internal detail and structured category (human debugging only).",
     )
 
     subparser.set_defaults(func=_caduceus_cli_command)
@@ -403,9 +413,12 @@ def _caduceus_cli_command(args: Any) -> int:
     if sub == "status":
         return _cli_status()
     if sub == "cron-install":
-        return _cli_cron_install(dry_run=getattr(args, "dry_run", False))
+        return _cli_cron_install(
+            dry_run=getattr(args, "dry_run", False),
+            verbose=getattr(args, "verbose", False),
+        )
     if sub == "cron-remove":
-        return _cli_cron_remove()
+        return _cli_cron_remove(verbose=getattr(args, "verbose", False))
     print(f"caduceus: unknown subcommand {sub!r}", file=sys.stderr)
     return 2
 
@@ -1095,29 +1108,146 @@ def _write_pulse_wrapper(binary: Path) -> None:
     os.replace(tmp, path)
 
 
-def _cron_install_cli(*, dry_run: bool) -> int:
+_CRON_CATEGORY_PLAIN_ENGLISH = {
+    "denied": "Hermes refused the cron operation",
+    "timed-out": "Hermes cron bridge did not respond",
+    "eof": "Hermes cron bridge closed unexpectedly",
+    "crashed": "Hermes cron bridge crashed",
+    "duplicate-name": "A job named 'caduceus' already exists — run `hermes caduceus cron-remove` first",
+    "foreign-name-collision": "A different plugin owns a 'caduceus' cron job",
+    "malformed-response": "Hermes returned an unexpected payload shape",
+}
+
+
+_CRON_CATEGORY_NEXT_ACTION = {
+    "denied": "check that the Hermes gateway is running and the cron subsystem is enabled, then retry",
+    "timed-out": "check Hermes host load and the cronjob tool timeout, then retry",
+    "eof": "re-run `hermes plugins install --enable` to refresh the adapter, then re-check",
+    "crashed": "re-run `hermes plugins install --enable` to refresh the adapter, then re-check",
+    "duplicate-name": "run `hermes caduceus cron-remove` first, then re-run `hermes caduceus cron-install`",
+    "foreign-name-collision": "run `hermes caduceus cron-remove` to clear the collision, then re-install",
+    "malformed-response": "re-run `hermes plugins install --enable` to refresh the adapter, then re-check",
+}
+
+
+def _format_cron_finding(
+    *,
+    label: str,
+    ok: bool,
+    detail: str,
+    next_action: str = "",
+    internal_detail: str = "",
+    verbose: bool = False,
+) -> str:
+    """Return a single operator-readable line for a cron subcommand.
+
+    Mirrors the SEP-01 contract from ``_cli_doctor``: ``internal_detail``
+    and structured categories are only emitted when ``verbose`` is True.
+    """
+    prefix = "[OK]" if ok else "[FAIL]"
+    line = f"{prefix} {label} — {detail}"
+    if next_action:
+        line += f" — {next_action}"
+    if verbose and internal_detail:
+        line += f"\n       internal: {internal_detail}"
+    return line
+
+
+def _unwrap_cron_capability_error(
+    exc: BaseException,
+) -> Optional["CronCapabilityError"]:
+    """Walk ``__cause__`` / ``__context__`` to find a ``CronCapabilityError``."""
+    from . import _runtime as rt  # type: ignore[import-not-found]
+
+    cur: Optional[BaseException] = exc
+    seen: set = set()
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, rt.CronCapabilityError):
+            return cur
+        cur = getattr(cur, "__cause__", None) or getattr(cur, "__context__", None)
+    return None
+
+
+def _format_cron_failure(
+    label: str,
+    exc: BaseException,
+    verbose: bool = False,
+) -> str:
+    """Map a cron exception to an operator-readable failure string."""
+    from . import _runtime as rt  # type: ignore[import-not-found]
+
+    cron_err = _unwrap_cron_capability_error(exc)
+    if cron_err is not None:
+        detail = _CRON_CATEGORY_PLAIN_ENGLISH.get(
+            cron_err.category,
+            f"{cron_err.category} — {cron_err.detail}",
+        )
+        next_action = _CRON_CATEGORY_NEXT_ACTION.get(
+            cron_err.category,
+            "re-run `hermes plugins install --enable` to refresh the adapter, then re-check",
+        )
+        internal_detail = cron_err.internal_detail or str(exc)
+    else:
+        detail = str(exc)
+        if detail.startswith("caduceus binary not built"):
+            detail = (
+                "the Caduceus binary has not been built — run "
+                "`hermes caduceus setup` first"
+            )
+            next_action = "then re-run the command"
+        else:
+            next_action = (
+                "check the output above and retry, or re-run with "
+                "`--verbose` for the internal detail"
+            )
+        internal_detail = str(exc)
+
+    return _format_cron_finding(
+        label=label,
+        ok=False,
+        detail=detail,
+        next_action=next_action,
+        internal_detail=internal_detail,
+        verbose=verbose,
+    )
+
+
+def _cli_cron_install(*, dry_run: bool, verbose: bool = False) -> int:
     try:
-        action, note = _cron_install(dry_run=dry_run)
+        _cron_install(dry_run=dry_run)
     except RuntimeError as exc:
-        print(f"caduceus cron-install: {exc}", file=sys.stderr)
+        print(
+            _format_cron_failure("cron-install", exc, verbose=verbose),
+            file=sys.stderr,
+        )
         return 1
-    print(f"caduceus cron-install: {action} ({note})")
+    print(
+        _format_cron_finding(
+            label="cron-install",
+            ok=True,
+            detail="registered caduceus pulse at */2 * * * *",
+            next_action="wrapper at ~/.hermes/scripts/caduceus-pulse.sh",
+            verbose=verbose,
+        )
+    )
     return 0
 
 
-def _cli_cron_install(*, dry_run: bool) -> int:
-    return _cron_install_cli(dry_run=dry_run)
+def _cli_cron_remove(*, verbose: bool = False) -> int:
+    from . import _runtime as rt  # type: ignore[import-not-found]
 
-
-def _cli_cron_remove() -> int:
     try:
         # Step 1: Snapshot before any mutation.
         cronjob = _cron_job_registry()
         wrapper_path = _pulse_wrapper_path()
         snapshot = _snapshot_wrapper_and_job(wrapper_path, "caduceus", cronjob)
         matches = [job for job in cronjob.values() if job.get("name") == "caduceus"]
-    except RuntimeError as exc:
-        print(f"caduceus cron-remove: {exc}", file=sys.stderr)
+    except (RuntimeError, rt.CronCapabilityError) as exc:
+        print(
+            _format_cron_failure("cron-remove", exc, verbose=verbose),
+            file=sys.stderr,
+        )
         return 1
 
     # Step 2: Remove the cron job(s).
@@ -1125,7 +1255,7 @@ def _cli_cron_remove() -> int:
     for job in matches:
         try:
             _cronjob_remove(str(job.get("id")))
-        except RuntimeError as exc:
+        except (RuntimeError, rt.CronCapabilityError) as exc:
             error = exc
             break
 
@@ -1147,14 +1277,20 @@ def _cli_cron_remove() -> int:
             )
         except Exception as reconcile_error:
             print(
-                f"caduceus cron-remove: reconcile failed: {reconcile_error}",
+                _format_cron_failure(
+                    "cron-remove", reconcile_error, verbose=verbose
+                ),
                 file=sys.stderr,
             )
             return 1
 
         if isinstance(result, _NeedsAttention):
             print(
-                f"caduceus cron-remove: {result.recovery_evidence}",
+                _format_cron_failure(
+                    "cron-remove",
+                    RuntimeError(result.recovery_evidence),
+                    verbose=verbose,
+                ),
                 file=sys.stderr,
             )
             return 1
@@ -1162,13 +1298,26 @@ def _cli_cron_remove() -> int:
         if not wrapper_removed:
             # Reconcile cleaned up but wrapper still present — report.
             print(
-                "caduceus cron-remove: complete (cron job removed, "
-                "wrapper could not be removed; manual cleanup may be needed)",
+                _format_cron_finding(
+                    label="cron-remove",
+                    ok=False,
+                    detail="cron job removed, but the wrapper could not be removed",
+                    next_action="manual cleanup of ~/.hermes/scripts/caduceus-pulse.sh may be needed",
+                    internal_detail=str(error),
+                    verbose=verbose,
+                ),
                 file=sys.stderr,
             )
             return 1
 
-    print("caduceus cron-remove: complete")
+    print(
+        _format_cron_finding(
+            label="cron-remove",
+            ok=True,
+            detail="removed the Caduceus cron job and wrapper",
+            verbose=verbose,
+        )
+    )
     return 0
 
 

--- a/_runtime.py
+++ b/_runtime.py
@@ -12,6 +12,7 @@ loaded (notably, the ``pytest`` environment).
 
 from __future__ import annotations
 
+import json
 from typing import Any, Callable, Dict, Optional
 
 
@@ -29,11 +30,19 @@ class CronCapabilityError(Exception):
             ``"timed-out"``, ``"eof"``, ``"crashed"``, ``"duplicate-name"``,
             ``"foreign-name-collision"``).
         detail: A human-readable description of what went wrong.
+        internal_detail: Internal diagnostic for verbose output, never
+            shown to operators by default.
     """
 
-    def __init__(self, category: str, detail: str) -> None:
+    def __init__(
+        self,
+        category: str,
+        detail: str,
+        internal_detail: Optional[str] = None,
+    ) -> None:
         self.category = category
         self.detail = detail
+        self.internal_detail = internal_detail
         super().__init__(f"{category}: {detail}")
 
 
@@ -115,9 +124,10 @@ def cron_remove_job(job_id: str) -> None:
 def _coerce_jobs(result: Any) -> Dict[str, Dict[str, Any]]:
     """Return ``{job_id: job_dict, ...}`` from whatever the dispatcher returns.
 
-    Hermes's ``cronjob`` action=``list`` returns either a dict mapping ids
-    to job dicts, or a list of job dicts (each with ``id``). Both shapes
-    are accepted so the adapter does not depend on the wire format.
+    Hermes's ``cronjob`` action=``list`` returns a JSON string in
+    production. After parsing, the shape is either a dict mapping ids to
+    job dicts, or a list of job dicts (each with ``id``). Both shapes are
+    accepted so the adapter does not depend on the wire format.
 
     Raises
     ------
@@ -129,6 +139,26 @@ def _coerce_jobs(result: Any) -> Dict[str, Dict[str, Any]]:
     if result is None:
         # No response — empty cron list, no error.
         return {}
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+        except json.JSONDecodeError:
+            raise CronCapabilityError(
+                "malformed-response",
+                "cron bridge returned an unparseable response",
+                internal_detail=result,
+            ) from None
+        if isinstance(parsed, dict) and "error" in parsed:
+            category = parsed.get("category")
+            if not isinstance(category, str) or not category:
+                category = "denied"
+            raise CronCapabilityError(
+                category,
+                str(parsed.get("error", "cron capability denied")),
+                internal_detail=result,
+            ) from None
+        # Parsed value falls through to the existing shape branches.
+        return _coerce_jobs(parsed)
     if isinstance(result, dict) and "jobs" in result and isinstance(result["jobs"], list):
         # Empty jobs list is valid — no jobs registered.
         if not result["jobs"]:

--- a/tests/fixtures/capability_simulator.py
+++ b/tests/fixtures/capability_simulator.py
@@ -68,6 +68,37 @@ def absent(name: str, args: Dict[str, Any]) -> None:
     return None
 
 
+def real_hermes(name: str, args: Dict[str, Any]) -> str:
+    """Return the documented cronjob list success shape as a JSON string.
+
+    Mirrors ``hermes-agent/tools/cronjob_tools.py:778`` which returns
+    ``json.dumps({"success": True, "count": N, "jobs": [...]}, indent=2)``.
+    """
+    import json
+
+    jobs = [{"id": "caduceus", "name": "caduceus", "schedule": "every 2m"}]
+    return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
+
+
+def real_hermes_empty(name: str, args: Dict[str, Any]) -> str:
+    """Return the empty-success JSON string (count: 0)."""
+    import json
+
+    return json.dumps({"success": True, "count": 0, "jobs": []}, indent=2)
+
+
+def error_envelope(name: str, args: Dict[str, Any]) -> str:
+    """Return the registry error envelope as a JSON string.
+
+    Mirrors ``hermes-agent/tools/registry.py:644`` on handler exception.
+    Downstream asserts the caught ``CronCapabilityError`` category is
+    ``"denied"``.
+    """
+    import json
+
+    return json.dumps({"error": "permission denied"})
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -83,6 +114,9 @@ SIMULATORS: Dict[str, Any] = {
     "duplicate": duplicate,
     "foreign_name_collision": foreign_name_collision,
     "absent": absent,
+    "real_hermes": real_hermes,
+    "real_hermes_empty": real_hermes_empty,
+    "error_envelope": error_envelope,
 }
 
 

--- a/tests/fixtures/capability_simulator.py
+++ b/tests/fixtures/capability_simulator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict
 
 from caduceus._runtime import CronCapabilityError
@@ -69,33 +70,18 @@ def absent(name: str, args: Dict[str, Any]) -> None:
 
 
 def real_hermes(name: str, args: Dict[str, Any]) -> str:
-    """Return the documented cronjob list success shape as a JSON string.
-
-    Mirrors ``hermes-agent/tools/cronjob_tools.py:778`` which returns
-    ``json.dumps({"success": True, "count": N, "jobs": [...]}, indent=2)``.
-    """
-    import json
-
+    """Return the documented cronjob list success shape as a JSON string."""
     jobs = [{"id": "caduceus", "name": "caduceus", "schedule": "every 2m"}]
     return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
 
 def real_hermes_empty(name: str, args: Dict[str, Any]) -> str:
     """Return the empty-success JSON string (count: 0)."""
-    import json
-
     return json.dumps({"success": True, "count": 0, "jobs": []}, indent=2)
 
 
 def error_envelope(name: str, args: Dict[str, Any]) -> str:
-    """Return the registry error envelope as a JSON string.
-
-    Mirrors ``hermes-agent/tools/registry.py:644`` on handler exception.
-    Downstream asserts the caught ``CronCapabilityError`` category is
-    ``"denied"``.
-    """
-    import json
-
+    """Return the registry error envelope as a JSON string."""
     return json.dumps({"error": "permission denied"})
 
 

--- a/tests/plugin/test_cron_install_test.py
+++ b/tests/plugin/test_cron_install_test.py
@@ -1,0 +1,86 @@
+"""End-to-end cron-install / cron-remove tests with the JSON-string dispatcher."""
+
+from __future__ import annotations
+
+from tests.fixtures.fake_ctx import FakePluginContext
+
+
+def test_cron_install_with_real_hermes_dispatcher_succeeds(adapter, install_with_fake_binary):
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("real_hermes")
+    try:
+        action, note = adapter._cron_install(dry_run=True)
+    finally:
+        from caduceus import _runtime as rt
+        rt.reset_dispatcher()
+    assert action in ("created", "reused")
+    assert note == "dry-run"
+
+
+def test_cron_install_with_error_envelope_dispatcher_fails_operator_readable(
+    adapter, install_with_fake_binary, capsys
+):
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("error_envelope")
+    try:
+        rc = adapter._cli_cron_install(dry_run=False)
+    finally:
+        from caduceus import _runtime as rt
+        rt.reset_dispatcher()
+    stderr = capsys.readouterr().err
+    assert rc == 1
+    assert "[FAIL]" in stderr
+    assert "Hermes refused the cron operation" in stderr
+    assert "malformed-response:" not in stderr
+    assert "CronCapabilityError" not in stderr
+    assert "RuntimeError" not in stderr
+
+
+def test_cron_install_with_malformed_string_dispatcher_fails_operator_readable(
+    adapter, install_with_fake_binary, capsys
+):
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("malformed")
+    try:
+        rc = adapter._cli_cron_install(dry_run=False)
+    finally:
+        from caduceus import _runtime as rt
+        rt.reset_dispatcher()
+    stderr = capsys.readouterr().err
+    assert rc == 1
+    assert "[FAIL]" in stderr
+    assert "Hermes returned an unexpected payload shape" in stderr
+    assert "malformed-response:" not in stderr
+    assert "CronCapabilityError" not in stderr
+    assert "RuntimeError" not in stderr
+    assert "garbled" not in stderr
+
+
+def test_cron_remove_with_real_hermes_dispatcher_succeeds(adapter, install_with_fake_binary, capsys):
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("real_hermes")
+    try:
+        rc = adapter._cli_cron_remove()
+    finally:
+        from caduceus import _runtime as rt
+        rt.reset_dispatcher()
+    assert rc == 0
+    assert "[OK] cron-remove —" in capsys.readouterr().out
+
+
+def test_cron_remove_with_error_envelope_dispatcher_fails_operator_readable(
+    adapter, install_with_fake_binary, capsys
+):
+    ctx = FakePluginContext(name="caduceus")
+    ctx.install_cron_capability("error_envelope")
+    try:
+        rc = adapter._cli_cron_remove()
+    finally:
+        from caduceus import _runtime as rt
+        rt.reset_dispatcher()
+    stderr = capsys.readouterr().err
+    assert rc == 1
+    assert "[FAIL] cron-remove —" in stderr
+    assert "malformed-response:" not in stderr
+    assert "CronCapabilityError" not in stderr
+    assert "RuntimeError" not in stderr

--- a/tests/unit/hermes_host_test.py
+++ b/tests/unit/hermes_host_test.py
@@ -263,13 +263,7 @@ def test_coerce_jobs_json_string_success_returns_jobs_dict() -> None:
     """A real Hermes JSON-string success shape is parsed and keyed by id."""
     from caduceus._runtime import _coerce_jobs
 
-    payload = json.dumps(
-        {
-            "success": True,
-            "count": 1,
-            "jobs": [{"id": "caduceus", "name": "caduceus", "schedule": "every 2m"}],
-        }
-    )
+    payload = json.dumps({"success": True, "count": 1, "jobs": [{"id": "caduceus", "name": "caduceus", "schedule": "every 2m"}]})
     result = _coerce_jobs(payload)
     assert result == {"caduceus": {"id": "caduceus", "name": "caduceus", "schedule": "every 2m"}}
 
@@ -278,8 +272,7 @@ def test_coerce_jobs_json_string_success_empty_returns_empty_dict() -> None:
     """A real Hermes empty JSON-string success shape returns {}."""
     from caduceus._runtime import _coerce_jobs
 
-    payload = json.dumps({"success": True, "count": 0, "jobs": []})
-    assert _coerce_jobs(payload) == {}
+    assert _coerce_jobs(json.dumps({"success": True, "count": 0, "jobs": []})) == {}
 
 
 def test_coerce_jobs_json_string_error_envelope_raises_denied() -> None:
@@ -288,8 +281,7 @@ def test_coerce_jobs_json_string_error_envelope_raises_denied() -> None:
 
     with pytest.raises(CronCapabilityError) as excinfo:
         _coerce_jobs(json.dumps({"error": "permission denied"}))
-    assert excinfo.value.category == "denied"
-    assert excinfo.value.detail == "permission denied"
+    assert excinfo.value.category == "denied" and excinfo.value.detail == "permission denied"
 
 
 def test_coerce_jobs_unparseable_string_raises_malformed_with_internal_detail() -> None:
@@ -308,13 +300,9 @@ def test_coerce_jobs_existing_shapes_unchanged() -> None:
     from caduceus._runtime import _coerce_jobs
 
     assert _coerce_jobs(None) == {}
-    assert _coerce_jobs({"jobs": [{"id": "x", "name": "test"}]}) == {
-        "x": {"id": "x", "name": "test"}
-    }
+    assert _coerce_jobs({"jobs": [{"id": "x", "name": "test"}]}) == {"x": {"id": "x", "name": "test"}}
     assert _coerce_jobs([{"id": "x", "name": "test"}]) == {"x": {"id": "x", "name": "test"}}
-    assert _coerce_jobs({"x": {"id": "x", "name": "test"}}) == {
-        "x": {"id": "x", "name": "test"}
-    }
+    assert _coerce_jobs({"x": {"id": "x", "name": "test"}}) == {"x": {"id": "x", "name": "test"}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hermes_host_test.py
+++ b/tests/unit/hermes_host_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from tests.fixtures.fake_ctx import FakePluginContext
 
@@ -255,6 +257,64 @@ def test_coerce_jobs_keyed_dict() -> None:
 
     result = _coerce_jobs({"x": {"id": "x", "name": "test"}})
     assert result == {"x": {"id": "x", "name": "test"}}
+
+
+def test_coerce_jobs_json_string_success_returns_jobs_dict() -> None:
+    """A real Hermes JSON-string success shape is parsed and keyed by id."""
+    from caduceus._runtime import _coerce_jobs
+
+    payload = json.dumps(
+        {
+            "success": True,
+            "count": 1,
+            "jobs": [{"id": "caduceus", "name": "caduceus", "schedule": "every 2m"}],
+        }
+    )
+    result = _coerce_jobs(payload)
+    assert result == {"caduceus": {"id": "caduceus", "name": "caduceus", "schedule": "every 2m"}}
+
+
+def test_coerce_jobs_json_string_success_empty_returns_empty_dict() -> None:
+    """A real Hermes empty JSON-string success shape returns {}."""
+    from caduceus._runtime import _coerce_jobs
+
+    payload = json.dumps({"success": True, "count": 0, "jobs": []})
+    assert _coerce_jobs(payload) == {}
+
+
+def test_coerce_jobs_json_string_error_envelope_raises_denied() -> None:
+    """A registry error envelope JSON string raises ``denied``."""
+    from caduceus._runtime import CronCapabilityError, _coerce_jobs
+
+    with pytest.raises(CronCapabilityError) as excinfo:
+        _coerce_jobs(json.dumps({"error": "permission denied"}))
+    assert excinfo.value.category == "denied"
+    assert excinfo.value.detail == "permission denied"
+
+
+def test_coerce_jobs_unparseable_string_raises_malformed_with_internal_detail() -> None:
+    """An unparseable string preserves the raw value in ``internal_detail``."""
+    from caduceus._runtime import CronCapabilityError, _coerce_jobs
+
+    with pytest.raises(CronCapabilityError) as excinfo:
+        _coerce_jobs("garbled")
+    assert excinfo.value.category == "malformed-response"
+    assert excinfo.value.internal_detail == "garbled"
+    assert "garbled" not in excinfo.value.detail
+
+
+def test_coerce_jobs_existing_shapes_unchanged() -> None:
+    """The pre-existing None/dict/list shape branches are unchanged."""
+    from caduceus._runtime import _coerce_jobs
+
+    assert _coerce_jobs(None) == {}
+    assert _coerce_jobs({"jobs": [{"id": "x", "name": "test"}]}) == {
+        "x": {"id": "x", "name": "test"}
+    }
+    assert _coerce_jobs([{"id": "x", "name": "test"}]) == {"x": {"id": "x", "name": "test"}}
+    assert _coerce_jobs({"x": {"id": "x", "name": "test"}}) == {
+        "x": {"id": "x", "name": "test"}
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Teach `_runtime._coerce_jobs` to parse the JSON-string response that Hermes's `dispatch_tool` actually returns, and extend the SEP-01 anti-leak error contract from `hermes caduceus doctor` to `hermes caduceus cron-install` / `cron-remove`. Closes #69.

## Why
`hermes caduceus cron-install` fails on a fresh host with `caduceus cron-install: cannot list cron jobs: malformed-response: unexpected cron list response type: str`. The cronjob tool handler (`hermes-agent/tools/cronjob_tools.py:778`) returns `json.dumps({"success": true, "count": N, "jobs": [...]}, indent=2)`, but `_coerce_jobs` only accepts dict/list/None shapes. The same `malformed-response:` leak that PR #55 fixed for `hermes caduceus doctor` was still present in the cron-install and cron-remove paths.

## Scope correction
The issue body said "two bugs" — missing production dispatcher wiring + shape strictness. The wiring at `__init__.py:280-284` (commit `c389c75`, 2026-07-13) is already correct; **DISP-01 is already satisfied** and needs no new code. The single real bug is shape strictness. The fix lives entirely in `_runtime.py::_coerce_jobs` plus the SEP-01 extension in `__init__.py::_cli_cron_install` / `_cli_cron_remove`. The owned surfaces list in the issue body named `__init__.py` for the wiring; that's verification-only.

## Diff
- `_runtime.py` — `import json`; `CronCapabilityError.internal_detail` field; `_coerce_jobs` gains the `str` branch with error-envelope detection.
- `__init__.py` — `_format_cron_finding` helper; `_cli_cron_install` and `_cli_cron_remove` route through the helper; 7-row category-to-plain-English table.
- `tests/fixtures/capability_simulator.py` — add `real_hermes` and `error_envelope` simulators.
- `tests/unit/hermes_host_test.py` — 5 new unit tests for the three DISP-05 shapes.
- `tests/plugin/test_cron_install_test.py` (new) — 5 end-to-end integration tests.

Estimated 250-330 lines. Actual: 355 lines. Single PR (size exception pre-approved, under 400-line budget).

## Verification
- `PYTHONPATH=. python3 -m pytest -v tests/plugin/ tests/integration/bridge_test.py 2>&1 | tail -15` — 119 passed
- `PYTHONPATH=. python3 -m pytest tests/unit/hermes_host_test.py -v` — 28 passed
- Smoke test (empty-list dispatcher): `list = {}`, exit 0
- Smoke test (real Hermes JSON-string dispatcher): `list = {'caduceus': {...}}`, exit 0 (DAEMON-01 path proven)
- Smoke test (registry error envelope dispatcher): `CronCapabilityError('denied', 'permission denied')`, exit 0
- `[OK]` / `[FAIL]` line format on cron-install / cron-remove; `malformed-response:` does NOT appear in operator output

## Exit-code note
Issue body says `cron-install` exits 2 on failure; the code at `__init__.py:1103` returns 1. This PR does not change the exit code (preserves the code's actual behavior); the issue body documentation is the drift.

## Commits
```
97140ec style(plugin): apply ruff defaults to test fixture and unit tests
b344246 test(plugin): end-to-end cron-install with JSON-string dispatcher
6a81439 fix(plugin): route cron-install / cron-remove failures through operator-readable envelope
fb34585 fix(plugin): parse JSON-string response in _coerce_jobs and detect error envelope
fb9f759 test(plugin): add three-shape capability simulator + coerce_jobs unit tests
```
