### PR TITLE
fix(worktree): remove .worktrees/.lock on worker create/abort (closes #80)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,6 +28,7 @@ plugin compatibility contract in ``planning/caduceus-v0.1/CONTRACTS.md``:
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import shlex
@@ -682,6 +683,93 @@ def _doctor_check_hermes_home() -> _DoctorFinding:
     )
 
 
+def _doctor_check_worktree_lock(ctx: Any) -> _DoctorFinding:
+    """Detect leftover .worktrees/.lock files via non-blocking flock probe.
+
+    Scans ``<hermes_home>/projects/*/*/.worktrees/.lock`` and attempts a
+    non-blocking exclusive flock. Stale (acquirable) locks are reported as a
+    daemon defect; held locks (EWOULDBLOCK) are expected while a daemon tick
+    is running. Missing locks are clean.
+
+    Limitation: this check only inspects the default ``projects`` layout.
+    Non-default ``workdir_base`` values configured in the daemon rely on the
+    Rust-side tolerance filter as the load-bearing fallback.
+    """
+    del ctx  # ctx is not needed for this filesystem scan
+    workdir_base = Path(_hermes_home()) / "projects"
+    if not workdir_base.is_dir():
+        return _DoctorFinding(
+            category="daemon-defect",
+            status="ok",
+            detail=f"workdir_base {workdir_base} not present (no lock to check)",
+            next_action="",
+            internal_detail="",
+        )
+
+    stale: list[Path] = []
+    held: list[Path] = []
+    for owner_dir in workdir_base.iterdir():
+        if not owner_dir.is_dir():
+            continue
+        for repo_dir in owner_dir.iterdir():
+            if not repo_dir.is_dir():
+                continue
+            lock = repo_dir / ".worktrees" / ".lock"
+            if not lock.is_file():
+                continue
+            try:
+                fd = os.open(str(lock), os.O_RDWR)
+            except FileNotFoundError:
+                continue
+            except OSError:
+                stale.append(lock)
+                continue
+            try:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    held.append(lock)
+                else:
+                    stale.append(lock)
+            finally:
+                os.close(fd)
+
+    if not stale and not held:
+        return _DoctorFinding(
+            category="daemon-defect",
+            status="ok",
+            detail=f"no stale .worktrees/.lock files in {workdir_base}",
+            next_action="",
+            internal_detail=f"workdir_base={workdir_base}",
+        )
+    if stale:
+        return _DoctorFinding(
+            category="daemon-defect",
+            status="fail",
+            detail=(
+                f"stale .worktrees/.lock at {stale[0]} "
+                f"(no Caduceus daemon holds the flock)"
+            ),
+            next_action=(
+                f"remove {stale[0]} with `rm` if no Caduceus daemon is currently running, "
+                f"or restart the daemon so the next tick can clean it up"
+            ),
+            internal_detail=(
+                f"workdir_base={workdir_base}; "
+                f"stale_count={len(stale)} held_count={len(held)}"
+            ),
+        )
+    return _DoctorFinding(
+        category="daemon-defect",
+        status="ok",
+        detail=(
+            f"{len(held)} .worktrees/.lock file(s) currently held by the daemon"
+        ),
+        next_action="",
+        internal_detail=f"workdir_base={workdir_base}; held={held}",
+    )
+
+
 def _cli_doctor(verbose: bool = False) -> int:
     """Run all doctor checks and print a structured report (AC-06/07/08/11).
 
@@ -706,6 +794,7 @@ def _cli_doctor(verbose: bool = False) -> int:
         ("Bridge Harness", _doctor_check_bridge_harness()),
         ("Provider Secret", _doctor_check_provider_secret()),
         ("Cron Capability", _doctor_check_cron_capability(ctx=None)),
+        ("Worktree Lock", _doctor_check_worktree_lock(ctx=None)),
         ("Hermes Home", _doctor_check_hermes_home()),
     ]
 

--- a/src/worktree/gc.rs
+++ b/src/worktree/gc.rs
@@ -186,14 +186,16 @@ pub async fn gc(config: &Config, older_than_days: u64, dry_run: bool) -> Caduceu
 /// just the path and the branch (the porcelain format
 /// contains more keys, but those are enough for GC).
 #[derive(Debug, Clone)]
-struct WorktreeListEntry {
-    path: PathBuf,
-    branch: String,
+pub(crate) struct WorktreeListEntry {
+    pub(crate) path: PathBuf,
+    pub(crate) branch: String,
 }
 
 /// Read `git worktree list --porcelain` for *main_path* and
 /// return each entry's path and branch.
-async fn list_worktrees_porcelain(main_path: &Path) -> CaduceusResult<Vec<WorktreeListEntry>> {
+pub(crate) async fn list_worktrees_porcelain(
+    main_path: &Path,
+) -> CaduceusResult<Vec<WorktreeListEntry>> {
     let runner = build_runner();
     let shim_cfg = runner_inner_cfg();
     let output = runner_run_in_std(

--- a/src/worktree/repository.rs
+++ b/src/worktree/repository.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code, unused_imports)]
 use super::*;
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
@@ -40,6 +41,31 @@ pub struct RepositoryInfo {
     /// host-validation purposes the host is derived from this
     /// value, not the daemon's `api_base`.
     pub remote_url: String,
+}
+
+/// Return true when *worktrees_dir* contains exactly one entry named
+/// `.lock` and that entry is a zero-byte file. Used by
+/// `find_main_clone` to decide whether the untracked `.worktrees/`
+/// directory is only the daemon's transient lock file.
+fn worktrees_dir_contains_only_empty_lock(worktrees_dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(worktrees_dir) else {
+        return false;
+    };
+    let mut found_empty_lock = false;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name == ".lock" {
+            match entry.metadata() {
+                Ok(meta) if meta.len() == 0 => found_empty_lock = true,
+                _ => return false,
+            }
+        } else {
+            // Any other entry (worktree sub-dir, stray file, etc.)
+            // means the directory is not *just* a transient lock.
+            return false;
+        }
+    }
+    found_empty_lock
 }
 
 /// Discover the local main clone for *key*. The path is
@@ -89,7 +115,53 @@ pub async fn find_main_clone(
     // dirty main checkout (operator visible signal that the
     // branch is mid-edit).
     let porcelain = git_string(runner, &path, "status", &["--porcelain"]).await?;
-    if !porcelain.is_empty() {
+
+    // Defence-in-depth: tolerate a 0-byte .worktrees/.lock that was
+    // left behind when a previous tick aborted, but only when no
+    // daemon-owned worktree sub-dir is currently registered. Any other
+    // untracked/modified file still hard-fails.
+    let worktrees_dir = path.join(".worktrees");
+    let lock_path = worktrees_dir.join(".lock");
+    let registered = crate::worktree::gc::list_worktrees_porcelain(&path).await?;
+    let registered_paths: HashSet<PathBuf> =
+        registered.into_iter().map(|entry| entry.path).collect();
+    let has_registered_worktree = registered_paths
+        .iter()
+        .any(|p| p.strip_prefix(&worktrees_dir).is_ok());
+    let lock_is_empty = std::fs::metadata(&lock_path)
+        .map(|meta| meta.len() == 0)
+        .unwrap_or(false);
+    let tolerated: Vec<&str> = porcelain
+        .lines()
+        .filter(|line| {
+            if line.is_empty() {
+                return false;
+            }
+            let file_path = line.split_once(' ').map(|(_, rest)| rest).unwrap_or("");
+            if file_path.is_empty() {
+                return true;
+            }
+            let resolved = path.join(file_path);
+            // `git status --porcelain` reports an untracked `.worktrees/`
+            // directory when the only thing inside is the transient lock.
+            if resolved == worktrees_dir
+                && worktrees_dir_contains_only_empty_lock(&worktrees_dir)
+                && !has_registered_worktree
+            {
+                return false; // tolerate the directory line
+            }
+            if resolved == lock_path && lock_is_empty && !has_registered_worktree {
+                return false; // tolerate an explicit .lock line
+            }
+            if registered_paths.contains(&resolved) {
+                return false; // registered worktree sub-dirs are not "dirt"
+            }
+            true
+        })
+        .collect();
+    let porcelain = tolerated.join("\n");
+
+    if !porcelain.trim().is_empty() {
         return Err(CaduceusError::Worktree {
             context: "discover",
             stderr: format!(

--- a/src/worktree/worktree.rs
+++ b/src/worktree/worktree.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_imports)]
 use super::*;
 use std::ffi::OsStr;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -49,6 +49,44 @@ pub struct Worktree {
     /// branch when `fresh = true`).
     pub fresh: bool,
     pub created_at: DateTime<Utc>,
+}
+
+/// Guard that releases an `fs2` flock and removes the underlying
+/// lock file when it drops. Mirrors the `TmpGuard` pattern in
+/// `src/infra/config/mod.rs` but adds the flock release step.
+struct LockGuard {
+    file: File,
+    path: PathBuf,
+    armed: bool,
+}
+
+impl LockGuard {
+    fn new(file: File, path: PathBuf) -> Self {
+        Self {
+            file,
+            path,
+            armed: true,
+        }
+    }
+
+    /// Suppress the Drop-side cleanup. Currently unused by
+    /// `create()` (the lock file is removed on every exit), but
+    /// kept for future code paths that may want to keep the file.
+    #[allow(dead_code)]
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            // Release the flock first so a concurrent `create()`
+            // can race for it; then remove the inode we created.
+            let _ = FileExt::unlock(&self.file);
+            let _ = fs::remove_file(&self.path);
+        }
+    }
 }
 
 /// Provision an isolated worktree + branch. The flow per
@@ -129,19 +167,21 @@ pub async fn create(
             stderr: format!("open worktree lock {}: {err}", lock_path.display()),
         })?;
     if let Err(err) = lock_file.lock_exclusive() {
+        // The file was created by `OpenOptions::open` even when
+        // the flock itself could not be acquired. Remove it so a
+        // subsequent `git status --porcelain` does not see a stale
+        // untracked file.
+        let _ = fs::remove_file(&lock_path);
         return Err(CaduceusError::Worktree {
             context: "create",
             stderr: format!("lock worktree-home {}: {err}", lock_path.display()),
         });
     }
 
+    let _guard = LockGuard::new(lock_file, lock_path.clone());
+
     let result = create_locked(cfg, runner, repo, key, run_id, &branch_name, &worktree_path).await;
 
-    // Release the flock regardless of outcome. `fs2::FileExt`
-    // documents that the lock is released on close; explicit
-    // `unlock` here keeps the lock held file usable for
-    // further flock-based coordination in Phase 5/7.
-    let _ = FileExt::unlock(&lock_file);
     result
 }
 
@@ -158,6 +198,12 @@ async fn create_locked(
     worktree_path: &Path,
 ) -> CaduceusResult<Worktree> {
     let _ = cfg;
+
+    // Test-only hook to exercise panic-path cleanup in integration
+    // tests without adding a public surface to the daemon.
+    if std::env::var_os("_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED").is_some() {
+        panic!("injected panic for lock cleanup test");
+    }
 
     // (5) Pre-flight: branch / path already exist? Resolve
     // each case to "ours" (reconcile) or "theirs" (collision).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,25 @@ TESTS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = TESTS_DIR.parent
 
 
+def _register_caduceus_package() -> None:
+    """Ensure ``import caduceus`` resolves from the repository root.
+
+    The checkout directory may not be named ``caduceus`` (e.g. a git
+    worktree), so pytest needs a namespace-style package entry that points
+    at ``<repo>/`` for ``from caduceus import _runtime`` imports during test
+    collection. The ``adapter`` fixture later loads the real plugin copy.
+    """
+    import types
+
+    pkg = types.ModuleType("caduceus")
+    pkg.__package__ = "caduceus"
+    pkg.__path__ = [str(REPO_ROOT)]  # type: ignore[attr-defined]
+    sys.modules.setdefault("caduceus", pkg)
+
+
+_register_caduceus_package()
+
+
 @pytest.fixture(scope="session")
 def repo_root() -> Path:
     """Absolute path to the Caduceus repository root."""

--- a/tests/plugin/test_doctor_checks.py
+++ b/tests/plugin/test_doctor_checks.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import fcntl
 import os
+import threading
+import time
 from pathlib import Path
 from typing import Any, Dict
 
@@ -167,3 +170,81 @@ def test_doctor_check_gateway_renamed_to_hermes_home(
     assert isinstance(finding, tuple)
     assert finding.category == "gateway-inactive"
     assert finding.status in ("ok", "fail")
+
+
+
+def test_doctor_check_worktree_lock_no_locks(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """No .worktrees/.lock files means the check is clean."""
+    finding = adapter._doctor_check_worktree_lock(ctx=None)
+    assert finding.category == "daemon-defect"
+    assert finding.status == "ok"
+    assert "no stale" in finding.detail.lower() or "not present" in finding.detail.lower()
+
+
+
+def test_doctor_check_worktree_lock_stale_lock(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """An empty, unheld .worktrees/.lock is reported as a stale daemon defect."""
+    lock = (
+        isolated_hermes_home
+        / "projects"
+        / "octocat"
+        / "Hello-World"
+        / ".worktrees"
+        / ".lock"
+    )
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text("")
+
+    finding = adapter._doctor_check_worktree_lock(ctx=None)
+    assert finding.category == "daemon-defect"
+    assert finding.status == "fail"
+    assert str(lock) in finding.detail
+    assert "stale" in finding.detail.lower()
+
+
+
+def test_doctor_check_worktree_lock_held_lock(
+    adapter, isolated_hermes_home: Path
+) -> None:
+    """A .worktrees/.lock currently held by the daemon is not stale."""
+    lock = (
+        isolated_hermes_home
+        / "projects"
+        / "owner"
+        / "repo"
+        / ".worktrees"
+        / ".lock"
+    )
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text("")
+
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def _hold_flock() -> None:
+        fd = os.open(str(lock), os.O_RDWR)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            acquired.set()
+            release.wait(timeout=5.0)
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+    thread = threading.Thread(target=_hold_flock, daemon=True)
+    thread.start()
+    acquired.wait(timeout=5.0)
+
+    try:
+        finding = adapter._doctor_check_worktree_lock(ctx=None)
+    finally:
+        release.set()
+        thread.join(timeout=5.0)
+
+    assert finding.category == "daemon-defect"
+    assert finding.status == "ok"
+    assert "held" in finding.detail.lower()

--- a/tests/plugin/test_doctor_cli.py
+++ b/tests/plugin/test_doctor_cli.py
@@ -293,3 +293,36 @@ def test_doctor_prints_failures_on_exit_2(
     assert rc == 2
     # Should show what failed.
     assert "fail" in captured.out.lower() or "FAIL" in captured.out
+
+
+
+def test_doctor_exit_1_when_worktree_lock_stale(
+    adapter, install_with_fake_binary: Path, isolated_hermes_home: Path, monkeypatch
+) -> None:
+    """A stale .worktrees/.lock makes _cli_doctor exit 1 (daemon-defect)."""
+    from caduceus import _runtime
+
+    monkeypatch.setenv("CADUCEUS_GITHUB_TOKEN", "ghp_test-secret-configured")
+    bridge = isolated_hermes_home / "caduceus" / "worker-bridge.py"
+    bridge.parent.mkdir(parents=True, exist_ok=True)
+    bridge.write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    bridge.chmod(0o755)
+
+    lock = (
+        isolated_hermes_home
+        / "projects"
+        / "octocat"
+        / "Hello-World"
+        / ".worktrees"
+        / ".lock"
+    )
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text("")
+
+    registry = {}
+    _stub_cron_runtime(adapter, registry)
+    try:
+        rc = adapter._cli_doctor()
+    finally:
+        _runtime.reset_dispatcher()
+    assert rc == 1

--- a/tests/repo/repository_discovery_test.rs
+++ b/tests/repo/repository_discovery_test.rs
@@ -426,6 +426,83 @@ async fn find_main_clone_rejects_dirty_main_checkout() {
 }
 
 #[tokio::test]
+async fn find_main_clone_tolerates_empty_lock_with_no_registered_worktrees() {
+    let root = tempdir("lock-empty-no-worktrees");
+    let workdir = root.join("workdirs");
+    fs::create_dir_all(&workdir).unwrap();
+    let dest = workdir.join("octocat").join("Hello-World");
+    fs::create_dir_all(&dest).unwrap();
+    init_working_repo(&dest, "https://github.com/octocat/Hello-World.git");
+
+    let lock = dest.join(".worktrees").join(".lock");
+    fs::create_dir_all(lock.parent().unwrap()).unwrap();
+    fs::write(&lock, "").unwrap();
+    assert_eq!(lock.metadata().unwrap().len(), 0);
+
+    let cfg = config_for(&root, "https://api.github.com");
+    let runner = GitRunner::new(&cfg);
+    let info = find_main_clone(&cfg, &runner, &key("octocat", "Hello-World", 1))
+        .await
+        .expect("discovery should tolerate empty .worktrees/.lock");
+    assert_eq!(info.path, dest);
+}
+
+#[tokio::test]
+async fn find_main_clone_rejects_lock_when_a_worktree_subdir_is_registered() {
+    let root = tempdir("lock-with-registered-worktree");
+    let workdir = root.join("workdirs");
+    fs::create_dir_all(&workdir).unwrap();
+    let dest = workdir.join("octocat").join("Hello-World");
+    fs::create_dir_all(&dest).unwrap();
+    init_working_repo(&dest, "https://github.com/octocat/Hello-World.git");
+
+    let lock = dest.join(".worktrees").join(".lock");
+    fs::create_dir_all(lock.parent().unwrap()).unwrap();
+    fs::write(&lock, "").unwrap();
+
+    let worktree_dir = dest.join(".worktrees").join("registered-run");
+    fs::create_dir_all(&worktree_dir).unwrap();
+    run_command(Command::new("git").current_dir(&dest).args([
+        "worktree",
+        "add",
+        "-b",
+        "registered-branch",
+        worktree_dir.to_str().unwrap(),
+    ]));
+
+    let cfg = config_for(&root, "https://api.github.com");
+    let runner = GitRunner::new(&cfg);
+    let err = find_main_clone(&cfg, &runner, &key("octocat", "Hello-World", 1))
+        .await
+        .unwrap_err();
+    let text = format!("{err:?}");
+    assert!(text.contains("dirty"), "got: {text}");
+}
+
+#[tokio::test]
+async fn find_main_clone_rejects_nonempty_lock() {
+    let root = tempdir("lock-nonempty");
+    let workdir = root.join("workdirs");
+    fs::create_dir_all(&workdir).unwrap();
+    let dest = workdir.join("octocat").join("Hello-World");
+    fs::create_dir_all(&dest).unwrap();
+    init_working_repo(&dest, "https://github.com/octocat/Hello-World.git");
+
+    let lock = dest.join(".worktrees").join(".lock");
+    fs::create_dir_all(lock.parent().unwrap()).unwrap();
+    fs::write(&lock, "hold").unwrap();
+    assert!(lock.metadata().unwrap().len() > 0);
+
+    let cfg = config_for(&root, "https://api.github.com");
+    let runner = GitRunner::new(&cfg);
+    let err = find_main_clone(&cfg, &runner, &key("octocat", "Hello-World", 1))
+        .await
+        .unwrap_err();
+    let text = format!("{err:?}");
+    assert!(text.contains("dirty"), "got: {text}");
+}
+
+#[tokio::test]
 async fn find_main_clone_succeeds_when_workdir_base_path_contains_spaces() {
     let root = tempdir("path-with-spaces");
     let workdir = root.join("path with spaces");

--- a/tests/repo/worktree_create_test.rs
+++ b/tests/repo/worktree_create_test.rs
@@ -24,12 +24,19 @@
 #![allow(unused_variables)]
 
 use std::fs;
+use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+use tokio::runtime::Runtime;
 
 use caduceus::config::Config;
 use caduceus::issue::IssueKey;
 use caduceus::worktree::{create as create_worktree, GitRunner, RepositoryInfo, Worktree};
+
+/// Serialises the two .lock-env-var tests so the global
+/// `_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED` flag cannot leak between them.
+static LOCK_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Unique tempdir per call so parallel test invocations don't
 /// trample each other.
@@ -455,6 +462,10 @@ async fn create_surfaces_precise_error_on_fetch_failure() {
         !probe.status.success(),
         "create must NOT have created {branch_ref}"
     );
+    assert!(
+        !dest.join(".worktrees").join(".lock").exists(),
+        ".worktrees/.lock must be removed on fetch failure"
+    );
 }
 
 // Collision (path / branch owned by a foreign run id)
@@ -486,6 +497,10 @@ async fn create_returns_collision_when_path_owned_by_foreign_run_id() {
     assert!(
         text.contains("collision") || text.contains("already exists"),
         "got: {text}"
+    );
+    assert!(
+        !dest.join(".worktrees").join(".lock").exists(),
+        ".worktrees/.lock must be removed after path collision error"
     );
 }
 
@@ -672,6 +687,77 @@ async fn create_leaves_parent_main_checkout_unchanged() {
     assert!(
         offending.is_empty(),
         "parent checkout had unexpected changes after create: {offending:?}"
+    );
+    assert!(
+        !dest.join(".worktrees").join(".lock").exists(),
+        ".worktrees/.lock must be removed after successful create"
+    );
+}
+
+#[test]
+fn leftover_lock_is_removed_on_normal_exit() {
+    let _guard = LOCK_TEST_MUTEX.lock().unwrap();
+    let owner = "octocat";
+    let repo = "Hello-World";
+    let root = tempdir("lock-removed-normal");
+    let bare = root.join("remote.git");
+    init_bare_repo(&bare);
+    let workdir = root.join("workdirs");
+    fs::create_dir_all(&workdir).unwrap();
+    let dest = workdir.join(owner).join(repo);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    clone_into(&bare, &dest);
+
+    let cfg = config_for(&root, "https://api.github.com");
+    let runner = GitRunner::new(&cfg);
+    let info = info_for(&dest, "main");
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        create_worktree(&cfg, &runner, &info, &key(owner, repo, 99), HAPPY_RUN_ID)
+            .await
+            .expect("create should succeed");
+    });
+
+    assert!(
+        !dest.join(".worktrees").join(".lock").exists(),
+        ".worktrees/.lock must be removed on normal exit"
+    );
+}
+
+#[test]
+fn leftover_lock_is_removed_on_panic() {
+    let _guard = LOCK_TEST_MUTEX.lock().unwrap();
+    let owner = "octocat";
+    let repo = "Hello-World";
+    let root = tempdir("lock-removed-panic");
+    let bare = root.join("remote.git");
+    init_bare_repo(&bare);
+    let workdir = root.join("workdirs");
+    fs::create_dir_all(&workdir).unwrap();
+    let dest = workdir.join(owner).join(repo);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    clone_into(&bare, &dest);
+
+    let cfg = config_for(&root, "https://api.github.com");
+    let runner = GitRunner::new(&cfg);
+    let info = info_for(&dest, "main");
+    let issue_key = key(owner, repo, 99);
+    let lock_path = dest.join(".worktrees").join(".lock");
+
+    let rt = Runtime::new().unwrap();
+    let outcome = std::panic::catch_unwind(AssertUnwindSafe(move || {
+        rt.block_on(async {
+            std::env::set_var("_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED", "1");
+            let _ = create_worktree(&cfg, &runner, &info, &issue_key, HAPPY_RUN_ID).await;
+            std::env::remove_var("_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED");
+        });
+    }));
+
+    std::env::remove_var("_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED");
+    assert!(outcome.is_err(), "expected a panic during create_worktree");
+    assert!(
+        !lock_path.exists(),
+        ".worktrees/.lock must be removed after panic"
     );
 }
 


### PR DESCRIPTION
## Summary

The daemon's `create_worktree` opened a `flock` on `<repo>/.worktrees/.lock` but never unlinked the file. After a normal exit, panic, or external kill (SIGTERM, SIGKILL, OOM, supervisor timeout), the empty file persisted in the main checkout's working tree. The next dispatch attempt failed `find_main_clone`'s `git status --porcelain` dirty-check with:

```
worktree discover failure: main checkout is dirty at <path>; refusing to operate
```

This is the daemon poisoning itself. The fix is a three-layer defence:

1. **In-process (LOCK-01, LOCK-02)**: `LockGuard` Drop guard in `src/worktree/worktree.rs` that always removes the lock file on every exit path (success, error, panic unwind). The `lock_exclusive` Err arm also removes the file explicitly to cover the brief open→lock window.
2. **Rust tolerance (LOCK-03)**: defence-in-depth filter in `find_main_clone` (`src/worktree/repository.rs`) that filters an empty `.worktrees/.lock` from porcelain output IF the file is 0 bytes AND no worktree sub-dir is registered with `git worktree list`. Covers the SIGKILL/OOM case where Drop cannot run.
3. **Python doctor (LOCK-06)**: `_doctor_check_worktree_lock` in `__init__.py` that scans `<hermes_home>/projects/*/*/.worktrees/.lock` and probes each via `fcntl.flock(LOCK_EX|LOCK_NB)`. Stale (acquirable) → FAIL; held (EWOULDBLOCK) → OK; missing → OK.

## Acceptance criteria

| ID | Status | Evidence |
|---|---|---|
| LOCK-01 | ✅ | `leftover_lock_is_removed_on_normal_exit`; post-conditions on 3 error tests |
| LOCK-02 | ✅ | `leftover_lock_is_removed_on_panic`; `LockGuard::Drop` verified |
| LOCK-03 | ✅ | 3 tests: tolerate empty, reject when worktree registered, reject non-empty |
| LOCK-04 | ✅ | Tests for LOCK-01 and LOCK-02 exist and pass |
| LOCK-05 | ✅ | 114 lib tests pass; no collateral regressions |
| LOCK-06 | ✅ | 3 doctor tests + 1 exit-code test pass |

## Verification gates

- `cargo fmt --check`: ✅ exit 0
- `cargo clippy --locked --all-targets -- -D warnings`: ✅ exit 0
- `cargo test --locked --test worktree_create_test`: ✅ 13/13 passed
- `cargo test --locked --test repository_discovery_test`: ✅ 30/30 passed
- `cargo test --locked --lib`: ✅ 114/114 passed
- `pytest -q tests/plugin/ tests/integration/bridge_test.py`: ✅ 135 passed

`cargo test --locked --all-targets` was not run in the worktree (triggers the long `hermes_lifecycle` integration test that prunes the worktree). CI will run the full suite on the PR head SHA.

## Changes

| File | Lines |
|---|---|
| `__init__.py` | +89 |
| `src/worktree/gc.rs` | +10 |
| `src/worktree/repository.rs` | +74 |
| `src/worktree/worktree.rs` | +58 |
| `tests/conftest.py` | +19 |
| `tests/plugin/test_doctor_checks.py` | +81 |
| `tests/plugin/test_doctor_cli.py` | +33 |
| `tests/repo/repository_discovery_test.rs` | +77 |
| `tests/repo/worktree_create_test.rs` | +86 |
| **Total** | **+516 / -11** |

516 lines is above the nominal 400-line review budget. Size exception was pre-approved by operator policy (always auto-accept).

## Deviations

1. **Env-var panic hook `_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED` in production code** (`create_locked` in `src/worktree/worktree.rs`) — gated by a private env var. Intentional test-only injection point. `create_locked` has no natural panic surface and `GitRunner` is not trait/mockable at the call site. Consider trait-based injection in a follow-up.
2. **Added tolerance for untracked `.worktrees/` directory line** (not just `.worktrees/.lock`) — `git status --porcelain` aggregates the lone file into the parent directory line.
3. **`tests/conftest.py` caduceus package alias** (19 lines) — environment-specific workaround for worktree directory not named `caduceus`.

## Out of scope

- `src/scheduler/leadership.rs` `DaemonLock` lifecycle — untouched
- Cron-side `script_timeout_seconds` mismatch — untouched (Hermes concern)
- Refactoring the worktree-home layout or moving the lock — not done; the fix is "remove the file at the right times"

Closes #80