### PR TITLE
fix(status): expose real app version and fix Python formatter (closes #81)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -316,19 +316,39 @@ def _handle_caduceus_status(raw_args: str) -> Optional[str]:
 
 
 def _format_status_for_chat(payload: Dict[str, Any]) -> str:
-    """Render a status JSON payload as a short chat-friendly summary."""
-    version = payload.get("version") or "unknown"
-    last_tick = payload.get("last_tick") or "never"
-    last_outcome = payload.get("last_outcome") or "n/a"
-    phases = payload.get("phases") or {}
-    phase_counts = ", ".join(f"{k}={v}" for k, v in phases.items()) or "none"
-    next_head = payload.get("next_head") or "none"
-    rate_limit = payload.get("rate_limit") or {}
-    rl = (
-        f"rate_limit={rate_limit.get('remaining')}/{rate_limit.get('limit')}"
-        if rate_limit.get("limit")
-        else "rate_limit=unknown"
+    """Render a status JSON payload as a short chat-friendly summary.
+
+    Reads from the nested ``report`` sub-object when present and falls
+    back to the root level for backward compatibility with flat payloads.
+    Prefers the new ``app_version`` field over the legacy ``version``
+    field so the chat output reflects the actual crate version rather
+    than the JSON schema version. Surfaces ``last_tick_started`` and
+    ``last_tick_finished`` separately because there is no combined
+    ``last_tick`` field in the Rust output.
+    """
+    if isinstance(payload, dict):
+        data = payload.get("report", payload)
+    else:
+        data = {}
+    version = (
+        data.get("app_version")
+        or payload.get("app_version")
+        or data.get("version")
+        or payload.get("version")
+        or "unknown"
     )
+    started = data.get("last_tick_started") or "never"
+    finished = data.get("last_tick_finished") or "never"
+    last_tick = f"started={started} finished={finished}"
+    last_outcome = data.get("last_outcome") or "n/a"
+    phases = data.get("phases") or {}
+    phase_counts = ", ".join(f"{k}={v}" for k, v in phases.items()) or "none"
+    next_head = data.get("next_head") or "none"
+    rate_limit = data.get("rate_limit") or {}
+    if rate_limit.get("limit"):
+        rl = f"rate_limit={rate_limit.get('remaining')}/{rate_limit.get('limit')}"
+    else:
+        rl = "rate_limit=unknown"
     return (
         f"caduceus {version} — last tick: {last_tick} ({last_outcome})\n"
         f"  queue: {phase_counts}\n"

--- a/src/daemon/status.rs
+++ b/src/daemon/status.rs
@@ -549,6 +549,7 @@ pub fn report(state_dir: &Path, json: bool) -> CaduceusResult<(String, Option<St
         // "no state yet" / "corrupt" cases without
         // parsing the human format.
         let payload = serde_json::json!({
+            "app_version": env!("CARGO_PKG_VERSION"),
             "version": report.version,
             "state_dir": report.state_dir,
             "diagnostic": match diagnostic.as_ref() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def install_with_fake_binary(install_plugin: Path) -> Path:
         ' in real setup\n'
         'if [ "$1" = "status" ]; then\n'
         '  if [ "$2" = "--json" ]; then\n'
-        '    printf \'{"version":"0.1.0","last_tick":"never","last_outcome":"idle","phases":{"queued":0},"next_head":null,"rate_limit":null}\'\n'
+        '    printf \'{"app_version":"0.1.0","version":"0.1.0","diagnostic":null,"report":{"version":"0.1.0","last_tick_started":null,"last_tick_finished":null,"last_outcome":"idle","phases":{"queued":0},"next_head":null,"rate_limit":null}}\'\n'
         "  else\n"
         '    echo "caduceus: stub status"\n'
         "  fi\n"

--- a/tests/daemon/status_test.rs
+++ b/tests/daemon/status_test.rs
@@ -576,7 +576,13 @@ fn report_json_includes_app_version_from_cargo_pkg_version() {
     std::fs::create_dir_all(&cfg.state_dir).expect("state dir");
     let (output, _diag) = report(cfg.state_dir.as_path(), true).expect("report");
     let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid json");
-    assert_eq!(parsed["app_version"].as_str(), Some(env!("CARGO_PKG_VERSION")));
+    assert_eq!(
+        parsed["app_version"].as_str(),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
     assert_eq!(parsed["version"].as_str(), Some(STATUS_SCHEMA_VERSION));
-    assert_eq!(parsed["report"]["version"].as_str(), Some(STATUS_SCHEMA_VERSION));
+    assert_eq!(
+        parsed["report"]["version"].as_str(),
+        Some(STATUS_SCHEMA_VERSION)
+    );
 }

--- a/tests/daemon/status_test.rs
+++ b/tests/daemon/status_test.rs
@@ -568,3 +568,15 @@ fn status_exit_1_for_corrupt_queue() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn report_json_includes_app_version_from_cargo_pkg_version() {
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    std::fs::create_dir_all(&cfg.state_dir).expect("state dir");
+    let (output, _diag) = report(cfg.state_dir.as_path(), true).expect("report");
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid json");
+    assert_eq!(parsed["app_version"].as_str(), Some(env!("CARGO_PKG_VERSION")));
+    assert_eq!(parsed["version"].as_str(), Some(STATUS_SCHEMA_VERSION));
+    assert_eq!(parsed["report"]["version"].as_str(), Some(STATUS_SCHEMA_VERSION));
+}

--- a/tests/plugin/test_status.py
+++ b/tests/plugin/test_status.py
@@ -79,3 +79,67 @@ def test_status_slash_redacts_token_like_strings(
     # No ``ghp_`` token made it into chat output.
     assert "ghp_" not in result
     assert "<redacted>" not in result  # the fake didn't leak one — defensive
+
+
+def test_format_status_for_chat_reads_nested_report_key(adapter) -> None:
+    """When the payload carries a nested ``report`` key, the formatter reads
+    the app version from there. This is the shape the live ``caduceus
+    status --json`` produces today.
+    """
+    payload = {
+        "report": {
+            "app_version": "1.2.3",
+            "last_tick_started": None,
+            "last_tick_finished": None,
+            "last_outcome": "idle",
+            "phases": {},
+        }
+    }
+    result = adapter._format_status_for_chat(payload)
+    assert "1.2.3" in result
+    assert "started=" in result
+    assert "finished=" in result
+
+
+def test_format_status_for_chat_falls_back_to_root(adapter) -> None:
+    """When the payload is flat (no ``report`` key), the formatter falls
+    back to the root level so legacy consumers keep working.
+    """
+    payload = {"version": "1.2.3", "phases": {}}
+    result = adapter._format_status_for_chat(payload)
+    assert "1.2.3" in result
+
+
+def test_format_status_for_chat_prefers_app_version_over_version(adapter) -> None:
+    """When both ``app_version`` and ``version`` are present, the formatter
+    prefers ``app_version`` so the chat shows the real crate version, not
+    the JSON schema version.
+    """
+    payload = {
+        "app_version": "2.0.0",
+        "version": "7.5.0",
+        "report": {"version": "7.5.0"},
+    }
+    result = adapter._format_status_for_chat(payload)
+    assert "2.0.0" in result
+    assert "7.5.0" not in result
+
+
+def test_format_status_for_chat_shows_last_tick_started_and_finished(
+    adapter,
+) -> None:
+    """The summary surfaces both ``last_tick_started`` and
+    ``last_tick_finished`` timestamps, not a single non-existent
+    ``last_tick`` field.
+    """
+    payload = {
+        "report": {
+            "app_version": "1.0.0",
+            "last_tick_started": "2024-01-01T00:00:00Z",
+            "last_tick_finished": "2024-01-01T00:00:30Z",
+            "phases": {},
+        }
+    }
+    result = adapter._format_status_for_chat(payload)
+    assert "2024-01-01T00:00:00Z" in result
+    assert "2024-01-01T00:00:30Z" in result

--- a/tests/plugin/test_status.py
+++ b/tests/plugin/test_status.py
@@ -65,7 +65,7 @@ def test_status_slash_redacts_token_like_strings(
         "#!/usr/bin/env bash\n"
         'if [ "$1" = "status" ]; then\n'
         '  if [ "$2" = "--json" ]; then\n'
-        '    printf \'{"version":"0.1.0","last_tick":"never","last_outcome":"idle"}\'\n'
+        '    printf \'{"app_version":"0.1.0","version":"0.1.0","diagnostic":null,"report":{"version":"0.1.0","last_tick_started":null,"last_tick_finished":null,"last_outcome":"idle","phases":{"queued":0},"next_head":null,"rate_limit":null}}\'\n'
         "  fi\n"
         "  exit 0\n"
         "fi\n"


### PR DESCRIPTION
Closes #81

Two independent bugs produced a dead-looking 'caduceus status' output.

Bug 1 — Version mismatch: STATUS_SCHEMA_VERSION ("7.5.0") is the JSON
schema version, not the crate version. The Python formatter read it as
the app version.

Bug 2 — Data nesting mismatch: report() wraps useful data inside a
'report' sub-object. The Python formatter read from the root level, so
everything resolved to fallback dead values ('never', 'n/a', 'none').
There is no 'last_tick' field — it is split into last_tick_started and
last_tick_finished.

Fix:
- report() adds 'app_version' at JSON root from env!('CARGO_PKG_VERSION')
  (= "1.0.0"). Preserves existing 'version' field for backward compat.
- _format_status_for_chat reads from payload.get('report', payload),
  prefers app_version over version, and renders last_tick_started +
  last_tick_finished.

Out of scope:
- StatusReport struct field names unchanged
- STATUS_SCHEMA_VERSION unchanged ("7.5.0")
- JSON schema contract unchanged (additive only)