### PR TITLE
test(state): isolate config_bootstrap retry test from host env

### DIFF
--- a/tests/state/config_bootstrap_test.rs
+++ b/tests/state/config_bootstrap_test.rs
@@ -289,110 +289,117 @@ fn readiness_diagnostics_bridge_present() {
 
 #[test]
 fn setup_config_creates_mode_0600() {
-    let root = tempdir("ac06-create");
-    let hermes_home = root.join("hermes");
-    std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
+    with_env(&[("CADUCEUS_CONFIG", None)], || {
+        let root = tempdir("ac06-create");
+        let hermes_home = root.join("hermes");
+        std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
 
-    let report =
-        caduceus::config::setup_config(&hermes_home, false).expect("setup_config creates config");
-    assert_eq!(report.action, SetupAction::Created, "should be Created");
-    assert!(report.path.is_file(), "config file should exist");
+        let report = caduceus::config::setup_config(&hermes_home, false)
+            .expect("setup_config creates config");
+        assert_eq!(report.action, SetupAction::Created, "should be Created");
+        assert!(report.path.is_file(), "config file should exist");
 
-    // Verify mode via permissions
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let meta = std::fs::metadata(&report.path).expect("metadata");
-        let mode = meta.permissions().mode() & 0o777;
-        // Mode should be 0o600 (or narrower if umask affected it)
-        assert!(mode <= 0o600, "mode should be <= 0o600, got: {mode:o}");
-    }
+        // Verify mode via permissions
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = std::fs::metadata(&report.path).expect("metadata");
+            let mode = meta.permissions().mode() & 0o777;
+            // Mode should be 0o600 (or narrower if umask affected it)
+            assert!(mode <= 0o600, "mode should be <= 0o600, got: {mode:o}");
+        }
 
-    // Verify the file has valid YAML with caduceus config keys
-    let content = std::fs::read_to_string(&report.path).expect("read config");
-    assert!(
-        content.contains("poll_interval_seconds"),
-        "config should contain poll_interval_seconds"
-    );
-    assert!(
-        content.contains("state_dir"),
-        "config should contain state_dir"
-    );
-    assert!(
-        content.contains("workdir_base"),
-        "config should contain workdir_base"
-    );
-    // The first run creates a standalone file (no Hermes shape)
-    assert!(
-        !content.contains("caduceus:"),
-        "standalone config should not have a caduceus: section wrapper"
-    );
+        // Verify the file has valid YAML with caduceus config keys
+        let content = std::fs::read_to_string(&report.path).expect("read config");
+        assert!(
+            content.contains("poll_interval_seconds"),
+            "config should contain poll_interval_seconds"
+        );
+        assert!(
+            content.contains("state_dir"),
+            "config should contain state_dir"
+        );
+        assert!(
+            content.contains("workdir_base"),
+            "config should contain workdir_base"
+        );
+        // The first run creates a standalone file (no Hermes shape)
+        assert!(
+            !content.contains("caduceus:"),
+            "standalone config should not have a caduceus: section wrapper"
+        );
+    });
 }
 
 #[test]
 fn setup_config_dry_run_does_not_write() {
-    let root = tempdir("ac06-dry-run");
-    let hermes_home = root.join("hermes");
-    std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
+    with_env(&[("CADUCEUS_CONFIG", None)], || {
+        let root = tempdir("ac06-dry-run");
+        let hermes_home = root.join("hermes");
+        std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
 
-    let report = caduceus::config::setup_config(&hermes_home, true).expect("setup_config dry-run");
-    assert_eq!(report.action, SetupAction::Skipped, "should be Skipped");
-    // The file should NOT exist after a dry-run
-    assert!(
-        !report.path.is_file(),
-        "config file should not exist after dry-run"
-    );
+        let report =
+            caduceus::config::setup_config(&hermes_home, true).expect("setup_config dry-run");
+        assert_eq!(report.action, SetupAction::Skipped, "should be Skipped");
+        // The file should NOT exist after a dry-run
+        assert!(
+            !report.path.is_file(),
+            "config file should not exist after dry-run"
+        );
+    });
 }
 
 #[test]
 fn setup_config_preserves_existing_mode_and_yaml() {
-    let root = tempdir("ac07-preserve");
-    let hermes_home = root.join("hermes");
-    std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
+    with_env(&[("CADUCEUS_CONFIG", None)], || {
+        let root = tempdir("ac07-preserve");
+        let hermes_home = root.join("hermes");
+        std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
 
-    // Create an existing Hermes-shaped config with a known mode
-    let config_path = hermes_home.join("config.yaml");
-    write(
-        &config_path,
-        r#"
-        model:
-          default: hermes-model
-        "#,
-    );
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640))
-            .expect("set mode 0640");
-    }
+        // Create an existing Hermes-shaped config with a known mode
+        let config_path = hermes_home.join("config.yaml");
+        write(
+            &config_path,
+            r#"
+            model:
+              default: hermes-model
+            "#,
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640))
+                .expect("set mode 0640");
+        }
 
-    let report =
-        caduceus::config::setup_config(&hermes_home, false).expect("setup_config updates existing");
-    assert_eq!(report.action, SetupAction::Updated, "should be Updated");
+        let report = caduceus::config::setup_config(&hermes_home, false)
+            .expect("setup_config updates existing");
+        assert_eq!(report.action, SetupAction::Updated, "should be Updated");
 
-    // Verify the file now has a caduceus: section
-    let content = std::fs::read_to_string(&report.path).expect("read config");
-    assert!(
-        content.contains("caduceus:"),
-        "merged config should have caduceus: section"
-    );
-    assert!(
-        content.contains("hermes-model"),
-        "merged config should preserve original hermes keys"
-    );
-    assert!(
-        content.contains("poll_interval_seconds"),
-        "merged config should have caduceus config keys"
-    );
+        // Verify the file now has a caduceus: section
+        let content = std::fs::read_to_string(&report.path).expect("read config");
+        assert!(
+            content.contains("caduceus:"),
+            "merged config should have caduceus: section"
+        );
+        assert!(
+            content.contains("hermes-model"),
+            "merged config should preserve original hermes keys"
+        );
+        assert!(
+            content.contains("poll_interval_seconds"),
+            "merged config should have caduceus config keys"
+        );
 
-    // Verify mode was preserved (not widened above 0600)
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let meta = std::fs::metadata(&report.path).expect("metadata");
-        let mode = meta.permissions().mode() & 0o777;
-        assert!(mode <= 0o640, "mode should be <= 0o640, got: {mode:o}");
-    }
+        // Verify mode was preserved (not widened above 0600)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = std::fs::metadata(&report.path).expect("metadata");
+            let mode = meta.permissions().mode() & 0o777;
+            assert!(mode <= 0o640, "mode should be <= 0o640, got: {mode:o}");
+        }
+    });
 }
 
 #[test]

--- a/tests/state/config_bootstrap_test.rs
+++ b/tests/state/config_bootstrap_test.rs
@@ -397,32 +397,34 @@ fn setup_config_preserves_existing_mode_and_yaml() {
 
 #[test]
 fn setup_config_interrupt_before_rename_is_retryable() {
-    let root = tempdir("ac08-retry");
-    let hermes_home = root.join("hermes");
-    std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
+    with_env(&[("CADUCEUS_CONFIG", None)], || {
+        let root = tempdir("ac08-retry");
+        let hermes_home = root.join("hermes");
+        std::fs::create_dir_all(&hermes_home).expect("create hermes_home");
 
-    // Simulate a leftover .tmp file from a previous interrupted run
-    let tmp_path = hermes_home.join("config.yaml.tmp");
-    write(&tmp_path, "leftover garbage\n");
+        // Simulate a leftover .tmp file from a previous interrupted run
+        let tmp_path = hermes_home.join("config.yaml.tmp");
+        write(&tmp_path, "leftover garbage\n");
 
-    // First run should succeed and clean up the tmp file
-    let report = caduceus::config::setup_config(&hermes_home, false)
-        .expect("first setup_config succeeds despite leftover tmp");
-    assert_eq!(report.action, SetupAction::Created, "should be Created");
-    assert!(report.path.is_file(), "config file should exist");
+        // First run should succeed and clean up the tmp file
+        let report = caduceus::config::setup_config(&hermes_home, false)
+            .expect("first setup_config succeeds despite leftover tmp");
+        assert_eq!(report.action, SetupAction::Created, "should be Created");
+        assert!(report.path.is_file(), "config file should exist");
 
-    // The tmp file should be gone
-    assert!(!tmp_path.is_file(), "leftover tmp file should be removed");
+        // The tmp file should be gone
+        assert!(!tmp_path.is_file(), "leftover tmp file should be removed");
 
-    // Second run should succeed (idempotent)
-    let report2 =
-        caduceus::config::setup_config(&hermes_home, false).expect("second setup_config succeeds");
-    assert_eq!(
-        report2.action,
-        SetupAction::Updated,
-        "second run should Update"
-    );
-    assert!(report2.path.is_file(), "config file should still exist");
+        // Second run should succeed (idempotent)
+        let report2 = caduceus::config::setup_config(&hermes_home, false)
+            .expect("second setup_config succeeds");
+        assert_eq!(
+            report2.action,
+            SetupAction::Updated,
+            "second run should Update"
+        );
+        assert!(report2.path.is_file(), "config file should still exist");
+    });
 }
 
 #[test]


### PR DESCRIPTION
## What

Two commits on this branch both wrap tests in `tests/state/config_bootstrap_test.rs` in `with_env(&[("CADUCEUS_CONFIG", None)], || { ... })` so they pass when the CI runner exports `CADUCEUS_CONFIG`.

## Why

`caduceus::config::setup_config` (`src/infra/config/mod.rs:323`) refuses to run when `CADUCEUS_CONFIG` is set. The tests in `tests/state/config_bootstrap_test.rs` exercise `setup_config` directly. Four of them (`setup_config_creates_mode_0600`, `setup_config_dry_run_does_not_write`, `setup_config_preserves_existing_mode_and_yaml`, `setup_config_interrupt_before_rename_is_retryable`) bypassed the file's existing `with_env` wrapper helper and were failing on the CI runner when its environment exported `CADUCEUS_CONFIG`.

## Commits

- **`f906394`** — `setup_config_interrupt_before_rename_is_retryable` (the test named in #100). Original orchestrator output.
- **`b5cb51d`** — sibling wrap for the other three tests. Supervising-agent follow-up after running the full `config_bootstrap_test` suite with `CADUCEUS_CONFIG` set and discovering three more tests in the same file exhibited the same defect.

## Verification

| condition | result |
|---|---|
| `cargo test --locked --test config_bootstrap_test` (no env) | 18 passed, 0 failed |
| `CADUCEUS_CONFIG=/tmp/anything.yaml cargo test --locked --test config_bootstrap_test` | 18 passed, 0 failed |
| `cargo fmt --check` | clean |
| `cargo clippy --locked --all-targets -- -D warnings` | clean |
| `cargo test --locked --lib` | 114 passed, 0 failed |

## Out of scope

- Production-side refactor of `setup_config` to accept an `RawEnv` parameter (the principled fix). Deferred — this PR is the minimal test-only fix that unsticks CI. Tracked separately if/when needed.
- The four `hermes_lifecycle` integration tests that fail under `cargo test --locked --all-targets` due to parallel-timeout collisions (`hermes caduceus setup` 240s timeout). Pre-existing on clean main when tests run in parallel; not caused by this change.

Closes #100