### PR TITLE
fix(finalize): persist PR number onto queue entry (closes #89)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,6 +445,10 @@ name = "integration_test"
 path = "tests/integration/integration_test.rs"
 
 [[test]]
+name = "finalize_pr_number_test"
+path = "tests/integration/finalize_pr_number_test.rs"
+
+[[test]]
 name = "docs_contract_test"
 path = "tests/architecture/docs_contract_test.rs"
 

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -89,7 +89,7 @@ pub(crate) fn next_stage_after(
 pub(crate) async fn run_resume_finalization(
     cfg: Config,
     services: &Services,
-    _store: &StateStore,
+    store: &StateStore,
     _meta: &MetaStore,
     client: Arc<Client>,
     claimed: ClaimedEntry,
@@ -204,7 +204,20 @@ pub(crate) async fn run_resume_finalization(
             persist_checkpoint(&conn, &ctx.run_id, Committed, None, None, None)?;
             push_and_finalize(&ctx, &runner).await?;
             persist_checkpoint(&conn, &ctx.run_id, Pushed, None, None, None)?;
-            find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            let pr_output =
+                find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            store.save_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::PrCreated,
+                    commit_oid: None,
+                    pr_number: pr_output.pr_number,
+                    pr_url: pr_output.pr_url,
+                },
+            )?;
             persist_checkpoint(&conn, &ctx.run_id, PrCreated, None, None, None)?;
             post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
             persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
@@ -214,7 +227,20 @@ pub(crate) async fn run_resume_finalization(
             persist_checkpoint(&conn, &ctx.run_id, Committed, None, None, None)?;
             push_and_finalize(&ctx, &runner).await?;
             persist_checkpoint(&conn, &ctx.run_id, Pushed, None, None, None)?;
-            find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            let pr_output =
+                find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            store.save_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::PrCreated,
+                    commit_oid: None,
+                    pr_number: pr_output.pr_number,
+                    pr_url: pr_output.pr_url,
+                },
+            )?;
             persist_checkpoint(&conn, &ctx.run_id, PrCreated, None, None, None)?;
             post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
             persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
@@ -222,7 +248,20 @@ pub(crate) async fn run_resume_finalization(
         }
         Pushed => {
             persist_checkpoint(&conn, &ctx.run_id, Pushed, None, None, None)?;
-            find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            let pr_output =
+                find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            store.save_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::PrCreated,
+                    commit_oid: None,
+                    pr_number: pr_output.pr_number,
+                    pr_url: pr_output.pr_url,
+                },
+            )?;
             persist_checkpoint(&conn, &ctx.run_id, PrCreated, None, None, None)?;
             post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
             persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
@@ -291,7 +330,22 @@ pub(crate) async fn run_code_finalize(
         None,
         None,
     )?;
-    find_or_create_pr_and_finalize(ctx, client, worker_result).await?;
+    let pr_output = find_or_create_pr_and_finalize(ctx, client, worker_result).await?;
+    // Persist the durable finalization checkpoint so the awaiting-review
+    // poller can satisfy its `finalization.pr_number.is_some()` filter.
+    // The PR number is the only durable link from queue entry → PR.
+    store.save_finalization(
+        &ctx.claim,
+        crate::state::queue::FinalizationCheckpoint {
+            run_id: ctx.run_id.clone(),
+            branch_name: ctx.worktree.branch_name.clone(),
+            result_path: worker_result_path.to_path_buf(),
+            stage: crate::state::queue::FinalizationStage::PrCreated,
+            commit_oid: None,
+            pr_number: pr_output.pr_number,
+            pr_url: pr_output.pr_url,
+        },
+    )?;
 
     // Stage 4: PrCreated — about to post completion comment
     persist_checkpoint(

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -336,6 +336,7 @@ pub(crate) async fn run_code_finalize(
     Ok(FinalizeOutput {
         action: crate::finalize::FinalizeAction::AwaitingReview,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: vec![
             "awaiting_review".to_string(),
             format!("issue={}", ctx.issue.key.display_key()),

--- a/src/finalize/comment_close.rs
+++ b/src/finalize/comment_close.rs
@@ -185,6 +185,7 @@ pub async fn post_completion_and_close_and_finalize(
     Ok(FinalizeOutput {
         action: FinalizeAction::Commented,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: observations,
     })
 }
@@ -259,6 +260,7 @@ pub async fn post_completion_only(
     Ok(FinalizeOutput {
         action: FinalizeAction::Commented,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: vec![format!("comment_posted={comment_posted}")],
     })
 }

--- a/src/finalize/commit.rs
+++ b/src/finalize/commit.rs
@@ -431,6 +431,7 @@ pub fn commit_code_and_finalize(
     Ok(FinalizeOutput {
         action: FinalizeAction::Committed,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: vec![
             "committed".to_string(),
             format!("oid={}", outcome.commit_oid),

--- a/src/finalize/dry_run_archive.rs
+++ b/src/finalize/dry_run_archive.rs
@@ -185,6 +185,7 @@ pub fn dry_run_finalize(
     Ok(FinalizeOutput {
         action: FinalizeAction::Previewed,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: vec![
             "dry-run".to_string(),
             format!("report={}", report_path.display()),

--- a/src/finalize/failure_investigation.rs
+++ b/src/finalize/failure_investigation.rs
@@ -150,6 +150,7 @@ pub async fn post_failure_comment_and_finalize(
     Ok(FinalizeOutput {
         action: FinalizeAction::Commented,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: vec![format!(
             "failure_comment_posted={}",
             outcome.comment_posted
@@ -245,6 +246,7 @@ pub async fn post_investigation_comment_and_finalize(
     Ok(FinalizeOutput {
         action: FinalizeAction::InvestigationCommented,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: vec![
             format!("investigation_comment_posted={}", outcome.comment_posted),
             format!("investigation_label_removed={}", outcome.label_removed),

--- a/src/finalize/pr.rs
+++ b/src/finalize/pr.rs
@@ -148,6 +148,7 @@ pub async fn find_or_create_pr_and_finalize(
     Ok(FinalizeOutput {
         action: FinalizeAction::PrCreated,
         pr_url: Some(pr.url.clone()),
+        pr_number: Some(pr.number),
         idempotency_observations: observations,
     })
 }

--- a/src/finalize/push.rs
+++ b/src/finalize/push.rs
@@ -152,6 +152,7 @@ pub async fn push_and_finalize(
     Ok(FinalizeOutput {
         action: FinalizeAction::Pushed,
         pr_url: None,
+        pr_number: None,
         idempotency_observations: vec![
             "pushed".to_string(),
             format!("branch={}", outcome.branch),

--- a/src/finalize/voice.rs
+++ b/src/finalize/voice.rs
@@ -118,6 +118,8 @@ pub struct FinalizeOutput {
     pub action: FinalizeAction,
     /// Canonical PR URL, if the action created or updated one.
     pub pr_url: Option<String>,
+    /// GitHub PR number, if the action created or updated one.
+    pub pr_number: Option<u64>,
     /// Per-step idempotency notes (e.g. "comment already posted",
     /// "branch already pushed"). The orchestrator logs these
     /// but does not retry on them.

--- a/tests/integration/finalize_pr_number_test.rs
+++ b/tests/integration/finalize_pr_number_test.rs
@@ -1,0 +1,215 @@
+//! Integration test: the PR number returned by GitHub during code-ticket
+//! finalization must reach `QueueEntry.finalization.pr_number`.
+//!
+//! The fixture drives `find_or_create_pr_and_finalize` against a mock
+//! GitHub API, then saves the returned checkpoint through
+//! `StateStore::save_finalization` exactly as the daemon's resume path
+//! does, and asserts the queue entry carries the PR number.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use caduceus::config::{Config, LoadContext, RawConfig};
+use caduceus::finalize::{find_or_create_pr_and_finalize, FinalizeContext, FinalizeRequest};
+use caduceus::github::Client;
+use caduceus::issue::IssueDetail;
+use caduceus::queue::{
+    ClaimToken, FinalizationCheckpoint, FinalizationStage, Phase, StateStore, TicketType,
+};
+use caduceus::worker::{WorkerResult, WorkerStatus};
+use caduceus::worktree::{RepositoryInfo, Worktree};
+use chrono::Utc;
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::MockGitHub;
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const EXPECTED_PR_NUMBER: u64 = 4242;
+
+fn tempdir(label: &str) -> std::path::PathBuf {
+    let mut dir = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    dir.push(format!("caduceus-finalize-pr-number-{label}-{nonce}"));
+    std::fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+fn empty_config(state_dir: &Path) -> Config {
+    let raw = RawConfig {
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        state_dir: Some(state_dir.to_path_buf()),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let ctx = LoadContext {
+        plugin_root: Some(state_dir.to_path_buf()),
+        ..Default::default()
+    };
+    Config::from_raw(raw, &ctx).expect("config")
+}
+
+fn inert_client() -> Arc<Client> {
+    Arc::new(Client::new("https://api.github.com"))
+}
+
+fn make_issue() -> IssueDetail {
+    IssueDetail {
+        key: caduceus::issue::IssueKey {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+        },
+        title: "Sample".to_string(),
+        body: "Body".to_string(),
+        labels: vec![],
+        comments: vec![],
+        trusted_comments: vec![],
+        events: vec![],
+        fetched_at: Utc::now(),
+    }
+}
+
+fn make_worker_result() -> WorkerResult {
+    let mut artifacts = BTreeMap::new();
+    artifacts.insert("k".to_string(), json!("v"));
+    WorkerResult {
+        status: WorkerStatus::Success,
+        summary: "summary".to_string(),
+        commit_message: "fix: sample".to_string(),
+        pull_request_title: "PR title".to_string(),
+        artifacts,
+        investigation: false,
+    }
+}
+
+fn make_context(cfg: &Config, issue: &IssueDetail, run_id: &str) -> FinalizeContext {
+    let branch_name = "automation/issue-1".to_string();
+    let wt = Worktree {
+        issue: issue.key.clone(),
+        run_id: run_id.to_string(),
+        branch_name: branch_name.clone(),
+        path: Path::new("/tmp/wt").to_path_buf(),
+        base_oid: "deadbeef".to_string(),
+        fresh: false,
+        created_at: Utc::now(),
+    };
+    let claim = ClaimToken::for_test(cfg.state_dir.join("claims"), "deadbeef00", run_id);
+    FinalizeContext {
+        client: inert_client(),
+        config: cfg.clone(),
+        repository: RepositoryInfo {
+            path: Path::new("/tmp/repo").to_path_buf(),
+            base_branch: "main".to_string(),
+            remote_url: "file://localhost".to_string(),
+        },
+        issue: issue.clone(),
+        claim,
+        run_id: run_id.to_string(),
+        worktree: wt,
+        result: FinalizeRequest {
+            issue: issue.key.clone(),
+            branch_name,
+            worktree_path: Path::new("/tmp/wt").to_path_buf(),
+        },
+    }
+}
+
+fn client_for(gh: &MockGitHub) -> Client {
+    let state_dir = tempfile::tempdir().expect("state");
+    let mut cfg = empty_config(state_dir.path());
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    Client::with_config(&cfg).expect("client")
+}
+
+#[tokio::test]
+async fn pr_number_reaches_queue_entry_after_pr_creation() {
+    let gh = MockGitHub::start().await;
+
+    // No existing open PR: empty list response.
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls"))
+        .and(query_param("state", "open"))
+        .and(query_param("head", "owner:automation/issue-1"))
+        .and(query_param("base", "main"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<serde_json::Value>::new()))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+
+    // GitHub creates the PR and returns its number.
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/pulls"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "number": EXPECTED_PR_NUMBER,
+            "html_url": format!("https://github.com/owner/repo/pull/{EXPECTED_PR_NUMBER}"),
+        })))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+
+    // Set up state store and claim a code ticket.
+    let root = tempdir("state");
+    let store = StateStore::open(&root).expect("open store");
+    let key = caduceus::issue::IssueKey {
+        owner: "owner".to_string(),
+        repo: "repo".to_string(),
+        number: 1,
+    };
+    store
+        .enqueue(&key, TicketType::Code, false)
+        .expect("enqueue");
+    let now = Utc::now();
+    let claimed = store
+        .acquire_next("RUN1", 1, now)
+        .expect("acquire")
+        .expect("claimed entry");
+
+    // Build the finalization context using the real claim token.
+    let cfg = empty_config(&root);
+    let issue = make_issue();
+    let mut ctx = make_context(&cfg, &issue, "RUN1");
+    ctx.claim = claimed.claim.clone();
+    ctx.client = Arc::new(client_for(&gh));
+
+    // Run the PR finalization pipeline.
+    let output = find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &make_worker_result())
+        .await
+        .expect("finalize");
+
+    // The output carries the PR number returned by GitHub.
+    assert_eq!(output.pr_number, Some(EXPECTED_PR_NUMBER));
+
+    // Persist the checkpoint as the daemon would at every call site.
+    let checkpoint = FinalizationCheckpoint {
+        run_id: "RUN1".to_string(),
+        branch_name: ctx.worktree.branch_name.clone(),
+        result_path: root.join("runs").join("RUN1.result.json"),
+        stage: FinalizationStage::PrCreated,
+        commit_oid: None,
+        pr_number: output.pr_number,
+        pr_url: output.pr_url,
+    };
+    store
+        .save_finalization(&claimed.claim, checkpoint)
+        .expect("save finalization");
+
+    // The queue entry now records the PR number.
+    let snap = store.snapshot().expect("snapshot");
+    let entry = snap.entry(&key).expect("entry present");
+    assert_eq!(entry.phase, Phase::InProgress, "phase unchanged by save");
+    let finalization = entry
+        .finalization
+        .as_ref()
+        .expect("finalization checkpoint persisted");
+    assert_eq!(finalization.pr_number, Some(EXPECTED_PR_NUMBER));
+}


### PR DESCRIPTION
Closes #89

## Root cause

Successful PRs stayed stuck in `Phase::AwaitingReview` forever because
`find_or_create_pr_and_finalize` computed the GitHub PR number but never
exposed it on its returned `FinalizeOutput`, and every production call
site discarded the entire `FinalizeOutput` with `.await?`. Three coupled
defects:

1. `FinalizeOutput` (src/finalize/voice.rs) lacked a `pr_number` field.
2. `find_or_create_pr_and_finalize` (src/finalize/pr.rs:136) populated the
   PR number internally but only returned `pr_url`.
3. All four production call sites
   (`src/daemon/tick/resume.rs:208/231/252/333`) discarded the returned
   value with `.await?` and never called `StateStore::save_finalization`.

The awaiting-review poller
(`src/daemon/tick/awaiting_review.rs:55-60`) correctly filters on
`finalization.pr_number.is_some()`, but no path ever wrote that field.

## Fix

Three work-unit commits:

1. **`test(finalize): assert pr_number persisted onto queue entry`** (30778a0)
   — adds `tests/integration/finalize_pr_number_test.rs` that drives
   `find_or_create_pr_and_finalize` against a mock GitHub, persists the
   checkpoint via `StateStore::save_finalization`, and asserts the queue
   entry carries the PR number.

2. **`feat(finalize): carry PR number in FinalizeOutput`** (5cccee1)
   — adds `pr_number: Option<u64>` to `FinalizeOutput` and populates it
   in `find_or_create_pr_and_finalize`. Updates every other
   `FinalizeOutput` literal to default to `pr_number: None`.

3. **`fix(daemon): persist finalization checkpoint at every PR site`** (d7e290b)
   — binds the returned `FinalizeOutput` at all four production call sites
   (`run_resume_finalization` ResultValidated/Committed/Pushed and
   `run_code_finalize` Pushed→PrCreated) and calls
   `StateStore::save_finalization` with a `FinalizationCheckpoint`
   carrying the PR number and URL. Renames `_store` → `store` on
   `run_resume_finalization` so the body can call it.

## Grep audit (mandatory)

Every `find_or_create_pr_and_finalize` site in `src/`:

- `src/finalize/pr.rs:136` — definition (unchanged).
- `src/daemon/tick/{mod,resume,awaiting_review,per_claim}.rs` lines 50/15/15/15 — imports only (no calls).
- `src/daemon/tick/resume.rs:208/231/252/333` — all four production call sites; each now binds `pr_output` and calls `store.save_finalization(...)`. None silently discard the PR number.

## Verification

- `cargo fmt --check` — clean.
- `cargo clippy --locked --all-targets -- -D warnings` — clean.
- `cargo test --locked --lib` — 114 passed; 0 failed (matches baseline).
- `cargo test --locked --test finalize_pr_number_test` — 1 passed; 0 failed.
- `cargo test --locked --test state_store_test` — 27 passed; 0 failed.
- `cargo test --locked --test integration_scenarios` — 11 passed; 0 failed.
- `cargo test --locked --test integration_test` — 5 passed; 0 failed.
- `cargo test --locked --all-targets` — 4 `hermes_lifecycle` tests fail with
  240s parallel-timeout (test_ac04, ac06, ac07, ac08). This is
  PRE-EXISTING on clean main and unrelated to this PR.

## Out of scope

- `src/state/checkpoints.rs` (#90).
- `src/daemon/tick/awaiting_review.rs` — poller is correct; no edits.
- #97 cleanup (`#[allow(dead_code)]`, `use super::*`, inline test modules).

## Review

Per caduceus AGENTS.md, this PR requires human review and merge. The
supervising agent will merge after CI passes. Do not merge via automation.