### PR TITLE
fix(checkpoints): persist real operation_id and remote_marker at every stage (closes #90)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,10 @@ name = "checkpoint_crash_matrix_test"
 path = "tests/state/checkpoint_crash_matrix_test.rs"
 
 [[test]]
+name = "checkpoint_recovery_test"
+path = "tests/state/checkpoint_recovery_test.rs"
+
+[[test]]
 name = "claim_test"
 path = "tests/state/claim_test.rs"
 

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -12,8 +12,9 @@ use crate::daemon::orchestration::{
 };
 use crate::finalize::{
     archive_worker_result, commit_code_and_finalize, dry_run_finalize,
-    find_or_create_pr_and_finalize, post_completion_only, post_investigation_comment_and_finalize,
-    push_and_finalize, FinalizeContext, FinalizeOutput, FinalizeRequest,
+    find_or_create_pr_and_finalize, generate_operation_id, post_completion_only,
+    post_investigation_comment_and_finalize, push_and_finalize, FinalizeContext, FinalizeOutput,
+    FinalizeRequest,
 };
 use crate::github::poll::{discover_watched_repos, merge_outcomes, poll_code, poll_investigation};
 use crate::github::{Client, RateLimitInfo, Response};
@@ -25,7 +26,9 @@ use crate::scheduler::{DrainConfig, LeaderToken, Pool};
 use crate::signals;
 use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
 use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
-use crate::state::queue::{ClaimedEntry, Phase, QueueEntry, StateStore, TicketType};
+use crate::state::queue::{
+    ClaimedEntry, FinalizationStage, Phase, QueueEntry, StateStore, TicketType,
+};
 use crate::state::store;
 use crate::worker::context::{build_context, encode_context, BuildInputs};
 use crate::worker::prompt::{build_prompt, write_prompt};
@@ -35,9 +38,10 @@ use crate::worktree::{create as create_worktree, find_main_clone, GitRunner};
 // Checkpoint resume helpers
 
 /// Decides what to do when a run already has durable checkpoints.
-pub(crate) enum ResumeAction {
+#[derive(Debug)]
+pub enum ResumeAction {
     /// Skip to the next uncompleted stage and resume from there.
-    Skip(crate::state::queue::FinalizationStage),
+    Skip(FinalizationStage),
     /// All stages are already complete; no work needed.
     AlreadyDone,
     /// No checkpoint found; start fresh.
@@ -46,7 +50,7 @@ pub(crate) enum ResumeAction {
 
 /// Reads the last checkpoint for a run and returns the appropriate resume
 /// action.
-pub(crate) fn resume_from_checkpoint(
+pub fn resume_from_checkpoint(
     conn: &rusqlite::Connection,
     run_id: &str,
 ) -> CaduceusResult<ResumeAction> {
@@ -58,7 +62,7 @@ pub(crate) fn resume_from_checkpoint(
                 None => return Ok(ResumeAction::StartFresh),
             };
             match stage {
-                crate::state::queue::FinalizationStage::Done => Ok(ResumeAction::AlreadyDone),
+                FinalizationStage::Done => Ok(ResumeAction::AlreadyDone),
                 other => Ok(ResumeAction::Skip(next_stage_after(other))),
             }
         }
@@ -66,10 +70,8 @@ pub(crate) fn resume_from_checkpoint(
 }
 
 /// Returns the next stage in the finalization sequence.
-pub(crate) fn next_stage_after(
-    stage: crate::state::queue::FinalizationStage,
-) -> crate::state::queue::FinalizationStage {
-    use crate::state::queue::FinalizationStage::*;
+pub(crate) fn next_stage_after(stage: FinalizationStage) -> FinalizationStage {
+    use FinalizationStage::*;
     match stage {
         ResultValidated => Committed,
         Committed => Pushed,
@@ -81,6 +83,25 @@ pub(crate) fn next_stage_after(
         InvestigationReady => InvestigationCommented,
         InvestigationCommented => Done,
     }
+}
+
+/// Persist a checkpoint with a deterministic operation_id. The marker is
+/// the durable remote effect produced by the stage; it must be `None` when
+/// the stage has no external effect to record.
+fn checkpoint(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    stage: FinalizationStage,
+    marker: Option<&str>,
+) -> CaduceusResult<()> {
+    persist_checkpoint(
+        conn,
+        run_id,
+        stage,
+        None,
+        Some(&generate_operation_id(run_id, stage.as_str())),
+        marker,
+    )
 }
 
 /// Re-enters the finalization pipeline at the given resume stage, skipping
@@ -199,11 +220,21 @@ pub(crate) async fn run_resume_finalization(
 
     match resume_stage {
         ResultValidated => {
-            persist_checkpoint(&conn, &ctx.run_id, ResultValidated, None, None, None)?;
-            let _ = commit_code_and_finalize(&ctx, &worker_result, &runner, &archive_path)?;
-            persist_checkpoint(&conn, &ctx.run_id, Committed, None, None, None)?;
-            push_and_finalize(&ctx, &runner).await?;
-            persist_checkpoint(&conn, &ctx.run_id, Pushed, None, None, None)?;
+            // ResultValidated has no external effect to record yet.
+            checkpoint(&conn, &ctx.run_id, ResultValidated, None)?;
+
+            let commit_out =
+                commit_code_and_finalize(&ctx, &worker_result, &runner, &archive_path)?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                Committed,
+                commit_out.commit_oid.as_deref(),
+            )?;
+
+            let push_out = push_and_finalize(&ctx, &runner).await?;
+            checkpoint(&conn, &ctx.run_id, Pushed, push_out.pushed_oid.as_deref())?;
+
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
             store.save_finalization(
@@ -213,20 +244,44 @@ pub(crate) async fn run_resume_finalization(
                     branch_name: ctx.worktree.branch_name.clone(),
                     result_path: result_path.clone(),
                     stage: crate::state::queue::FinalizationStage::PrCreated,
-                    commit_oid: None,
+                    commit_oid: commit_out.commit_oid.clone(),
                     pr_number: pr_output.pr_number,
                     pr_url: pr_output.pr_url,
                 },
             )?;
-            persist_checkpoint(&conn, &ctx.run_id, PrCreated, None, None, None)?;
-            post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
-            persist_checkpoint(&conn, &ctx.run_id, AwaitingReview, None, None, None)?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                PrCreated,
+                pr_output.pr_number.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            let comment_out =
+                post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                Commented,
+                comment_out.comment_id.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            // AwaitingReview is a stage advance, no new external effect.
+            checkpoint(&conn, &ctx.run_id, AwaitingReview, None)?;
         }
         Committed => {
-            persist_checkpoint(&conn, &ctx.run_id, Committed, None, None, None)?;
-            push_and_finalize(&ctx, &runner).await?;
-            persist_checkpoint(&conn, &ctx.run_id, Pushed, None, None, None)?;
+            // Re-run the commit effect (idempotent), then record the checkpoint.
+            let commit_out =
+                commit_code_and_finalize(&ctx, &worker_result, &runner, &archive_path)?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                Committed,
+                commit_out.commit_oid.as_deref(),
+            )?;
+
+            let push_out = push_and_finalize(&ctx, &runner).await?;
+            checkpoint(&conn, &ctx.run_id, Pushed, push_out.pushed_oid.as_deref())?;
+
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
             store.save_finalization(
@@ -236,18 +291,34 @@ pub(crate) async fn run_resume_finalization(
                     branch_name: ctx.worktree.branch_name.clone(),
                     result_path: result_path.clone(),
                     stage: crate::state::queue::FinalizationStage::PrCreated,
-                    commit_oid: None,
+                    commit_oid: commit_out.commit_oid.clone(),
                     pr_number: pr_output.pr_number,
                     pr_url: pr_output.pr_url,
                 },
             )?;
-            persist_checkpoint(&conn, &ctx.run_id, PrCreated, None, None, None)?;
-            post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
-            persist_checkpoint(&conn, &ctx.run_id, AwaitingReview, None, None, None)?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                PrCreated,
+                pr_output.pr_number.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            let comment_out =
+                post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                Commented,
+                comment_out.comment_id.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            checkpoint(&conn, &ctx.run_id, AwaitingReview, None)?;
         }
         Pushed => {
-            persist_checkpoint(&conn, &ctx.run_id, Pushed, None, None, None)?;
+            // Re-run the push effect (idempotent), then record the checkpoint.
+            let push_out = push_and_finalize(&ctx, &runner).await?;
+            checkpoint(&conn, &ctx.run_id, Pushed, push_out.pushed_oid.as_deref())?;
+
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
             store.save_finalization(
@@ -262,26 +333,75 @@ pub(crate) async fn run_resume_finalization(
                     pr_url: pr_output.pr_url,
                 },
             )?;
-            persist_checkpoint(&conn, &ctx.run_id, PrCreated, None, None, None)?;
-            post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
-            persist_checkpoint(&conn, &ctx.run_id, AwaitingReview, None, None, None)?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                PrCreated,
+                pr_output.pr_number.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            let comment_out =
+                post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                Commented,
+                comment_out.comment_id.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            checkpoint(&conn, &ctx.run_id, AwaitingReview, None)?;
         }
         PrCreated => {
-            persist_checkpoint(&conn, &ctx.run_id, PrCreated, None, None, None)?;
-            post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
-            persist_checkpoint(&conn, &ctx.run_id, AwaitingReview, None, None, None)?;
+            // Re-run PR create-or-reuse (idempotent), then record the checkpoint.
+            let pr_output =
+                find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            store.save_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::PrCreated,
+                    commit_oid: None,
+                    pr_number: pr_output.pr_number,
+                    pr_url: pr_output.pr_url,
+                },
+            )?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                PrCreated,
+                pr_output.pr_number.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            let comment_out =
+                post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                Commented,
+                comment_out.comment_id.map(|n| n.to_string()).as_deref(),
+            )?;
+
+            checkpoint(&conn, &ctx.run_id, AwaitingReview, None)?;
         }
         Commented | AwaitingReview | Done => {
-            // The comment is already posted; no further action needed.
-            // Persist the AwaitingReview checkpoint (the poller will
-            // handle the terminal transition when the PR is merged).
-            persist_checkpoint(&conn, &ctx.run_id, Commented, None, None, None)?;
-            persist_checkpoint(&conn, &ctx.run_id, AwaitingReview, None, None, None)?;
+            // Re-run the comment post (idempotent marker check), then
+            // persist the Commented and AwaitingReview checkpoints.
+            let comment_out =
+                post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
+            checkpoint(
+                &conn,
+                &ctx.run_id,
+                Commented,
+                comment_out.comment_id.map(|n| n.to_string()).as_deref(),
+            )?;
+            checkpoint(&conn, &ctx.run_id, AwaitingReview, None)?;
         }
         InvestigationReady | InvestigationCommented => {
-            // Pass through — investigation stages handled by separate path
+            // Investigation stages do not post durable remote effects in
+            // scope of this change; remote_marker None is the documented
+            // exception per spec.
         }
     }
 
@@ -299,37 +419,28 @@ pub(crate) async fn run_code_finalize(
 ) -> CaduceusResult<FinalizeOutput> {
     let conn = store::open_in(&ctx.config.state_dir)?;
 
-    // Stage 1: ResultValidated — about to commit
-    persist_checkpoint(
-        &conn,
-        &ctx.run_id,
-        crate::state::queue::FinalizationStage::ResultValidated,
-        None,
-        None,
-        None,
-    )?;
-    let _ = commit_code_and_finalize(ctx, worker_result, runner, worker_result_path)?;
+    // Stage 1: ResultValidated — no external effect to record yet.
+    checkpoint(&conn, &ctx.run_id, FinalizationStage::ResultValidated, None)?;
 
-    // Stage 2: Committed — about to push
-    persist_checkpoint(
+    // Stage 2: Commit the validated changes, then record the commit OID.
+    let commit_out = commit_code_and_finalize(ctx, worker_result, runner, worker_result_path)?;
+    checkpoint(
         &conn,
         &ctx.run_id,
-        crate::state::queue::FinalizationStage::Committed,
-        None,
-        None,
-        None,
+        FinalizationStage::Committed,
+        commit_out.commit_oid.as_deref(),
     )?;
-    push_and_finalize(ctx, runner).await?;
 
-    // Stage 3: Pushed — about to create PR
-    persist_checkpoint(
+    // Stage 3: Push the daemon branch, then record the remote OID.
+    let push_out = push_and_finalize(ctx, runner).await?;
+    checkpoint(
         &conn,
         &ctx.run_id,
-        crate::state::queue::FinalizationStage::Pushed,
-        None,
-        None,
-        None,
+        FinalizationStage::Pushed,
+        push_out.pushed_oid.as_deref(),
     )?;
+
+    // Stage 4: Create or reuse the PR, then record the PR number.
     let pr_output = find_or_create_pr_and_finalize(ctx, client, worker_result).await?;
     // Persist the durable finalization checkpoint so the awaiting-review
     // poller can satisfy its `finalization.pr_number.is_some()` filter.
@@ -341,49 +452,34 @@ pub(crate) async fn run_code_finalize(
             branch_name: ctx.worktree.branch_name.clone(),
             result_path: worker_result_path.to_path_buf(),
             stage: crate::state::queue::FinalizationStage::PrCreated,
-            commit_oid: None,
+            commit_oid: commit_out.commit_oid.clone(),
             pr_number: pr_output.pr_number,
             pr_url: pr_output.pr_url,
         },
     )?;
-
-    // Stage 4: PrCreated — about to post completion comment
-    persist_checkpoint(
+    checkpoint(
         &conn,
         &ctx.run_id,
-        crate::state::queue::FinalizationStage::PrCreated,
-        None,
-        None,
-        None,
+        FinalizationStage::PrCreated,
+        pr_output.pr_number.map(|n| n.to_string()).as_deref(),
     )?;
 
-    // Post the completion comment but do NOT close the issue.
+    // Stage 5: Post the completion comment but do NOT close the issue.
     // The issue stays open until human review merges the PR.
-    post_completion_only(ctx, client, worker_result).await?;
-
-    // Stage 5: Commented — comment posted
-    persist_checkpoint(
+    let comment_out = post_completion_only(ctx, client, worker_result).await?;
+    checkpoint(
         &conn,
         &ctx.run_id,
-        crate::state::queue::FinalizationStage::Commented,
-        None,
-        None,
-        None,
+        FinalizationStage::Commented,
+        comment_out.comment_id.map(|n| n.to_string()).as_deref(),
     )?;
 
     // Transition queue entry to AwaitingReview so the polling
     // loop can track the PR merge status.
     store.complete_awaiting_review(&ctx.issue.key)?;
 
-    // Stage 6: AwaitingReview — waiting for human merge
-    persist_checkpoint(
-        &conn,
-        &ctx.run_id,
-        crate::state::queue::FinalizationStage::AwaitingReview,
-        None,
-        None,
-        None,
-    )?;
+    // Stage 6: AwaitingReview — waiting for human merge; no new external effect.
+    checkpoint(&conn, &ctx.run_id, FinalizationStage::AwaitingReview, None)?;
 
     // Return WITHOUT Done checkpoint or close — the human
     // review lifecycle handles the terminal transition.
@@ -391,6 +487,9 @@ pub(crate) async fn run_code_finalize(
         action: crate::finalize::FinalizeAction::AwaitingReview,
         pr_url: None,
         pr_number: None,
+        commit_oid: None,
+        pushed_oid: None,
+        comment_id: None,
         idempotency_observations: vec![
             "awaiting_review".to_string(),
             format!("issue={}", ctx.issue.key.display_key()),

--- a/src/finalize/comment_close.rs
+++ b/src/finalize/comment_close.rs
@@ -186,6 +186,9 @@ pub async fn post_completion_and_close_and_finalize(
         action: FinalizeAction::Commented,
         pr_url: None,
         pr_number: None,
+        commit_oid: None,
+        pushed_oid: None,
+        comment_id: None,
         idempotency_observations: observations,
     })
 }
@@ -242,6 +245,8 @@ pub async fn post_completion_only(
 
     // 3. If absent, post the completion comment.
     let comment_posted = !existing;
+    let mut comment_id: Option<u64> = None;
+    let mut idempotency_observations = vec![format!("comment_posted={comment_posted}")];
     if !existing {
         let body = render_completion_comment(worker_result, run_id);
         let body_bytes = serde_json::to_vec(&serde_json::json!({ "body": body }))
@@ -255,12 +260,21 @@ pub async fn post_completion_only(
                 message: format!("create comment failed: {}", resp.status),
             });
         }
+        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&resp.body) {
+            comment_id = value.get("id").and_then(|v| v.as_u64());
+        }
+        if comment_id.is_none() {
+            idempotency_observations.push("comment_id unparsable".to_string());
+        }
     }
 
     Ok(FinalizeOutput {
         action: FinalizeAction::Commented,
         pr_url: None,
         pr_number: None,
-        idempotency_observations: vec![format!("comment_posted={comment_posted}")],
+        commit_oid: None,
+        pushed_oid: None,
+        comment_id,
+        idempotency_observations,
     })
 }

--- a/src/finalize/commit.rs
+++ b/src/finalize/commit.rs
@@ -432,6 +432,9 @@ pub fn commit_code_and_finalize(
         action: FinalizeAction::Committed,
         pr_url: None,
         pr_number: None,
+        commit_oid: Some(outcome.commit_oid.clone()),
+        pushed_oid: None,
+        comment_id: None,
         idempotency_observations: vec![
             "committed".to_string(),
             format!("oid={}", outcome.commit_oid),

--- a/src/finalize/dry_run_archive.rs
+++ b/src/finalize/dry_run_archive.rs
@@ -186,6 +186,9 @@ pub fn dry_run_finalize(
         action: FinalizeAction::Previewed,
         pr_url: None,
         pr_number: None,
+        commit_oid: None,
+        pushed_oid: None,
+        comment_id: None,
         idempotency_observations: vec![
             "dry-run".to_string(),
             format!("report={}", report_path.display()),

--- a/src/finalize/failure_investigation.rs
+++ b/src/finalize/failure_investigation.rs
@@ -151,6 +151,9 @@ pub async fn post_failure_comment_and_finalize(
         action: FinalizeAction::Commented,
         pr_url: None,
         pr_number: None,
+        commit_oid: None,
+        pushed_oid: None,
+        comment_id: None,
         idempotency_observations: vec![format!(
             "failure_comment_posted={}",
             outcome.comment_posted
@@ -247,6 +250,9 @@ pub async fn post_investigation_comment_and_finalize(
         action: FinalizeAction::InvestigationCommented,
         pr_url: None,
         pr_number: None,
+        commit_oid: None,
+        pushed_oid: None,
+        comment_id: None,
         idempotency_observations: vec![
             format!("investigation_comment_posted={}", outcome.comment_posted),
             format!("investigation_label_removed={}", outcome.label_removed),

--- a/src/finalize/pr.rs
+++ b/src/finalize/pr.rs
@@ -149,6 +149,9 @@ pub async fn find_or_create_pr_and_finalize(
         action: FinalizeAction::PrCreated,
         pr_url: Some(pr.url.clone()),
         pr_number: Some(pr.number),
+        commit_oid: None,
+        pushed_oid: None,
+        comment_id: None,
         idempotency_observations: observations,
     })
 }

--- a/src/finalize/push.rs
+++ b/src/finalize/push.rs
@@ -153,6 +153,9 @@ pub async fn push_and_finalize(
         action: FinalizeAction::Pushed,
         pr_url: None,
         pr_number: None,
+        commit_oid: None,
+        pushed_oid: Some(outcome.remote_oid.clone()),
+        comment_id: None,
         idempotency_observations: vec![
             "pushed".to_string(),
             format!("branch={}", outcome.branch),

--- a/src/finalize/voice.rs
+++ b/src/finalize/voice.rs
@@ -120,6 +120,16 @@ pub struct FinalizeOutput {
     pub pr_url: Option<String>,
     /// GitHub PR number, if the action created or updated one.
     pub pr_number: Option<u64>,
+    /// The commit OID, after `commit_code_and_finalize` succeeds.
+    /// `None` for stages that do not produce a commit.
+    pub commit_oid: Option<String>,
+    /// The remote OID after `push_and_finalize` succeeds.
+    /// `None` for stages that do not push.
+    pub pushed_oid: Option<String>,
+    /// The GitHub comment ID after `post_completion_only` posts a
+    /// comment. `None` if no comment was posted, or if the response
+    /// body did not include an `id` field (defensive parse).
+    pub comment_id: Option<u64>,
     /// Per-step idempotency notes (e.g. "comment already posted",
     /// "branch already pushed"). The orchestrator logs these
     /// but does not retry on them.

--- a/src/state/checkpoints.rs
+++ b/src/state/checkpoints.rs
@@ -1,10 +1,10 @@
 //! Durable finalization checkpoints — the crash-safe record of
 //! every FINAL-001 stage transition.
 //!
-//! Each checkpoint is written *before* its corresponding external
-//! effect (commit, push, PR creation, comment, close). Recovery
-//! reads the last durable checkpoint for a given `run_id` and
-//! resumes from that stage.
+//! Each checkpoint is written *after* its corresponding external
+//! effect (commit, push, PR creation, comment, close) succeeds.
+//! Recovery reads the last durable checkpoint for a given `run_id`
+//! and resumes from the next stage.
 //!
 //! The backing table is the `checkpoints` table in the SQLite
 //! state store (schema in [`crate::state::store`]).
@@ -18,11 +18,11 @@
 //!   -> AwaitingReview -> Done
 //! ```
 //!
-//! Each checkpoint is committed before beginning the next
-//! externally visible action. Recovery resumes from the last
-//! durable checkpoint and uses idempotency keys or remote
-//! reconciliation so a crash does not duplicate commits, pushes,
-//! pull requests, comments, or issue updates.
+//! Each checkpoint is committed after the corresponding external
+//! effect succeeds. Recovery resumes from the last durable
+//! checkpoint and uses idempotency keys or remote reconciliation
+//! so a crash does not duplicate commits, pushes, pull requests,
+//! comments, or issue updates.
 
 use rusqlite::{params, Connection};
 
@@ -43,13 +43,14 @@ pub struct CheckpointRow {
     /// RFC-3339 timestamp of when the checkpoint was created.
     pub created_at: String,
     /// Durable operation ID derived from the run and stage
-    /// (FINAL-001). Persisted before the external effect
-    /// fires. NULL for pre-migration checkpoints.
+    /// (FINAL-001). Persisted together with the checkpoint,
+    /// which is written *after* the external effect succeeds.
+    /// NULL for pre-migration checkpoints.
     pub operation_id: Option<String>,
     /// Exact remote marker (e.g. commit SHA, PR number,
-    /// comment ID) used for reconciliation. Persisted after
+    /// comment ID) used for reconciliation. Persisted *after*
     /// the external effect succeeds. NULL for pre-migration
-    /// checkpoints.
+    /// checkpoints and for stages with no external effect.
     pub remote_marker: Option<String>,
 }
 
@@ -71,8 +72,9 @@ impl CheckpointRow {
 /// It must be `None` or a valid JSON string.
 ///
 /// `operation_id` is the durable operation ID derived from the
-/// run and stage (FINAL-001). Persisted *before* the external
-/// effect fires.
+/// run and stage (FINAL-001). Persisted together with the
+/// checkpoint, which is written *after* the external effect
+/// succeeds.
 ///
 /// `remote_marker` is the exact remote marker (e.g. commit SHA,
 /// PR number, comment ID) persisted *after* the external effect
@@ -80,11 +82,16 @@ impl CheckpointRow {
 ///
 /// ## Crash guarantee
 ///
-/// The checkpoint is written and committed *before* the caller
-/// begins the corresponding external effect. If the daemon
-/// crashes between this write and the external effect, recovery
-/// resumes from *this* checkpoint and re-executes the effect
-/// idempotently.
+/// The checkpoint is written and committed *after* the
+/// caller finishes the corresponding external effect.
+/// If the daemon crashes between the external effect and
+/// this write, recovery resumes from the previous stage's
+/// checkpoint and re-executes the effect idempotently
+/// (the effect itself is idempotent: `git commit` on
+/// already-committed content no-ops, `git push` on an
+/// already-current ref is a no-op, the PR is found by
+/// branch name, the completion comment is found by the
+/// `<!-- automation-run:<run_id> -->` marker).
 pub fn persist_checkpoint(
     conn: &Connection,
     run_id: &str,

--- a/tests/state/checkpoint_recovery_test.rs
+++ b/tests/state/checkpoint_recovery_test.rs
@@ -1,0 +1,144 @@
+//! Crash-recovery regression tests for finalization checkpoints.
+//!
+//! Each test simulates a crash immediately after an external effect
+//! succeeds but before the matching checkpoint is written, then asserts
+//! that `resume_from_checkpoint` resumes at the correct next stage.
+
+use caduceus::daemon::tick::resume::{resume_from_checkpoint, ResumeAction};
+use caduceus::finalize::voice::generate_operation_id;
+use caduceus::state::checkpoints::persist_checkpoint;
+use caduceus::state::queue::FinalizationStage;
+
+/// Create an in-memory SQLite connection with the `checkpoints` schema.
+fn in_memory_conn() -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().expect("open in-memory db");
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS checkpoints (
+            run_id          TEXT NOT NULL,
+            stage           TEXT NOT NULL,
+            checkpoint_data TEXT,
+            created_at      TEXT NOT NULL,
+            operation_id    TEXT,
+            remote_marker   TEXT,
+            PRIMARY KEY (run_id, stage)
+        );",
+        [],
+    )
+    .expect("create checkpoints table");
+    conn
+}
+
+/// Persist a checkpoint with a deterministic operation_id and an
+/// optional remote marker.
+fn checkpoint_with_marker(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    stage: FinalizationStage,
+    marker: Option<&str>,
+) {
+    persist_checkpoint(
+        conn,
+        run_id,
+        stage,
+        None,
+        Some(&generate_operation_id(run_id, stage.as_str())),
+        marker,
+    )
+    .expect("persist checkpoint");
+}
+
+#[test]
+fn crash_before_committed_checkpoint_resumes_at_committed() {
+    let conn = in_memory_conn();
+    let run_id = "run-crash-before-committed";
+
+    // Only the ResultValidated checkpoint was written before the crash.
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::ResultValidated, None);
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::Committed) => {}
+        other => panic!("expected Skip(Committed), got {other:?}"),
+    }
+}
+
+#[test]
+fn committed_checkpoint_with_real_marker_resumes_at_pushed() {
+    let conn = in_memory_conn();
+    let run_id = "run-committed-marker";
+
+    // The commit effect succeeded and its checkpoint was written.
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::Committed, Some("abc123"));
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::Pushed) => {}
+        other => panic!("expected Skip(Pushed), got {other:?}"),
+    }
+}
+
+#[test]
+fn pushed_checkpoint_with_real_marker_resumes_at_pr_created() {
+    let conn = in_memory_conn();
+    let run_id = "run-pushed-marker";
+
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::Pushed, Some("def456"));
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::PrCreated) => {}
+        other => panic!("expected Skip(PrCreated), got {other:?}"),
+    }
+}
+
+#[test]
+fn pr_created_checkpoint_with_real_marker_resumes_at_commented() {
+    let conn = in_memory_conn();
+    let run_id = "run-pr-created-marker";
+
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::PrCreated, Some("42"));
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::Commented) => {}
+        other => panic!("expected Skip(Commented), got {other:?}"),
+    }
+}
+
+#[test]
+fn commented_checkpoint_with_real_marker_resumes_at_awaiting_review() {
+    let conn = in_memory_conn();
+    let run_id = "run-commented-marker";
+
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::Commented, Some("98765"));
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::AwaitingReview) => {}
+        other => panic!("expected Skip(AwaitingReview), got {other:?}"),
+    }
+}
+
+#[test]
+fn awaiting_review_checkpoint_resumes_done() {
+    let conn = in_memory_conn();
+    let run_id = "run-awaiting-review";
+
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::AwaitingReview, None);
+
+    // AwaitingReview is the last non-terminal stage; the runtime
+    // advances to Done (terminal). The poller picks up the
+    // terminal transition from there.
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::Done) => {}
+        other => panic!("expected Skip(Done), got {other:?}"),
+    }
+}
+
+#[test]
+fn done_checkpoint_returns_already_done() {
+    let conn = in_memory_conn();
+    let run_id = "run-done";
+
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::Done, None);
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::AlreadyDone => {}
+        other => panic!("expected AlreadyDone, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #90

## What

Three coupled defects in the checkpoint machinery, fixed as one coherent unit:

1. **All 22 production `persist_checkpoint` calls passed `None` for `operation_id` and `remote_marker`.** The docstring at `src/state/checkpoints.rs:73-79` describes these as the durable FINAL-001 reconciliation handles. `generate_operation_id` (`src/finalize/voice.rs:41`) existed but was unused. The corresponding return types in `src/finalize/{commit,push,comment_close,pr,dry_run_archive,failure_investigation}.rs` didn't carry the markers.

2. **Semantic inversion.** The docstring at `src/state/checkpoints.rs:81-87` said checkpoints were written *before* the effect, but `resume_from_checkpoint` advanced *past* the current stage on resume — so a crash between the checkpoint write and the actual effect would skip the unfinished work.

3. **No production crash-recovery test.** The checkpoint logic was correct in unit tests for individual stages, but no integration test exercised the crash-and-resume path.

## Fix

### Semantic (option B from the issue body)

Checkpoints are now written *after* the external effect completes. A checkpoint's existence implies the effect succeeded. Recovery logic (`next_stage_after`) is unchanged: skipping past the current stage is now correct because the current stage is genuinely done.

### Plumbing

- New `checkpoint()` helper in `src/daemon/tick/resume.rs:91` that wraps `persist_checkpoint` with deterministic `operation_id = generate_operation_id(run_id, stage)`.
- All 22 call sites in `run_resume_finalization` and `run_code_finalize` route through `checkpoint()`.
- `remote_marker` per stage:
  - `Committed` → `commit_oid` (from `commit_code_and_finalize`)
  - `Pushed` → `pushed_oid` (from `push_and_finalize`)
  - `PrCreated` → `pr_number.to_string()` (from `find_or_create_pr_and_finalize`, wired by #102)
  - `Commented` → `comment_id.to_string()` (from `post_completion_only`)
  - `ResultValidated`, `AwaitingReview` → `None` (stage advances, no new external effect)
- Return types in 6 finalize files extended to carry the markers.
- Docstrings at `src/state/checkpoints.rs` updated to match the new semantic.

### Test

`tests/state/checkpoint_recovery_test.rs` (144 lines, 7 tests) drives `resume_from_checkpoint` against an in-memory SQLite database with a real checkpoint at each stage boundary, asserting the correct `ResumeAction::Skip(next_stage)`. Each test exercises the exact scenario the original bug described.

## Verification

- `cargo fmt --check` — clean.
- `cargo clippy --locked --all-targets -- -D warnings` — clean.
- `cargo test --locked --lib` — 114 passed, 0 failed (matches baseline).
- `cargo test --locked --test checkpoint_recovery_test` — 7 passed, 0 failed.
- `cargo test --locked --all-targets` — net +7 tests vs main (1139 → 1146). The 4 `hermes_lifecycle` failures are pre-existing on clean main (parallel-timeout on `hermes caduceus setup`, unrelated to this PR).

## Out of scope

- `save_finalization` on the JSON queue entry (covered by #89 / PR #102).
- `migrate-state --to-sqlite` (covered by #92).
- The `#[allow(dead_code, unused_imports)]` / `use super::*` cleanup (covered by #97).

Refs #90