### PR TITLE
fix(scheduler): hold admission guard for run_claim lifetime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ name = "pool_test"
 path = "tests/scheduler/pool_test.rs"
 
 [[test]]
+name = "admission_guard_test"
+path = "tests/scheduler/admission_guard_test.rs"
+
+[[test]]
 name = "circuit_test"
 path = "tests/scheduler/circuit_test.rs"
 

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -56,7 +56,7 @@ use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::logging;
 use crate::scheduler::circuit::{AdmissionResult, CircuitConfig, CircuitStore};
-use crate::scheduler::{DrainConfig, LeaderToken, Pool};
+use crate::scheduler::{Admission, DrainConfig, LeaderToken, Pool};
 use crate::signals;
 use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
 use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
@@ -357,21 +357,24 @@ pub async fn tick(
     //  global concurrency and per-repo exclusion before any
     //  setup or worker dispatch occurs.
     let repo_key = format!("{}/{}", claimed.entry.key.owner, claimed.entry.key.repo);
-    if let Err(err) = pool.admit(&repo_key).await {
-        // PoolSaturated is an infrastructure failure; requeue with
-        // backoff and surface as NeedsAttention.
-        let log_path = state_dir.join("processor.log");
-        let mut guard = ActiveRunGuard::new(
-            claimed.claim.clone(),
-            Arc::clone(&store),
-            log_path,
-            claimed.entry.key.clone(),
-        );
-        let class = classify_error(&err);
-        let outcome = handle_infra_or_retry(cfg, &mut guard, &err, class).await?;
-        finish_tick_outcome(&gate, &meta, now, outcome, None, Some(&err))?;
-        return Ok(outcome);
-    }
+    let admit = match pool.admit(&repo_key).await {
+        Ok(a) => a,
+        Err(err) => {
+            // PoolSaturated is an infrastructure failure; requeue with
+            // backoff and surface as NeedsAttention.
+            let log_path = state_dir.join("processor.log");
+            let mut guard = ActiveRunGuard::new(
+                claimed.claim.clone(),
+                Arc::clone(&store),
+                log_path,
+                claimed.entry.key.clone(),
+            );
+            let class = classify_error(&err);
+            let outcome = handle_infra_or_retry(cfg, &mut guard, &err, class).await?;
+            finish_tick_outcome(&gate, &meta, now, outcome, None, Some(&err))?;
+            return Ok(outcome);
+        }
+    };
 
     // 7. Build the guard and run the work, finalization, and
     //  teardown phases inside one explicit cleanup scope.
@@ -387,6 +390,7 @@ pub async fn tick(
         cfg,
         &services,
         Arc::clone(&pool),
+        admit,
         store.as_ref(),
         &meta,
         client,

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -21,7 +21,7 @@ use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::logging;
 use crate::scheduler::circuit::{AdmissionResult, CircuitConfig, CircuitStore};
-use crate::scheduler::{DrainConfig, LeaderToken, Pool};
+use crate::scheduler::{Admission, DrainConfig, LeaderToken, Pool};
 use crate::signals;
 use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
 use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
@@ -41,6 +41,7 @@ pub(crate) async fn run_claim(
     cfg: Config,
     services: &Services,
     _pool: Arc<Pool>,
+    _admit: Admission,
     store: &StateStore,
     _meta: &MetaStore,
     client: Arc<Client>,

--- a/tests/scheduler/admission_guard_test.rs
+++ b/tests/scheduler/admission_guard_test.rs
@@ -1,0 +1,57 @@
+//! Regression tests for the bounded-concurrency admission guard.
+//!
+//! These tests exercise the `Pool::admit` contract directly and
+//! complement the binding fix in `src/daemon/tick/mod.rs` by
+//! documenting the cap and capacity-restoration semantics.
+
+use std::time::Duration;
+
+use caduceus::scheduler::{DrainConfig, Pool, PoolState};
+
+fn drain_config() -> DrainConfig {
+    DrainConfig::from_seconds_and_ms(5, 100) // 5s drain, 100ms backpressure
+}
+
+#[tokio::test]
+async fn admission_guard_enforces_parallelism_cap() {
+    // GIVEN worker_parallelism = 2 and two slots are already held
+    let pool = Pool::new(2, drain_config());
+    let _admit_a = pool.admit("owner/repo-a").await.unwrap();
+    let _admit_b = pool.admit("owner/repo-b").await.unwrap();
+
+    // THEN the pool reports itself as saturated
+    assert_eq!(pool.state(), PoolState::Saturated);
+
+    // AND a third admit on a distinct repo is rejected with the
+    // expected saturation error.
+    let err = pool.admit("owner/repo-c").await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            caduceus::CaduceusError::PoolSaturated {
+                current_depth: 2,
+                max_depth: 2,
+            }
+        ),
+        "expected PoolSaturated {{ current_depth: 2, max_depth: 2 }}, got {err}"
+    );
+}
+
+#[tokio::test]
+async fn admission_guard_restores_capacity_on_drop() {
+    // GIVEN worker_parallelism = 2 and two slots are held
+    let pool = Pool::new(2, drain_config());
+    let admit_a = pool.admit("owner/repo-a").await.unwrap();
+    let admit_b = pool.admit("owner/repo-b").await.unwrap();
+    assert_eq!(pool.state(), PoolState::Saturated);
+
+    // WHEN the first admission is dropped
+    drop(admit_a);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(pool.state(), PoolState::Active(1));
+
+    // WHEN the second admission is dropped
+    drop(admit_b);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(pool.state(), PoolState::Idle);
+}


### PR DESCRIPTION
Closes #91

## What

The documented "bounded concurrency" feature in `CHANGELOG.md` (lines 24-26) was a no-op. The `Admission` value returned by `pool.admit()` at `src/daemon/tick/mod.rs:360` was consumed by `if let Err(err)` and dropped at the closing brace. The semaphore permit and per-repo exclusion lock were released before `run_claim` started, so the daemon could dispatch arbitrarily many workers in parallel despite the contract.

## Fix

Plumb the `Admission::Admitted { _permit, _exclusion }` value through `run_claim` as a new `_admit: Admission` parameter, held only for its `Drop` side-effect. The guard's `Drop` now runs at function exit (success, error, or panic — RAII), enforcing the contract the CHANGELOG already promises.

### Diff

```
 Cargo.toml                              |  4 +++
 src/daemon/tick/mod.rs                  | 36 ++++++++++++---------
 src/daemon/tick/per_claim.rs            |  3 +-
 tests/scheduler/admission_guard_test.rs | 57 +++++++++++++++++++++++++++++++++
 4 files changed, 83 insertions(+), 17 deletions(-)
```

- `src/daemon/tick/mod.rs`: replaced `if let Err(err) = pool.admit(...)` with `let admit = match pool.admit(...) { Ok(a) => a, Err(err) => { /* same infra/retry body */ } };`. The Ok value is bound to a local named `admit` and passed into `run_claim`.
- `src/daemon/tick/per_claim.rs`: `run_claim` signature gains `_admit: Admission` parameter right after `_pool: Arc<Pool>`. Function body unchanged.
- `tests/scheduler/admission_guard_test.rs` (NEW): 2 `#[tokio::test]` cases proving the cap is enforced.
- `Cargo.toml`: registers the new test binary (matches the existing convention used by `pool_test`, `circuit_test`, etc.).

## Test Results

```
cargo fmt --check                                              → exit 0, clean
cargo clippy --locked --all-targets -- -D warnings             → exit 0, no warnings
cargo test --locked --lib                                      → 114 passed, 0 failed
scheduler/daemon integration tests (11 binaries)              → 63 passed, 0 failed
  - admission_guard_test: 2 passed (NEW)
  - pool_test: 6 passed
  - circuit_test: 5 passed
  - circuit_dispatch_test: 5 passed
  - drain_test: 4 passed
  - scheduler_leadership_test: 5 passed
  - scheduler_leases_test: 7 passed
  - daemon_lock_test: 9 passed
  - tick_test: 15 passed
  - tick_dispatch_test: 1 passed
  - failure_separation_test: 4 passed
```

`hermes_lifecycle_test` was excluded from the local gate (10-30 min subprocess test); CI will exercise it.

## Class-Bug Scope Audit

`grep -rn "pool.admit\|run_claim" src/ tests/` — all 28 results correctly scoped:

- `src/daemon/tick/mod.rs:360` (match block): Ok arm captures `admit`.
- `src/daemon/tick/mod.rs:389` (`run_claim` call): `admit` passed as parameter.
- `src/daemon/tick/per_claim.rs:40` (`run_claim` definition): `_admit: Admission` parameter present.
- All test sites hold the returned `Admission` for the test scope (pre-existing pattern, correct).

No silent drops. No scope violations.

## Out of Scope (Explicit Non-Goals)

This PR fixes defect 1 only. The following are intentionally NOT addressed and remain follow-ups:

- **Defect 2**: `src/daemon/tick/mod.rs:386` calls `run_claim(...)` synchronously. There is no `JoinSet`, no claim loop, no task collection. Each tick processes exactly one entry, so even with the guard held, there is nothing to bound within a single tick. Multi-entry parallelism is a separate effort.
- **Defect 3**: The in-memory `Pool` cannot enforce host-wide concurrency because each cron invocation spawns a fresh `caduceus run` process. The `src/scheduler/leases.rs` module exists for cross-process fencing but the production orchestration does not acquire leases. Cross-process enforcement is a separate effort.

## Regression Test Design

The new `tests/scheduler/admission_guard_test.rs` exercises `Pool` directly (matching the `pool_test.rs` precedent) rather than calling `run_claim`. Two cases:

1. `admission_guard_enforces_parallelism_cap` — `Pool::new(2, ...)`, hold 2 admissions, assert the 3rd `pool.admit(...).await` returns `Err(CaduceusError::PoolSaturated { current_depth: 2, max_depth: 2 })`.
2. `admission_guard_restores_capacity_on_drop` — hold 2 admissions, drop one at a time, assert `pool.state()` transitions `Saturated → Active(1) → Idle`.

Note: this test passes both before and after the fix because `Pool` itself correctly enforces the cap. The test exists as regression coverage of the API contract; the binding bug at `mod.rs:360` was verifiable only by code inspection at the call site.

## Cancellation Propagation

`_admit: Admission` is held on the async stack of `run_claim`. On any exit path (return, panic, cancellation token fire), Rust runs `Drop` as part of stack unwinding — both the semaphore permit and the per-repo exclusion lock are released. This is idiomatic RAII; no explicit test was added because the behavior follows from the language semantics.

## Reviewer Notes

- The match arm at `src/daemon/tick/mod.rs:360-381` reproduces the original `if let Err` body verbatim. The only structural change is the addition of an `Ok(a) => a` arm.
- `_admit` is underscore-prefixed per Rust convention for "guard held for side-effect only."
- The author convention matches the in-tree commit history: `Barkley Assistant <barkleyassistant@gmail.com>`.
- No `Co-authored-by` lines per the project's `AGENTS.md`.

Refs: #91