### PR TITLE
feat(scheduler): enforce worker_parallelism host-wide via lease store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
       - name: clippy
         run: cargo clippy --locked --all-targets -- -D warnings
       - name: test
+        # hermes_lifecycle tests (ac04/ac06/ac07/ac08) each shell out to
+        # `hermes caduceus setup` which takes 2-3 minutes to compile the
+        # release binary; running four of them in parallel saturates the
+        # 240s per-test timeout. Allow up to 15 minutes for the test step.
+        timeout-minutes: 15
         run: cargo test --locked --all-targets
 
   python:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,10 @@ name = "scheduler_leases_test"
 path = "tests/scheduler/scheduler_leases_test.rs"
 
 [[test]]
+name = "cross_process_lease_test"
+path = "tests/scheduler/cross_process_lease_test.rs"
+
+[[test]]
 name = "api_base_allowlist_test"
 path = "tests/state/api_base_allowlist_test.rs"
 

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -106,10 +106,26 @@ pub fn run_blocking(cfg: Config) -> CaduceusResult<TickOutcome> {
         .build()
         .map_err(|err| CaduceusError::Other(format!("build tokio runtime: {err}")))?;
     let cancellation = CancellationToken::new();
-    let pool = Arc::new(Pool::new(
-        cfg.worker_parallelism,
-        DrainConfig::from_seconds_and_ms(cfg.drain_timeout_seconds, cfg.backpressure_budget_ms),
-    ));
+    // Open the host-wide lease store once per process. The pool
+    // consults this before granting a permit so overlapping cron
+    // ticks cannot exceed the configured `worker_parallelism`
+    // (issue #106 — closes the SCHED-001 "bounded single-host
+    // concurrency" contract gap). `LeaseStore::open` returns
+    // `CaduceusError::State(...)` on I/O failure, which surfaces as
+    // a non-zero exit per the CLI contract.
+    let lease_store = Arc::new(std::sync::Mutex::new(crate::scheduler::LeaseStore::open(
+        &cfg.state_dir,
+    )?));
+    let pool = Arc::new(
+        Pool::new(
+            cfg.worker_parallelism,
+            DrainConfig::from_seconds_and_ms(cfg.drain_timeout_seconds, cfg.backpressure_budget_ms),
+        )
+        .with_lease_store(
+            lease_store,
+            std::time::Duration::from_secs(cfg.worker_lease_ttl_seconds),
+        ),
+    );
     rt.block_on(async move {
         tokio::select! {
         outcome = run_with_config(cfg, Arc::clone(&pool), cancellation.clone()) => outcome,
@@ -390,8 +406,11 @@ pub async fn tick(
         // 6.3. Admit the entry to the worker pool. The pool's
         //      lazy, per-iteration acquire ensures
         //      `in_flight <= worker_parallelism` whenever the
-        //      dispatch loop pulls a new claim.
-        let admit = match pool.admit(&repo_key).await {
+        //      dispatch loop pulls a new claim. The lease store
+        //      wired into the pool at construction promotes the
+        //      "one worker per repo" contract from process-local
+        //      to host-wide (issue #106 / SCHED-001).
+        let admit = match pool.admit(&format!("repo:{repo_key}"), &repo_key).await {
             Ok(a) => a,
             Err(err) => {
                 // PoolSaturated / DrainTimeout is an

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -113,16 +113,15 @@ pub fn run_blocking(cfg: Config) -> CaduceusResult<TickOutcome> {
     // concurrency" contract gap). `LeaseStore::open` returns
     // `CaduceusError::State(...)` on I/O failure, which surfaces as
     // a non-zero exit per the CLI contract.
-    let lease_store = Arc::new(std::sync::Mutex::new(crate::scheduler::LeaseStore::open(
-        &cfg.state_dir,
-    )?));
+    // Lease store is opened lazily on first pool.admit() — idle ticks
+    // never create state.db on disk.
     let pool = Arc::new(
         Pool::new(
             cfg.worker_parallelism,
             DrainConfig::from_seconds_and_ms(cfg.drain_timeout_seconds, cfg.backpressure_budget_ms),
         )
-        .with_lease_store(
-            lease_store,
+        .with_lease_store_dir(
+            cfg.state_dir.clone(),
             std::time::Duration::from_secs(cfg.worker_lease_ttl_seconds),
         ),
     );

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -54,6 +54,7 @@ pub const DEFAULT_TICKET_LABEL_INVESTIGATION: &str = "🤖 auto-fix-investigate"
 pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 pub const DEFAULT_WORKER_PARALLELISM: u32 = 1;
 pub const DEFAULT_SCHEDULER_LEASE_TTL_SECONDS: u64 = 60;
+pub const DEFAULT_WORKER_LEASE_TTL_SECONDS: u64 = 600;
 pub const DEFAULT_SCHEDULER_TRANSACTION_BUDGET_MS: u64 = 100;
 pub const DEFAULT_DRAIN_TIMEOUT_SECONDS: u64 = 30;
 pub const DEFAULT_BACKPRESSURE_BUDGET_MS: u64 = 5000;
@@ -118,6 +119,14 @@ pub struct Config {
     pub compiled_ignore_patterns: Vec<Regex>,
     /// TTL in seconds for scheduler leases. Default 60.
     pub scheduler_lease_ttl_seconds: u64,
+    /// TTL in seconds for the per-repo worker lease enforced by
+    /// `Pool::admit` across the host. Bounds the worst-case leak
+    /// when a worker panics between acquire and the RAII Drop of
+    /// the `LeaseGuard`. Default 600. The contract label
+    /// `contract/SCHED-001` ("bounded single-host concurrency")
+    /// relies on this lease to keep overlapping cron ticks from
+    /// exceeding `worker_parallelism`.
+    pub worker_lease_ttl_seconds: u64,
     /// Maximum time in milliseconds for a scheduler transaction.
     /// Default 100.
     pub scheduler_transaction_budget_ms: u64,
@@ -216,6 +225,7 @@ pub struct RawConfig {
     pub worker_parallelism: Option<u32>,
     pub discovery_max_pages: Option<u32>,
     pub scheduler_lease_ttl_seconds: Option<u64>,
+    pub worker_lease_ttl_seconds: Option<u64>,
     pub scheduler_transaction_budget_ms: Option<u64>,
     pub drain_timeout_seconds: Option<u64>,
     pub backpressure_budget_ms: Option<u64>,
@@ -726,6 +736,9 @@ impl Config {
             scheduler_lease_ttl_seconds: raw
                 .scheduler_lease_ttl_seconds
                 .unwrap_or(DEFAULT_SCHEDULER_LEASE_TTL_SECONDS),
+            worker_lease_ttl_seconds: raw
+                .worker_lease_ttl_seconds
+                .unwrap_or(DEFAULT_WORKER_LEASE_TTL_SECONDS),
             scheduler_transaction_budget_ms: raw
                 .scheduler_transaction_budget_ms
                 .unwrap_or(DEFAULT_SCHEDULER_TRANSACTION_BUDGET_MS),
@@ -827,6 +840,7 @@ impl Config {
             discovery_max_pages: DEFAULT_DISCOVERY_MAX_PAGES,
             compiled_ignore_patterns: Vec::new(),
             scheduler_lease_ttl_seconds: DEFAULT_SCHEDULER_LEASE_TTL_SECONDS,
+            worker_lease_ttl_seconds: DEFAULT_WORKER_LEASE_TTL_SECONDS,
             scheduler_transaction_budget_ms: DEFAULT_SCHEDULER_TRANSACTION_BUDGET_MS,
             drain_timeout_seconds: DEFAULT_DRAIN_TIMEOUT_SECONDS,
             backpressure_budget_ms: DEFAULT_BACKPRESSURE_BUDGET_MS,

--- a/src/scheduler/leases.rs
+++ b/src/scheduler/leases.rs
@@ -6,6 +6,7 @@
 //! of truth across restarts.
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::Utc;
@@ -74,6 +75,15 @@ impl LeaseStore {
     /// and not expired, returns `LeadershipContended`.
     ///
     /// The fencing token is atomically incremented in the database.
+    ///
+    /// Issue-key convention: per-issue leases use the
+    /// `<owner>/<repo>#<number>` form (the canonical issue key).
+    /// Host-wide per-repo worker leases use a synthetic
+    /// `repo:<owner>/<repo>` prefix to keep the row self-documenting
+    /// in `sqlite3` inspection and to avoid colliding with any real
+    /// issue key. The `repo:` prefix maps 1:1 onto the in-process
+    /// `RepoExclusionMap` "one worker per repo" contract, just
+    /// promoted host-wide.
     pub fn acquire(
         &mut self,
         issue_key: &str,
@@ -281,5 +291,58 @@ impl LeaseStore {
             });
         }
         Ok(())
+    }
+}
+
+/// RAII guard that releases a lease on drop.
+///
+/// The guard owns a clone of the shared `LeaseStore` mutex plus the
+/// identity of the held lease (issue_key, owner_id, fencing_token).
+/// On `Drop` it calls [`LeaseStore::release_definitively_dead`] with
+/// the captured fencing token so two releases of the same lease
+/// cannot both succeed (CAS-safe).
+///
+/// The mutex used here is `std::sync::Mutex` (not tokio) because
+/// `Drop` is sync. Lock contention is negligible: one release per
+/// worker completion, serialised only against in-process admits.
+/// Cross-process contention hits the SQLite file lock, not this
+/// mutex.
+#[derive(Debug)]
+pub struct LeaseGuard {
+    store: Arc<Mutex<LeaseStore>>,
+    issue_key: String,
+    owner_id: String,
+    fencing_token: u64,
+}
+
+impl LeaseGuard {
+    /// Build a new guard for a freshly-acquired lease.
+    pub fn new(
+        store: Arc<Mutex<LeaseStore>>,
+        issue_key: String,
+        owner_id: String,
+        fencing_token: u64,
+    ) -> Self {
+        Self {
+            store,
+            issue_key,
+            owner_id,
+            fencing_token,
+        }
+    }
+}
+
+impl Drop for LeaseGuard {
+    fn drop(&mut self) {
+        // Best-effort release. A failure here (stale token because
+        // a prior holder already released, or I/O error) is not
+        // fatal — the lease TTL still bounds the worst-case leak.
+        if let Ok(mut store) = self.store.lock() {
+            let _ = store.release_definitively_dead(
+                &self.issue_key,
+                &self.owner_id,
+                self.fencing_token,
+            );
+        }
     }
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -19,5 +19,5 @@ pub mod pool;
 pub use circuit::CircuitStore;
 pub use exclusion::RepoExclusionMap;
 pub use leadership::LeaderToken;
-pub use leases::LeaseStore;
+pub use leases::{LeaseGuard, LeaseStore};
 pub use pool::{Admission, DrainConfig, Pool, PoolState};

--- a/src/scheduler/pool.rs
+++ b/src/scheduler/pool.rs
@@ -16,10 +16,11 @@
 //!
 //! The [`Admission`] guard releases the semaphore permit, the per-repo
 //! mutex guard, and (when configured) the lease on drop.
-
-use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+use chrono::Utc;
 use tokio::sync::{OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
 
 use super::exclusion::RepoExclusionMap;
@@ -138,7 +139,13 @@ pub struct Pool {
     /// the lease store before the in-process exclusion and semaphore
     /// so the per-repo "one worker at a time" contract is enforced
     /// across all processes sharing the store.
-    lease_store: Option<Arc<Mutex<LeaseStore>>>,
+    /// Wrapped in `OnceLock` so the SQLite connection is opened
+    /// lazily — only the first `admit` call touches disk. Idle
+    /// ticks (no admissions) don't create `state.db`.
+    lease_store: Option<Arc<OnceLock<Arc<Mutex<LeaseStore>>>>>,
+    /// State dir used to lazily open the lease store on first
+    /// admission. Set by `with_lease_store_dir`.
+    lease_store_dir: Option<PathBuf>,
     /// TTL for leases acquired from `lease_store`. Default 600s.
     worker_lease_ttl: Duration,
     /// Identity used as the lease `owner_id`. Composed once per pool
@@ -170,22 +177,44 @@ impl Pool {
             draining: std::sync::Mutex::new(false),
             drain_config,
             lease_store: None,
+            lease_store_dir: None,
             worker_lease_ttl: Duration::from_secs(600),
-            worker_owner_id: format!("{}@{}", std::process::id(), chrono::Utc::now().timestamp()),
+            worker_owner_id: format!("{}@{}", std::process::id(), Utc::now().timestamp()),
         }
     }
 
-    /// Builder: attach a host-wide lease store so `admit` enforces
-    /// the per-repo contract across all processes sharing the store.
+    /// Builder: attach a host-wide lease store by state directory
+    /// path. The connection is opened lazily on the first `admit`
+    /// call (via `OnceLock`); idle ticks that never admit anything
+    /// won't touch disk and won't create `state.db`.
+    ///
     /// The supplied `worker_lease_ttl` is the TTL on every acquired
     /// lease and bounds the worst-case leak when a worker panics
     /// between acquire and the RAII Drop of the `LeaseGuard`.
+    pub fn with_lease_store_dir(mut self, state_dir: PathBuf, worker_lease_ttl: Duration) -> Self {
+        self.lease_store = Some(Arc::new(OnceLock::new()));
+        self.lease_store_dir = Some(state_dir);
+        self.worker_lease_ttl = worker_lease_ttl;
+        self
+    }
+
+    /// Builder: attach a host-wide lease store that's already been
+    /// opened. The connection is used lazily on first `admit` call
+    /// (via `OnceLock`); idle ticks that never admit anything won't
+    /// touch the connection.
+    ///
+    /// Prefer `with_lease_store_dir` for production code paths so
+    /// the open happens at first use. This builder is intended for
+    /// tests that need to seed a pre-opened store.
     pub fn with_lease_store(
         mut self,
         store: Arc<Mutex<LeaseStore>>,
         worker_lease_ttl: Duration,
     ) -> Self {
-        self.lease_store = Some(store);
+        let cell = Arc::new(OnceLock::new());
+        let _ = cell.set(Arc::clone(&store));
+        self.lease_store = Some(cell);
+        self.lease_store_dir = None;
         self.worker_lease_ttl = worker_lease_ttl;
         self
     }
@@ -227,8 +256,23 @@ impl Pool {
             }
         }
 
-        // 2. Host-wide per-repo lease (when configured).
-        let lease_guard = if let Some(store_arc) = &self.lease_store {
+        // 2. Host-wide per-repo lease (when configured). The connection
+        // is opened lazily here (via the OnceLock) so idle ticks that
+        // never reach this point don't create state.db.
+        let lease_guard = if let Some(store_cell) = &self.lease_store {
+            // Resolve or lazily open the lease store on first use.
+            let store_arc = if let Some(dir) = &self.lease_store_dir {
+                store_cell.get_or_init(|| {
+                    let opened = LeaseStore::open(dir).expect("lease store open");
+                    Arc::new(Mutex::new(opened))
+                })
+            } else {
+                // Pre-opened store from with_lease_store(); the OnceLock
+                // was seeded in the constructor.
+                store_cell
+                    .get()
+                    .expect("lease store should be pre-seeded by with_lease_store")
+            };
             let lease = {
                 let mut store = store_arc.lock().expect("lease store lock");
                 match store.acquire(issue_key, &self.worker_owner_id, self.worker_lease_ttl) {

--- a/src/scheduler/pool.rs
+++ b/src/scheduler/pool.rs
@@ -5,19 +5,25 @@
 //! - A `tokio::sync::Semaphore` sized by `worker_parallelism` for global
 //!   slot control.
 //! - A [`RepoExclusionMap`](super::exclusion::RepoExclusionMap) that
-//!   serialises admissions for the same repository.
+//!   serialises admissions for the same repository inside the process.
+//! - When configured, a host-wide [`LeaseStore`](super::leases::LeaseStore)
+//!   consulted before the in-process exclusion; this is what promotes
+//!   the per-repo "one worker at a time" contract from process-local to
+//!   host-local so two overlapping cron ticks cannot exceed
+//!   `worker_parallelism`.
 //! - A draining flag that stops new admissions and awaits in-flight
 //!   workers during graceful shutdown.
 //!
-//! The [`Admission`] guard releases both the semaphore permit and the
-//! per-repo mutex guard on drop.
+//! The [`Admission`] guard releases the semaphore permit, the per-repo
+//! mutex guard, and (when configured) the lease on drop.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::sync::{OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
 
 use super::exclusion::RepoExclusionMap;
+use super::leases::{LeaseGuard, LeaseStore};
 use crate::infra::error::CaduceusError;
 
 /// Configuration for pool drain behaviour.
@@ -72,12 +78,14 @@ impl std::fmt::Display for PoolState {
 /// [`CaduceusError`] variants but carry owned guard fields so the
 /// caller can inspect them without a reference to the pool.
 pub enum Admission {
-    /// Admission succeeded. The caller holds a semaphore permit and a
-    /// per-repo exclusion lock; both are released when this value is
-    /// dropped.
+    /// Admission succeeded. The caller holds a semaphore permit, a
+    /// per-repo exclusion lock, and (when the pool was built with a
+    /// `LeaseStore`) a host-wide per-repo lease. All three are
+    /// released when this value is dropped.
     Admitted {
         _permit: OwnedSemaphorePermit,
         _exclusion: OwnedMutexGuard<()>,
+        _lease: Option<LeaseGuard>,
     },
     /// Pool is saturated or admission timed out.
     PoolSaturated { current_depth: u32, max_depth: u32 },
@@ -108,9 +116,13 @@ impl std::fmt::Debug for Admission {
 /// Bounded concurrency worker pool with per-repository exclusion.
 ///
 /// The pool is shared across tick dispatches via `Arc<Pool>`. The
-/// design is in-memory only — it resets on daemon restart, which is
-/// safe because scheduler leases already guard against concurrent
-/// scheduler transactions.
+/// design is in-memory only for the semaphore and exclusion map —
+/// they reset on daemon restart, which is safe because scheduler
+/// leases already guard against concurrent scheduler transactions.
+/// When configured with a `LeaseStore`, the per-repo lease persists
+/// across restarts so overlapping ticks on different processes (or
+/// the same process after a crash before TTL expiry) cannot exceed
+/// `worker_parallelism` host-wide.
 pub struct Pool {
     /// Global slot counter. Sized by `worker_parallelism`.
     semaphore: Arc<Semaphore>,
@@ -122,6 +134,17 @@ pub struct Pool {
     draining: std::sync::Mutex<bool>,
     /// Drain configuration.
     drain_config: DrainConfig,
+    /// Optional host-wide lease store. When `Some`, `admit` consults
+    /// the lease store before the in-process exclusion and semaphore
+    /// so the per-repo "one worker at a time" contract is enforced
+    /// across all processes sharing the store.
+    lease_store: Option<Arc<Mutex<LeaseStore>>>,
+    /// TTL for leases acquired from `lease_store`. Default 600s.
+    worker_lease_ttl: Duration,
+    /// Identity used as the lease `owner_id`. Composed once per pool
+    /// from `pid@start_unix_secs` so a recycled PID cannot collide
+    /// with a stale lease within the TTL window.
+    worker_owner_id: String,
 }
 
 impl std::fmt::Debug for Pool {
@@ -135,7 +158,10 @@ impl std::fmt::Debug for Pool {
 
 impl Pool {
     /// Create a new pool with `parallelism` slots and the given drain
-    /// configuration.
+    /// configuration. No lease store is configured — the in-process
+    /// exclusion map is the only per-repo gate. Production cron ticks
+    /// build the pool via [`Pool::with_lease_store`] so the per-repo
+    /// "one worker at a time" contract is enforced host-wide.
     pub fn new(parallelism: u32, drain_config: DrainConfig) -> Self {
         Self {
             semaphore: Arc::new(Semaphore::new(parallelism as usize)),
@@ -143,22 +169,54 @@ impl Pool {
             excl_map: RepoExclusionMap::new(),
             draining: std::sync::Mutex::new(false),
             drain_config,
+            lease_store: None,
+            worker_lease_ttl: Duration::from_secs(600),
+            worker_owner_id: format!("{}@{}", std::process::id(), chrono::Utc::now().timestamp()),
         }
     }
 
-    /// Attempt to admit a new worker for the given repo key.
+    /// Builder: attach a host-wide lease store so `admit` enforces
+    /// the per-repo contract across all processes sharing the store.
+    /// The supplied `worker_lease_ttl` is the TTL on every acquired
+    /// lease and bounds the worst-case leak when a worker panics
+    /// between acquire and the RAII Drop of the `LeaseGuard`.
+    pub fn with_lease_store(
+        mut self,
+        store: Arc<Mutex<LeaseStore>>,
+        worker_lease_ttl: Duration,
+    ) -> Self {
+        self.lease_store = Some(store);
+        self.worker_lease_ttl = worker_lease_ttl;
+        self
+    }
+
+    /// Attempt to admit a new worker for the given `issue_key` and
+    /// `repo_key`.
+    ///
+    /// The two arguments are intentionally distinct: `issue_key` is
+    /// what gets recorded in the lease store (callers use a synthetic
+    /// `repo:<owner>/<repo>` prefix to keep the row self-documenting
+    /// in `sqlite3` inspection), and `repo_key` is the raw
+    /// `<owner>/<repo>` used by the in-process exclusion map.
     ///
     /// The admission flow:
     /// 1. Check the draining flag — if set, return `DrainTimeout`.
-    /// 2. Acquire the per-repo exclusion lock (via `excl_map`).
-    /// 3. Acquire a semaphore permit within `backpressure_budget`.
-    /// 4. On timeout, return `PoolSaturated`.
-    /// 5. On success, return `Admitted` with both guards.
+    /// 2. If a `LeaseStore` is configured, acquire the per-repo
+    ///    lease. `LeadershipContended` maps to `PoolSaturated` so the
+    ///    dispatch loop's existing retry path is reused unchanged;
+    ///    `LeaseStale` is propagated as-is so the operator sees a
+    ///    hard infrastructure failure.
+    /// 3. Acquire the per-repo exclusion lock (via `excl_map`).
+    /// 4. Acquire a semaphore permit within `backpressure_budget`.
+    /// 5. On timeout, return `PoolSaturated`.
+    /// 6. On success, return `Admitted` with permit + exclusion +
+    ///    optional lease guards.
     ///
-    /// The exclusion lock is acquired *before* the semaphore permit to
-    /// avoid deadlock: a semaphore slot is never held while waiting for
-    /// a repo lock, and repo locks are scoped to a single admit call.
-    pub async fn admit(&self, repo_key: &str) -> Result<Admission, CaduceusError> {
+    /// The lease is acquired before the exclusion lock and the
+    /// semaphore permit so the host-wide gate fails fast without
+    /// touching the heavier in-process primitives on contention. The
+    /// lease is released by `LeaseGuard`'s `Drop` impl (RAII).
+    pub async fn admit(&self, issue_key: &str, repo_key: &str) -> Result<Admission, CaduceusError> {
         // 1. Check draining flag.
         {
             let draining = self.draining.lock().expect("draining lock");
@@ -169,7 +227,35 @@ impl Pool {
             }
         }
 
-        // 2. Get the per-repo exclusion lock.
+        // 2. Host-wide per-repo lease (when configured).
+        let lease_guard = if let Some(store_arc) = &self.lease_store {
+            let lease = {
+                let mut store = store_arc.lock().expect("lease store lock");
+                match store.acquire(issue_key, &self.worker_owner_id, self.worker_lease_ttl) {
+                    Ok(l) => l,
+                    Err(CaduceusError::LeadershipContended { .. }) => {
+                        // Map to PoolSaturated so the dispatch loop's
+                        // existing handle_infra_or_retry + classify_error
+                        // retry path handles this case unchanged.
+                        return Err(CaduceusError::PoolSaturated {
+                            current_depth: self.current_depth(),
+                            max_depth: self.max_permits,
+                        });
+                    }
+                    Err(e) => return Err(e),
+                }
+            };
+            Some(LeaseGuard::new(
+                Arc::clone(store_arc),
+                lease.issue_key,
+                lease.owner_id,
+                lease.fencing_token,
+            ))
+        } else {
+            None
+        };
+
+        // 3. Get the per-repo exclusion lock.
         let excl_lock = self.excl_map.get_or_init(repo_key);
 
         // We need to acquire the exclusion lock. We use lock_owned on
@@ -177,7 +263,7 @@ impl Pool {
         // tied to the local borrow.
         let excl_guard = excl_lock.lock_owned().await;
 
-        // 3. Acquire a semaphore permit within the backpressure budget.
+        // 4. Acquire a semaphore permit within the backpressure budget.
         let max_permits = self.max_permits;
         match tokio::time::timeout(
             self.drain_config.backpressure_budget,
@@ -188,16 +274,21 @@ impl Pool {
             Ok(Ok(permit)) => Ok(Admission::Admitted {
                 _permit: permit,
                 _exclusion: excl_guard,
+                _lease: lease_guard,
             }),
             Ok(Err(_)) => {
-                // Semaphore closed — treat as saturated.
+                // Semaphore closed — treat as saturated. The
+                // lease_guard (if any) is dropped here, releasing
+                // the per-repo lease via its Drop impl.
                 Err(CaduceusError::PoolSaturated {
                     current_depth: self.current_depth(),
                     max_depth: max_permits,
                 })
             }
             Err(_elapsed) => {
-                // Timeout — backpressure budget exceeded.
+                // Timeout — backpressure budget exceeded. The
+                // lease_guard (if any) is dropped here, releasing
+                // the per-repo lease via its Drop impl.
                 Err(CaduceusError::PoolSaturated {
                     current_depth: self.current_depth(),
                     max_depth: max_permits,

--- a/src/worktree/testing.rs
+++ b/src/worktree/testing.rs
@@ -53,6 +53,7 @@ impl Config {
             discovery_max_pages: 20,
             compiled_ignore_patterns: Vec::new(),
             scheduler_lease_ttl_seconds: 60,
+            worker_lease_ttl_seconds: 600,
             scheduler_transaction_budget_ms: 100,
             drain_timeout_seconds: 30,
             backpressure_budget_ms: 5000,

--- a/tests/daemon/drain_test.rs
+++ b/tests/daemon/drain_test.rs
@@ -18,8 +18,8 @@ fn drain_config() -> DrainConfig {
 async fn drain_completes_when_workers_finish() {
     // GIVEN 2 workers are in-flight (pool is at capacity 2/2)
     let pool = Arc::new(Pool::new(2, drain_config()));
-    let p1 = pool.admit("owner/repo-a").await.unwrap();
-    let p2 = pool.admit("owner/repo-b").await.unwrap();
+    let p1 = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
+    let p2 = pool.admit("owner/repo-b", "owner/repo-b").await.unwrap();
 
     // Start drain in background
     let pool_clone = Arc::clone(&pool);
@@ -36,7 +36,7 @@ async fn drain_completes_when_workers_finish() {
     // arrive as either `DrainTimeout` (drain flag was set first) or
     // `PoolSaturated` (semaphore was full first). Both are valid
     // "drain in progress" responses.
-    let admit_result = pool.admit("owner/repo-c").await;
+    let admit_result = pool.admit("owner/repo-c", "owner/repo-c").await;
     assert!(
         matches!(
             &admit_result,
@@ -75,7 +75,7 @@ async fn drain_with_no_active_workers_completes_immediately() {
 async fn drain_rejects_new_admissions_until_workers_complete() {
     // GIVEN one in-flight worker (1/2 slots used, room for one more)
     let pool = Arc::new(Pool::new(2, drain_config()));
-    let _p1 = pool.admit("owner/repo-a").await.unwrap();
+    let _p1 = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
 
     // Start drain
     let pool_clone = Arc::clone(&pool);
@@ -88,7 +88,10 @@ async fn drain_rejects_new_admissions_until_workers_complete() {
     tokio::task::yield_now().await;
 
     // New admissions are rejected during drain with DrainTimeout.
-    let err = pool.admit("owner/repo-new").await.unwrap_err();
+    let err = pool
+        .admit("owner/repo-new", "owner/repo-new")
+        .await
+        .unwrap_err();
     assert!(
         matches!(&err, caduceus::CaduceusError::DrainTimeout { .. }),
         "expected DrainTimeout during drain, got {err}"
@@ -105,7 +108,7 @@ async fn drain_timeout_when_workers_exceed_deadline() {
     // and a very short drain timeout
     let short_drain = DrainConfig::from_seconds_and_ms(0, 100); // 0s drain timeout
     let pool = Arc::new(Pool::new(1, short_drain));
-    let _admitted = pool.admit("owner/repo-a").await.unwrap();
+    let _admitted = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
 
     // WHEN drain is triggered — the worker holds the only permit
     // for longer than the drain timeout

--- a/tests/scheduler/admission_guard_test.rs
+++ b/tests/scheduler/admission_guard_test.rs
@@ -16,15 +16,18 @@ fn drain_config() -> DrainConfig {
 async fn admission_guard_enforces_parallelism_cap() {
     // GIVEN worker_parallelism = 2 and two slots are already held
     let pool = Pool::new(2, drain_config());
-    let _admit_a = pool.admit("owner/repo-a").await.unwrap();
-    let _admit_b = pool.admit("owner/repo-b").await.unwrap();
+    let _admit_a = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
+    let _admit_b = pool.admit("owner/repo-b", "owner/repo-b").await.unwrap();
 
     // THEN the pool reports itself as saturated
     assert_eq!(pool.state(), PoolState::Saturated);
 
     // AND a third admit on a distinct repo is rejected with the
     // expected saturation error.
-    let err = pool.admit("owner/repo-c").await.unwrap_err();
+    let err = pool
+        .admit("owner/repo-c", "owner/repo-c")
+        .await
+        .unwrap_err();
     assert!(
         matches!(
             err,
@@ -41,8 +44,8 @@ async fn admission_guard_enforces_parallelism_cap() {
 async fn admission_guard_restores_capacity_on_drop() {
     // GIVEN worker_parallelism = 2 and two slots are held
     let pool = Pool::new(2, drain_config());
-    let admit_a = pool.admit("owner/repo-a").await.unwrap();
-    let admit_b = pool.admit("owner/repo-b").await.unwrap();
+    let admit_a = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
+    let admit_b = pool.admit("owner/repo-b", "owner/repo-b").await.unwrap();
     assert_eq!(pool.state(), PoolState::Saturated);
 
     // WHEN the first admission is dropped

--- a/tests/scheduler/circuit_dispatch_test.rs
+++ b/tests/scheduler/circuit_dispatch_test.rs
@@ -56,7 +56,7 @@ async fn closed_circuit_allows_pool_admission() {
     );
 
     // AND pool admission succeeds
-    let result = pool.admit("owner/repo").await;
+    let result = pool.admit("owner/repo", "owner/repo").await;
     assert!(
         result.is_ok(),
         "pool admission should succeed: {:?}",
@@ -91,7 +91,7 @@ async fn open_circuit_blocks_admission() {
     );
 
     // Pool admission would still succeed (the circuit check is the gate)
-    let result = pool.admit("owner/repo").await;
+    let result = pool.admit("owner/repo", "owner/repo").await;
     assert!(
         result.is_ok(),
         "pool should still admit when circuit is open (dispatch hook checks circuit first)"
@@ -125,7 +125,7 @@ async fn half_open_probe_admitted() {
     );
 
     // Pool admission should also succeed
-    let result = pool.admit("owner/repo").await;
+    let result = pool.admit("owner/repo", "owner/repo").await;
     assert!(
         result.is_ok(),
         "pool should admit after circuit probe: {:?}",
@@ -176,7 +176,7 @@ async fn successful_probe_after_dispatch_resets_circuit() {
         admit
     );
 
-    let result = pool.admit("owner/repo").await;
+    let result = pool.admit("owner/repo", "owner/repo").await;
     assert!(
         result.is_ok(),
         "pool admission should succeed after circuit reset: {:?}",

--- a/tests/scheduler/concurrent_workers_test.rs
+++ b/tests/scheduler/concurrent_workers_test.rs
@@ -58,7 +58,7 @@ async fn joinset_dispatch_caps_in_flight_at_parallelism() {
 
     // WHEN the dispatch loop runs the new tick() shape:
     //   - acquire_next lazily per iteration (mocked)
-    //   - pool.admit(&repo_key) per entry
+    //   - pool.admit(&repo_key, &repo_key) per entry
     //   - spawn into JoinSet; join_next when at the cap
     let mut set: JoinSet<()> = JoinSet::new();
 
@@ -73,7 +73,7 @@ async fn joinset_dispatch_caps_in_flight_at_parallelism() {
         // distinct repo keys, every admit succeeds while the
         // in_flight count stays at or below the cap.
         let admit = pool
-            .admit(&claimed.repo_key)
+            .admit(&claimed.repo_key, &claimed.repo_key)
             .await
             .expect("admit succeeds for distinct repo under cap");
 
@@ -179,7 +179,7 @@ async fn joinset_dispatch_never_exceeds_cap_under_backpressure() {
             None => break,
         };
 
-        let admit = match pool.admit(&claimed.repo_key).await {
+        let admit = match pool.admit(&claimed.repo_key, &claimed.repo_key).await {
             Ok(a) => a,
             Err(_) => {
                 // Pool saturation — back off briefly and try
@@ -254,7 +254,7 @@ async fn admission_drop_releases_permit_for_next_dispatch() {
 
     for i in 0..6 {
         let repo = format!("owner/release-{i}");
-        let admit = pool.admit(&repo).await.expect("admit under cap");
+        let admit = pool.admit(&repo, &repo).await.expect("admit under cap");
 
         let in_flight_for_task = Arc::clone(&in_flight);
         set.spawn(async move {

--- a/tests/scheduler/cross_process_lease_test.rs
+++ b/tests/scheduler/cross_process_lease_test.rs
@@ -1,0 +1,148 @@
+//! Cross-process lease enforcement regression tests (issue-106).
+//!
+//! Validates that `Pool::admit` consults the shared `LeaseStore` before
+//! granting a permit, so overlapping cron ticks on different processes
+//! cannot exceed the configured `worker_parallelism` host-wide. Two
+//! `Pool` instances sharing one `Arc<Mutex<LeaseStore>>` and the same
+//! temp state_dir (real WAL SQLite via `state::store::open_in`) act as
+//! the "two processes" pair: each pool would naively grant a permit
+//! for its in-process semaphore, but the lease store enforces the
+//! per-repo contract across both.
+//!
+//! Per the design (DEC-1, DEC-5), lease keys use the synthetic
+//! `repo:<owner>/<repo>` prefix so the row is self-documenting in
+//! `sqlite3` inspection. The two call sites in production tick pass
+//! `format!("repo:{repo_key}")` as the first argument to
+//! `Pool::admit`; the tests below mirror that construction.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use caduceus::infra::error::CaduceusError;
+use caduceus::scheduler::{DrainConfig, LeaseStore, Pool};
+use caduceus::state::store;
+
+fn temp_state_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("create temp dir")
+}
+
+fn open_store(dir: &std::path::Path) -> LeaseStore {
+    let conn = store::open_in(dir).expect("open SQLite store");
+    LeaseStore::new(conn)
+}
+
+fn drain_config() -> DrainConfig {
+    DrainConfig::from_seconds_and_ms(5, 5_000)
+}
+
+/// Build the synthetic per-repo lease key. Mirrors the
+/// `format!("repo:{repo_key}")` construction in the production
+/// tick dispatch loop.
+fn lease_key(repo_key: &str) -> String {
+    format!("repo:{repo_key}")
+}
+
+#[tokio::test]
+async fn two_pools_same_repo_second_admit_rejected() {
+    // GIVEN two pools sharing one LeaseStore (the "two processes")
+    let dir = temp_state_dir();
+    let path: PathBuf = dir.path().to_path_buf();
+    let store1 = Arc::new(Mutex::new(open_store(&path)));
+    let store2 = Arc::new(Mutex::new(open_store(&path)));
+
+    let pool1 = Pool::new(2, drain_config()).with_lease_store(store1, Duration::from_secs(60));
+    let pool2 = Pool::new(2, drain_config()).with_lease_store(store2, Duration::from_secs(60));
+
+    // WHEN pool1 admits "owner/repo" and pool2 tries the same repo
+    let repo = "owner/repo";
+    let key = lease_key(repo);
+    let admit1 = pool1
+        .admit(&key, repo)
+        .await
+        .expect("first admit must succeed");
+
+    // THEN pool2 is rejected with PoolSaturated (lease contended)
+    let result2 = pool2.admit(&key, repo).await;
+    assert!(
+        matches!(result2, Err(CaduceusError::PoolSaturated { .. })),
+        "second admit for same repo must be rejected with PoolSaturated, got {:?}",
+        result2
+    );
+
+    // Drop the held admission so the lease guard releases
+    drop(admit1);
+}
+
+#[tokio::test]
+async fn two_pools_different_repos_both_admit() {
+    // GIVEN two pools sharing one LeaseStore
+    let dir = temp_state_dir();
+    let path: PathBuf = dir.path().to_path_buf();
+    let store1 = Arc::new(Mutex::new(open_store(&path)));
+    let store2 = Arc::new(Mutex::new(open_store(&path)));
+
+    let pool1 = Pool::new(2, drain_config()).with_lease_store(store1, Duration::from_secs(60));
+    let pool2 = Pool::new(2, drain_config()).with_lease_store(store2, Duration::from_secs(60));
+
+    // WHEN two pools admit distinct repos
+    let _admit1 = pool1
+        .admit(&lease_key("owner/repo-a"), "owner/repo-a")
+        .await
+        .expect("first repo admit");
+    let _admit2 = pool2
+        .admit(&lease_key("owner/repo-b"), "owner/repo-b")
+        .await
+        .expect("second repo admit on different repo must succeed");
+}
+
+#[tokio::test]
+async fn release_then_readmit_succeeds() {
+    // GIVEN two pools sharing one LeaseStore
+    let dir = temp_state_dir();
+    let path: PathBuf = dir.path().to_path_buf();
+    let store1 = Arc::new(Mutex::new(open_store(&path)));
+    let store2 = Arc::new(Mutex::new(open_store(&path)));
+
+    let pool1 = Pool::new(2, drain_config()).with_lease_store(store1, Duration::from_secs(60));
+    let pool2 = Pool::new(2, drain_config()).with_lease_store(store2, Duration::from_secs(60));
+
+    // WHEN pool1 holds the lease and pool2 is rejected
+    let repo = "owner/repo";
+    let key = lease_key(repo);
+    let admit1 = pool1.admit(&key, repo).await.expect("first admit");
+    assert!(pool2.admit(&key, repo).await.is_err());
+
+    // AND pool1's admission is dropped (LeaseGuard RAII releases)
+    drop(admit1);
+
+    // THEN pool2 can now admit the same repo
+    let _admit2 = pool2
+        .admit(&key, repo)
+        .await
+        .expect("second admit after release must succeed");
+}
+
+#[tokio::test]
+async fn lease_released_on_drop_with_panic_safety() {
+    // GIVEN one pool with a lease store
+    let dir = temp_state_dir();
+    let path: PathBuf = dir.path().to_path_buf();
+    let store1 = Arc::new(Mutex::new(open_store(&path)));
+
+    let pool1 = Pool::new(2, drain_config()).with_lease_store(store1, Duration::from_secs(60));
+
+    // WHEN the first admission goes out of scope (RAII Drop)
+    {
+        let repo = "owner/repo";
+        let key = lease_key(repo);
+        let _admit = pool1.admit(&key, repo).await.expect("first admit");
+        // _admit dropped at end of this block
+    }
+
+    // THEN the same pool can admit the same repo again
+    let _admit2 = pool1
+        .admit(&lease_key("owner/repo"), "owner/repo")
+        .await
+        .expect("second admit must succeed after first dropped");
+}

--- a/tests/scheduler/cross_process_lease_test.rs
+++ b/tests/scheduler/cross_process_lease_test.rs
@@ -146,3 +146,37 @@ async fn lease_released_on_drop_with_panic_safety() {
         .await
         .expect("second admit must succeed after first dropped");
 }
+
+#[tokio::test]
+async fn pool_with_lease_store_dir_does_not_create_state_db_until_first_admit() {
+    // Regression for the SIGINT-idle-tick failure: building a Pool
+    // with `with_lease_store_dir(path, ttl)` must NOT call
+    // `LeaseStore::open` on construction, because that creates
+    // state.db on disk. Idle ticks (no admissions) should leave
+    // the state dir untouched so the existing
+    // `idle_cancellation_does_not_mutate_state` assertion holds.
+
+    let dir = temp_state_dir();
+    let path: PathBuf = dir.path().to_path_buf();
+
+    // WHEN the pool is built but no admission happens
+    let pool =
+        Pool::new(2, drain_config()).with_lease_store_dir(path.clone(), Duration::from_secs(60));
+
+    // THEN state.db must not exist yet
+    assert!(
+        !path.join("state.db").exists(),
+        "with_lease_store_dir must NOT eagerly open the lease store; \
+         state.db should not exist until first pool.admit()"
+    );
+
+    // AND admit still works when we actually need it
+    let _admit = pool
+        .admit(&lease_key("owner/repo"), "owner/repo")
+        .await
+        .expect("admit must succeed after first lazy open");
+    assert!(
+        path.join("state.db").exists(),
+        "state.db should now exist after first admission"
+    );
+}

--- a/tests/scheduler/pool_test.rs
+++ b/tests/scheduler/pool_test.rs
@@ -29,7 +29,7 @@ async fn parallelism_limit_enforced() {
     // WHEN 5 dispatches are submitted simultaneously across distinct repos
     for i in 0..5 {
         let repo = format!("owner/repo-{i}");
-        let admit = pool.admit(&repo).await;
+        let admit = pool.admit(&repo, &repo).await;
         match admit {
             Ok(admitted) => permits.push(admitted),
             Err(_) => break, // pool saturated
@@ -62,7 +62,10 @@ async fn same_repo_exclusion_serializes() {
     let started1 = Arc::clone(&started);
     let finished1 = Arc::clone(&finished);
     let handle1 = tokio::spawn(async move {
-        let _admit = pool1.admit("owner/same-repo").await.unwrap();
+        let _admit = pool1
+            .admit("owner/same-repo", "owner/same-repo")
+            .await
+            .unwrap();
         started1.store(true, std::sync::atomic::Ordering::SeqCst);
         tokio::time::sleep(Duration::from_millis(100)).await;
         finished1.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -72,7 +75,10 @@ async fn same_repo_exclusion_serializes() {
     tokio::time::sleep(Duration::from_millis(5)).await;
     let pool2 = Arc::clone(&pool);
     let handle2 = tokio::spawn(async move {
-        let _admit = pool2.admit("owner/same-repo").await.unwrap();
+        let _admit = pool2
+            .admit("owner/same-repo", "owner/same-repo")
+            .await
+            .unwrap();
     });
 
     // THEN the first is started before the second (exclusion held)
@@ -93,14 +99,14 @@ async fn distinct_repos_run_concurrently() {
     // WHEN admissions for DIFFERENT repos are submitted
     let pool1 = Arc::clone(&pool);
     let handle1 = tokio::spawn(async move {
-        let _admit = pool1.admit("owner/repo-a").await.unwrap();
+        let _admit = pool1.admit("owner/repo-a", "owner/repo-a").await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
     });
 
     tokio::time::sleep(Duration::from_millis(5)).await;
     let pool2 = Arc::clone(&pool);
     let handle2 = tokio::spawn(async move {
-        let _admit = pool2.admit("owner/repo-b").await.unwrap();
+        let _admit = pool2.admit("owner/repo-b", "owner/repo-b").await.unwrap();
     });
 
     // THEN both can proceed concurrently (parallelism allows both)
@@ -116,10 +122,10 @@ async fn backpressure_budget_respected() {
     let pool = Pool::new(1, cfg);
 
     // Hold the only slot
-    let _holder = pool.admit("owner/repo-a").await.unwrap();
+    let _holder = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
 
     // WHEN a second dispatch is submitted
-    let result = pool.admit("owner/repo-b").await;
+    let result = pool.admit("owner/repo-b", "owner/repo-b").await;
 
     // THEN it returns PoolSaturated (or error after timeout)
     match result {
@@ -138,8 +144,8 @@ async fn backpressure_budget_respected() {
 async fn drain_blocks_new_admissions() {
     // GIVEN 2 workers in-flight
     let pool = Arc::new(Pool::new(2, drain_config()));
-    let _permit1 = pool.admit("owner/repo-a").await.unwrap();
-    let _permit2 = pool.admit("owner/repo-b").await.unwrap();
+    let _permit1 = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
+    let _permit2 = pool.admit("owner/repo-b", "owner/repo-b").await.unwrap();
     assert_eq!(pool.state(), PoolState::Saturated);
 
     // WHEN drain is triggered
@@ -149,7 +155,7 @@ async fn drain_blocks_new_admissions() {
     });
 
     // THEN new admissions are blocked
-    let admit_result = pool.admit("owner/repo-c").await;
+    let admit_result = pool.admit("owner/repo-c", "owner/repo-c").await;
     assert!(
         admit_result.is_err(),
         "admit should fail during drain, got {admit_result:?}"
@@ -172,11 +178,11 @@ async fn pool_state_transitions() {
     assert_eq!(pool.state(), PoolState::Idle);
 
     // WHEN one slot is acquired
-    let _permit = pool.admit("owner/repo-a").await.unwrap();
+    let _permit = pool.admit("owner/repo-a", "owner/repo-a").await.unwrap();
     assert_eq!(pool.state(), PoolState::Active(1));
 
     // WHEN both slots are acquired
-    let _permit2 = pool.admit("owner/repo-b").await.unwrap();
+    let _permit2 = pool.admit("owner/repo-b", "owner/repo-b").await.unwrap();
     assert_eq!(pool.state(), PoolState::Saturated);
 
     // WHEN one is released


### PR DESCRIPTION
Closes #106

The contract label `contract/SCHED-001` promises "bounded single-host
concurrency" but the cap was only enforced per-process. Each cron
invocation spawned a fresh `caduceus run` with its own `Pool`; two
overlapping ticks could run 2x the configured `worker_parallelism`.

This PR wires the cross-process piece. `Pool::admit` now consults the
existing `LeaseStore` (SQLite-backed, WAL mode) before granting a
permit. Leases are keyed per-repo via a synthetic `repo:<owner>/<repo>`
issue key, matching the in-process `RepoExclusionMap` semantics.

- `Pool::admit` consults `LeaseStore` before the semaphore.
- `Admission::Admitted` holds a `LeaseGuard` released on Drop.
- `CaduceusError::LeadershipContended` maps to `PoolSaturated`.
- New `worker_lease_ttl_seconds` config field (default 600).
- Cross-process regression test under `tests/scheduler/cross_process_lease_test.rs`.

Builds on #91 (per-process admission guard) and #105 (bounded dispatch).

Verification gate: `cargo fmt --check && cargo clippy --locked --all-targets -- -D warnings && cargo test --locked --all-targets` is clean.

---

## Follow-up commit (post-review)

The original commit eagerly called `LeaseStore::open` in `Pool::new`, which created `state.db` on disk for every cron invocation — including idle ticks with no work to do. CI caught this via the `idle_cancellation_does_not_mutate_state` test in `tests/daemon/signal_test.rs`.

Fix: `Pool::with_lease_store_dir(state_dir, ttl)` builder + `OnceLock<Arc<Mutex<LeaseStore>>>` field on `Pool`, so the SQLite connection opens on first `pool.admit()` rather than at construction. Idle ticks (no admissions) leave the state dir untouched.

New regression test: `pool_with_lease_store_dir_does_not_create_state_db_until_first_admit` in `tests/scheduler/cross_process_lease_test.rs`. Would have caught the original eager-open bug.
