### PR TITLE
fix(executor): OCI isolation broken — docker -d flag and security flags placed after image

### DIFF
--- a/src/executor/oci_args.rs
+++ b/src/executor/oci_args.rs
@@ -54,8 +54,7 @@ pub fn build_argv(
     let cli = cfg.oci_cli.to_string_lossy().to_string();
     let mut argv = vec![
         cli,
-        "run".to_string(),
-        "-d".to_string(),
+        "create".to_string(),
         "--name".to_string(),
         spec.run_id.clone(),
     ];

--- a/src/executor/oci_args.rs
+++ b/src/executor/oci_args.rs
@@ -139,3 +139,13 @@ fn derive_daemon_id(cfg: &Config) -> String {
 fn derive_image_name(_cfg: &Config) -> String {
     "caduceus-worker".to_string()
 }
+
+/// Find the position of the image token in an OCI CLI argv vector.
+///
+/// The image token is content-addressable: it always contains `@sha256:`
+/// because `policy::validate_image_digest` guarantees a digest-pinned
+/// reference. This marker is used to separate engine flags (before the
+/// image) from worker command arguments (after the image).
+pub fn find_image_position(argv: &[String]) -> Option<usize> {
+    argv.iter().position(|arg| arg.contains("@sha256:"))
+}

--- a/src/executor/policy.rs
+++ b/src/executor/policy.rs
@@ -21,7 +21,7 @@
 use std::path::PathBuf;
 
 use crate::executor::network::NetworkPolicy;
-use crate::executor::oci_args::{build_argv, MountSpec};
+use crate::executor::oci_args::{build_argv, find_image_position, MountSpec};
 use crate::executor::secret_transport::EphemeralSecretFile;
 use crate::executor::ExecutorSpec;
 use crate::infra::config::{Config, OciPullPolicy};
@@ -78,9 +78,15 @@ impl IsolationPolicy {
         // 6. Add baseline enforcement flags.
         argv = inject_baseline_flags(argv, config)?;
 
-        // 7. Merge network flags from NetworkPolicy.
+        // 7. Merge network flags from NetworkPolicy before the image token.
         let network_args = NetworkPolicy::build_network_args(spec, config)?;
-        argv.extend(network_args);
+        let image_idx =
+            find_image_position(&argv).ok_or_else(|| CaduceusError::OciBaselineViolation {
+                detail: "image token not found in argv after baseline injection".to_string(),
+            })?;
+        for (i, arg) in network_args.into_iter().enumerate() {
+            argv.insert(image_idx + i, arg);
+        }
 
         // 8. Compute secret handles from config.secret_grants.
         //    (Secrets are resolved at the daemon level; the policy
@@ -149,37 +155,49 @@ fn inject_baseline_flags(mut argv: Vec<String>, _config: &Config) -> CaduceusRes
     // worker container. The oci_args builder already sets --user.
     let has_user = argv.iter().any(|a| a == "--user");
     if !has_user {
-        // Insert --user 1000:1000 after the "run" command.
-        let run_pos = argv.iter().position(|a| a == "run").unwrap_or(0);
-        argv.insert(run_pos + 1, "--user".to_string());
-        argv.insert(run_pos + 2, "1000:1000".to_string());
+        // Insert --user 1000:1000 right after the "create" command.
+        let create_pos = argv.iter().position(|a| a == "create").unwrap_or(1);
+        argv.insert(create_pos + 1, "--user".to_string());
+        argv.insert(create_pos + 2, "1000:1000".to_string());
     }
 
     // --cap-drop ALL
     let has_cap_drop = argv.iter().any(|a| a == "--cap-drop");
     if !has_cap_drop {
-        let run_pos = argv.iter().position(|a| a == "run").unwrap_or(0);
+        let create_pos = argv.iter().position(|a| a == "create").unwrap_or(1);
         // Find the insertion point after --user if present
-        let insert_pos = if argv.get(run_pos + 1).is_some_and(|a| a == "--user") {
-            run_pos + 3
+        let insert_pos = if argv.get(create_pos + 1).is_some_and(|a| a == "--user") {
+            create_pos + 3
         } else {
-            run_pos + 1
+            create_pos + 1
         };
         argv.insert(insert_pos, "--cap-drop".to_string());
         argv.insert(insert_pos + 1, "ALL".to_string());
     }
 
+    // All remaining baseline flags must appear BEFORE the image token so
+    // the engine interprets them as container options, not worker args.
+    let image_idx =
+        find_image_position(&argv).ok_or_else(|| CaduceusError::OciBaselineViolation {
+            detail: "image token not found in argv".to_string(),
+        })?;
+
     // --security-opt no-new-privileges
     let has_no_new = argv.iter().any(|a| a == "no-new-privileges");
     if !has_no_new {
-        argv.push("--security-opt".to_string());
-        argv.push("no-new-privileges".to_string());
+        argv.insert(image_idx, "--security-opt".to_string());
+        argv.insert(image_idx + 1, "no-new-privileges".to_string());
     }
 
     // --read-only
     let has_read_only = argv.iter().any(|a| a == "--read-only");
     if !has_read_only {
-        argv.push("--read-only".to_string());
+        // Recompute image position because previous inserts shifted it.
+        let image_idx =
+            find_image_position(&argv).ok_or_else(|| CaduceusError::OciBaselineViolation {
+                detail: "image token not found in argv".to_string(),
+            })?;
+        argv.insert(image_idx, "--read-only".to_string());
     }
 
     // --tmpfs /tmp:size=64M
@@ -188,8 +206,12 @@ fn inject_baseline_flags(mut argv: Vec<String>, _config: &Config) -> CaduceusRes
         // Don't duplicate --tmpfs flags
         let has_tmpfs = argv.iter().any(|a| a == "--tmpfs");
         if !has_tmpfs {
-            argv.push("--tmpfs".to_string());
-            argv.push("/tmp:size=64M".to_string());
+            let image_idx =
+                find_image_position(&argv).ok_or_else(|| CaduceusError::OciBaselineViolation {
+                    detail: "image token not found in argv".to_string(),
+                })?;
+            argv.insert(image_idx, "--tmpfs".to_string());
+            argv.insert(image_idx + 1, "/tmp:size=64M".to_string());
         }
     }
 

--- a/tests/executor/oci_args_test.rs
+++ b/tests/executor/oci_args_test.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use caduceus::executor::oci_args::{build_argv, MountSpec, OciEngine};
+use caduceus::executor::oci_args::{build_argv, find_image_position, MountSpec, OciEngine};
 use caduceus::executor::ExecutorSpec;
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
@@ -207,5 +207,48 @@ fn oci_engine_detects_docker_or_podman() {
         OciEngine::from_binary_name("nerdctl"),
         OciEngine::Docker,
         "unknown binary defaults to Docker"
+    );
+}
+
+// find_image_position (used by policy.rs to keep engine flags before image)
+
+#[test]
+fn find_image_position_finds_sha256() {
+    assert_eq!(
+        find_image_position(&[
+            "docker".to_string(),
+            "create".to_string(),
+            "caduceus-worker@sha256:abc123".to_string(),
+            "bridge.py".to_string(),
+        ]),
+        Some(2)
+    );
+}
+
+#[test]
+fn find_image_position_none_when_missing() {
+    assert_eq!(
+        find_image_position(&["docker".to_string(), "create".to_string()]),
+        None
+    );
+}
+
+#[test]
+fn find_image_position_correct_among_other_tokens() {
+    assert_eq!(
+        find_image_position(&[
+            "docker".to_string(),
+            "create".to_string(),
+            "--mount".to_string(),
+            "type=bind,src=/host,dst=/container".to_string(),
+            "-e".to_string(),
+            "FOO=bar".to_string(),
+            "-v".to_string(),
+            "/data:/data:ro".to_string(),
+            "caduceus-worker@sha256:abc123".to_string(),
+            "bridge.py".to_string(),
+            "--arg".to_string(),
+        ]),
+        Some(8)
     );
 }

--- a/tests/executor/policy_test.rs
+++ b/tests/executor/policy_test.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use caduceus::executor::network::NetworkProfile;
+use caduceus::executor::oci_args::find_image_position;
 use caduceus::executor::policy::IsolationPolicy;
 use caduceus::executor::ExecutorSpec;
 use caduceus::github::issue::IssueKey;
@@ -292,4 +293,118 @@ fn no_network_profile_gives_none() {
             panic!("enforcement failed with: {e:?}");
         }
     }
+}
+
+// EXEC-002 positional regression: every engine flag must appear before the
+// image token. If any flag lands after the image, Docker treats it as a
+// worker argument and the isolation is silently dropped.
+
+#[test]
+fn isolation_flags_precede_image() {
+    let cfg = test_cfg();
+    let spec = test_spec("test-flag-position");
+
+    let enforced = IsolationPolicy::enforce(&spec, &cfg).expect("enforce must succeed");
+    let argv = &enforced.argv;
+
+    let image_idx = find_image_position(argv).expect("image token must be present");
+
+    let engine_flags = [
+        "--user",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--tmpfs",
+        "--network",
+        "none",
+    ];
+
+    for flag in &engine_flags {
+        let pos = argv
+            .iter()
+            .position(|a| a == *flag)
+            .unwrap_or_else(|| panic!("expected engine flag {flag} in argv: {argv:?}"));
+        assert!(
+            pos < image_idx,
+            "engine flag {flag} at index {pos} must be before image at index {image_idx}: {argv:?}"
+        );
+    }
+
+    // The tmpfs mount target is a separate value that must also precede image.
+    let tmpfs_target_idx = argv
+        .iter()
+        .position(|a| a.starts_with("/tmp:size="))
+        .expect("tmpfs target must be present");
+    assert!(
+        tmpfs_target_idx < image_idx,
+        "tmpfs target at index {tmpfs_target_idx} must be before image at index {image_idx}: {argv:?}"
+    );
+}
+
+/// Verify that every engine flag in `argv` appears before the image token.
+fn assert_flags_before_image(argv: &[String]) -> Result<(), String> {
+    let image_idx =
+        find_image_position(argv).ok_or_else(|| "image token not found in argv".to_string())?;
+
+    let engine_flags = [
+        "--user",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--tmpfs",
+        "--network",
+    ];
+
+    for flag in &engine_flags {
+        if let Some(pos) = argv.iter().position(|a| a == *flag) {
+            if pos >= image_idx {
+                return Err(format!(
+                    "engine flag {flag} at index {pos} is after image at index {image_idx}"
+                ));
+            }
+        }
+    }
+
+    if let Some(pos) = argv.iter().position(|a| a.starts_with("/tmp:size=")) {
+        if pos >= image_idx {
+            return Err(format!(
+                "tmpfs target at index {pos} is after image at index {image_idx}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn rejects_post_image_flags() {
+    // Manually construct the buggy argv shape: baseline flags trail the image
+    // token, which is exactly how Docker interprets them as worker args.
+    let broken_argv = vec![
+        "docker".to_string(),
+        "create".to_string(),
+        "caduceus-worker@sha256:abc123".to_string(),
+        "--security-opt".to_string(),
+        "no-new-privileges".to_string(),
+        "--read-only".to_string(),
+        "--tmpfs".to_string(),
+        "/tmp:size=64M".to_string(),
+    ];
+    assert!(
+        assert_flags_before_image(&broken_argv).is_err(),
+        "broken argv with flags after image must be rejected"
+    );
+
+    // The fixed enforcement output must pass the same assertion.
+    let cfg = test_cfg();
+    let spec = test_spec("test-regression-clean");
+    let enforced = IsolationPolicy::enforce(&spec, &cfg).expect("enforce must succeed");
+    assert!(
+        assert_flags_before_image(&enforced.argv).is_ok(),
+        "enforced argv must keep all engine flags before image"
+    );
 }


### PR DESCRIPTION
Closes #88

## Summary

Two related OCI isolation defects in `src/executor/` that together meant the OCI executor did not deliver contract/EXEC-002 isolation guarantees.

- **Bug 1 (docker -d)**: `build_argv` at `oci_args.rs:55-58` hardcoded `-d` and verb `run`. The lifecycle calls `docker run -d` which creates AND starts in one shot, then calls `docker start <container_id>` on the already-running container. Fixed by removing `-d` and flipping verb to `create`.

- **Bug 2 (flags after image)**: `inject_baseline_flags` pushed isolation flags (`--security-opt no-new-privileges`, `--read-only`, `--tmpfs /tmp:size=64M`) AFTER the image token via `argv.push()`. Network flags were also appended after via `argv.extend()`. Docker interprets everything after the image as the worker's command argv. **Result: workers ran with zero baseline isolation.** Fixed by inserting all engine flags before the image using the new `find_image_position` content-addressable helper.

## Changes

| File | Change |
|------|--------|
| `src/executor/oci_args.rs` | Removed `-d`, flipped verb `run`→`create`, added `find_image_position` helper |
| `src/executor/policy.rs` | Refactored `inject_baseline_flags` to insert before image, fixed network flag position |
| `tests/executor/oci_args_test.rs` | Added 3 `find_image_position` tests (present, missing, among other tokens) |
| `tests/executor/policy_test.rs` | Added `isolation_flags_precede_image` + `rejects_post_image_flags` tests |

## Test Plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo test --locked --all-targets` — 0 failures (all 46 binaries green)
- [x] `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 139 passed
- [x] New `isolation_flags_precede_image` asserts every engine flag index < image index
- [x] New `rejects_post_image_flags` regression test fails on the old bug shape and passes on fixed output
- [x] All 24 targeted executor tests pass (oci_args 9 + policy 10 + lifecycle 5)

## Commits

- `d8179e5` — `fix(executor): add find_image_position helper and add tests`
- `cc519ad` — `fix(executor): replace run -d with create, insert flags before image`
- `fad4eb6` — `test(executor): add positional assertion and regression tests for EXEC-002`

## Contract

Reference: **contract/EXEC-002** — OCI isolation guarantees from `src/executor/policy.rs:1-19`.