### PR TITLE
fix(supervisor): worker command arguments corrupted by per-arg -- separator (closes #93)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,6 +365,10 @@ name = "supervisor_env_test"
 path = "tests/worker/supervisor_env_test.rs"
 
 [[test]]
+name = "worker_command_args_test"
+path = "tests/worker/worker_command_args_test.rs"
+
+[[test]]
 name = "worker_parent_death_test"
 path = "tests/worker/worker_parent_death_test.rs"
 

--- a/src/worker/supervisor/process_lifecycle.rs
+++ b/src/worker/supervisor/process_lifecycle.rs
@@ -225,8 +225,9 @@ pub fn build_supervisor_command(
     cmd.arg("--issue-body").arg(issue_body);
     cmd.arg("--issue-labels-json").arg(&labels_json);
     cmd.arg("--branch-name").arg(branch_name);
+    cmd.arg("--");
     for arg in worker_command {
-        cmd.arg("--").arg(arg);
+        cmd.arg(arg);
     }
     // The supervisor's stdin/stdout/stderr are the daemon's
     // control/status pipes. Stderr is captured separately so a

--- a/tests/worker/worker_command_args_test.rs
+++ b/tests/worker/worker_command_args_test.rs
@@ -1,0 +1,153 @@
+//! Tests for `build_supervisor_command` argument construction —
+//! regression guard for contract/EXEC-001 (issue #93).
+//!
+//! The bug: the `--` separator was prepended to *every* worker arg
+//! instead of once before the first one, corrupting the argv with
+//! spurious `--` tokens embedded in the worker command.
+
+use std::path::PathBuf;
+
+use caduceus::issue::IssueKey;
+use caduceus::worker_supervisor::build_supervisor_command;
+
+/// Helper: parse the `Debug` representation of a `Command` into
+/// a `Vec<String>` of everything after the program path.
+fn debug_args(cmd: &std::process::Command) -> Vec<String> {
+    let dbg = format!("{cmd:?}");
+    // Rust's Command Debug looks like:
+    //   "/path/to/exe" "--arg1" "val1" "--arg2" "val2"
+    // We split on '"' and collect every other token.
+    let mut args = Vec::new();
+    let mut in_quote = false;
+    let mut current = String::new();
+    for ch in dbg.chars() {
+        match ch {
+            '"' => {
+                if in_quote {
+                    if !current.is_empty() {
+                        args.push(current.clone());
+                        current.clear();
+                    }
+                    in_quote = false;
+                } else {
+                    in_quote = true;
+                }
+            }
+            ' ' | '\n' | '\t' if !in_quote => {
+                if !current.is_empty() {
+                    current.clear();
+                }
+            }
+            _ if in_quote => current.push(ch),
+            _ => {}
+        }
+    }
+    // If there's trailing unclosed content (shouldn't happen), push it
+    if !current.is_empty() {
+        args.push(current);
+    }
+    args
+}
+
+fn sample_cmd(worker_command: Vec<String>) -> std::process::Command {
+    build_supervisor_command(
+        &PathBuf::from("/usr/bin/caduceus"),
+        &PathBuf::from("/tmp/worktree"),
+        "run-99",
+        &IssueKey {
+            owner: "o".into(),
+            repo: "r".into(),
+            number: 99,
+        },
+        r#"{"key":"val"}"#,
+        &worker_command,
+        &PathBuf::from("/tmp/transcript.log"),
+        &PathBuf::from("/tmp/heartbeat.log"),
+        3600,
+        1024,
+        "Test PR title",
+        "Test PR body",
+        &["🤖 auto-fix".to_string()],
+        "automation/issue-99",
+    )
+}
+
+// ── Unit test ──────────────────────────────────────────────────
+
+#[test]
+fn build_supervisor_command_emits_exactly_one_separator() {
+    let worker_command = vec!["cargo".to_string(), "test".to_string(), "--lib".to_string()];
+    let cmd = sample_cmd(worker_command);
+    let args = debug_args(&cmd);
+
+    // Collect all `--` tokens from the args (excluding the hidden command name)
+    let separator_positions: Vec<usize> = args
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| *a == "--")
+        .map(|(i, _)| i)
+        .collect();
+
+    // Exactly one `--` separator
+    assert_eq!(
+        separator_positions.len(),
+        1,
+        "Expected exactly one `--` separator token, found {}: {:?}",
+        separator_positions.len(),
+        separator_positions
+            .iter()
+            .map(|&i| format!("args[{}]='{}'", i, args[i]))
+            .collect::<Vec<_>>()
+    );
+
+    let sep_idx = separator_positions[0];
+
+    // Everything after the separator must be the worker command verbatim
+    let after_sep: Vec<&str> = args[sep_idx + 1..].iter().map(|s| s.as_str()).collect();
+    assert_eq!(
+        after_sep,
+        vec!["cargo", "test", "--lib"],
+        "Worker args after `--` must be: cargo, test, --lib (in order, no extra separators)"
+    );
+
+    // The separator must appear after the last supervisor flag
+    let before_sep: Vec<&str> = args[..sep_idx].iter().map(|s| s.as_str()).collect();
+    assert!(
+        before_sep.contains(&"/usr/bin/caduceus"),
+        "First arg must be the self_exe path"
+    );
+    assert!(
+        before_sep.contains(&"--branch-name"),
+        "Before separator must contain --branch-name (the last supervisor flag)"
+    );
+}
+
+// ── Integration test ───────────────────────────────────────────
+
+#[test]
+fn build_supervisor_command_preserves_multi_arg_worker_command() {
+    // A worker command with 4 elements including flags and a flag-like value
+    let worker_command = vec![
+        "python3".to_string(),
+        "script.py".to_string(),
+        "--config".to_string(),
+        "dev.toml".to_string(),
+    ];
+    let cmd = sample_cmd(worker_command);
+    let args = debug_args(&cmd);
+
+    // Find the separator
+    let sep_pos = args
+        .iter()
+        .position(|a| a == "--")
+        .expect("must have -- separator");
+
+    // Collect everything after the separator
+    let worker_args: Vec<&str> = args[sep_pos + 1..].iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(
+        worker_args,
+        vec!["python3", "script.py", "--config", "dev.toml"],
+        "Worker args must appear exactly as provided, with no extra `--` tokens"
+    );
+}


### PR DESCRIPTION
## Fixes #93

### The bug
`src/worker/supervisor/process_lifecycle.rs:228-230` injected a `--` separator before EVERY worker arg:

```rust
for arg in worker_command {
    cmd.arg("--").arg(arg);  // before
}
```

The supervisor-side parser at `src/main.rs:115-120` stops collecting worker args at the FIRST `--`. So a 3-arg worker command `[cargo, test, --lib]` reached the worker as `[--, cargo, --, test, --, --lib]` — the parser only captured `[cargo]`, dropping the rest.

Tests only use single-arg worker commands, so this never surfaced.

### The fix
One separator, then the worker args verbatim:

```rust
cmd.arg("--");
for arg in worker_command {
    cmd.arg(arg);  // after
}
```

### Diff
| File | Lines | Purpose |
|---|---|---|
| `src/worker/supervisor/process_lifecycle.rs` | +3/−1 | The fix |
| `tests/worker/worker_command_args_test.rs` (new) | +153 | Unit + integration test |
| `Cargo.toml` | +4 | Test target registration |

3 files, 159 insertions, 1 deletion. No scope creep.

### Tests
| Test | Asserts |
|---|---|
| `build_supervisor_command_preserves_multi_arg_worker_command` | The full worker argv reaches the worker unchanged (TDD RED on main, GREEN after fix) |
| `build_supervisor_command_emits_exactly_one_separator` | Exactly one `--` in the final argv, at the engine/worker boundary |

Both tests fail on clean main with the buggy code (RED), pass after the fix (GREEN). TDD order observed.

### Verified by supervisor (independent re-run on the PR branch)
- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo test --locked --test worker_command_args_test` — 2/2 pass
- `cargo test --locked worker` — all worker subsystem tests pass

### CI confirmation
All 7 GitHub checks pass on the PR head: `rust-stable` (6m08s), `python` (23s), `check` (commit-policy), `Analyze (rust/python/actions)`, `CodeQL`. `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`.

### Checklist
- [x] Closes #93
- [x] Conventional Commits subject (`fix(supervisor):`, lowercase, ≤80 chars, no trailing period)
- [x] Required scope present
- [x] Per-repo commit identity (`Barkley Assistant <barkleyassistant@gmail.com>`)
- [x] No Co-Authored-By attribution
- [x] fmt + clippy -D warnings clean
- [x] Test suite clean on the touched subsystem
- [x] CI green
- [x] Working tree clean