### PR TITLE
fix(ci): commit-policy workflow actually validates commit subjects (closes #96)

### DIFF
--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -76,3 +76,5 @@ jobs:
             fi
             echo "range=${prev_sha}..${head_sha}" >> "$GITHUB_OUTPUT"
           fi
+      - name: validate commit subjects
+        run: bash scripts/check-commits.sh "${{ steps.subjects.outputs.range }}"

--- a/scripts/check-commits.sh
+++ b/scripts/check-commits.sh
@@ -13,7 +13,15 @@
 set -euo pipefail
 
 readonly MAX_LEN=80
-readonly RE='^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z0-9_-]+\))!?: [a-z][^.]*$'
+# AGENTS.md says "no trailing period", not "no period anywhere". The previous
+# regex used `[^.]*$` which incorrectly rejected valid subjects containing
+# period characters in the middle (e.g. filenames like `check-commits.sh`).
+# The scope group is REQUIRED per AGENTS.md (`type(<scope>): <description>`
+# with `a required, non-empty scope`), so we do not allow `?` on the scope
+# group. Permissive pattern + explicit trailing-period check below matches
+# the AGENTS.md contract faithfully without false positives.
+readonly RE='^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)\([a-z0-9_-]+\)!?: [a-z].*$'
+readonly TRAILING_PERIOD_RE='\.$'
 
 if [ "$#" -ne 1 ] || [ -z "$1" ]; then
   echo "usage: check-commits.sh <git-range>" >&2
@@ -34,6 +42,11 @@ while IFS= read -r line; do
 
   if [[ ! "${subject}" =~ ${RE} ]]; then
     echo "::error file=${hash},line=1,title=Conventional commit::Subject does not match <type>(<scope>): <description> pattern"
+    failures=$((failures + 1))
+  fi
+
+  if [[ "${subject}" =~ ${TRAILING_PERIOD_RE} ]]; then
+    echo "::error file=${hash},line=1,title=Trailing period::Subject ends with a period (AGENTS.md: no trailing period)"
     failures=$((failures + 1))
   fi
 done < <(git log --no-merges --format='%H %s' "${range}")

--- a/scripts/check-commits.sh
+++ b/scripts/check-commits.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# scripts/check-commits.sh — Validate commit subjects against the
+# conventional-commit policy (CONTRACTS.md CI-003).
+#
+# Usage:
+#   bash scripts/check-commits.sh <git-range>
+#
+# Exit codes:
+#   0 — all subjects pass
+#   1 — one or more subjects violate the policy
+#   2 — usage error
+
+set -euo pipefail
+
+readonly MAX_LEN=80
+readonly RE='^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z0-9_-]+\))!?: [a-z][^.]*$'
+
+if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+  echo "usage: check-commits.sh <git-range>" >&2
+  exit 2
+fi
+
+range="$1"
+failures=0
+
+while IFS= read -r line; do
+  hash="${line%% *}"
+  subject="${line#* }"
+
+  if [ "${#subject}" -gt "${MAX_LEN}" ]; then
+    echo "::error file=${hash},line=1,title=Commit length::Subject exceeds 80 characters (${#subject} chars)"
+    failures=$((failures + 1))
+  fi
+
+  if [[ ! "${subject}" =~ ${RE} ]]; then
+    echo "::error file=${hash},line=1,title=Conventional commit::Subject does not match <type>(<scope>): <description> pattern"
+    failures=$((failures + 1))
+  fi
+done < <(git log --no-merges --format='%H %s' "${range}")
+
+if [ "${failures}" -eq 0 ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/tests/ci/test-check-commits.sh
+++ b/tests/ci/test-check-commits.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# tests/ci/test-check-commits.sh — Verify scripts/check-commits.sh enforces
+# the conventional-commit subject policy.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/check-commits.sh"
+ORIGINAL_DIR="$(pwd)"
+
+pass_count=0
+fail_count=0
+
+cleanup() {
+  cd "${ORIGINAL_DIR}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  fail_count=$((fail_count + 1))
+}
+
+pass() {
+  echo "PASS: $*"
+  pass_count=$((pass_count + 1))
+}
+
+run_case() {
+  local expected_exit="$1"
+  local subject="$2"
+  local description="$3"
+  local dir
+  local actual_exit=0
+
+  dir="$(mktemp -d)"
+  (
+    cd "${dir}"
+    git init -q
+    git -c user.name="Test User" -c user.email="test@example.com" \
+      commit --allow-empty -q -m "initial: baseline"
+    git -c user.name="Test User" -c user.email="test@example.com" \
+      commit --allow-empty -q -m "${subject}"
+    "${SCRIPT}" HEAD~1..HEAD 2>/dev/null
+  ) || actual_exit=$?
+  rm -rf "${dir}"
+
+  if [ "${actual_exit}" -eq "${expected_exit}" ]; then
+    pass "${description} (exit ${actual_exit})"
+  else
+    fail "${description}: expected exit ${expected_exit}, got ${actual_exit}"
+  fi
+}
+
+run_usage_case() {
+  local expected_exit="$1"
+  local args="$2"
+  local description="$3"
+  local actual_exit=0
+
+  # shellcheck disable=SC2086
+  "${SCRIPT}" ${args} >/dev/null 2>/dev/null || actual_exit=$?
+
+  if [ "${actual_exit}" -eq "${expected_exit}" ]; then
+    pass "${description} (exit ${actual_exit})"
+  else
+    fail "${description}: expected exit ${expected_exit}, got ${actual_exit}"
+  fi
+}
+
+if [ ! -f "${SCRIPT}" ]; then
+  echo "FAIL: ${SCRIPT} does not exist" >&2
+  exit 1
+fi
+
+# Good cases
+run_case 0 "fix(ci): add validation to commit-policy" "valid subject with scope"
+run_case 0 "feat(api)!: breaking api change" "valid breaking change subject"
+
+# Bad cases
+run_case 1 "Refactor: remove planning scaffolding and simplify Rust implementation across src/ (#85)" "historical violation: uppercase type, missing scope, length"
+run_case 1 "fix: simple fix" "missing scope"
+run_case 1 "fix(ci): add validation." "trailing period"
+run_case 1 "Fix(ci): add validation" "uppercase type"
+
+# Usage cases
+run_usage_case 2 "" "missing argument"
+run_usage_case 2 "'a b'" "too many arguments"
+
+echo ""
+echo "Results: ${pass_count} passed, ${fail_count} failed"
+
+if [ "${fail_count}" -ne 0 ]; then
+  exit 1
+fi

--- a/tests/ci/test-check-commits.sh
+++ b/tests/ci/test-check-commits.sh
@@ -76,6 +76,8 @@ fi
 # Good cases
 run_case 0 "fix(ci): add validation to commit-policy" "valid subject with scope"
 run_case 0 "feat(api)!: breaking api change" "valid breaking change subject"
+run_case 0 "fix(scheduler): add max_issues_per_tick (closes #108)" "valid subject with closes ref"
+run_case 0 "feat(ci): add check-commits.sh script for commit subject validation" "valid subject with .sh filename"
 
 # Bad cases
 run_case 1 "Refactor: remove planning scaffolding and simplify Rust implementation across src/ (#85)" "historical violation: uppercase type, missing scope, length"


### PR DESCRIPTION
## Fixes #96

### What changed
3 commits, 158 insertions, 1 deletion across 3 files:

| File | Purpose |
|---|---|
| `scripts/check-commits.sh` (new) | Validation logic — runs `git log --format='%H %s' <range>` through the conventional-commits regex, plus an 80-char length check and a trailing-period check |
| `tests/ci/test-check-commits.sh` (new) | 10 acceptance tests: 4 valid + 6 invalid (the historical `Refactor:` violation, missing scope, trailing period, uppercase type, plus usage cases) |
| `.github/workflows/commit-policy.yml` | Added a third step `validate commit subjects` that invokes the script via `bash scripts/check-commits.sh "${{ steps.subjects.outputs.range }}"` |

### Why this is bigger than the issue body suggested
The orchestrator's first pass implemented the regex from the issue body's "Proposed fix" section verbatim — but that regex had two real bugs that only surfaced during supervisor verification:

1. **`[^.]*$` over-restricted periods** — the character class means "no period anywhere". This rejected valid subjects containing filenames (`check-commits.sh`, `config.yaml`, etc.). Fixed by switching to `.*$` (permissive on periods) and adding an explicit trailing-period check that matches the AGENTS.md contract ("no trailing period"). Caught when the validator rejected the orchestrator's own first commit subject.

2. **`?` made scope optional** — the issue body's regex had `(\\([a-z0-9_-]+\\))?` with a `?` quantifier, contradicting AGENTS.md's "required, non-empty scope" rule. Tightened to `\\([a-z0-9_-]+\\)` (no `?`). Caught when the test case `fix: simple fix` was passing through unchanged.

Both fixes are documented inline in the script with comments citing AGENTS.md.

### Tests
`tests/ci/test-check-commits.sh` — 10/10 pass on my supervisor-side re-run, including:
- Valid scope, scope + breaking change `!`, `(closes #N)` ref, `.sh` filename in description
- Historical violation (`Refactor: remove planning scaffolding and simplify Rust implementation across src/ (#85)` from PR #85)
- Missing scope (`fix: simple fix`)
- Trailing period (`fix(ci): add validation.`)
- Uppercase type (`Fix(ci): add validation`)
- Usage: missing argument, too many arguments

### Independent verification (this PR branch)
- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `shellcheck scripts/check-commits.sh` — clean (no warnings)
- `tests/ci/test-check-commits.sh` — 10/10 pass
- YAML syntax check on `.github/workflows/commit-policy.yml` — clean, 3 steps (checkout, determine subjects, validate subjects)
- Self-test: `bash scripts/check-commits.sh HEAD~3..HEAD` — exit 0 (orchestrator's own commits pass)
- YAML workflow step references `${{ steps.subjects.outputs.range }}` correctly

### Side-finding (not in scope for this PR)
Running the validator against recent merges on `main` reveals **pre-existing** subjects that violate the 80-char rule:

| Commit | Subject | Length | Reason |
|---|---|---|---|
| `0b36e11` | `fix(supervisor): worker command arguments corrupted by per-arg -- separator (closes #93)` | 88 chars | My own squash merge for PR #112 earlier today — I broke my own rule |
| `9469cdf` | `fix(executor): OCI isolation broken — docker -d flag and security flags placed after image (#111)` | 97 chars | PR #111 squash merge |
| `1f0455d` | `fix(state): migrate-state --to-sqlite now switches daemon to SQLite backend (#110)` | 82 chars | PR #110 squash merge |
| `2a9d564` | `fix(checkpoints): persist real operation_id and remote_marker at every stage (closes #90)` | 83 chars | PR #103 squash merge |

**Recommendation:** tighten the merge-train subject template or pre-squash truncate. The workflow is forward-looking only — these merges already exist and the workflow cannot retroactively fail them. Filing as a follow-up note rather than expanding this PR's scope.

### Checklist
- [x] Closes #96
- [x] Conventional Commits subject (`fix(ci):`, lowercase, ≤80 chars, no trailing period)
- [x] Required scope present
- [x] Per-repo commit identity (`Barkley Assistant <barkleyassistant@gmail.com>`)
- [x] No Co-Authored-By attribution
- [x] shellcheck clean
- [x] YAML syntax clean
- [x] All 10 acceptance tests pass
- [x] Self-test passes (orchestrator's commits validate against its own script)