### PR TITLE
docs: update architecture.md and state-recovery.md to reflect SQLite state model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,27 +75,82 @@ without breaking any operator contract.
 
 ## The Lock Discipline
 
-Two locks:
+The daemon uses two independent locks. Their roles differ by
+state backend; the active backend is selected by the
+`state_backend` config field (`"json"` or `"sqlite"`).
 
-- **The daemon lock (`<state_dir>/daemon.lock`)** — a
-  whole-tick nonblocking `flock`. A second cron
-  invocation exits 0 without polling or claiming.
-  This lock covers the entire tick.
-- **The state lock (`<state_dir>/state.lock`)** — an
-  exclusive `flock` taken by `StateStore` for every
-  read-modify-write cycle of `state.json`. Concurrent
-  `StateStore` instances pointing at the same state
-  directory see the queue as strictly serialised.
+### The daemon lock (`<state_dir>/daemon.lock`)
 
-The daemon lock is per-host. The state lock is per-
-state directory. They are not the same lock.
+A whole-tick nonblocking `flock`. The first cron invocation
+holds it; a second concurrent invocation exits 0 without
+polling or claiming. This lock covers the entire tick and is
+used in both backends. Operators running `caduceus queue reset`
+or `caduceus migrate-state` also take the daemon lock so a
+tick cannot start while recovery is in flight.
 
-Operators running `caduceus queue reset` or
-`caduceus migrate-state` take the daemon lock so a
-tick cannot start while the recovery is in flight.
-This is why those commands can fail with "another tick
-holds daemon.lock; retry after the next tick
-completes."
+The daemon lock is per-host, not per-state-directory. It is
+not the same as the state lock described below.
+
+### The state lock — JSON backend (`<state_dir>/state.lock`)
+
+With the `"json"` backend, `state.lock` is an exclusive `flock`
+taken by `StateStore` for every read-modify-write cycle of
+`state.json`. Concurrent `StateStore` instances pointing at
+the same state directory see the queue as strictly serialised.
+
+### SQLite backend — no separate state lock
+
+With the `"sqlite"` backend, there is no `state.lock`. The
+SQLite connection itself serialises concurrent access:
+
+- The database is opened with `PRAGMA journal_mode=WAL` for
+  read concurrency without blocking writers.
+- Every read-modify-write cycle runs inside a
+  `BEGIN IMMEDIATE` transaction, which acquires a reserved
+  lock on the database file and blocks concurrent writers.
+- Write transactions use `INSERT OR REPLACE` inside a single
+  SQLite transaction. The database engine guarantees
+  atomicity and serialisability; no separate `flock` is
+  needed.
+
+Claims (`<state_dir>/claims/`) remain as files on disk in
+both backends per the crash-safety contract — they are not
+moved into SQLite.
+
+### Dual-model summary
+
+| Lock | JSON backend | SQLite backend |
+|---|---|---|
+| `daemon.lock` (flock) | Prevents concurrent ticks | Same |
+| `state.lock` (flock) | Serialises state-file writes | Not used — SQLite transactions handle serialisation |
+| SQLite WAL / IMMEDIATE | N/A | Read concurrency + write serialisation |
+
+The daemon lock is per-host. The state-level serialisation is
+per-state-directory. They are not the same lock.
+
+### State-backend dual model
+
+The daemon supports two state backends, selected by the
+`state_backend` config field:
+
+- **SQLite** (`"sqlite"`): the active, default store. Queue
+  entries and metadata live in `<state_dir>/state.db`, opened
+  with WAL journal mode. The `caduceus migrate-state
+  --to-sqlite` command migrates from JSON.
+- **JSON** (`"json"`): the legacy store. Queue entries live in
+  `state.json`, metadata in `state_meta.json`. This backend is
+  retained for pre-migration operators and as a validated
+  backup after migration.
+
+JSON files are never silently deleted. After `migrate-state
+--to-sqlite`, the JSON files remain on disk as a validated
+backup at their original paths. The SQLite store is the
+authoritative source once the migration completes.
+
+For new installations the daemon initialises the SQLite
+backend automatically. The JSON backend is only needed when
+upgrading from a v0.1.x installation that still has
+`state.json` files.
 
 ## The Polling Loop
 
@@ -190,9 +245,13 @@ The orchestrator classifies failures into:
   transport errors, local I/O errors, rate-limit
   responses, operator-cancellation signals. Does not
   consume the retry budget.
-- **Corruption** — `state.json` or `state_meta.json`
-  is malformed. The daemon refuses to start; recovery
-  is documented in `state-recovery.md`.
+- **Corruption** — The active state store is unreadable.
+  For the JSON backend this means `state.json` or
+  `state_meta.json` is malformed; for the SQLite backend
+  this means the database cannot be opened, fails schema
+  validation, or reports integrity violations via
+  `PRAGMA integrity_check`. The daemon refuses to start;
+  recovery is documented in `state-recovery.md`.
 - **Configuration** — config-load errors. The daemon
   refuses to start; fix the config and retry.
 - **Invariant** — something the daemon's own logic

--- a/docs/state-recovery.md
+++ b/docs/state-recovery.md
@@ -1,22 +1,171 @@
 # State Recovery
 
 The daemon owns its state. Operators own their recovery.
-**Do not edit `state.json`, `state_meta.json`, claim
-files, or transcripts in place.** The lock and
-atomic-write discipline only hold for the programmatic
-API. This doc is the API.
+The daemon uses SQLite (`<state_dir>/state.db`) as its
+primary state store. Legacy installations may still have
+JSON files (`state.json`, `state_meta.json`) from the
+v0.1.x era; see the appendix for the JSON recovery path.
 
-The migration procedure from a prior installation is
-in [`../MIGRATION.md`](../MIGRATION.md) at the
-repository root. This doc covers in-place recovery,
-which is different: state has become corrupt
-in-place and the daemon is refusing to start.
+**Do not edit `state.db`, claim files, or transcripts in
+place.** The lock and transaction discipline only hold for
+the programmatic API. This doc is the API.
 
-## The Failure Modes
+The migration procedure from a prior installation is in
+[`../MIGRATION.md`](../MIGRATION.md) at the repository
+root. This doc covers in-place recovery, which is
+different: state has become corrupt in-place and the
+daemon is refusing to start.
+
+## Detecting Corruption (SQLite)
+
+The daemon's SQLite store validates the database on every
+`open_in()`. When it detects corruption, it surfaces a
+`StateCorrupt` error with a descriptive message and exits
+non-zero. Unlike the JSON backend, the SQLite store does
+**not** write marker files — corruption is surfaced as an
+open/query error.
+
+### Common error messages
+
+| Error pattern | Likely cause |
+|---|---|
+| `cannot open SQLite store at ...` | `state.db` is missing, permissions are wrong, or the file is not a valid SQLite database |
+| `cannot set pragmas: ...` | WAL journal mode could not be enabled (filesystem or permission issue) |
+| `SQLite store has schema v{N} but this daemon only supports v{M}` | The database was written by a newer daemon version; upgrade the daemon |
+| `cannot read schema_version: ...` | The schema_version table is missing or corrupted |
+| `cannot begin IMMEDIATE transaction: ...` | The database file is locked by another process or corrupted |
+| `PRAGMA integrity_check` output shows errors | Run `PRAGMA integrity_check` manually (see recovery workflow below) |
+
+### Manual integrity check
+
+```bash
+sqlite3 $STATE_DIR/state.db "PRAGMA integrity_check;"
+```
+
+A healthy database prints `ok`. Any other output indicates
+corruption; proceed to the recovery workflow.
+
+## The Recovery Workflow (SQLite)
+
+Recovery is a sequence, not a single command. Do not skip
+steps.
+
+1. **Stop the daemon.** Whichever path you used to start
+   it (Hermes cron, system cron, manual invocation), kill
+   the active tick. The daemon's whole-tick `daemon.lock`
+   flock handles in-flight locks, but new ticks would race
+   your recovery.
+
+2. **Run integrity check.** Capture the current state of
+   corruption:
+
+   ```bash
+   sqlite3 $STATE_DIR/state.db "PRAGMA integrity_check;"
+   ```
+
+   If this returns something other than `ok`, save the
+   output for diagnostics.
+
+3. **Create a safe backup.** Use one of these methods:
+
+   ```bash
+   # Method A: .backup (preferred — live-safe, consistent snapshot)
+   sqlite3 $STATE_DIR/state.db ".backup $STATE_DIR/state.db.bak-$(date +%s)"
+
+   # Method B: VACUUM INTO (requires SQLite 3.27+; rewrites the file)
+   sqlite3 $STATE_DIR/state.db \
+     "VACUUM INTO '$STATE_DIR/state.db.vacuum-$(date +%s)';"
+   ```
+
+   The backup is your rollback point. Keep it until the
+   daemon has processed at least one successful tick after
+   recovery.
+
+4. **Attempt surgical repair.** If the corruption is
+   localised to specific rows, you can repair in-place
+   with SQL:
+
+   ```bash
+   # Remove entries with corrupt data (identified by error messages)
+   sqlite3 $STATE_DIR/state.db \
+     "DELETE FROM queue_entries WHERE issue_key = 'owner/repo#123';"
+
+   # Re-insert a corrected entry
+   sqlite3 $STATE_DIR/state.db \
+     "INSERT OR REPLACE INTO queue_entries \
+      (issue_key, phase, ticket_type, attempts, queued_at, updated_at) \
+      VALUES ('owner/repo#123', 'queued', 'code', 0, \
+              '$(date -u +%Y-%m-%dT%H:%M:%SZ)', \
+              '$(date -u +%Y-%m-%dT%H:%M:%SZ)');"
+   ```
+
+   Use `caduceus status --json` to inspect the current
+   queue before repairing. For widespread corruption, use
+   the full-replace path (step 5a).
+
+5. **Replace the database (full recovery).** When surgical
+   repair is not feasible:
+
+   a. **Dump salvageable data** (if the database is
+      partially readable):
+
+      ```bash
+      sqlite3 $STATE_DIR/state.db \
+        ".output $STATE_DIR/state.db.dump.sql" ".dump"
+      ```
+
+   b. **Move the corrupt database aside:**
+
+      ```bash
+      mv $STATE_DIR/state.db $STATE_DIR/state.db.corrupt-$(date +%s)
+      mv $STATE_DIR/state.db-wal $STATE_DIR/state.db-wal.corrupt-$(date +%s) 2>/dev/null; true
+      mv $STATE_DIR/state.db-shm $STATE_DIR/state.db-shm.corrupt-$(date +%s) 2>/dev/null; true
+      ```
+
+   c. **Create a fresh database** (the daemon initialises
+      one automatically on next start, but you can also
+      use `caduceus migrate-state --to-sqlite` from a JSON
+      backup):
+
+      ```bash
+      # If you have a JSON backup:
+      caduceus migrate-state --to-sqlite
+
+      # If you have a SQL dump from step (a):
+      sqlite3 $STATE_DIR/state.db < $STATE_DIR/state.db.dump.sql
+      ```
+
+   d. **Verify the fresh database** starts cleanly:
+
+      ```bash
+      sqlite3 $STATE_DIR/state.db "PRAGMA integrity_check;"
+      ```
+
+6. **Verify with the daemon.** Run the status command to
+   confirm the daemon can load the recovered state:
+
+   ```bash
+   caduceus status --json
+   ```
+
+   Expect a normal status response. If it fails with a
+   `StateCorrupt` error, the recovery did not take —
+   restore from the backup created in step 3 and retry.
+
+7. **Restart the daemon.**
+
+## Appendix: JSON Recovery Path (Legacy)
+
+This section applies only to pre-migration installations
+still using `state.json` and `state_meta.json` (the `"json"`
+state backend). If you have already migrated to SQLite,
+skip this appendix.
+
+### Failure modes (JSON)
 
 The daemon's loader validates `state.json` and
-`state_meta.json` on every `state_dir` open. When it
-finds a malformed file:
+`state_meta.json` on every `state_dir` open. When it finds
+a malformed file:
 
 1. The file is preserved at its original path (no silent
    truncation; no overwrite with empty state).
@@ -26,90 +175,96 @@ finds a malformed file:
 3. A corruption marker file is written at
    `<state_dir>/state.json.corrupt` (or
    `state_meta.corrupt`).
-4. The daemon exits with the `StateCorrupt` error and
-   a non-zero exit code.
+4. The daemon exits with the `StateCorrupt` error and a
+   non-zero exit code.
 
 The daemon refuses to call the GitHub API while a
-corruption marker is present. The documentation says
-"use the recovery path"; this is what we mean.
+corruption marker is present.
 
-## The Recovery Workflow
+### Recovery workflow (JSON)
 
-Recovery is a sequence, not a single command. Do not
-skip steps.
+Recovery is a sequence, not a single command. Do not skip
+steps.
 
-1. **Stop the daemon.** Whichever path you used to
-   start it (Hermes cron, system cron, manual
-   invocation), kill the active tick. The daemon's
-   whole-tick flock handles in-flight locks, but new
-   ticks would race your recovery.
-2. **Read the marker file.** The marker file is empty;
-   its presence is the signal. `cat
+1. **Stop the daemon.** Whichever path you used to start
+   it (Hermes cron, system cron, manual invocation), kill
+   the active tick. The daemon's whole-tick flock handles
+   in-flight locks, but new ticks would race your recovery.
+
+2. **Read the marker file.** The marker file is empty; its
+   presence is the signal. `cat
    $STATE_DIR/state.json.corrupt` (or
    `state_meta.corrupt`) will return immediately.
+
 3. **Read the archive.** The original file lives at
-   `state.json.corrupt-<ts>` (or the metadata
-   equivalent). Open it; understand what's wrong. The
-   most common causes are:
+   `state.json.corrupt-<ts>` (or the metadata equivalent).
+   Open it; understand what's wrong. The most common causes
+   are:
    - A half-written file from a crash mid-write (the
-     atomic-write discipline should prevent this; if
-     you see it, file a bug).
-   - Operator hand-edit (the daemon never does this;
-     see the warning at the top of this doc).
-   - Filesystem corruption (rare; check `dmesg` for
-     I/O errors).
-4. **Build a repaired file.** The repaired file must
-   be a valid envelope:
-   - `state.json` must parse as the `QueueState`
-     schema (`entries` as a map of display keys to
-     `QueueEntry` records).
+     atomic-write discipline should prevent this; if you
+     see it, file a bug).
+   - Operator hand-edit (the daemon never does this; see
+     the warning at the top of this doc).
+   - Filesystem corruption (rare; check `dmesg` for I/O
+     errors).
+
+4. **Build a repaired file.** The repaired file must be a
+   valid envelope:
+   - `state.json` must parse as the `QueueState` schema
+     (`entries` as a map of display keys to `QueueEntry`
+     records).
    - `state_meta.json` must parse as the `StateMeta`
      schema.
-   If you don't know how to write that by hand, the
-    easiest path is to run `caduceus migrate-state
-    --from <file>` against a prior-state JSON file
-    (see `MIGRATION.md`).
-5. **Apply the repaired file.** There are two paths
-   here; pick the one that fits the situation:
-   - **Library API:** if you have a Rust binary at
-     hand and want the safe, daemon-lock-protected
-     path, call `caduceus::migrate::recover_state(
+   If you don't know how to write that by hand, the easiest
+   path is to run `caduceus migrate-state --from <file>`
+   against a prior-state JSON file (see `MIGRATION.md`).
+
+5. **Apply the repaired file.** There are two paths here;
+   pick the one that fits the situation:
+   - **Library API:** if you have a Rust binary at hand and
+     want the safe, daemon-lock-protected path, call
+     `caduceus::migrate::recover_state(
      repaired_path, state_dir, /*clear_marker=*/ true,
-     /*hold_daemon_lock=*/ true)`. The function
-     archives the corrupt original, atomically
-     installs the repaired file, and only then clears
-     the corruption marker. The canonical source for
-     this API is `src/state/migrate.rs` in the Caduceus
-     source tree.
-   - **Direct install:** if you understand what
-     you're doing, manually move the corrupt file
-     aside (rename `state.json` →
-     `state.json.corrupt-<your-ts>`), write the
-     repaired content with the canonical
-     temp+fsync+rename pattern, and remove the
-     corruption marker with `rm
-     <state_dir>/state.json.corrupt`. **This path
-     bypasses the daemon-lock protection and the
-     library's archive logic.** Use the library path
-     if you can.
-6. **Verify.** `caduceus status --json` should report
-   the recovered state and a clean `state_corrupt:
-   false`. If it doesn't, do not push; the recovery
-   didn't take.
+     /*hold_daemon_lock=*/ true)`. The function archives
+     the corrupt original, atomically installs the repaired
+     file, and only then clears the corruption marker.
+     The canonical source for this API is
+     `src/state/migrate.rs`.
+   - **Direct install:** if you understand what you're
+     doing, manually move the corrupt file aside (rename
+     `state.json` → `state.json.corrupt-<your-ts>`), write
+     the repaired content with the canonical temp+fsync+
+     rename pattern, and remove the corruption marker with
+     `rm <state_dir>/state.json.corrupt`. **This path
+     bypasses the daemon-lock protection and the library's
+     archive logic.** Use the library path if you can.
+
+6. **Verify.** `caduceus status --json` should report the
+   recovered state and a clean `state_corrupt: false`. If
+   it doesn't, do not push; the recovery didn't take.
+
 7. **Restart the daemon.**
 
 ## The `migrate-state` Subcommand
 
 ```text
-caduceus migrate-state --from <file> [--dry-run]
+caduceus migrate-state [--to-sqlite] [--from <file>] [--dry-run]
 ```
 
-Imports a JSON-formatted state file from a prior installation into
-the current schema. Documented in detail in `MIGRATION.md`. This is
-*not* the same as recovery; recovery is for in-place corruption,
-migration is for cross-format import.
+- **`caduceus migrate-state --to-sqlite`** — Migrates the
+  active JSON state (`state.json`, `state_meta.json`) into
+  the SQLite store (`state.db`). Preserves the original
+  JSON files as a validated backup. Updates the
+  `state_backend` config field to `"sqlite"`.
+- **`caduceus migrate-state --from <file>`** — Imports a
+  JSON-formatted state file from a prior installation into
+  the current schema. Documented in detail in `MIGRATION.md`.
 
-If your `~/.caduceus/caduceus.db` is already SQLite, migration is
+This is *not* the same as recovery; recovery is for
+in-place corruption, migration is for cross-format import.
+
+If your `<state_dir>/state.db` already has an up-to-date
+schema and no JSON files remain to import, migration is
 not needed.
 
 ## The `queue reset` Subcommand
@@ -118,50 +273,62 @@ not needed.
 caduceus queue reset owner/repo#number [--dry-run] [--force-finalization-reset]
 ```
 
-The recovery operation for a `Failed` or `Skipped`
-entry. Moves the entry back to `Queued`. The persisted
+The recovery operation for a `Failed` or `Skipped` entry.
+Moves the entry back to `Queued`. The persisted
 `FinalizationCheckpoint` (branch / PR / run ID / commit
-OID) is preserved by default so a follow-up tick
-resumes from the saved state. `--force-finalization-reset`
-drops the checkpoint and the daemon prints a warning
-listing the branch and PR URL; the daemon never
-deletes remote branches or PRs.
+OID) is preserved by default so a follow-up tick resumes
+from the saved state. `--force-finalization-reset` drops
+the checkpoint and the daemon prints a warning listing the
+branch and PR URL; the daemon never deletes remote
+branches or PRs.
 
-The subcommand takes the daemon lock and refuses
-entries with an active claim file. **Removing and
-re-adding the trigger label is not a substitute** for
-this command; the budget of three total worker
-attempts is preserved across label churn and only the
-explicit reset path clears it.
+The subcommand takes the daemon lock and refuses entries
+with an active claim file. **Removing and re-adding the
+trigger label is not a substitute** for this command; the
+budget of three total worker attempts is preserved across
+label churn and only the explicit reset path clears it.
 
 ## Backup Retention
 
-Every migration install writes a new
-`state.json.bak-<unix-ts>` to the state directory.
-The daemon does not currently sweep these. Operators
-can `rm` old backups manually:
+- **After `migrate-state --to-sqlite`**, the original JSON
+  files are preserved at their original paths as validated
+  backups. They are not automatically removed.
+- **SQLite backups** created during recovery
+  (`state.db.bak-<ts>`, `state.db.corrupt-<ts>`) are never
+  automatically swept. Operators can remove old backups
+  manually:
 
-```bash
-# keep the most recent 5
-ls -t $STATE_DIR/state.json.bak-* | tail -n +6 | xargs rm -f
-```
+  ```bash
+  # keep the most recent 5
+  ls -t $STATE_DIR/state.db.bak-* | tail -n +6 | xargs rm -f
+  ```
 
-A retention sweep inside the daemon is a future
-feature; the operator is responsible for
-housekeeping.
+- **JSON backups** from pre-migration recovery
+  (`state.json.bak-<ts>`) follow the same pattern:
+
+  ```bash
+  # keep the most recent 5
+  ls -t $STATE_DIR/state.json.bak-* | tail -n +6 | xargs rm -f
+  ```
+
+A retention sweep inside the daemon is a future feature;
+the operator is responsible for housekeeping.
 
 ## When to File a Bug
 
-- The daemon wrote a `state.json.corrupt-<ts>` archive
-  whose content is parseable as the current schema
-  (this means the daemon's loader had a false positive;
-  please file with the archive attached).
-- The daemon refused a recovery that, in your
-  judgement, was valid (attach both the corrupted
-  original and your repaired file).
-- The recovery succeeded but the daemon's behaviour on
-  the next tick was wrong (attach the recovered state
-  and the relevant tick log).
+- The daemon reported a `StateCorrupt` error for a
+  `state.db` that passes `PRAGMA integrity_check` (this
+  means the daemon's loader had a false positive; file
+  with `state.db` attached).
+- The daemon reported a `StateCorrupt` error for a JSON
+  file whose content is parseable as the current schema
+  (same — false positive; file with the archive attached).
+- The daemon refused a recovery that, in your judgement,
+  was valid (attach both the corrupted original and your
+  repaired file or SQL script).
+- The recovery succeeded but the daemon's behaviour on the
+  next tick was wrong (attach the recovered state and the
+  relevant tick log).
 
-In all cases, file at the project's GitHub issues. Do
-not include secrets.
+In all cases, file at the project's GitHub issues. Do not
+include secrets.

--- a/worker-prompt.md
+++ b/worker-prompt.md
@@ -1,0 +1,191 @@
+# caduceus worker prompt
+
+You are the worker for a single Caduceus run. The daemon owns
+the lifecycle; you own one task: complete the work the daemon
+describes below.
+
+## Run metadata
+
+- issue: barkley-assistant/caduceus#86
+- ticket_type: code
+- branch_name: automation/issue-86-01kyqf9w9gb7qa0fefjgmfmy68
+
+## Hard constraints (read these first)
+
+1. Do **not** run `git commit`, `git push`, `git checkout`,
+`git switch`, `git branch -m`, or `git reset --hard`. The
+daemon runs every commit, push, and branch creation itself
+via the finalization path. Your job is to write code and
+leave it on disk.
+2. Do **not** modify `.git/` or any file the daemon wrote.
+The daemon's finalization commit is computed from the diff
+between the worktree at start and end; any change to
+`.git/` or the daemon control files would corrupt that diff.
+3. Write your final report to `worker-result.json` in the
+worktree root. Do not write to any other path the daemon
+did not provide.
+4. Do not assume the daemon can do anything on GitHub on your
+behalf. The daemon does have GitHub API access; the worker
+does **not**. You never call `gh`, the GitHub REST API, or
+any network endpoint. (See the "GitHub access" section
+below.)
+
+## Branch
+
+The daemon has already created the branch `automation/issue-86-01kyqf9w9gb7qa0fefjgmfmy68` and checked
+it out in this worktree. Do not check out a different branch,
+rename it, or create a new one. Every commit you make (the
+daemon will make exactly one) must land on this branch.
+
+## Forbidden paths
+
+The following paths are owned by the daemon. You must not
+modify, create, or delete them. The daemon's finalization
+excludes them from its computed diff, so any change you make
+to them is silently dropped.
+
+- `.git/` (the git working tree metadata)
+- `worker-prompt.md` (this file)
+- `worker-result.json` (your final report — you may write
+this file but only via the documented shape; do not edit
+any pre-existing daemon control files)
+- `<state_dir>/runs/<run_id>.dry-run.md` and other dry-run
+artefacts when the daemon is in dry-run mode.
+
+## GitHub access
+
+The worker cannot reach GitHub. The daemon will read your
+`worker-result.json`, run the finalization commit, push the
+branch, open the pull request, and post the completion
+comment — all of that is the daemon's job, not yours.
+
+Treat any error message or guidance that suggests calling
+`gh`, `curl`-ing `api.github.com`, or otherwise reaching
+GitHub from inside this worktree as a misconfiguration.
+
+## Behavior
+
+Ticket type: **code**.
+
+
+This is a code-change ticket. Make the smallest correct
+change to the worktree's code, run the existing tests
+(and add new ones if the contract demands it), and
+summarise what you did in `worker-result.json`.
+
+Your summary is the only thing the daemon surfaces to
+the operator; be specific.
+
+## Output schema
+
+You must write `<worktree>/worker-result.json` with exactly this
+shape (the daemon parses it as JSON and validates every field):
+
+```json
+{
+  "status": "success" | "failure",
+  "summary": "<= 64 KiB Markdown summary>",
+  "commit_message": "<= 256 chars; one-line subject preferred; multi-line allowed; no control characters other than newline>",
+  "pull_request_title": "<= 256 chars; single line; no control characters>",
+  "artifacts": {
+    "<= 128-char key>": <any JSON value>
+  },
+  "investigation": false
+}
+```
+
+Notes:
+- `status`: `"success"` means the bridge can finalise. `"failure"`
+  means the daemon should record the failure and retry on the
+  next tick (until the retry budget is exhausted).
+- `summary` is rendered verbatim into the PR / investigation
+  comment; **no tool names leak**. Treat it as public voice.
+- `commit_message` may contain newlines but no other control
+  characters.
+- `pull_request_title` is one line with no control characters.
+- `artifacts` is a map with at most 100 keys, each key ≤ 128 chars.
+- `investigation`: set `true` only if you have a strong reason to
+  override the daemon's classification; usually the daemon's
+  ticket_type is authoritative.
+
+Do **not** add fields outside this schema. Do **not** write to
+any other file in the worktree unless your fix demands it.
+
+## Issue
+
+- title: docs: update architecture.md and state-recovery.md to reflect SQLite state model
+- repo: barkley-assistant/caduceus
+- number: 86
+- labels: P2, area/docs, type/chore, 🤖 auto-fix
+
+### Body
+
+```text
+## Summary
+
+The v0.1.0 docs in `docs/` describe the daemon's state as JSON files (`state.json` / `state_meta.json`) with `temp + fsync + rename` persistence. The daemon now uses SQLite as its primary state store (the `caduceus.db` migration). The architecture doc and the state-recovery doc still describe the JSON model, which is misleading for anyone reading the docs to understand the current system.
+
+## Where
+
+- `docs/architecture.md` — the `Lock Discipline` and `StateStore` sections describe `state.json` read-modify-write. The lock discipline section still describes the state lock, but the SQLite migration changed the interaction model.
+- `docs/state-recovery.md` — the entire recovery workflow is written around JSON files (`state.json.corrupt-<ts>`, `state_meta.json.corrupt-<ts>`, `temp + fsync + rename`). The SQLite equivalent (`PRAGMA integrity_check`, `caduceus.db-wal` / `caduceus.db-shm`, backup/restore) is not documented.
+
+## What needs to change
+
+### `docs/architecture.md`
+
+- `Lock Discipline` section: update the state-store description to reflect that state is SQLite, not JSON. Explain that the SQLite connection itself serialises concurrent access (no separate `state.lock` needed for the DB).
+- `Failure-Class Mapping` section: update the `Corruption` entry to mention SQLite integrity checks in addition to JSON validation.
+- Add a brief note on the dual model: SQLite is the active store; JSON is the legacy import source (for `migrate-state`).
+
+### `docs/state-recovery.md`
+
+- **Rewrite the recovery workflow** for SQLite. The current 7-step procedure (marker file → archive → repair → apply → verify → restart) is JSON-specific. The SQLite equivalent is:
+  1. `PRAGMA integrity_check` to detect corruption.
+  2. `VACUUM INTO` or `sqlite3 <db> .backup` for safe backup.
+  3. `DELETE FROM` or `INSERT OR REPLACE` for surgical repair (when the corruption is localised).
+  4. Atomic swap of the repaired DB file using the daemon's lock discipline.
+- Keep the existing JSON recovery path as a migration-era appendix (for operators who still have `state.json` from a pre-SQLite install).
+- Add a "how to detect corruption" section with the actual SQLite error messages the daemon surfaces.
+
+## Out of scope
+
+- `docs/configuration.md` — the config schema is already accurate (no `state.json` references).
+- `docs/the-bridge.md` — the bridge contract is unaffected by the state store.
+- `docs/installation.md` — the install path is unaffected.
+- `docs/faq.md` — the FAQ still mentions "JSON state" which is broadly true for the format the operator interacts with; only the on-disk implementation changed.
+- `docs/ci.md`, `docs/public-voice.md`, `docs/troubleshooting.md`, `docs/hermes-integration.md` — unaffected.
+
+## Why now
+
+The CHANGELOG update (v1.0.0 development section) documents the SQLite migration as part of the ongoing work. An operator reading the changelog and then the architecture doc gets contradictory information about how state is persisted. This is the kind of stale-doc failure mode issue #85 was explicitly designed to fix — the docs should be honest about the current codebase.
+
+## Acceptance criteria
+
+| ID | Required behaviour |
+|---|---|
+| DOC-01 | `docs/architecture.md` explains that the daemon uses SQLite (`caduceus.db`) as its primary state store, with JSON as a legacy import format. The lock discipline section describes the SQLite WAL-mode concurrency model. |
+| DOC-02 | `docs/state-recovery.md` has a complete SQLite recovery path (integrity check, backup, surgical repair, atomic swap). The JSON recovery path is retained as an appendix for pre-migration operators. |
+| DOC-03 | Both docs reference the correct CLI commands (`caduceus status`, `caduceus queue reset`, `caduceus migrate-state`) and the correct file paths (`<state_dir>/caduceus.db`, not `state.json`). |
+| DOC-04 | Both docs are internally consistent — no section says "JSON" and another says "SQLite" without explaining the dual model. |
+| DOC-05 | `cargo test --doc` passes after the changes (doc-tests in the Rust source are unaffected, but the doc changes should not introduce stale cross-references). |
+
+## Related
+
+- #85 — the planning-scaffolding pass that stripped stale `Task N.N` / `Phase N` markers from `src/`. This ticket is the same idea applied to `docs/`.
+- The CHANGELOG v1.0.0 development section documents the SQLite migration.
+```
+
+### Context (verbatim `CADUCEUS_CONTEXT_JSON`)
+
+```json
+{"schema_version":1,"issue":{"owner":"barkley-assistant","repo":"caduceus","number":86},"issue_title":"docs: update architecture.md and state-recovery.md to reflect SQLite state model","issue_body":"## Summary\n\nThe v0.1.0 docs in `docs/` describe the daemon's state as JSON files (`state.json` / `state_meta.json`) with `temp + fsync + rename` persistence. The daemon now uses SQLite as its primary state store (the `caduceus.db` migration). The architecture doc and the state-recovery doc still describe the JSON model, which is misleading for anyone reading the docs to understand the current system.\n\n## Where\n\n- `docs/architecture.md` — the `Lock Discipline` and `StateStore` sections describe `state.json` read-modify-write. The lock discipline section still describes the state lock, but the SQLite migration changed the interaction model.\n- `docs/state-recovery.md` — the entire recovery workflow is written around JSON files (`state.json.corrupt-<ts>`, `state_meta.json.corrupt-<ts>`, `temp + fsync + rename`). The SQLite equivalent (`PRAGMA integrity_check`, `caduceus.db-wal` / `caduceus.db-shm`, backup/restore) is not documented.\n\n## What needs to change\n\n### `docs/architecture.md`\n\n- `Lock Discipline` section: update the state-store description to reflect that state is SQLite, not JSON. Explain that the SQLite connection itself serialises concurrent access (no separate `state.lock` needed for the DB).\n- `Failure-Class Mapping` section: update the `Corruption` entry to mention SQLite integrity checks in addition to JSON validation.\n- Add a brief note on the dual model: SQLite is the active store; JSON is the legacy import source (for `migrate-state`).\n\n### `docs/state-recovery.md`\n\n- **Rewrite the recovery workflow** for SQLite. The current 7-step procedure (marker file → archive → repair → apply → verify → restart) is JSON-specific. The SQLite equivalent is:\n  1. `PRAGMA integrity_check` to detect corruption.\n  2. `VACUUM INTO` or `sqlite3 <db> .backup` for safe backup.\n  3. `DELETE FROM` or `INSERT OR REPLACE` for surgical repair (when the corruption is localised).\n  4. Atomic swap of the repaired DB file using the daemon's lock discipline.\n- Keep the existing JSON recovery path as a migration-era appendix (for operators who still have `state.json` from a pre-SQLite install).\n- Add a \"how to detect corruption\" section with the actual SQLite error messages the daemon surfaces.\n\n## Out of scope\n\n- `docs/configuration.md` — the config schema is already accurate (no `state.json` references).\n- `docs/the-bridge.md` — the bridge contract is unaffected by the state store.\n- `docs/installation.md` — the install path is unaffected.\n- `docs/faq.md` — the FAQ still mentions \"JSON state\" which is broadly true for the format the operator interacts with; only the on-disk implementation changed.\n- `docs/ci.md`, `docs/public-voice.md`, `docs/troubleshooting.md`, `docs/hermes-integration.md` — unaffected.\n\n## Why now\n\nThe CHANGELOG update (v1.0.0 development section) documents the SQLite migration as part of the ongoing work. An operator reading the changelog and then the architecture doc gets contradictory information about how state is persisted. This is the kind of stale-doc failure mode issue #85 was explicitly designed to fix — the docs should be honest about the current codebase.\n\n## Acceptance criteria\n\n| ID | Required behaviour |\n|---|---|\n| DOC-01 | `docs/architecture.md` explains that the daemon uses SQLite (`caduceus.db`) as its primary state store, with JSON as a legacy import format. The lock discipline section describes the SQLite WAL-mode concurrency model. |\n| DOC-02 | `docs/state-recovery.md` has a complete SQLite recovery path (integrity check, backup, surgical repair, atomic swap). The JSON recovery path is retained as an appendix for pre-migration operators. |\n| DOC-03 | Both docs reference the correct CLI commands (`caduceus status`, `caduceus queue reset`, `caduceus migrate-state`) and the correct file paths (`<state_dir>/caduceus.db`, not `state.json`). |\n| DOC-04 | Both docs are internally consistent — no section says \"JSON\" and another says \"SQLite\" without explaining the dual model. |\n| DOC-05 | `cargo test --doc` passes after the changes (doc-tests in the Rust source are unaffected, but the doc changes should not introduce stale cross-references). |\n\n## Related\n\n- #85 — the planning-scaffolding pass that stripped stale `Task N.N` / `Phase N` markers from `src/`. This ticket is the same idea applied to `docs/`.\n- The CHANGELOG v1.0.0 development section documents the SQLite migration.","labels":["P2","area/docs","type/chore","🤖 auto-fix"],"comments":[],"trusted_comments":[],"events":[{"kind":"labeled","actor":"barkley-assistant","created_at":"2026-07-27T09:00:04Z","label_name":"P2"},{"kind":"labeled","actor":"barkley-assistant","created_at":"2026-07-27T09:00:04Z","label_name":"area/docs"},{"kind":"labeled","actor":"barkley-assistant","created_at":"2026-07-27T09:00:04Z","label_name":"type/chore"},{"kind":"labeled","actor":"barkley-assistant","created_at":"2026-07-29T17:36:10Z","label_name":"🤖 auto-fix"}],"truncation":{"comments_truncated":false,"trusted_comments_truncated":false,"events_truncated":false,"dropped_untrusted_comments":0,"dropped_trusted_comments":0,"dropped_events":0,"body_truncated_count":0,"total_body_bytes_dropped":0},"built_at":"2026-07-29T17:38:38.041871455Z"}
+```
+
+## End of prompt
+
+If the prompt above is truncated or missing, refuse to
+proceed and write a `status: "failure"` `worker-result.json`
+with a clear summary. The daemon will record the failure and
+retry on the next tick.
+


### PR DESCRIPTION
Updated two docs to reflect the SQLite state model:

**docs/architecture.md**
- Rewrote the Lock Discipline section to describe both backends: `daemon.lock` (same for both), `state.lock` (JSON only), and SQLite's WAL + `BEGIN IMMEDIATE` transaction model (no separate flock).
- Added a dual-model summary table comparing lock roles across backends.
- Added a State-backend dual model subsection explaining SQLite is the active store and JSON is the legacy import source (for `migrate-state --to-sqlite`).
- Updated the Corruption entry in Failure-Class Mapping to mention SQLite integrity checks and schema validation.
- Corrected path references to use `<state_dir>/state.db` (the actual filename, not `caduceus.db`).

**docs/state-recovery.md**
- Rewrote the opening to reflect SQLite as the primary store.
- Added a Detecting Corruption (SQLite) section with common error messages and `PRAGMA integrity_check` instructions.
- Wrote a new SQLite Recovery Workflow (7 steps: stop → integrity check → backup → surgical repair → replace → verify → restart).
- Added specific SQL commands for backup (`.backup`, `VACUUM INTO`), surgical repair (`DELETE`, `INSERT OR REPLACE`), and full database replacement.
- Moved the original JSON recovery path into an appendix for pre-migration operators.
- Updated the `migrate-state` subcommand section to document `--to-sqlite`.
- Updated Backup Retention for both SQLite and JSON backup patterns.
- Updated When to File a Bug for both backends.

All paths and CLI commands (`caduceus status`, `caduceus queue reset`, `caduceus migrate-state --to-sqlite`) reflect the actual codebase. `cargo test --doc` passes (0 test changes needed).

Closes #86

Artifacts (1):

```json
{
  "changed_files": "docs/architecture.md, docs/state-recovery.md"
}
```

<!-- caduceus-pr-body:run=01KYQF9W9GB7QA0FEFJGMFMY68 -->