### PR TITLE
fix(tick): stop worker result redispatch loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,10 @@ name = "tick_dispatch_test"
 path = "tests/daemon/tick_dispatch_test.rs"
 
 [[test]]
+name = "per_claim_test"
+path = "tests/daemon/per_claim_test.rs"
+
+[[test]]
 name = "oci_config_test"
 path = "tests/executor/oci_config_test.rs"
 

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -25,11 +25,13 @@ use crate::scheduler::{Admission, DrainConfig, LeaderToken, Pool};
 use crate::signals;
 use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
 use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
-use crate::state::queue::{ClaimedEntry, Phase, QueueEntry, StateStore, TicketType};
+use crate::state::queue::{
+    ClaimedEntry, FinalizationStage, Phase, QueueEntry, StateStore, TicketType,
+};
 use crate::state::store;
 use crate::worker::context::{build_context, encode_context, BuildInputs};
 use crate::worker::prompt::{build_prompt, write_prompt};
-use crate::worker::WorkerResult;
+use crate::worker::{WorkerResult, WorkerStatus};
 use crate::worktree::{create as create_worktree, find_main_clone, GitRunner};
 
 // Per-claim work loop
@@ -51,14 +53,57 @@ pub(crate) async fn run_claim(
     http_status: &mut Option<u16>,
 ) -> CaduceusResult<TickOutcome> {
     // 7a. If the entry already has a finalization checkpoint,
-    //     jump to the resume stage and re-enter the pipeline
-    //     at the first uncompleted stage.
+    //     reconcile the durable state. A checkpoint at or beyond
+    //     `PrCreated` with a PR number means the PR already exists
+    //     durably: transition directly to `AwaitingReview` (the
+    //     merge poller owns the `Done` transition) without
+    //     re-dispatching the worker. This is the issue #118
+    //     recovery path — a prior run that created a PR but left
+    //     the entry `Queued` (e.g. after a retry verdict nulling
+    //     `last_run_id`) must not re-dispatch.
+    if let Some(fin) = claimed.entry.finalization.as_ref() {
+        if fin.stage == FinalizationStage::Done {
+            info!(
+                issue = %claimed.entry.key.display_key(),
+                "durable Done finalization checkpoint; preserving terminal state"
+            );
+            if claimed.entry.ticket_type == TicketType::Investigation {
+                guard.finish_investigation().await?;
+            } else {
+                guard.finish_success().await?;
+            }
+            return Ok(TickOutcome::Processed);
+        }
+        if matches!(
+            fin.stage,
+            FinalizationStage::PrCreated
+                | FinalizationStage::Commented
+                | FinalizationStage::AwaitingReview
+        ) && fin.pr_number.is_some()
+        {
+            info!(
+                issue = %claimed.entry.key.display_key(),
+                stage = ?fin.stage,
+                pr = ?fin.pr_number,
+                "durable finalization checkpoint with PR; reconciling to AwaitingReview"
+            );
+            guard.finish_awaiting_review().await?;
+            return Ok(TickOutcome::Processed);
+        }
+    }
+    // 7b. Otherwise, if a checkpoint exists but the PR was not yet
+    //     created durably, try to resume finalization from the last
+    //     recorded SQLite stage. The queue checkpoint's `run_id`
+    //     (not the freshly acquired claim run_id) is the resume
+    //     cursor when `last_run_id` was nulled by a retry verdict.
     if claimed.entry.finalization.is_some() {
         let conn = store::open_in(&cfg.state_dir)?;
         let run_id = claimed
             .entry
-            .last_run_id
-            .as_deref()
+            .finalization
+            .as_ref()
+            .map(|f| f.run_id.as_str())
+            .or(claimed.entry.last_run_id.as_deref())
             .unwrap_or_else(|| guard.run_id());
         match resume_from_checkpoint(&conn, run_id)? {
             ResumeAction::Skip(stage) => {
@@ -225,38 +270,51 @@ pub(crate) async fn run_claim(
     }
     let _ = services.clock.now();
 
-    // 14. Reject a worker that exited nonzero without being
-    //     signalled: the result is invalid, so treat it as a
-    //     worker-attributable failure through the retry budget.
-    if !supervisor_outcome.signaled && supervisor_outcome.status != 0 {
-        let err = CaduceusError::Worker {
-            context: "result",
-            stderr: format!(
-                "worker exited {} without producing a valid result",
-                supervisor_outcome.status
-            ),
-        };
-        let class = classify_error(&err);
-        return handle_infra_or_retry(cfg, guard, &err, class).await;
-    }
-
-    // 15. Read the worker result from the worktree; a missing
-    //     or unparseable result is a worker-attributable failure.
+    // 14. Read the worker result from the worktree; a missing or
+    //     unparseable result is a worker-attributable failure through
+    //     the retry budget. A valid `worker-result.json` is the
+    //     success signal even if the bridge exited nonzero (issue
+    //     #118); a result whose own `status` is `failure` is still a
+    //     worker-attributable failure.
     let worktree_result_path = worktree.path.join("worker-result.json");
     let worker_result =
         match crate::worker::parse_result_file(&worktree_result_path, &claimed.entry.key) {
             Ok(r) => r,
-            Err(_) => {
+            Err(err) => {
+                let stderr = if !supervisor_outcome.signaled && supervisor_outcome.status != 0 {
+                    format!(
+                        "worker exited {} without producing a valid result",
+                        supervisor_outcome.status
+                    )
+                } else {
+                    format!("worker did not produce a valid worker-result.json: {err}")
+                };
                 let err = CaduceusError::Worker {
                     context: "result",
-                    stderr: "worker did not produce a valid worker-result.json".to_string(),
+                    stderr,
                 };
                 let class = classify_error(&err);
                 return handle_infra_or_retry(cfg, guard, &err, class).await;
             }
         };
+    if worker_result.status == WorkerStatus::Failure {
+        let stderr = if !supervisor_outcome.signaled && supervisor_outcome.status != 0 {
+            format!(
+                "worker reported failure (exit {})",
+                supervisor_outcome.status
+            )
+        } else {
+            "worker reported failure in worker-result.json".to_string()
+        };
+        let err = CaduceusError::Worker {
+            context: "result",
+            stderr,
+        };
+        let class = classify_error(&err);
+        return handle_infra_or_retry(cfg, guard, &err, class).await;
+    }
 
-    // 16. Archive the parsed result before finalization so the
+    // 15. Archive the parsed result before finalization so the
     //     daemon can resume from it later.
     let archive_path = match archive_worker_result(&worktree_result_path, &cfg.state_dir, &run_id) {
         Ok(p) => p,
@@ -266,7 +324,7 @@ pub(crate) async fn run_claim(
         }
     };
 
-    // 17. Run finalization.
+    // 16. Run finalization.
     let final_ctx = FinalizeContext {
         client: Arc::clone(&client),
         config: cfg.clone(),

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -32,7 +32,7 @@ use crate::state::queue::{
 use crate::state::store;
 use crate::worker::context::{build_context, encode_context, BuildInputs};
 use crate::worker::prompt::{build_prompt, write_prompt};
-use crate::worker::WorkerResult;
+use crate::worker::{WorkerResult, WorkerStatus};
 use crate::worktree::{create as create_worktree, find_main_clone, GitRunner};
 
 // Checkpoint resume helpers
@@ -121,8 +121,18 @@ pub(crate) async fn run_resume_finalization(
 ) -> CaduceusResult<TickOutcome> {
     use crate::state::queue::FinalizationStage::*;
 
+    let resume_checkpoint =
+        claimed
+            .entry
+            .finalization
+            .clone()
+            .ok_or_else(|| CaduceusError::StateCorrupt {
+                path: cfg.state_dir.join("state.json"),
+                message: "resume requested without a finalization checkpoint".to_string(),
+            })?;
+
     // Build the minimal context needed for finalization.
-    let run_id = guard.run_id().to_string();
+    let run_id = resume_checkpoint.run_id.clone();
     let runner = services.git.runner().clone();
     let repository = match find_main_clone(&cfg, &runner, &claimed.entry.key).await {
         Ok(r) => r,
@@ -140,6 +150,22 @@ pub(crate) async fn run_resume_finalization(
                 return handle_infra_or_retry(cfg, guard, &err, class).await;
             }
         };
+    if worktree.branch_name != resume_checkpoint.branch_name {
+        if let Err(err) = crate::worktree::remove(&worktree).await {
+            tracing::warn!(
+                error = %err,
+                worktree = %worktree.path.display(),
+                "failed to clean up mismatched resume worktree"
+            );
+        }
+        return Err(CaduceusError::StateCorrupt {
+            path: cfg.state_dir.join("state.json"),
+            message: format!(
+                "resume checkpoint branch {:?} does not match reconstructed branch {:?}",
+                resume_checkpoint.branch_name, worktree.branch_name
+            ),
+        });
+    }
 
     // Check for cancellation
     if cancellation.is_cancelled() {
@@ -188,26 +214,28 @@ pub(crate) async fn run_resume_finalization(
 
     // Resume at the appropriate stage
     // We need a worker_result to pass to the step functions. On resume, we
-    // read the worker result from disk.
-    let result_path = ctx
-        .config
-        .state_dir
-        .join("runs")
-        .join(format!("{}.result.json", ctx.run_id));
-    let worker_result = match std::fs::read_to_string(&result_path) {
-        Ok(json) => match serde_json::from_str::<WorkerResult>(&json) {
-            Ok(wr) => wr,
-            Err(err) => {
-                return Err(CaduceusError::StateCorrupt {
-                    path: result_path,
-                    message: format!("failed to deserialize worker result for resume: {err}"),
-                });
-            }
-        },
+    // read the archived worker result through the canonical parser so the
+    // same read-side invariants (O_NOFOLLOW, size cap, field validation)
+    // and the `WorkerStatus::Failure` retry contract apply as on the
+    // fresh path (issue #118). Bypassing them let a malformed or
+    // failure-status archived result silently finalize.
+    let result_path = resume_checkpoint.result_path.clone();
+    let worker_result = match crate::worker::parse_result_file(&result_path, &ctx.issue.key) {
+        Ok(wr) => wr,
         Err(err) => {
-            return Err(CaduceusError::Io(err));
+            return Err(CaduceusError::Worker {
+                context: "resume",
+                stderr: format!("{}: {err}", result_path.display()),
+            });
         }
     };
+    if worker_result.status == WorkerStatus::Failure {
+        return Err(CaduceusError::Worker {
+            context: "resume",
+            stderr: "archived worker result declared failure; refusing to resume finalization"
+                .to_string(),
+        });
+    }
 
     let archive_path = match archive_worker_result(&result_path, &ctx.config.state_dir, &ctx.run_id)
     {
@@ -237,7 +265,7 @@ pub(crate) async fn run_resume_finalization(
 
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            store.save_finalization(
+            store.save_resumed_finalization(
                 &ctx.claim,
                 crate::state::queue::FinalizationCheckpoint {
                     run_id: ctx.run_id.clone(),
@@ -284,7 +312,7 @@ pub(crate) async fn run_resume_finalization(
 
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            store.save_finalization(
+            store.save_resumed_finalization(
                 &ctx.claim,
                 crate::state::queue::FinalizationCheckpoint {
                     run_id: ctx.run_id.clone(),
@@ -321,7 +349,7 @@ pub(crate) async fn run_resume_finalization(
 
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            store.save_finalization(
+            store.save_resumed_finalization(
                 &ctx.claim,
                 crate::state::queue::FinalizationCheckpoint {
                     run_id: ctx.run_id.clone(),
@@ -355,7 +383,7 @@ pub(crate) async fn run_resume_finalization(
             // Re-run PR create-or-reuse (idempotent), then record the checkpoint.
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
-            store.save_finalization(
+            store.save_resumed_finalization(
                 &ctx.claim,
                 crate::state::queue::FinalizationCheckpoint {
                     run_id: ctx.run_id.clone(),
@@ -402,10 +430,20 @@ pub(crate) async fn run_resume_finalization(
             // Investigation stages do not post durable remote effects in
             // scope of this change; remote_marker None is the documented
             // exception per spec.
+            //
+            // Investigation tickets have no PR/merge step, so resume
+            // completes the entry to Done.
+            guard.finish_investigation().await?;
+            return Ok(TickOutcome::Processed);
         }
     }
 
-    guard.finish_success().await?;
+    // Code-ticket resume arms (ResultValidated..AwaitingReview, plus
+    // the no-op Done arm) must leave the entry in AwaitingReview —
+    // the merge poller owns the AwaitingReview -> Done transition.
+    // Resume must not call finish_success() here, which would mark an
+    // unmerged PR Done (issue #118 audit).
+    guard.finish_awaiting_review().await?;
     Ok(TickOutcome::Processed)
 }
 

--- a/src/state/queue/store.rs
+++ b/src/state/queue/store.rs
@@ -260,6 +260,27 @@ impl StateStore {
                 ),
             });
         }
+        self.save_finalization_verified(claim, checkpoint)
+    }
+
+    /// Persist a checkpoint found during recovery under the currently
+    /// valid claim. The checkpoint run ID intentionally remains the
+    /// original run ID so future SQLite/result lookups use the durable
+    /// recovery cursor rather than the fresh claim ID.
+    pub fn save_resumed_finalization(
+        &self,
+        claim: &ClaimToken,
+        checkpoint: FinalizationCheckpoint,
+    ) -> CaduceusResult<()> {
+        self.verify_claim_run_id(claim)?;
+        self.save_finalization_verified(claim, checkpoint)
+    }
+
+    fn save_finalization_verified(
+        &self,
+        claim: &ClaimToken,
+        checkpoint: FinalizationCheckpoint,
+    ) -> CaduceusResult<()> {
         self.with_exclusive(|store| {
             let mut state = store.load_validated()?;
             let entry = state

--- a/tests/daemon/per_claim_test.rs
+++ b/tests/daemon/per_claim_test.rs
@@ -1,0 +1,731 @@
+//! Regression tests for issue #118 — the per-claim tick must
+//! trust a parseable `worker-result.json` over the bridge's
+//! non-zero exit code.
+//!
+//! Acceptance checks (LOOP-01..04): see
+//! https://github.com/barkley-assistant/caduceus/issues/118
+//!
+//! The tests spawn the real `caduceus` binary against a
+//! wiremock GitHub surface and a disposable `git daemon` origin
+//! on 127.0.0.1, mirroring the harness in
+//! `tests/integration/release_canary_test.rs`. Each test seeds a
+//! `Queued` entry and a stub worker shell script that either
+//! writes a valid `worker-result.json` then `exit 1` (LOOP-01/02)
+//! or just `exit 1` (LOOP-03), and asserts on the resulting
+//! `StateStore` snapshot.
+//!
+//! LOOP-05 lives in `tests/daemon/status_test.rs` because the
+//! `caduceus status --json` subprocess harness is already wired
+//! up there.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+use caduceus::issue::IssueKey;
+use caduceus::queue::{
+    serialize_queue_state, FinalizationCheckpoint, FinalizationStage, Phase, QueueEntry,
+    QueueState, TicketType, QUEUE_FILE_VERSION,
+};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::{clone_main, run_with_timeout, GitDaemon, MockGitHub};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TICK_TIMEOUT: Duration = Duration::from_secs(60);
+const OWNER: &str = "owner";
+const REPO: &str = "repo";
+const ISSUE_NUMBER: u64 = 86;
+const CODE_LABEL: &str = "🤖 auto-fix";
+const EXPECTED_PR_NUMBER: u64 = 117;
+
+// ---------------------------------------------------------------------------
+// Harness: stub worker script.
+// ---------------------------------------------------------------------------
+
+/// Write a worker script that writes a fix, writes a valid
+/// success `worker-result.json`, then `exit 1`. This is the LOOP-01/02
+/// repro: a bridge that produced real output but exited non-zero.
+fn write_worker_exit1_with_success(dir: &Path) -> PathBuf {
+    let path = dir.join("worker-loop-success.sh");
+    let body = "#!/bin/sh\n\
+        set -e\n\
+        echo \"loop repro fix\" > ./fix.txt\n\
+        cat > ./worker-result.json <<'EOF'\n\
+        {\"status\":\"success\",\"summary\":\"loop repro 86\",\"commit_message\":\"fix: repro 86\",\"pull_request_title\":\"Repro issue 86\",\"investigation\":false}\n\
+        EOF\n\
+        exit 1\n";
+    write_executable(&path, body);
+    path
+}
+
+/// Write a worker script that writes a `worker-result.json` whose
+/// own `status` is `failure`, then `exit 1`. The daemon must treat
+/// the declared failure as a worker-attributable failure and retry,
+/// regardless of the result file being parseable (worker contract:
+/// `status: "failure"` means "record the failure and retry").
+fn write_worker_exit1_with_failure(dir: &Path) -> PathBuf {
+    let path = dir.join("worker-loop-failure.sh");
+    let body = "#!/bin/sh\n\
+        set -e\n\
+        cat > ./worker-result.json <<'EOF'\n\
+        {\"status\":\"failure\",\"summary\":\"worker could not complete the task\",\"commit_message\":\"fix: repro 86\",\"pull_request_title\":\"Repro issue 86\",\"investigation\":false}\n\
+        EOF\n\
+        exit 1\n";
+    write_executable(&path, body);
+    path
+}
+
+/// Write a worker script that just `exit 1` with no result file —
+/// the LOOP-03 original "worker failed mid-run" case.
+fn write_worker_exit1_no_result(dir: &Path) -> PathBuf {
+    let path = dir.join("worker-loop-no-result.sh");
+    let body = "#!/bin/sh\nexit 1\n";
+    write_executable(&path, body);
+    path
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).expect("write worker.sh");
+    let mut mode = fs::metadata(path).expect("stat worker").permissions();
+    mode.set_mode(0o755);
+    fs::set_permissions(path, mode).expect("chmod worker");
+}
+
+// ---------------------------------------------------------------------------
+// Harness: config + seeded queue.
+// ---------------------------------------------------------------------------
+
+fn write_config(
+    config_path: &Path,
+    api_base: &str,
+    state_dir: &Path,
+    workdir_base: &Path,
+    worker: &Path,
+    max_retries: u32,
+) {
+    let mut yaml = String::new();
+    yaml.push_str("caduceus:\n");
+    yaml.push_str(&format!("  state_dir: \"{}\"\n", state_dir.display()));
+    yaml.push_str(&format!(
+        "  log_path: \"{}/processor.log\"\n",
+        state_dir.display()
+    ));
+    yaml.push_str(&format!("  api_base: \"{}\"\n", api_base));
+    yaml.push_str("  github_token: \"ghp_loop_token_value\"\n");
+    yaml.push_str("  poll_interval_seconds: 1\n");
+    yaml.push_str(&format!("  workdir_base: \"{}\"\n", workdir_base.display()));
+    yaml.push_str(&format!("  watched_repos:\n    - \"{}/{}\"\n", OWNER, REPO));
+    yaml.push_str(&format!(
+        "  worker_command:\n    - \"{}\"\n",
+        worker.display()
+    ));
+    yaml.push_str(&format!("  ticket_label_code: \"{}\"\n", CODE_LABEL));
+    yaml.push_str("  ticket_label_investigation: \"🤖 auto-fix-investigate\"\n");
+    yaml.push_str("  dry_run: false\n");
+    yaml.push_str("  reduced_containment_acknowledged: true\n");
+    yaml.push_str(&format!("  max_retries_per_issue: {max_retries}\n"));
+    yaml.push_str("  retry_backoff_seconds: 1\n");
+    fs::write(config_path, yaml).expect("write loop config");
+}
+
+/// Build a `Queued` code-ticket entry, optionally with a pre-existing
+/// `FinalizationCheckpoint` (the issue #118 observed end-state).
+fn build_entry(finalization: Option<FinalizationCheckpoint>) -> QueueEntry {
+    QueueEntry {
+        key: IssueKey {
+            owner: OWNER.to_string(),
+            repo: REPO.to_string(),
+            number: ISSUE_NUMBER,
+        },
+        phase: Phase::Queued,
+        ticket_type: TicketType::Code,
+        attempts: 0,
+        last_error: None,
+        last_run_id: None,
+        next_attempt_at: None,
+        finalization,
+        queued_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        generation: 1,
+    }
+}
+
+fn seed_state(state_dir: &Path, entry: QueueEntry) {
+    let mut entries = BTreeMap::new();
+    entries.insert(entry.key.display_key(), entry);
+    let body = serialize_queue_state(&QueueState {
+        version: QUEUE_FILE_VERSION,
+        entries,
+    })
+    .expect("serialize queue");
+    fs::write(state_dir.join("state.json"), body).expect("write state.json");
+}
+
+fn pr_created_checkpoint(state_dir: &Path) -> FinalizationCheckpoint {
+    FinalizationCheckpoint {
+        run_id: "RUN-PREV".to_string(),
+        branch_name: "automation/issue-86-run-prev".to_string(),
+        result_path: state_dir.join("runs").join("RUN-PREV.result.json"),
+        stage: FinalizationStage::PrCreated,
+        commit_oid: Some("abc123".to_string()),
+        pr_number: Some(EXPECTED_PR_NUMBER),
+        pr_url: Some(format!(
+            "https://github.com/{OWNER}/{REPO}/pull/{EXPECTED_PR_NUMBER}"
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harness: GitHub surface (matches the daemon's per-claim calls).
+// ---------------------------------------------------------------------------
+
+async fn mount_github_surface(gh: &MockGitHub) {
+    gh.mount_status(
+        "GET",
+        "/repos/owner/repo/issues",
+        200,
+        serde_json::json!([]),
+    )
+    .await;
+    let issue_detail = serde_json::json!({
+        "number": ISSUE_NUMBER,
+        "title": "docs: update architecture.md and state-recovery.md",
+        "body": "Reproducible #86 body",
+        "labels": [{"name": CODE_LABEL}],
+        "state": "open",
+        "user": {"login": "octocat"},
+        "updated_at": "2026-07-29T00:00:00Z",
+    });
+    gh.mount_status(
+        "GET",
+        &format!("/repos/owner/repo/issues/{ISSUE_NUMBER}"),
+        200,
+        issue_detail,
+    )
+    .await;
+    gh.mount_status(
+        "GET",
+        &format!("/repos/owner/repo/issues/{ISSUE_NUMBER}/comments"),
+        200,
+        serde_json::json!([]),
+    )
+    .await;
+    gh.mount_status(
+        "GET",
+        &format!("/repos/owner/repo/issues/{ISSUE_NUMBER}/events"),
+        200,
+        serde_json::json!([]),
+    )
+    .await;
+    gh.mount_status("GET", "/repos/owner/repo/pulls", 200, serde_json::json!([]))
+        .await;
+    let pr_create = serde_json::json!({
+        "number": EXPECTED_PR_NUMBER,
+        "html_url": format!("https://github.com/{OWNER}/{REPO}/pull/{EXPECTED_PR_NUMBER}"),
+    });
+    gh.mount_status("POST", "/repos/owner/repo/pulls", 201, pr_create)
+        .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/owner/repo/issues/{ISSUE_NUMBER}/comments"),
+        201,
+        serde_json::json!({ "id": 99 }),
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Shared driver: spin up the fixtures + run one caduceus tick.
+// ---------------------------------------------------------------------------
+
+struct LoopHarness {
+    _root: TempDir,
+    state_dir: PathBuf,
+    _workdir_base: PathBuf,
+    config_path: PathBuf,
+    gh: MockGitHub,
+    _origin: GitDaemon,
+}
+
+async fn harness(label: &str, worker: &Path, max_retries: u32) -> LoopHarness {
+    let gh = MockGitHub::start().await;
+    let api_base = gh.uri();
+    let origin = GitDaemon::start(label, OWNER, REPO);
+    let origin_uri = origin.uri();
+    let root = TempDir::with_prefix(format!("caduceus-loop-{label}-")).expect("root tempdir");
+    let state_dir = root.path().join("state");
+    let workdir_base = root.path().join("wd");
+    fs::create_dir_all(&state_dir).expect("mkdir state_dir");
+    fs::create_dir_all(&workdir_base).expect("mkdir workdir_base");
+    clone_main(&workdir_base, &origin_uri, OWNER, REPO);
+    let config_path = state_dir.join("config.yaml");
+    write_config(
+        &config_path,
+        &api_base,
+        &state_dir,
+        &workdir_base,
+        worker,
+        max_retries,
+    );
+    mount_github_surface(&gh).await;
+    LoopHarness {
+        _root: root,
+        state_dir,
+        _workdir_base: workdir_base,
+        config_path,
+        gh,
+        _origin: origin,
+    }
+}
+
+fn run_one_tick(h: &LoopHarness, label: &str) -> (i32, String, String) {
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_caduceus"));
+    run_with_timeout(
+        Command::new(&bin)
+            .env("CADUCEUS_CONFIG", &h.config_path)
+            .arg("run")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped()),
+        TICK_TIMEOUT,
+        label,
+    )
+}
+
+fn entry_key() -> String {
+    format!("{OWNER}/{REPO}#{ISSUE_NUMBER}")
+}
+
+fn load_entry(h: &LoopHarness) -> QueueEntry {
+    let store = caduceus::queue::StateStore::open(&h.state_dir).expect("open store");
+    let snap = store.snapshot().expect("snapshot");
+    let key = caduceus::issue::IssueKey::parse(&entry_key()).expect("parse key");
+    snap.entry(&key)
+        .unwrap_or_else(|| panic!("entry {} missing", entry_key()))
+        .clone()
+}
+
+// ---------------------------------------------------------------------------
+// LOOP-01: exit-1 with a parseable success result advances the
+// entry to AwaitingReview, NOT Queued.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn loop01_exit1_with_success_result_advances_to_awaiting_review() {
+    let worker_dir = TempDir::with_prefix("caduceus-loop01-worker-").expect("worker dir");
+    let worker = write_worker_exit1_with_success(worker_dir.path());
+    let h = harness("loop01", &worker, 3).await;
+    seed_state(&h.state_dir, build_entry(None));
+
+    let (code, stdout, stderr) = run_one_tick(&h, "caduceus run (loop01)");
+    assert_eq!(
+        code, 0,
+        "loop01: tick must exit 0; got {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+
+    let entry = load_entry(&h);
+    assert_eq!(
+        entry.phase,
+        Phase::AwaitingReview,
+        "LOOP-01: phase must be AwaitingReview; got {:?}\nlast_error={:?}",
+        entry.phase,
+        entry.last_error
+    );
+    assert!(
+        entry.last_error.is_none()
+            || !entry
+                .last_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("worker exited 1"),
+        "LOOP-01: last_error must not mention worker exit; got {:?}",
+        entry.last_error
+    );
+    assert_eq!(
+        entry.attempts, 0,
+        "LOOP-01: attempts must not increment; got {}",
+        entry.attempts
+    );
+    let fin = entry.finalization.expect("finalization present");
+    assert_eq!(fin.stage, FinalizationStage::PrCreated);
+    assert_eq!(fin.pr_number, Some(EXPECTED_PR_NUMBER));
+
+    // External side effects: exactly one PR creation and one completion
+    // comment — no duplicate dispatch despite the worker's exit 1.
+    assert_eq!(
+        count_pr_posts(&h),
+        1,
+        "LOOP-01: exactly one PR creation POST expected"
+    );
+    assert_eq!(
+        count_comment_posts(&h),
+        1,
+        "LOOP-01: exactly one completion comment POST expected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LOOP-01b: exit-1 with a parseable worker-result.json whose own
+// `status` is `failure` is a worker-attributable failure — it must
+// route through the retry budget, NOT finalize. This pins the worker
+// contract (`prompt.rs`: "status: failure means the daemon should
+// record the failure and retry").
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn loop01b_exit1_with_failure_result_routes_through_retry_budget() {
+    let worker_dir = TempDir::with_prefix("caduceus-loop01b-worker-").expect("worker dir");
+    let worker = write_worker_exit1_with_failure(worker_dir.path());
+    let h = harness("loop01b", &worker, 2).await;
+    seed_state(&h.state_dir, build_entry(None));
+
+    let (code, stdout, stderr) = run_one_tick(&h, "caduceus run (loop01b)");
+    assert_eq!(
+        code, 0,
+        "loop01b: tick must exit 0; got {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+
+    let entry = load_entry(&h);
+    assert_eq!(
+        entry.phase,
+        Phase::Queued,
+        "LOOP-01b: phase must be Queued (declared failure, retry budget); got {:?}\nlast_error={:?}",
+        entry.phase,
+        entry.last_error
+    );
+    assert_eq!(
+        entry.attempts, 1,
+        "LOOP-01b: attempts must increment to 1; got {}",
+        entry.attempts
+    );
+    let last_error = entry.last_error.expect("last_error present");
+    assert!(
+        last_error.contains("failure"),
+        "LOOP-01b: last_error must record the declared failure; got {last_error:?}"
+    );
+    assert!(
+        entry.finalization.is_none(),
+        "LOOP-01b: no finalization checkpoint may be written for a failed result"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LOOP-02: a worker that exits 1 with a success result on an
+// entry that ALREADY has a pr_created checkpoint does not
+// re-dispatch on the next tick; phase stays terminal.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn loop02_exit1_with_existing_checkpoint_stays_terminal_no_redispatch() {
+    let worker_dir = TempDir::with_prefix("caduceus-loop02-worker-").expect("worker dir");
+    let worker = write_worker_exit1_with_success(worker_dir.path());
+    let h = harness("loop02", &worker, 3).await;
+    seed_state(
+        &h.state_dir,
+        build_entry(Some(pr_created_checkpoint(&h.state_dir))),
+    );
+
+    let started = Instant::now();
+    let pr_posts_before = count_pr_posts(&h);
+
+    let (code, stdout, stderr) = run_one_tick(&h, "caduceus run (loop02 tick1)");
+    assert_eq!(
+        code, 0,
+        "loop02 tick1: exit 0 expected; got {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+
+    // The durable PrCreated checkpoint with PR #117 must short-circuit
+    // to AwaitingReview WITHOUT dispatching the worker or opening a
+    // new PR. This is the core issue #118 recovery guarantee.
+    let pr_posts_after_tick1 = count_pr_posts(&h);
+    assert_eq!(
+        pr_posts_after_tick1, pr_posts_before,
+        "LOOP-02 tick1: must not open any PR; \
+         POSTs to /pulls went {pr_posts_before} -> {pr_posts_after_tick1}"
+    );
+
+    let entry_after_tick1 = load_entry(&h);
+    assert_eq!(
+        entry_after_tick1.phase,
+        Phase::AwaitingReview,
+        "LOOP-02 tick1: phase must reconcile to AwaitingReview; got {:?}\nlast_error={:?}",
+        entry_after_tick1.phase,
+        entry_after_tick1.last_error
+    );
+    assert!(
+        entry_after_tick1
+            .last_error
+            .as_deref()
+            .unwrap_or("")
+            .is_empty()
+            || !entry_after_tick1
+                .last_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("worker exited"),
+        "LOOP-02 tick1: last_error must not mention worker exit; got {:?}",
+        entry_after_tick1.last_error
+    );
+    // The durable checkpoint must be preserved with the original PR.
+    let fin = entry_after_tick1
+        .finalization
+        .as_ref()
+        .expect("finalization preserved");
+    assert_eq!(fin.stage, FinalizationStage::PrCreated);
+    assert_eq!(fin.pr_number, Some(EXPECTED_PR_NUMBER));
+
+    // Second tick: should be a no-op for this entry — phase is
+    // terminal, no fresh dispatch, no new PR.
+    let (code2, stdout2, stderr2) = run_one_tick(&h, "caduceus run (loop02 tick2)");
+    assert_eq!(
+        code2, 0,
+        "loop02 tick2: exit 0 expected; got {code2}\n--- stdout ---\n{stdout2}\n--- stderr ---\n{stderr2}"
+    );
+
+    let entry_after_tick2 = load_entry(&h);
+    assert_eq!(
+        entry_after_tick2.phase,
+        Phase::AwaitingReview,
+        "LOOP-02 tick2: phase must stay AwaitingReview; got {:?}",
+        entry_after_tick2.phase
+    );
+
+    let pr_posts_after_tick2 = count_pr_posts(&h);
+    assert_eq!(
+        pr_posts_after_tick2, pr_posts_after_tick1,
+        "LOOP-02: second tick must not open a new PR; \
+         POSTs to /pulls went {pr_posts_after_tick1} -> {pr_posts_after_tick2}"
+    );
+
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "LOOP-04: full reproduction must finish < 30s; took {elapsed:?}"
+    );
+}
+
+// A queued entry with a durable Done checkpoint is inconsistent, but
+// reconciliation must preserve the terminal checkpoint rather than
+// downgrading it to AwaitingReview.
+#[tokio::test]
+async fn done_checkpoint_is_not_downgraded_to_awaiting_review() {
+    let worker_dir = TempDir::with_prefix("caduceus-done-checkpoint-worker-").expect("worker dir");
+    let worker = write_worker_exit1_with_success(worker_dir.path());
+    let h = harness("done-checkpoint", &worker, 3).await;
+    let mut checkpoint = pr_created_checkpoint(&h.state_dir);
+    checkpoint.stage = FinalizationStage::Done;
+    seed_state(&h.state_dir, build_entry(Some(checkpoint)));
+
+    let (code, stdout, stderr) = run_one_tick(&h, "caduceus run (done checkpoint)");
+    assert_eq!(
+        code, 0,
+        "done checkpoint: tick must exit 0; got {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+    let entry = load_entry(&h);
+    assert_eq!(
+        entry.phase,
+        Phase::Done,
+        "Done checkpoint must remain terminal; got {:?}",
+        entry.phase
+    );
+    assert_eq!(
+        count_pr_posts(&h),
+        0,
+        "Done reconciliation must not create a PR"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LOOP-03: exit-1 without a worker-result.json still routes
+// through handle_infra_or_retry and consumes the retry budget.
+// (Regression guard so the reorder doesn't break the original
+// worker-failed-mid-run path.)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn loop03_exit1_no_result_routes_through_retry_budget() {
+    let worker_dir = TempDir::with_prefix("caduceus-loop03-worker-").expect("worker dir");
+    let worker = write_worker_exit1_no_result(worker_dir.path());
+    // Budget of 2 so the first failure stays under budget (Queued).
+    let h = harness("loop03", &worker, 2).await;
+    seed_state(&h.state_dir, build_entry(None));
+
+    let (code, stdout, stderr) = run_one_tick(&h, "caduceus run (loop03)");
+    assert_eq!(
+        code, 0,
+        "loop03: tick must exit 0 (Processed); got {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+
+    let entry = load_entry(&h);
+    assert_eq!(
+        entry.phase,
+        Phase::Queued,
+        "LOOP-03: phase must be Queued (under-budget retry); got {:?}",
+        entry.phase
+    );
+    assert_eq!(
+        entry.attempts, 1,
+        "LOOP-03: attempts must increment to 1; got {}",
+        entry.attempts
+    );
+    let last_error = entry.last_error.expect("last_error present");
+    assert!(
+        last_error.contains("worker exited 1"),
+        "LOOP-03: last_error must mention exit code; got {last_error:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LOOP-04: the issue #86 reproduction completes in < 30s.
+// (Covered by the timed assertion inside loop02; this test exists
+// as the explicit, named acceptance check so a future refactor
+// can't quietly drop the budget guarantee.)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn loop04_issue86_reproduction_completes_under_30s() {
+    let worker_dir = TempDir::with_prefix("caduceus-loop04-worker-").expect("worker dir");
+    let worker = write_worker_exit1_with_success(worker_dir.path());
+    let h = harness("loop04", &worker, 3).await;
+    // Seed the exact observed end-state from issue #118: Queued
+    // entry with a pr_created finalization checkpoint and a nulled
+    // last_run_id.
+    seed_state(
+        &h.state_dir,
+        build_entry(Some(pr_created_checkpoint(&h.state_dir))),
+    );
+
+    // The <30s budget (issue #118 LOOP-04) covers the tick latency —
+    // the reconciliation path that runs once the harness is set up.
+    // Harness construction (git-daemon spawn, clone, wiremock) is
+    // excluded; the meaningful budget is the per-claim tick itself.
+    let started = Instant::now();
+
+    let (code, stdout, stderr) = run_one_tick(&h, "caduceus run (loop04)");
+    assert_eq!(
+        code, 0,
+        "loop04: tick must exit 0; got {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+
+    let entry = load_entry(&h);
+    assert_eq!(
+        entry.phase,
+        Phase::AwaitingReview,
+        "LOOP-04: phase must reconcile to AwaitingReview; got {:?}",
+        entry.phase
+    );
+
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "LOOP-04: reproduction must finish < 30s; took {elapsed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LOOP-05 (issue #118): `caduceus status --json` against the state
+// produced by a real LOOP-01 run (worker exits 1 after writing a
+// success result) must show `phase: awaiting_review`, NOT `phase:
+// queued` with `last_error: "worker exited N..."`. This runs the
+// actual daemon, then invokes the CLI status surface.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn loop05_status_json_after_exit1_success_shows_awaiting_review() {
+    let worker_dir = TempDir::with_prefix("caduceus-loop05-worker-").expect("worker dir");
+    let worker = write_worker_exit1_with_success(worker_dir.path());
+    let h = harness("loop05", &worker, 3).await;
+    seed_state(&h.state_dir, build_entry(None));
+
+    // Run the daemon: worker exits 1 after writing a success result;
+    // the per-claim tick must advance the entry to AwaitingReview.
+    let (code, stdout, stderr) = run_one_tick(&h, "caduceus run (loop05 setup)");
+    assert_eq!(
+        code, 0,
+        "loop05 setup: tick must exit 0; got {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+    let entry = load_entry(&h);
+    assert_eq!(
+        entry.phase,
+        Phase::AwaitingReview,
+        "LOOP-05 precondition: entry must be AwaitingReview after the run"
+    );
+
+    // Now invoke `caduceus status --json` against the resulting state.
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_caduceus"));
+    let output = Command::new(&bin)
+        .env("CADUCEUS_CONFIG", &h.config_path)
+        .args(["status", "--json"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn caduceus status --json");
+    assert!(
+        output.status.success(),
+        "LOOP-05: caduceus status --json must exit 0; got {:?}\n--- stderr ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid json on stdout");
+    let phases = json["report"]["phases"]
+        .as_object()
+        .expect("report.phases object present");
+    let awaiting = phases
+        .get("awaiting_review")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let queued = phases.get("queued").and_then(|v| v.as_u64()).unwrap_or(0);
+    assert_eq!(
+        awaiting, 1,
+        "LOOP-05: phases.awaiting_review must be 1; got {awaiting}\nfull json: {json}"
+    );
+    assert_eq!(
+        queued, 0,
+        "LOOP-05: phases.queued must be 0 (no re-dispatch loop); got {queued}\nfull json: {json}"
+    );
+    // The stale worker-exit error must not surface.
+    let recent_errors = json["report"]["recent_errors"]
+        .as_array()
+        .expect("recent_errors array present");
+    for err in recent_errors {
+        let s = err.as_str().unwrap_or("");
+        assert!(
+            !s.contains("worker exited"),
+            "LOOP-05: recent_errors must not mention worker exit; found {s:?}\nfull json: {json}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn count_pr_posts(h: &LoopHarness) -> usize {
+    h.gh.received_requests()
+        .into_iter()
+        .filter(|r| r.method.as_str() == "POST" && r.url.path() == "/repos/owner/repo/pulls")
+        .count()
+}
+
+fn count_comment_posts(h: &LoopHarness) -> usize {
+    h.gh.received_requests()
+        .into_iter()
+        .filter(|r| {
+            r.method.as_str() == "POST"
+                && r.url.path() == format!("/repos/owner/repo/issues/{ISSUE_NUMBER}/comments")
+        })
+        .count()
+}

--- a/tests/daemon/status_test.rs
+++ b/tests/daemon/status_test.rs
@@ -146,6 +146,7 @@ fn all_phase_counts_are_present() {
         "queued",
         "in_progress",
         "previewed",
+        "awaiting_review",
         "done",
         "failed",
         "skipped",
@@ -586,3 +587,9 @@ fn report_json_includes_app_version_from_cargo_pkg_version() {
         Some(STATUS_SCHEMA_VERSION)
     );
 }
+
+// LOOP-05 (issue #118) is an end-to-end test that runs the real
+// `caduceus run` with a worker that exits 1 after writing a success
+// result, then invokes `caduceus status --json` against the resulting
+// state. It lives in `tests/daemon/per_claim_test.rs` alongside the
+// other LOOP tests so it can reuse the shared harness.

--- a/tests/fixtures/git_daemon.rs
+++ b/tests/fixtures/git_daemon.rs
@@ -1,0 +1,315 @@
+//! Disposable `git daemon` origin fixture.
+//!
+//! Serves a bare repo over the `git://` protocol on 127.0.0.1 so
+//! the daemon's `git fetch` / `git push` exercise real git
+//! subprocesses without github.com. The host `127.0.0.1` matches
+//! the wiremock `api_base` host, so `validate_origin_host` accepts
+//! the origin (this is why a `git daemon` is needed rather than a
+//! `file://` `LocalOrigin`).
+//!
+//! Shared by `tests/daemon/per_claim_test.rs` and
+//! `tests/integration/release_canary_test.rs`. Each consumer wires
+//! the fixture in via `#[path = "fixtures/mod.rs"] mod fixtures;`
+//! and imports what it uses. The `#![allow(dead_code)]` covers
+//! methods only one consumer binary exercises — same rationale as
+//! `github.rs` and `git_origin.rs`.
+
+#![allow(dead_code)]
+
+use std::fs;
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime};
+
+use tempfile::TempDir;
+
+/// Owns a `git daemon` subprocess serving a bare repo at
+/// `git://127.0.0.1:<port>/<owner>/<repo>`. The child is killed on
+/// drop before the tempdir is removed.
+pub struct GitDaemon {
+    _root: TempDir,
+    bare: PathBuf,
+    port: u16,
+    child: std::process::Child,
+    owner: String,
+    repo: String,
+}
+
+impl GitDaemon {
+    /// Create the bare repo, seed an empty commit on `main`, and start
+    /// `git daemon` on a free 127.0.0.1 port. `owner`/`repo` form the
+    /// `git://` path the daemon's clone should use.
+    ///
+    /// If the daemon fails to become ready, the spawned child is killed
+    /// before this function panics, so no orphan `git daemon` leaks.
+    pub fn start(label: &str, owner: &str, repo: &str) -> Self {
+        let root = TempDir::with_prefix(format!("caduceus-origin-{label}-")).expect("origin");
+        let gitroot = root.path().join("gitroot");
+        let bare = gitroot.join(owner).join(repo);
+        fs::create_dir_all(&bare).expect("mkdir bare");
+        init_bare_with_empty_main(&bare);
+
+        // Enable push over the git protocol.
+        git_in(&bare, &["config", "daemon.receivepack", "true"]);
+        git_in(&bare, &["config", "daemon.uploadarch", "true"]);
+
+        let port = free_port_127();
+        let log_path = root.path().join("git-daemon.log");
+        let log = fs::File::create(&log_path).expect("create daemon log");
+        // Guard the child so a readiness panic kills it instead of
+        // orphaning a `git daemon` that holds no TempDir owner yet.
+        let mut child = {
+            struct KillOnDrop(Option<std::process::Child>);
+            impl Drop for KillOnDrop {
+                fn drop(&mut self) {
+                    if let Some(mut c) = self.0.take() {
+                        let _ = c.kill();
+                        let _ = c.wait();
+                    }
+                }
+            }
+            KillOnDrop(Some(
+                Command::new("git")
+                    .args([
+                        "daemon",
+                        "--reuseaddr",
+                        "--listen=127.0.0.1",
+                        &format!("--port={port}"),
+                        &format!("--base-path={}", gitroot.display()),
+                        "--export-all",
+                    ])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::from(log.try_clone().expect("clone log")))
+                    .stderr(Stdio::from(log))
+                    .spawn()
+                    .unwrap_or_else(|e| panic!("spawn git daemon: {e}")),
+            ))
+        };
+
+        // Wait for the daemon to accept a connection so the clone below
+        // does not race the bind. Also confirm the child has not already
+        // exited (a bind error would make it die before readiness).
+        wait_for_port_127(port, Duration::from_secs(5));
+        match child.0.as_mut().unwrap().try_wait() {
+            Ok(None) => {}
+            Ok(Some(status)) => {
+                let log = fs::read_to_string(&log_path).unwrap_or_default();
+                panic!("git daemon exited before becoming ready (status {status}); log:\n{log}");
+            }
+            Err(e) => panic!("git daemon readiness try_wait: {e}"),
+        }
+
+        let child = child.0.take().expect("child present after readiness");
+        Self {
+            _root: root,
+            bare,
+            port,
+            child,
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+        }
+    }
+
+    /// `git://127.0.0.1:<port>/<owner>/<repo>` — the URL the daemon's
+    /// clone should use as `remote.origin.url`.
+    pub fn uri(&self) -> String {
+        format!("git://127.0.0.1:{}/{}/{}", self.port, self.owner, self.repo)
+    }
+
+    /// Path to the bare repository directory on disk.
+    pub fn path(&self) -> &Path {
+        &self.bare
+    }
+
+    /// Number of refs under `refs/heads/` in the bare repo. Used to
+    /// prove a scheduled tick pushed exactly one new branch.
+    pub fn head_refs(&self) -> Vec<String> {
+        let out = Command::new("git")
+            .current_dir(&self.bare)
+            .args(["for-each-ref", "--format=%(refname)", "refs/heads/"])
+            .output()
+            .expect("for-each-ref");
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    /// Count commits on `refs/heads/main`.
+    pub fn main_commit_count(&self) -> usize {
+        rev_list_count(&self.bare, "refs/heads/main")
+    }
+
+    /// Count commits on `branch` that are not on `main` (the new work
+    /// a scheduled tick pushed).
+    pub fn branch_commits_beyond_main(&self, branch: &str) -> usize {
+        let out = Command::new("git")
+            .current_dir(&self.bare)
+            .args(["rev-list", "--count", branch, "^refs/heads/main"])
+            .output()
+            .expect("rev-list count");
+        String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .parse::<usize>()
+            .unwrap_or(0)
+    }
+}
+
+impl Drop for GitDaemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn rev_list_count(bare: &Path, refspec: &str) -> usize {
+    let out = Command::new("git")
+        .current_dir(bare)
+        .args(["rev-list", "--count", refspec])
+        .output()
+        .expect("rev-list --count");
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<usize>()
+        .unwrap_or(0)
+}
+
+/// `git init --bare` at `path`, then seed an empty commit on `main`.
+pub fn init_bare_with_empty_main(path: &Path) {
+    git_in(path, &["init", "--bare"]);
+    git_in(path, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+    let tree = String::from_utf8(
+        Command::new("git")
+            .current_dir(path)
+            .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
+            .output()
+            .expect("hash-object")
+            .stdout,
+    )
+    .expect("utf8")
+    .trim()
+    .to_string();
+    let commit = String::from_utf8(
+        Command::new("git")
+            .current_dir(path)
+            .args(["commit-tree", &tree, "-m", "initial"])
+            .output()
+            .expect("commit-tree")
+            .stdout,
+    )
+    .expect("utf8")
+    .trim()
+    .to_string();
+    git_in(path, &["update-ref", "refs/heads/main", &commit]);
+}
+
+pub fn git_in(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("git spawn");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!(
+            "git {:?} in {} failed ({}); stderr:\n{}",
+            args,
+            dir.display(),
+            output.status,
+            stderr
+        );
+    }
+}
+
+/// Grab a free TCP port on 127.0.0.1 by briefly binding, then drop the
+/// listener so `git daemon` can take it.
+pub fn free_port_127() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+/// Poll until a TCP connection to `127.0.0.1:port` succeeds (the daemon
+/// is accepting). Panics after `timeout`.
+pub fn wait_for_port_127(port: u16, timeout: Duration) {
+    let deadline = SystemTime::now() + timeout;
+    while SystemTime::now() < deadline {
+        if let Ok(addr) = format!("127.0.0.1:{port}").parse() {
+            if TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
+                return;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("git daemon did not accept on 127.0.0.1:{port} within {timeout:?}");
+}
+
+/// Clone the bare origin into `workdir_base/<owner>/<repo>` so the
+/// daemon's `find_main_clone` discovers it with `remote.origin.url` =
+/// the origin's `git://` URI.
+pub fn clone_main(workdir_base: &Path, origin_uri: &str, owner: &str, repo: &str) -> PathBuf {
+    let main_path = workdir_base.join(owner).join(repo);
+    fs::create_dir_all(workdir_base).expect("mkdir workdir_base");
+    let output = Command::new("git")
+        .args([
+            "clone",
+            "-b",
+            "main",
+            origin_uri,
+            &main_path.to_string_lossy(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("git clone");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!(
+            "git clone of disposable origin failed ({}); stderr:\n{}",
+            output.status, stderr
+        );
+    }
+    main_path
+}
+
+/// Spawn `cmd` and wait up to `timeout`, returning `(exit_code, stdout,
+/// stderr)`. Uses `SystemTime` for the deadline. Panics if the process
+/// does not exit in time (after killing it).
+pub fn run_with_timeout(
+    cmd: &mut Command,
+    timeout: Duration,
+    label: &str,
+) -> (i32, String, String) {
+    use std::io::Read;
+    let mut child = cmd.spawn().unwrap_or_else(|e| panic!("spawn {label}: {e}"));
+    let deadline = SystemTime::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(s)) => break s,
+            Ok(None) => {
+                if SystemTime::now() > deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("{label} did not exit within {timeout:?}");
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => panic!("{label} try_wait: {e}"),
+        }
+    };
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut s) = child.stdout.take() {
+        let _ = s.read_to_string(&mut stdout);
+    }
+    if let Some(mut s) = child.stderr.take() {
+        let _ = s.read_to_string(&mut stderr);
+    }
+    (status.code().unwrap_or(-1), stdout, stderr)
+}

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -18,6 +18,8 @@
 #[cfg(test)]
 mod crash_point;
 #[cfg(test)]
+mod git_daemon;
+#[cfg(test)]
 mod git_origin;
 #[cfg(test)]
 mod github;
@@ -29,6 +31,12 @@ mod release_binary;
 #[cfg(test)]
 #[allow(unused_imports)]
 pub use crash_point::CrashPoint;
+#[cfg(test)]
+#[allow(unused_imports)]
+pub use git_daemon::{
+    clone_main, free_port_127, git_in, init_bare_with_empty_main, run_with_timeout,
+    wait_for_port_127, GitDaemon,
+};
 #[cfg(test)]
 #[allow(unused_imports)]
 pub use git_origin::LocalOrigin;

--- a/tests/integration/release_canary_test.rs
+++ b/tests/integration/release_canary_test.rs
@@ -46,12 +46,10 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::Read;
-use std::net::TcpListener;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use tempfile::TempDir;
 use wiremock::ResponseTemplate;
@@ -64,7 +62,7 @@ use caduceus::queue::{
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::{clone_main, run_with_timeout, GitDaemon, MockGitHub};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -212,42 +210,6 @@ fn build_release_binary() -> (PathBuf, String) {
 }
 
 // ---------------------------------------------------------------------------
-// Harness: run a subprocess with a timeout (no Instant::now — REQ-09).
-// ---------------------------------------------------------------------------
-
-/// Spawn `cmd` and wait up to `timeout`, returning `(exit_code, stdout,
-/// stderr)`. Uses `SystemTime` for the deadline (REQ-09: no
-/// `Instant::now()` in canary logic). Panics if the process does not
-/// exit in time (after killing it).
-fn run_with_timeout(cmd: &mut Command, timeout: Duration, label: &str) -> (i32, String, String) {
-    let mut child = cmd.spawn().unwrap_or_else(|e| panic!("spawn {label}: {e}"));
-    let deadline = SystemTime::now() + timeout;
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(s)) => break s,
-            Ok(None) => {
-                if SystemTime::now() > deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    panic!("{label} did not exit within {timeout:?}");
-                }
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            Err(e) => panic!("{label} try_wait: {e}"),
-        }
-    };
-    let mut stdout = String::new();
-    let mut stderr = String::new();
-    if let Some(mut s) = child.stdout.take() {
-        let _ = s.read_to_string(&mut stdout);
-    }
-    if let Some(mut s) = child.stderr.take() {
-        let _ = s.read_to_string(&mut stderr);
-    }
-    (status.code().unwrap_or(-1), stdout, stderr)
-}
-
-// ---------------------------------------------------------------------------
 // Harness: isolated HERMES_HOME tempdir (REQ-03).
 // ---------------------------------------------------------------------------
 
@@ -312,234 +274,6 @@ fn enable_plugin(hermes: &Path, home: &Path) -> i32 {
         Duration::from_secs(30),
     )
     .0
-}
-
-// ---------------------------------------------------------------------------
-// Harness: disposable git origin served by `git daemon` on 127.0.0.1
-// (REQ-04, AC-02).
-// ---------------------------------------------------------------------------
-
-/// Owns a `git daemon` subprocess serving a bare repo at
-/// `git://127.0.0.1:<port>/owner/repo`. The host `127.0.0.1` matches the
-/// wiremock api_base host so `validate_origin_host` accepts the origin.
-/// `receivepack` is enabled so the daemon's `git push` succeeds.
-struct GitDaemon {
-    _root: TempDir,
-    bare: PathBuf,
-    port: u16,
-    child: std::process::Child,
-    #[allow(dead_code)]
-    head_oid: String,
-}
-
-impl GitDaemon {
-    /// Create the bare repo, seed an empty commit on `main`, and start
-    /// `git daemon` on a free 127.0.0.1 port.
-    fn start(label: &str) -> Self {
-        let root = TempDir::with_prefix(format!("caduceus-canary-origin-{label}-"))
-            .expect("origin tempdir");
-        let gitroot = root.path().join("gitroot");
-        let bare = gitroot.join(OWNER).join(REPO);
-        fs::create_dir_all(&bare).expect("mkdir bare");
-
-        let (bare, head_oid) = init_bare_with_empty_main(&bare);
-
-        // Enable push over the git protocol.
-        git_in(&bare, &["config", "daemon.receivepack", "true"]);
-        git_in(&bare, &["config", "daemon.uploadarch", "true"]);
-
-        let port = free_port_127();
-        let log_path = root.path().join("git-daemon.log");
-        let log = fs::File::create(&log_path).expect("create daemon log");
-        let child = Command::new("git")
-            .args([
-                "daemon",
-                "--reuseaddr",
-                "--listen=127.0.0.1",
-                &format!("--port={port}"),
-                &format!("--base-path={}", gitroot.display()),
-                "--export-all",
-            ])
-            .stdin(Stdio::null())
-            .stdout(Stdio::from(log.try_clone().expect("clone log")))
-            .stderr(Stdio::from(log))
-            .spawn()
-            .unwrap_or_else(|e| panic!("spawn git daemon: {e}"));
-
-        // Wait for the daemon to accept a connection so the clone below
-        // does not race the bind.
-        wait_for_port_127(port, Duration::from_secs(5));
-
-        Self {
-            _root: root,
-            bare,
-            port,
-            child,
-            head_oid,
-        }
-    }
-
-    /// `git://127.0.0.1:<port>/owner/repo` — the URL the daemon's clone
-    /// should use as `remote.origin.url`.
-    fn uri(&self) -> String {
-        format!("git://127.0.0.1:{}/{OWNER}/{REPO}", self.port)
-    }
-
-    /// Number of refs under `refs/heads/` in the bare repo. Used to prove
-    /// the scheduled tick pushed exactly one new branch.
-    fn head_refs(&self) -> Vec<String> {
-        let out = Command::new("git")
-            .current_dir(&self.bare)
-            .args(["for-each-ref", "--format=%(refname)", "refs/heads/"])
-            .output()
-            .expect("for-each-ref");
-        String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .map(|s| s.to_string())
-            .collect()
-    }
-
-    /// Count commits on `refs/heads/main`.
-    fn main_commit_count(&self) -> usize {
-        rev_list_count(&self.bare, "refs/heads/main")
-    }
-
-    /// Count commits on `branch` that are not on `main` (the new work
-    /// the scheduled tick pushed).
-    fn branch_commits_beyond_main(&self, branch: &str) -> usize {
-        let out = Command::new("git")
-            .current_dir(&self.bare)
-            .args(["rev-list", "--count", branch, "^refs/heads/main"])
-            .output()
-            .expect("rev-list count");
-        String::from_utf8_lossy(&out.stdout)
-            .trim()
-            .parse::<usize>()
-            .unwrap_or(0)
-    }
-}
-
-impl Drop for GitDaemon {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-fn rev_list_count(bare: &Path, refspec: &str) -> usize {
-    let out = Command::new("git")
-        .current_dir(bare)
-        .args(["rev-list", "--count", refspec])
-        .output()
-        .expect("rev-list --count");
-    String::from_utf8_lossy(&out.stdout)
-        .trim()
-        .parse::<usize>()
-        .unwrap_or(0)
-}
-
-/// `git init --bare` at `path`, seed an empty commit on `main`, return
-/// `(bare_path, head_oid)`.
-fn init_bare_with_empty_main(path: &Path) -> (PathBuf, String) {
-    git_in(path, &["init", "--bare"]);
-    git_in(path, &["symbolic-ref", "HEAD", "refs/heads/main"]);
-    let tree = String::from_utf8(
-        Command::new("git")
-            .current_dir(path)
-            .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
-            .output()
-            .expect("hash-object")
-            .stdout,
-    )
-    .expect("utf8")
-    .trim()
-    .to_string();
-    let commit = String::from_utf8(
-        Command::new("git")
-            .current_dir(path)
-            .args(["commit-tree", &tree, "-m", "initial"])
-            .output()
-            .expect("commit-tree")
-            .stdout,
-    )
-    .expect("utf8")
-    .trim()
-    .to_string();
-    git_in(path, &["update-ref", "refs/heads/main", &commit]);
-    (path.to_path_buf(), commit)
-}
-
-fn git_in(dir: &Path, args: &[&str]) {
-    let status = Command::new("git")
-        .current_dir(dir)
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .status()
-        .expect("git spawn");
-    assert!(
-        status.success(),
-        "git {:?} in {} failed",
-        args,
-        dir.display()
-    );
-}
-
-/// Grab a free TCP port on 127.0.0.1 by briefly binding, then drop the
-/// listener so `git daemon` can take it.
-fn free_port_127() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind probe");
-    let port = listener.local_addr().expect("local addr").port();
-    drop(listener);
-    port
-}
-
-/// Poll until a TCP connection to `127.0.0.1:port` succeeds (the daemon
-/// is accepting). Falls back to checking the child has not already
-/// exited with an error.
-fn wait_for_port_127(port: u16, timeout: Duration) {
-    use std::net::TcpStream;
-    let deadline = SystemTime::now() + timeout;
-    while SystemTime::now() < deadline {
-        if let Ok(addr) = format!("127.0.0.1:{port}").parse() {
-            if TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
-                return;
-            }
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    panic!("git daemon did not accept on 127.0.0.1:{port} within {timeout:?}");
-}
-
-// ---------------------------------------------------------------------------
-// Harness: clone the main working repo at <workdir_base>/owner/repo.
-// ---------------------------------------------------------------------------
-
-/// Clone the bare origin into `workdir_base/owner/repo` so the daemon's
-/// `find_main_clone` discovers it with `remote.origin.url` =
-/// `git://127.0.0.1:<port>/owner/repo`.
-fn clone_main(workdir_base: &Path, origin_uri: &str) -> PathBuf {
-    let main_path = workdir_base.join(OWNER).join(REPO);
-    fs::create_dir_all(workdir_base).expect("mkdir workdir_base");
-    let status = Command::new("git")
-        .args([
-            "clone",
-            "-b",
-            "main",
-            origin_uri,
-            &main_path.to_string_lossy(),
-        ])
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .status()
-        .expect("git clone");
-    assert!(
-        status.success(),
-        "git clone of disposable origin failed (status {status})"
-    );
-    main_path
 }
 
 // ---------------------------------------------------------------------------
@@ -812,7 +546,7 @@ async fn release_binary_canary() {
     mount_github_surface(&gh).await;
 
     // --- REQ-04 / AC-02: disposable git origin on 127.0.0.1 ---
-    let origin = GitDaemon::start("canary");
+    let origin = GitDaemon::start("canary", OWNER, REPO);
     let origin_uri = origin.uri();
     assert!(
         origin_uri.starts_with("git://127.0.0.1:"),
@@ -839,8 +573,8 @@ async fn release_binary_canary() {
     // Clone a clean main working repo for each phase. Its
     // `remote.origin.url` is the `git://127.0.0.1` URI so
     // `validate_origin_host` accepts it.
-    let _main_dry = clone_main(&workdir_base_dry, &origin_uri);
-    let _main_sched = clone_main(&workdir_base_sched, &origin_uri);
+    let _main_dry = clone_main(&workdir_base_dry, &origin_uri, OWNER, REPO);
+    let _main_sched = clone_main(&workdir_base_sched, &origin_uri, OWNER, REPO);
 
     // --- AC-01: install + enable the candidate plugin ---
     bootstrap_plugin(&home);

--- a/tests/state/state_store_test.rs
+++ b/tests/state/state_store_test.rs
@@ -486,6 +486,38 @@ fn save_finalization_persists_checkpoint() {
 }
 
 #[test]
+fn save_resumed_finalization_preserves_original_run_id() {
+    let root = tempdir("save-resumed-finalization");
+    let store = StateStore::open(&root).expect("open");
+    let now = Utc::now();
+    store
+        .enqueue(&key("Owner", "Repo", 1), TicketType::Code, false)
+        .unwrap();
+    let claimed = store.acquire_next("RUN-NEW", 1, now).unwrap().unwrap();
+    let checkpoint = FinalizationCheckpoint {
+        run_id: "RUN-ORIGINAL".to_string(),
+        branch_name: "automation/issue-1-run-original".to_string(),
+        result_path: root.join("runs").join("RUN-ORIGINAL.result.json"),
+        stage: FinalizationStage::Committed,
+        commit_oid: Some("abc123".to_string()),
+        pr_number: None,
+        pr_url: None,
+    };
+    store
+        .save_resumed_finalization(&claimed.claim, checkpoint)
+        .expect("save resumed checkpoint");
+    let snap = store.snapshot().unwrap();
+    let stored = snap
+        .entry(&key("Owner", "Repo", 1))
+        .unwrap()
+        .finalization
+        .as_ref()
+        .expect("finalization present");
+    assert_eq!(stored.run_id, "RUN-ORIGINAL");
+    assert_eq!(stored.branch_name, "automation/issue-1-run-original");
+}
+
+#[test]
 fn save_finalization_with_wrong_run_id_is_rejected() {
     let root = tempdir("save-finalization-wrong");
     let store = StateStore::open(&root).expect("open");


### PR DESCRIPTION
## Summary

Fixes #118.

- Parse `worker-result.json` before treating a non-zero worker exit as a failure.
- Accept a valid `status: success` result even when the bridge exits 1.
- Route `status: failure`, missing, and malformed results through retry handling.
- Reconcile durable PR checkpoints without re-dispatching the worker.
- Resume from the original run ID, result path, and branch identity.
- Preserve terminal `Done` checkpoints without downgrading them.
- Add LOOP-01 through LOOP-05 regression coverage and harden the shared git-daemon fixture.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- Focused Rust regressions: all passing
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py`: 139 passed
- `cargo test --locked --all-targets`: all non-Hermes tests passed; five `hermes_lifecycle` tests hit the existing 240-second sandbox timeout during cold `cargo build --release`

No generated `.opencode/` artifacts are included in the commit.
