### PR TITLE
feat(scheduler): add max_issues_per_tick config field (closes #108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ across this period.
 - **Operator documentation.** Architecture, configuration, installation,
   plugin lifecycle, CI, public-voice, and Hermes-integration guides
   published under `docs/`.
+- **Per-tick claim cap.** `max_issues_per_tick` bounds how many queue
+  entries a single tick will claim before returning, so wall-clock per
+  tick is predictable. Default `worker_parallelism * 4`; `0` opts into
+  the unbounded drain-the-queue behavior. Closes #108.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,10 @@ name = "concurrent_workers_test"
 path = "tests/scheduler/concurrent_workers_test.rs"
 
 [[test]]
+name = "max_issues_per_tick_test"
+path = "tests/scheduler/max_issues_per_tick_test.rs"
+
+[[test]]
 name = "circuit_test"
 path = "tests/scheduler/circuit_test.rs"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,6 +342,18 @@ is a no-op. On the first non-dry tick, a still-labeled
 `Queued`, so previewing never prevents the eventual real
 run.
 
+### `max_issues_per_tick`
+
+**Type:** `u32`. **Default:** `worker_parallelism * 4`.
+
+Bounds how many queue entries a single tick will claim
+before returning, so wall-clock per tick is predictable
+even with a large eligible queue. The next cron tick
+picks up the remaining entries. `0` opts into the
+unbounded drain-the-queue behavior — in-flight workers
+always finish their current work on tick exit; the cap
+only stops claiming new entries.
+
 ## Environment Variables
 
 Caduceus reads these at process start. Set them in your

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -87,6 +87,15 @@ failures do **not** consume the worker budget. They count as transient
 and the daemon retries on the next tick without bumping the per-issue
 counter.
 
+## Per-Tick Claim Cap
+
+`max_issues_per_tick` (default `worker_parallelism * 4`) bounds how
+many queue entries a single tick will claim before returning. With the
+default, a tick with `worker_parallelism: 4` processes up to 16 issues
+and leaves the rest for the next tick. Set `0` to restore the unbounded
+drain-the-queue behavior. In-flight workers always finish their current
+work on tick exit; the cap only stops claiming new entries.
+
 ## State Recovery Procedure
 
 Both `queue.json` and `state_meta.json` use temp-file + `fsync` +

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -355,10 +355,21 @@ pub async fn tick(
     let mut http_status: Option<u16> = None;
     let mut last_error: Option<CaduceusError> = None;
     let worker_parallelism = cfg.worker_parallelism.max(1) as usize;
+    // Per-tick claim cap (issue #108): bounds how many queue entries
+    // one tick will claim before returning. 0 == unbounded (the
+    // pre-#108 drain-the-queue behavior). The cap only stops claiming
+    // new entries; the JoinSet drain below still runs to completion.
+    let max_issues_per_tick = cfg.max_issues_per_tick;
+    let mut processed: u32 = 0;
 
     let mut set: JoinSet<(CaduceusResult<TickOutcome>, Option<u16>)> = JoinSet::new();
 
     'dispatch: loop {
+        // Per-tick claim cap: check before acquiring the next entry
+        // so exactly `max_issues_per_tick` claims happen per tick.
+        if max_issues_per_tick != 0 && processed >= max_issues_per_tick {
+            break 'dispatch;
+        }
         // 6.1. Acquire the next eligible entry under the
         //      scheduler lock. Existing API, preserved exactly.
         let run_id_candidate = Ulid::new().to_string();
@@ -370,6 +381,11 @@ pub async fn tick(
             Some(c) => c,
             None => break 'dispatch,
         };
+        // Count the claim immediately: circuit-blocked and
+        // pool-saturated entries are requeued via `continue 'dispatch`
+        // below, but they still consume quota so a flood of blocked
+        // entries cannot starve real work (issue #108).
+        processed += 1;
 
         // 6.2. Circuit-breaker probe (inlined from the prior
         //      synchronous path). On a circuit-blocked repo or

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -53,6 +53,11 @@ pub const DEFAULT_TICKET_LABEL_CODE: &str = "🤖 auto-fix";
 pub const DEFAULT_TICKET_LABEL_INVESTIGATION: &str = "🤖 auto-fix-investigate";
 pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 pub const DEFAULT_WORKER_PARALLELISM: u32 = 1;
+/// Multiplier applied to `worker_parallelism` to derive the default
+/// `max_issues_per_tick` cap. Bounded but generous — a tick with
+/// `worker_parallelism: N` processes up to `N * 4` issues, leaving
+/// the rest for the next tick (issue #108).
+pub const DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER: u32 = 4;
 pub const DEFAULT_SCHEDULER_LEASE_TTL_SECONDS: u64 = 60;
 pub const DEFAULT_WORKER_LEASE_TTL_SECONDS: u64 = 600;
 pub const DEFAULT_SCHEDULER_TRANSACTION_BUDGET_MS: u64 = 100;
@@ -112,6 +117,15 @@ pub struct Config {
     pub dry_run: bool,
     /// Maximum number of concurrent worker processes. Default 1.
     pub worker_parallelism: u32,
+    /// Maximum number of queue entries a single tick will claim
+    /// before returning (issue #108). `0` means unbounded — the
+    /// pre-#108 drain-the-queue behavior. Default
+    /// `worker_parallelism * 4`, so unbounded is never accidental.
+    /// The JoinSet drain still runs to completion on tick exit;
+    /// this cap only stops claiming new entries and keeps
+    /// `contract/SCHED-001` (bounded single-host concurrency)
+    /// bounded across a long cron tick.
+    pub max_issues_per_tick: u32,
     /// Maximum number of pages to follow during paginated API
     /// discovery. Default 20.
     pub discovery_max_pages: u32,
@@ -226,6 +240,7 @@ pub struct RawConfig {
     pub api_base: Option<String>,
     pub dry_run: Option<bool>,
     pub worker_parallelism: Option<u32>,
+    pub max_issues_per_tick: Option<u32>,
     pub discovery_max_pages: Option<u32>,
     pub scheduler_lease_ttl_seconds: Option<u64>,
     pub worker_lease_ttl_seconds: Option<u64>,
@@ -707,6 +722,17 @@ impl Config {
         // delegate the merge.
         let dry_run = raw.dry_run.unwrap_or(false);
 
+        // Scheduler dispatch bounds. `worker_parallelism` caps
+        // in-flight workers; `max_issues_per_tick` defaults to a
+        // bounded multiple so a single cron tick never drains an
+        // unbounded queue (issue #108). Explicit `0` opts back into
+        // the unbounded drain-the-queue behavior — never the
+        // default.
+        let worker_parallelism = raw.worker_parallelism.unwrap_or(DEFAULT_WORKER_PARALLELISM);
+        let max_issues_per_tick = raw
+            .max_issues_per_tick
+            .unwrap_or(worker_parallelism.saturating_mul(DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER));
+
         if !errors.is_empty() {
             return Err(CaduceusError::Config(errors.join("; ")));
         }
@@ -743,7 +769,8 @@ impl Config {
             }),
             api_base,
             dry_run,
-            worker_parallelism: raw.worker_parallelism.unwrap_or(DEFAULT_WORKER_PARALLELISM),
+            worker_parallelism,
+            max_issues_per_tick,
             discovery_max_pages,
             compiled_ignore_patterns,
             scheduler_lease_ttl_seconds: raw
@@ -851,6 +878,8 @@ impl Config {
             api_base: DEFAULT_API_BASE.to_string(),
             dry_run: false,
             worker_parallelism: DEFAULT_WORKER_PARALLELISM,
+            max_issues_per_tick: DEFAULT_WORKER_PARALLELISM
+                .saturating_mul(DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER),
             discovery_max_pages: DEFAULT_DISCOVERY_MAX_PAGES,
             compiled_ignore_patterns: Vec::new(),
             scheduler_lease_ttl_seconds: DEFAULT_SCHEDULER_LEASE_TTL_SECONDS,

--- a/src/worktree/testing.rs
+++ b/src/worktree/testing.rs
@@ -51,6 +51,9 @@ impl Config {
             api_base: DEFAULT_API_BASE.to_string(),
             dry_run: false,
             worker_parallelism: 1,
+            // These runner tests don't exercise the dispatch loop, so
+            // unbounded is safe here.
+            max_issues_per_tick: 0,
             discovery_max_pages: 20,
             compiled_ignore_patterns: Vec::new(),
             scheduler_lease_ttl_seconds: 60,

--- a/tests/scheduler/max_issues_per_tick_test.rs
+++ b/tests/scheduler/max_issues_per_tick_test.rs
@@ -1,0 +1,227 @@
+//! Regression tests for the per-tick claim cap (issue #108).
+//!
+//! These tests pin the contract that a single tick claims at most
+//! `max_issues_per_tick` queue entries before returning, while `0`
+//! restores the unbounded drain-the-queue behavior. The cap counts
+//! the claim itself — circuit-blocked and pool-saturated entries are
+//! requeued via `continue 'dispatch` but still consume quota, so a
+//! flood of blocked entries cannot starve real work.
+//!
+//! The full `tick()` body would exercise many other concerns
+//! (cadence gate, GitHub client, lease store). This file mirrors the
+//! production dispatch shape from `src/daemon/tick/mod.rs` with a
+//! `Pool`-level stub: cap check at the top of the loop, the claim
+//! counter incremented after a successful acquire and before the
+//! circuit probe, and the JoinSet drained to completion on exit.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::JoinSet;
+
+use caduceus::scheduler::{DrainConfig, Pool};
+
+/// Small helper that builds a `DrainConfig` with a short
+/// backpressure budget and a generous drain window — the test
+/// doesn't exercise drain, only admission concurrency.
+fn drain_config() -> DrainConfig {
+    DrainConfig::from_seconds_and_ms(60, 5_000) // 60s drain, 5s backpressure
+}
+
+/// A "claimed entry" stand-in: the only fields the dispatch loop
+/// needs are the repo key and a stable index for simulating the
+/// circuit-breaker probe. The real `StateStore::acquire_next`
+/// returns a `ClaimedEntry`; the stub uses this trivial struct to
+/// keep the test focused on the cap shape.
+#[derive(Clone)]
+struct MockClaim {
+    index: usize,
+    repo_key: String,
+}
+
+/// Observable dispatch counts after a run.
+struct DispatchCounts {
+    claimed: usize,
+    spawned: usize,
+    completed: usize,
+}
+
+/// Mirrors the production `'dispatch` loop shape from
+/// `src/daemon/tick/mod.rs`: cap check at the top, claim counter
+/// incremented after a successful acquire (before the circuit probe
+/// and pool admit), and the JoinSet drained to completion on exit.
+/// Entries before `blocked_prefix` are treated as circuit-blocked
+/// and requeued via `continue 'dispatch` without spawning.
+async fn run_dispatch(
+    queue: Vec<MockClaim>,
+    cap: u32,
+    parallelism: usize,
+    blocked_prefix: usize,
+) -> DispatchCounts {
+    let pool = Arc::new(Pool::new(parallelism as u32, drain_config()));
+    let queue = Arc::new(std::sync::Mutex::new(queue.into_iter()));
+
+    let claimed = Arc::new(AtomicUsize::new(0));
+    let spawned = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    let mut set: JoinSet<()> = JoinSet::new();
+    let mut processed: u32 = 0;
+
+    'dispatch: loop {
+        // Per-tick claim cap — identical to production: `0` is
+        // unbounded, otherwise break before the next acquire once the
+        // cap is reached.
+        if cap != 0 && processed >= cap {
+            break 'dispatch;
+        }
+
+        // 6.1. Acquire the next entry (mocked via a queue iterator).
+        let claimed_entry = match queue.lock().unwrap().next() {
+            Some(c) => c,
+            None => break 'dispatch,
+        };
+        // Count the claim immediately: circuit-blocked and
+        // pool-saturated entries are requeued via `continue 'dispatch`
+        // below, but they still consume quota (issue #108).
+        processed += 1;
+        claimed.fetch_add(1, Ordering::SeqCst);
+
+        // 6.2. Simulated circuit-breaker probe. Entries before
+        // `blocked_prefix` are requeued without spawning, mirroring
+        // the production `continue 'dispatch` path.
+        if claimed_entry.index < blocked_prefix {
+            continue 'dispatch;
+        }
+
+        // 6.3. Admit the entry to the worker pool.
+        let admit = pool
+            .admit(&claimed_entry.repo_key, &claimed_entry.repo_key)
+            .await
+            .expect("admit succeeds for distinct repos under cap");
+
+        // 6.4. Spawn the stub worker into the JoinSet.
+        spawned.fetch_add(1, Ordering::SeqCst);
+        let completed_for_task = Arc::clone(&completed);
+        set.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            completed_for_task.fetch_add(1, Ordering::SeqCst);
+            // admit drops here, releasing the permit.
+            drop(admit);
+        });
+
+        // 6.5. When the JoinSet is at the cap, await one completion
+        // before pulling the next claim.
+        if set.len() >= parallelism {
+            if let Some(joined) = set.join_next().await {
+                joined.expect("task did not panic or abort");
+            }
+        }
+    }
+
+    // 6.6. Final drain — unchanged, runs to completion.
+    while set.join_next().await.is_some() {}
+
+    DispatchCounts {
+        claimed: claimed.load(Ordering::SeqCst),
+        spawned: spawned.load(Ordering::SeqCst),
+        completed: completed.load(Ordering::SeqCst),
+    }
+}
+
+fn queue_of(n: usize) -> Vec<MockClaim> {
+    (0..n)
+        .map(|i| MockClaim {
+            index: i,
+            repo_key: format!("owner/repo-{i}"),
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn dispatch_loop_breaks_at_cap() {
+    // GIVEN a cap of 4 and a queue of 12 distinct repos
+    let cap: u32 = 4;
+    let queue = queue_of(12);
+
+    // WHEN the dispatch loop runs with the production cap shape
+    let counts = run_dispatch(
+        queue.clone(),
+        cap,
+        /* parallelism */ 2,
+        /* blocked */ 0,
+    )
+    .await;
+
+    // THEN exactly `cap` entries were claimed
+    assert_eq!(
+        counts.claimed, cap as usize,
+        "loop must claim exactly max_issues_per_tick entries"
+    );
+
+    // AND every claimed entry was spawned and completed
+    assert_eq!(counts.spawned, cap as usize);
+    assert_eq!(counts.completed, cap as usize);
+
+    // AND the queue still holds the remaining entries for the next tick
+    let remaining = queue.len() - counts.claimed;
+    assert_eq!(
+        remaining, 8,
+        "unclaimed entries stay queued for the next tick"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_loop_zero_is_unbounded() {
+    // GIVEN cap = 0 (unbounded) and a queue of 12 distinct repos
+    let cap: u32 = 0;
+    let queue = queue_of(12);
+
+    // WHEN the dispatch loop runs
+    let counts = run_dispatch(
+        queue.clone(),
+        cap,
+        /* parallelism */ 3,
+        /* blocked */ 0,
+    )
+    .await;
+
+    // THEN every entry is claimed, spawned, and completed — `0` is
+    // the documented escape hatch that restores the pre-#108
+    // drain-the-queue behavior.
+    assert_eq!(counts.claimed, 12, "0 must be unbounded");
+    assert_eq!(counts.spawned, 12);
+    assert_eq!(counts.completed, 12);
+}
+
+#[tokio::test]
+async fn circuit_blocked_entry_consumes_quota() {
+    // GIVEN a cap of 3 and a queue of 6 where the first 2 entries
+    // are circuit-blocked and requeued without spawning
+    let cap: u32 = 3;
+    let queue = queue_of(6);
+
+    // WHEN the dispatch loop runs
+    let counts = run_dispatch(
+        queue.clone(),
+        cap,
+        /* parallelism */ 2,
+        /* blocked */ 2,
+    )
+    .await;
+
+    // THEN the loop claimed exactly 3 entries — the 2 blocked ones
+    // consumed quota and were requeued, and only 1 real worker was
+    // spawned before the cap stopped the drain.
+    assert_eq!(
+        counts.claimed, cap as usize,
+        "circuit-blocked claims must count toward the cap"
+    );
+    assert_eq!(counts.spawned, 1, "only the unblocked entry spawns");
+    assert_eq!(counts.completed, 1);
+
+    // AND the remaining entries stay queued for the next tick
+    let remaining = queue.len() - counts.claimed;
+    assert_eq!(remaining, 3, "blocked flood must not starve the cap");
+}


### PR DESCRIPTION
## Summary

Adds a `max_issues_per_tick` config field that bounds how many queue entries a single tick will claim before returning. After the concurrency set landed in #104 + #105 + #106, a single tick drained the entire eligible queue — wall-clock per tick became unbounded, which is a real operational surprise with long-running workers.

This is a config-only feature; the JoinSet drain on tick exit is unchanged so in-flight workers always finish their current work. The cap only stops claiming new entries.

## Design

| Layer | Field | Type | Default |
|---|---|---|---|
| `Config` | `max_issues_per_tick` | `u32` (resolved) | `worker_parallelism * 4` (computed) |
| `RawConfig` | `max_issues_per_tick` | `Option<u32>` | `None` |

**Default = `worker_parallelism * 4`** (the issue's recommendation). Bounded but generous — a tick with `worker_parallelism: 4` processes up to 16 issues and leaves the rest for the next tick.

**`0` = unbounded** (explicit opt-in). The issue's wording was self-contradictory ("`0` = unbounded" + "validator rejects `0`"); the plan resolves it by making the default non-zero (so unbounded is never accidental) and treating explicit `0` as the intentional opt-in to the pre-#108 drain-the-queue behavior. No validator rejection.

**Increment placement** — the counter increments immediately after `acquire_next` returns `Some(...)` and *before* the circuit-breaker probe (6.2) and pool admit (6.3). This means circuit-blocked and pool-saturated retries consume quota, so a flood of blocked entries cannot starve real work (the issue's open-question #4 recommendation).

## Files changed

- `src/infra/config/mod.rs` — new `DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER: u32 = 4` constant; `Config.max_issues_per_tick: u32` + `RawConfig.max_issues_per_tick: Option<u32>`; `from_raw` computes the default via `worker_parallelism.saturating_mul(DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER)`; `test_defaults` pins the computed value.
- `src/daemon/tick/mod.rs` — cap check at top of `'dispatch:` loop (`0` = unbounded), `processed += 1` after the successful claim, before the circuit/pool branches. JoinSet drain (6.6) untouched.
- `src/worktree/testing.rs` — added `max_issues_per_tick: 0` to the only full `Config { ... }` literal in the repo. All other test configs use `test_defaults` / struct-update and inherit safely.
- `tests/scheduler/max_issues_per_tick_test.rs` (NEW, 227 lines) — three regression tests pinning the contract:
  1. `dispatch_loop_breaks_at_cap` — cap=4, queue=12, assert exactly 4 claims
  2. `dispatch_loop_zero_is_unbounded` — cap=0, queue=12, assert all 12 claimed
  3. `circuit_blocked_entry_consumes_quota` — cap=3 with 2 simulated circuit-blocked entries, assert the cap counts the claim (not the spawn) so blocked retries don't starve real work
- `Cargo.toml` — registers the new test binary
- `CHANGELOG.md` — `### Added` bullet under `[1.0.0] - Unreleased`
- `skills/caduceus/SKILL.md` — operator-facing "Per-Tick Claim Cap" section
- `docs/configuration.md` — `### max_issues_per_tick` field reference entry

## Test plan

```bash
cargo fmt --check
cargo clippy --locked --all-targets -- -D warnings
cargo test --locked --all-targets
uv run pytest -q tests/plugin/ tests/integration/bridge_test.py
```

Gates verified locally on the build agent:
- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --all-targets` — 500 pass; 5 pre-existing environmental failures (verified identical on `origin/main` — `hermes_lifecycle` setup exceeds 240s timeout under concurrent release builds; `token_resolution_test` fails when a real `GITHUB_TOKEN` is exported, passes with `env -u GITHUB_TOKEN`)
- `uv run pytest` — 139/139 pass

## Contract impact

References `contract/SCHED-001` (bounded single-host concurrency) — the cap is a per-tick *extension* of the host-wide concurrency contract: bounded parallelism per tick is already enforced by the lease store; this adds bounded *throughput* per tick as a complementary guarantee. No contract changes required.

## Follow-ups (not blocking this PR)

These were flagged by the check-phase review as nice-to-haves, not amends:

1. **Pin the computed default** in `tests/state/config_test.rs::test_defaults_match_contract` so a future refactor can't silently change the multiplier or resolution order.
2. **`PoolSaturated` quota-consumption test** — only the circuit-blocked path is currently exercised. The doc comment claims pool-saturated retries also consume quota; a test would harden that.
3. **Tiny-cap test** — a case with `max_issues_per_tick < worker_parallelism` to prove the cap dominates the loop even when the JoinSet is nowhere near full.
4. **`docs/configuration.md` is broadly stale** — it already omits `worker_parallelism`, `circuit_*`, scheduler lease fields, etc. This PR adds `max_issues_per_tick` (matches the issue) but the broader cleanup is a separate docs ticket.

## Out of scope (separate issues)

- #91 / #104 (per-process admission guard) — merged
- #105 / #107 (JoinSet dispatch loop) — merged
- #106 / #109 (cross-process lease enforcement) — merged
- #88 — OCI isolation broken
- #92 — migrate-state --to-sqlite
- #94 — supervisor protocol
- #97 — maintainability cleanup
- #98 — v1.0 release-readiness tracker

Closes #108