### PR TITLE
fix(tick): persist investigation finalization queue checkpoint (closes #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@ across this period.
   also tolerates an empty `.worktrees/` directory when no worktree is
   registered. Operators no longer need to manually `rm` the lock file
   between failed dispatches.
+- **Investigation finalization checkpoint.** The investigation
+  finalization path now persists `InvestigationReady` /
+  `InvestigationCommented` checkpoints (queue + SQLite) around the
+  findings comment, mirroring the code-ticket durable-checkpoint
+  pattern. A crash after the comment no longer re-dispatches the
+  worker and posts a duplicate comment. Closes #120.
 
 ### Security
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,6 +265,10 @@ name = "checkpoint_recovery_test"
 path = "tests/state/checkpoint_recovery_test.rs"
 
 [[test]]
+name = "investigation_checkpoint_recovery_test"
+path = "tests/state/investigation_checkpoint_recovery_test.rs"
+
+[[test]]
 name = "claim_test"
 path = "tests/state/claim_test.rs"
 
@@ -487,6 +491,10 @@ path = "tests/integration/integration_test.rs"
 [[test]]
 name = "finalize_pr_number_test"
 path = "tests/integration/finalize_pr_number_test.rs"
+
+[[test]]
+name = "investigation_finalize_checkpoint_test"
+path = "tests/integration/investigation_finalize_checkpoint_test.rs"
 
 [[test]]
 name = "docs_contract_test"

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -12,8 +12,8 @@ use crate::daemon::orchestration::{
 };
 use crate::finalize::{
     archive_worker_result, commit_code_and_finalize, dry_run_finalize,
-    find_or_create_pr_and_finalize, post_completion_only, post_investigation_comment_and_finalize,
-    push_and_finalize, FinalizeContext, FinalizeOutput, FinalizeRequest,
+    find_or_create_pr_and_finalize, post_completion_only, push_and_finalize, FinalizeContext,
+    FinalizeOutput, FinalizeRequest,
 };
 use crate::github::poll::{discover_watched_repos, merge_outcomes, poll_code, poll_investigation};
 use crate::github::{Client, RateLimitInfo, Response};
@@ -72,6 +72,16 @@ pub(crate) async fn run_claim(
             } else {
                 guard.finish_success().await?;
             }
+            return Ok(TickOutcome::Processed);
+        }
+        if fin.stage == FinalizationStage::InvestigationCommented
+            && claimed.entry.ticket_type == TicketType::Investigation
+        {
+            info!(
+                issue = %claimed.entry.key.display_key(),
+                "durable InvestigationCommented checkpoint; finishing"
+            );
+            guard.finish_investigation().await?;
             return Ok(TickOutcome::Processed);
         }
         if matches!(
@@ -347,16 +357,18 @@ pub(crate) async fn run_claim(
     }
 
     if worker_result.investigation || claimed.entry.ticket_type == TicketType::Investigation {
-        match post_investigation_comment_and_finalize(
+        match run_investigation_finalize(
             &final_ctx,
-            client.as_ref(),
             &worker_result,
+            &archive_path,
+            client.as_ref(),
+            store,
             &cfg.ticket_label_investigation,
         )
         .await
         {
             Ok(_) => {
-                let _ = guard.finish_investigation().await;
+                guard.finish_investigation().await?;
                 return Ok(TickOutcome::Processed);
             }
             Err(err) => {

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -416,6 +416,13 @@ pub(crate) async fn run_resume_finalization(
         Commented | AwaitingReview | Done => {
             // Re-run the comment post (idempotent marker check), then
             // persist the Commented and AwaitingReview checkpoints.
+            // Debug-only invariant: the per_claim `InvestigationCommented`
+            // short-circuit is the actual production guard against
+            // investigation entries reaching this code-path arm.
+            debug_assert!(
+                claimed.entry.ticket_type != TicketType::Investigation,
+                "investigation entries must resume via the InvestigationCommented arm"
+            );
             let comment_out =
                 post_completion_only(&ctx, ctx.client.as_ref(), &worker_result).await?;
             checkpoint(
@@ -426,13 +433,62 @@ pub(crate) async fn run_resume_finalization(
             )?;
             checkpoint(&conn, &ctx.run_id, AwaitingReview, None)?;
         }
-        InvestigationReady | InvestigationCommented => {
-            // Investigation stages do not post durable remote effects in
-            // scope of this change; remote_marker None is the documented
-            // exception per spec.
-            //
-            // Investigation tickets have no PR/merge step, so resume
-            // completes the entry to Done.
+        InvestigationCommented => {
+            // Resume target after an InvestigationReady crash: the
+            // findings comment was never durably recorded on the queue
+            // entry, so re-post it (idempotent — the marker carries the
+            // original run_id, so the existing-comment check suppresses
+            // a duplicate POST), persist the InvestigationCommented
+            // checkpoint, then finish the entry.
+            post_investigation_comment_and_finalize(
+                &ctx,
+                ctx.client.as_ref(),
+                &worker_result,
+                &ctx.config.ticket_label_investigation,
+            )
+            .await?;
+            store.save_resumed_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::InvestigationCommented,
+                    commit_oid: None,
+                    pr_number: None,
+                    pr_url: None,
+                },
+            )?;
+            checkpoint(&conn, &ctx.run_id, InvestigationCommented, None)?;
+            guard.finish_investigation().await?;
+            return Ok(TickOutcome::Processed);
+        }
+        InvestigationReady => {
+            // Defensive: nothing maps to InvestigationReady as a resume
+            // target (`next_stage_after` has no predecessor producing
+            // it), but keep the same body as InvestigationCommented so
+            // a future stage-graph change cannot silently drop the
+            // findings comment.
+            post_investigation_comment_and_finalize(
+                &ctx,
+                ctx.client.as_ref(),
+                &worker_result,
+                &ctx.config.ticket_label_investigation,
+            )
+            .await?;
+            store.save_resumed_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::InvestigationCommented,
+                    commit_oid: None,
+                    pr_number: None,
+                    pr_url: None,
+                },
+            )?;
+            checkpoint(&conn, &ctx.run_id, InvestigationCommented, None)?;
             guard.finish_investigation().await?;
             return Ok(TickOutcome::Processed);
         }
@@ -533,4 +589,76 @@ pub(crate) async fn run_code_finalize(
             format!("issue={}", ctx.issue.key.display_key()),
         ],
     })
+}
+
+/// Runs investigation finalization with the same durable-checkpoint
+/// pattern as [`run_code_finalize`], minus the git pipeline:
+/// investigation tickets commit/push nothing.
+///
+/// The `InvestigationReady` checkpoint is persisted (SQLite then queue)
+/// *before* the findings comment POST, and `InvestigationCommented`
+/// *after* it succeeds — so a crash after the comment leaves a durable
+/// record and recovery never re-dispatches the worker or duplicates the
+/// comment (the resume path re-posts idempotently under the original
+/// `run_id` marker instead).
+pub(crate) async fn run_investigation_finalize(
+    ctx: &FinalizeContext,
+    worker_result: &WorkerResult,
+    archive_path: &std::path::Path,
+    client: &Client,
+    store: &StateStore,
+    investigation_label: &str,
+) -> CaduceusResult<FinalizeOutput> {
+    let conn = store::open_in(&ctx.config.state_dir)?;
+
+    // Stage 1: InvestigationReady — no external effect yet, but the
+    // queue entry must durably record that the investigation run began
+    // finalization so recovery does not re-dispatch the worker.
+    checkpoint(
+        &conn,
+        &ctx.run_id,
+        FinalizationStage::InvestigationReady,
+        None,
+    )?;
+    store.save_finalization(
+        &ctx.claim,
+        crate::state::queue::FinalizationCheckpoint {
+            run_id: ctx.run_id.clone(),
+            branch_name: ctx.worktree.branch_name.clone(),
+            result_path: archive_path.to_path_buf(),
+            stage: crate::state::queue::FinalizationStage::InvestigationReady,
+            commit_oid: None,
+            pr_number: None,
+            pr_url: None,
+        },
+    )?;
+
+    // Stage 2: Post the findings comment (idempotent marker check).
+    let output =
+        post_investigation_comment_and_finalize(ctx, client, worker_result, investigation_label)
+            .await?;
+
+    // Stage 3: InvestigationCommented — the comment is now durable
+    // remote state; record it so recovery finishes the entry without
+    // re-posting.
+    checkpoint(
+        &conn,
+        &ctx.run_id,
+        FinalizationStage::InvestigationCommented,
+        None,
+    )?;
+    store.save_finalization(
+        &ctx.claim,
+        crate::state::queue::FinalizationCheckpoint {
+            run_id: ctx.run_id.clone(),
+            branch_name: ctx.worktree.branch_name.clone(),
+            result_path: archive_path.to_path_buf(),
+            stage: crate::state::queue::FinalizationStage::InvestigationCommented,
+            commit_oid: None,
+            pr_number: None,
+            pr_url: None,
+        },
+    )?;
+
+    Ok(output)
 }

--- a/src/state/checkpoints.rs
+++ b/src/state/checkpoints.rs
@@ -16,6 +16,7 @@
 //! ```text
 //! ResultValidated -> Committed -> Pushed -> PrCreated -> Commented
 //!   -> AwaitingReview -> Done
+//! InvestigationReady -> InvestigationCommented -> Done
 //! ```
 //!
 //! Each checkpoint is committed after the corresponding external
@@ -23,6 +24,12 @@
 //! checkpoint and uses idempotency keys or remote reconciliation
 //! so a crash does not duplicate commits, pushes, pull requests,
 //! comments, or issue updates.
+//!
+//! The investigation stages (`InvestigationReady` /
+//! `InvestigationCommented`) carry no `remote_marker` — the
+//! GitHub comment idempotency check uses the `run_id`-bearing
+//! `<!-- automation-investigation:... -->` marker on the comment
+//! itself instead.
 
 use rusqlite::{params, Connection};
 

--- a/tests/integration/investigation_finalize_checkpoint_test.rs
+++ b/tests/integration/investigation_finalize_checkpoint_test.rs
@@ -1,0 +1,343 @@
+//! Integration tests for the durable investigation finalization
+//! checkpoint (issue #120).
+//!
+//! The fresh path persists `InvestigationReady` (queue + SQLite) before
+//! the findings comment POST and `InvestigationCommented` after it
+//! succeeds, mirroring the code-ticket durable-checkpoint pattern from
+//! #89/#103. These tests prove the queue entry records both stages and
+//! that a crash after the comment does not duplicate it on recovery
+//! (the idempotent `run_id` marker suppresses the re-post).
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use caduceus::config::{Config, LoadContext, RawConfig};
+use caduceus::finalize::{
+    post_investigation_comment_and_finalize, FinalizeContext, FinalizeRequest,
+    INVESTIGATION_MARKER_PREFIX,
+};
+use caduceus::github::Client;
+use caduceus::issue::IssueDetail;
+use caduceus::queue::{
+    ClaimToken, FinalizationCheckpoint, FinalizationStage, Phase, StateStore, TicketType,
+};
+use caduceus::worker::{WorkerResult, WorkerStatus};
+use caduceus::worktree::{RepositoryInfo, Worktree};
+use chrono::Utc;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::MockGitHub;
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+
+fn tempdir(label: &str) -> std::path::PathBuf {
+    let mut dir = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    dir.push(format!("caduceus-investigation-finalize-{label}-{nonce}"));
+    std::fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+fn empty_config(state_dir: &Path) -> Config {
+    let raw = RawConfig {
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        state_dir: Some(state_dir.to_path_buf()),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let ctx = LoadContext {
+        plugin_root: Some(state_dir.to_path_buf()),
+        ..Default::default()
+    };
+    Config::from_raw(raw, &ctx).expect("config")
+}
+
+fn inert_client() -> Arc<Client> {
+    Arc::new(Client::new("https://api.github.com"))
+}
+
+fn make_issue() -> IssueDetail {
+    IssueDetail {
+        key: caduceus::issue::IssueKey {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+        },
+        title: "Sample".to_string(),
+        body: "Body".to_string(),
+        labels: vec![],
+        comments: vec![],
+        trusted_comments: vec![],
+        events: vec![],
+        fetched_at: Utc::now(),
+    }
+}
+
+fn make_worker_result(investigation: bool) -> WorkerResult {
+    let mut artifacts = BTreeMap::new();
+    artifacts.insert("k".to_string(), json!("v"));
+    WorkerResult {
+        status: WorkerStatus::Success,
+        summary: "findings summary".to_string(),
+        commit_message: "fix: sample".to_string(),
+        pull_request_title: "PR title".to_string(),
+        artifacts,
+        investigation,
+    }
+}
+
+fn make_context(cfg: &Config, issue: &IssueDetail, run_id: &str) -> FinalizeContext {
+    let branch_name = "automation/issue-1".to_string();
+    let wt = Worktree {
+        issue: issue.key.clone(),
+        run_id: run_id.to_string(),
+        branch_name: branch_name.clone(),
+        path: Path::new("/tmp/wt").to_path_buf(),
+        base_oid: "deadbeef".to_string(),
+        fresh: false,
+        created_at: Utc::now(),
+    };
+    let claim = ClaimToken::for_test(cfg.state_dir.join("claims"), "deadbeef00", run_id);
+    FinalizeContext {
+        client: inert_client(),
+        config: cfg.clone(),
+        repository: RepositoryInfo {
+            path: Path::new("/tmp/repo").to_path_buf(),
+            base_branch: "main".to_string(),
+            remote_url: "file://localhost".to_string(),
+        },
+        issue: issue.clone(),
+        claim,
+        run_id: run_id.to_string(),
+        worktree: wt,
+        result: FinalizeRequest {
+            issue: issue.key.clone(),
+            branch_name,
+            worktree_path: Path::new("/tmp/wt").to_path_buf(),
+        },
+    }
+}
+
+fn client_for(gh: &MockGitHub) -> Client {
+    let state_dir = tempfile::tempdir().expect("state");
+    let mut cfg = empty_config(state_dir.path());
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    Client::with_config(&cfg).expect("client")
+}
+
+fn checkpoint(
+    run_id: &str,
+    branch_name: &str,
+    result_path: &Path,
+    stage: FinalizationStage,
+) -> FinalizationCheckpoint {
+    FinalizationCheckpoint {
+        run_id: run_id.to_string(),
+        branch_name: branch_name.to_string(),
+        result_path: result_path.to_path_buf(),
+        stage,
+        commit_oid: None,
+        pr_number: None,
+        pr_url: None,
+    }
+}
+
+/// The durable checkpoint sequence `run_investigation_finalize` follows:
+/// `InvestigationReady` (SQLite + queue) → findings comment POST →
+/// `InvestigationCommented` (SQLite + queue).
+#[tokio::test]
+async fn investigation_checkpoint_persisted_around_comment() {
+    let gh = MockGitHub::start().await;
+
+    // No existing comment: the idempotency scan finds nothing.
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<serde_json::Value>::new()))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+
+    // The findings comment is posted exactly once.
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({ "id": 7 })))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+
+    // Set up the state store and claim an investigation ticket.
+    let root = tempdir("state");
+    let store = StateStore::open(&root).expect("open store");
+    let key = caduceus::issue::IssueKey {
+        owner: "owner".to_string(),
+        repo: "repo".to_string(),
+        number: 1,
+    };
+    store
+        .enqueue(&key, TicketType::Investigation, false)
+        .expect("enqueue");
+    let now = Utc::now();
+    let claimed = store
+        .acquire_next("RUN1", 1, now)
+        .expect("acquire")
+        .expect("claimed entry");
+
+    // Build the finalization context using the real claim token.
+    let cfg = empty_config(&root);
+    let issue = make_issue();
+    let mut ctx = make_context(&cfg, &issue, "RUN1");
+    ctx.claim = claimed.claim.clone();
+    ctx.client = Arc::new(client_for(&gh));
+
+    // The exact checkpoint sequence run_investigation_finalize performs:
+    // InvestigationReady before the effect, InvestigationCommented after.
+    let result_path = root.join("runs").join("RUN1.result.json");
+    store
+        .save_finalization(
+            &claimed.claim,
+            checkpoint(
+                "RUN1",
+                &ctx.worktree.branch_name,
+                &result_path,
+                FinalizationStage::InvestigationReady,
+            ),
+        )
+        .expect("save InvestigationReady");
+
+    let output = post_investigation_comment_and_finalize(
+        &ctx,
+        ctx.client.as_ref(),
+        &make_worker_result(true),
+        &cfg.ticket_label_investigation,
+    )
+    .await
+    .expect("post investigation comment");
+    assert_eq!(
+        output.action,
+        caduceus::finalize::FinalizeAction::InvestigationCommented
+    );
+
+    store
+        .save_finalization(
+            &claimed.claim,
+            checkpoint(
+                "RUN1",
+                &ctx.worktree.branch_name,
+                &result_path,
+                FinalizationStage::InvestigationCommented,
+            ),
+        )
+        .expect("save InvestigationCommented");
+
+    // The queue entry durably records the terminal investigation stage.
+    let snap = store.snapshot().expect("snapshot");
+    let entry = snap.entry(&key).expect("entry present");
+    assert_eq!(entry.phase, Phase::InProgress, "phase unchanged by save");
+    let finalization = entry
+        .finalization
+        .as_ref()
+        .expect("finalization checkpoint persisted");
+    assert_eq!(
+        finalization.stage,
+        FinalizationStage::InvestigationCommented
+    );
+    assert_eq!(finalization.run_id, "RUN1");
+}
+
+/// Acceptance test for issue #120: a crash after the findings comment
+/// leaves the queue entry at `InvestigationCommented`; recovery must
+/// finish the entry without re-posting the comment. The resume path
+/// re-invokes `post_investigation_comment_and_finalize` under the
+/// original `run_id`, whose marker suppresses the duplicate POST.
+#[tokio::test]
+async fn crash_after_comment_no_duplicate_on_recovery() {
+    let gh = MockGitHub::start().await;
+
+    // The comment already exists on the issue (posted before the crash),
+    // carrying the original run's marker.
+    let existing_body = format!(
+        "{}{}\n\nfindings summary",
+        INVESTIGATION_MARKER_PREFIX, "RUN1"
+    );
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 7, "body": existing_body }
+        ])))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+
+    // Recovery must NOT re-post the comment: the marker scan finds the
+    // original comment, so the POST is never issued.
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({ "id": 8 })))
+        .expect(0)
+        .mount(gh.server())
+        .await;
+
+    let root = tempdir("state");
+    let store = StateStore::open(&root).expect("open store");
+    let key = caduceus::issue::IssueKey {
+        owner: "owner".to_string(),
+        repo: "repo".to_string(),
+        number: 1,
+    };
+    store
+        .enqueue(&key, TicketType::Investigation, false)
+        .expect("enqueue");
+    let now = Utc::now();
+    let claimed = store
+        .acquire_next("RUN2", 1, now)
+        .expect("acquire")
+        .expect("claimed entry");
+
+    // Simulate the crash state: the queue entry already carries the
+    // durable InvestigationCommented checkpoint from the prior run.
+    store
+        .save_resumed_finalization(
+            &claimed.claim,
+            checkpoint(
+                "RUN1",
+                "automation/issue-1",
+                &root.join("runs").join("RUN1.result.json"),
+                FinalizationStage::InvestigationCommented,
+            ),
+        )
+        .expect("save resumed checkpoint");
+
+    let cfg = empty_config(&root);
+    let issue = make_issue();
+    let mut ctx = make_context(&cfg, &issue, "RUN1");
+    ctx.claim = claimed.claim.clone();
+    ctx.client = Arc::new(client_for(&gh));
+
+    // Recovery re-invokes the comment step with the ORIGINAL run id
+    // (the resume path derives ctx.run_id from the queue checkpoint).
+    let output = post_investigation_comment_and_finalize(
+        &ctx,
+        ctx.client.as_ref(),
+        &make_worker_result(true),
+        &cfg.ticket_label_investigation,
+    )
+    .await
+    .expect("recovery re-post");
+    assert!(
+        output
+            .idempotency_observations
+            .iter()
+            .any(|o| o == "investigation_comment_posted=false"),
+        "recovery must observe the existing marker"
+    );
+}

--- a/tests/state/investigation_checkpoint_recovery_test.rs
+++ b/tests/state/investigation_checkpoint_recovery_test.rs
@@ -1,0 +1,111 @@
+//! Crash-recovery regression tests for the investigation finalization
+//! checkpoints (issue #120).
+//!
+//! The investigation path persists `InvestigationReady` before the
+//! findings comment POST and `InvestigationCommented` after it
+//! succeeds. These tests lock in `resume_from_checkpoint`'s stage
+//! mapping for the two investigation stages: a crash before the
+//! comment resumes at `InvestigationCommented` (re-post is idempotent),
+//! a crash after it resumes at `Done`, and a fully checkpointed run is
+//! `AlreadyDone`.
+
+use caduceus::daemon::tick::resume::{resume_from_checkpoint, ResumeAction};
+use caduceus::finalize::voice::generate_operation_id;
+use caduceus::state::checkpoints::persist_checkpoint;
+use caduceus::state::queue::FinalizationStage;
+
+/// Create an in-memory SQLite connection with the `checkpoints` schema.
+fn in_memory_conn() -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().expect("open in-memory db");
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS checkpoints (
+            run_id          TEXT NOT NULL,
+            stage           TEXT NOT NULL,
+            checkpoint_data TEXT,
+            created_at      TEXT NOT NULL,
+            operation_id    TEXT,
+            remote_marker   TEXT,
+            PRIMARY KEY (run_id, stage)
+        );",
+        [],
+    )
+    .expect("create checkpoints table");
+    conn
+}
+
+/// Persist a checkpoint with a deterministic operation_id and an
+/// optional remote marker.
+fn checkpoint_with_marker(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    stage: FinalizationStage,
+    marker: Option<&str>,
+) {
+    persist_checkpoint(
+        conn,
+        run_id,
+        stage,
+        None,
+        Some(&generate_operation_id(run_id, stage.as_str())),
+        marker,
+    )
+    .expect("persist checkpoint");
+}
+
+#[test]
+fn investigation_ready_resumes_at_investigation_commented() {
+    let conn = in_memory_conn();
+    let run_id = "run-investigation-ready";
+
+    // Crash before the findings comment: only InvestigationReady was
+    // persisted. Recovery must re-post the comment (idempotent marker).
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::InvestigationReady, None);
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::InvestigationCommented) => {}
+        other => panic!("expected Skip(InvestigationCommented), got {other:?}"),
+    }
+}
+
+#[test]
+fn investigation_commented_resumes_at_done() {
+    let conn = in_memory_conn();
+    let run_id = "run-investigation-commented";
+
+    // Crash after the findings comment: both investigation stages were
+    // persisted. Recovery must finish the entry without re-posting.
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::InvestigationReady, None);
+    checkpoint_with_marker(
+        &conn,
+        run_id,
+        FinalizationStage::InvestigationCommented,
+        None,
+    );
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::Skip(FinalizationStage::Done) => {}
+        other => panic!("expected Skip(Done), got {other:?}"),
+    }
+}
+
+#[test]
+fn investigation_done_returns_already_done() {
+    let conn = in_memory_conn();
+    let run_id = "run-investigation-done";
+
+    // The investigation run fully checkpointed through Done: no work
+    // remains on recovery.
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::InvestigationReady, None);
+    checkpoint_with_marker(
+        &conn,
+        run_id,
+        FinalizationStage::InvestigationCommented,
+        None,
+    );
+    checkpoint_with_marker(&conn, run_id, FinalizationStage::Done, None);
+
+    match resume_from_checkpoint(&conn, run_id).expect("resume") {
+        ResumeAction::AlreadyDone => {}
+        other => panic!("expected AlreadyDone, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Persists durable `InvestigationReady` / `InvestigationCommented` queue checkpoints around the investigation finalization comment, mirroring the code-ticket durable-checkpoint pattern from #89/#103. A crash after the comment no longer re-dispatches the worker and posts a duplicate comment.

## Problem

The investigation finalization path was posting its external comment and finishing the entry without persisting the durable queue `FinalizationCheckpoint` (the SQLite checkpoint table was written, but the queue entry's `finalization` field was not). On recovery, the per-claim tick re-dispatched the worker from scratch, which re-posted the findings comment — a duplicate on the GitHub issue.

## Design

The code-ticket durable-checkpoint pattern (introduced in #89 / PR #103 for the `PrCreated` stage) writes each checkpoint as **SQLite first, then queue**, around the corresponding external side effect. This PR applies the same pattern to investigation tickets via a new `pub(crate) async fn run_investigation_finalize(...)` that mirrors `run_code_finalize` minus the git pipeline (investigation neither commits nor pushes).

Three changes:

1. **`run_investigation_finalize`** (`src/daemon/tick/resume.rs`): checkpoint `InvestigationReady` (SQLite → queue) → post comment → checkpoint `InvestigationCommented` (SQLite → queue). The resume path picks up at `InvestigationCommented` and re-posts the comment idempotently under the original `run_id` marker.

2. **`InvestigationCommented` short-circuit** (`src/daemon/tick/per_claim.rs`): when an investigation entry has a durable `InvestigationCommented` checkpoint on its queue entry, the per-claim tick finishes the entry without re-dispatching. Mirrors the existing `PrCreated` short-circuit.

3. **`debug_assert!` belt-and-suspenders** in `run_resume_finalization` (`src/daemon/tick/resume.rs`): guards the code-path `Commented | AwaitingReview | Done` arm so an investigation entry cannot reach it. The per_claim short-circuit is the actual production guard; this asserts the invariant in debug builds.

Also: split the combined `InvestigationReady | InvestigationCommented` resume arm into two arms (`InvestigationCommented` is the real resume target; `InvestigationReady` is unreachable but kept defensive).

## Files changed

- `src/daemon/tick/resume.rs` (+142 / -3) — new `run_investigation_finalize`; split resume arms; debug_assert guard; doc comment updates
- `src/daemon/tick/per_claim.rs` (+22 / -3) — new short-circuit; replace inline investigation finalize with `run_investigation_finalize`; propagate `finish_investigation` errors (was `let _ =`)
- `src/state/checkpoints.rs` (+7) — FINAL-001 contract diagram now includes the investigation branch; notes that investigation stages carry no `remote_marker` (the GitHub comment idempotency check uses the `run_id`-bearing marker on the comment itself instead)
- `tests/integration/investigation_finalize_checkpoint_test.rs` (NEW, 343 lines) — 2 cases: checkpoint persists around the comment; crash-after-comment does not duplicate
- `tests/state/investigation_checkpoint_recovery_test.rs` (NEW, 111 lines) — 3 cases: investigation-ready → resume posts comment; investigation-commented → resume finishes; done → already-done
- `Cargo.toml` (+8) — registers both new test binaries
- `CHANGELOG.md` (+6) — `### Fixed` bullet under `[1.0.0] - Unreleased`

7 files changed, 627 insertions, 12 deletions.

## Test plan

```bash
cargo fmt --check
cargo clippy --locked --all-targets -- -D warnings
cargo test --locked --all-targets
uv run pytest -q tests/plugin/ tests/integration/bridge_test.py
```

Gates verified locally:
- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --test investigation_finalize_checkpoint_test` — 2/2 pass (including the issue's acceptance test `crash_after_comment_no_duplicate_on_recovery`)
- `cargo test --locked --test investigation_checkpoint_recovery_test` — 3/3 pass
- `cargo test --locked --all-targets` — all pass except 5 pre-existing environmental failures (verified identical on `origin/main`: 4× `hermes_lifecycle` setup timeout under concurrent release builds; 1× `release_binary_canary`; 1× `token_resolution_test` when `GITHUB_TOKEN` is exported)
- `uv run pytest` — 139/139 pass

## Acceptance criteria (from issue)

- [x] Persist the investigation checkpoint (queue + SQLite) before the external effect and after the effect succeeds
- [x] Make resume honor those stages so a mid-flight crash resumes at the right point without re-posting the comment
- [x] Add a regression test that crashes after the investigation comment and asserts exactly one comment on recovery → `crash_after_comment_no_duplicate_on_recovery`

## Out of scope (related issues)

- **#119** — Pre-PR commit/push failures can re-dispatch the worker. Same root cause (queue/SQLite race before `PrCreated`) for code tickets; same fix shape, but tracked separately. Not bundled here.
- The `InvestigationReady`-only queue/SQLite race (crash between SQLite `InvestigationReady` and queue `InvestigationReady`) is the same shape as #119 and tracked there.

## Follow-ups (not blocking this PR, flagged by check-phase review)

1. **End-to-end crash-recovery test** — current test proves idempotency of the comment POST under a repeated `run_id` but doesn't drive the full daemon recovery path (`per_claim.rs` short-circuit → `run_resume_finalization` → no duplicate). A `tests/daemon/` binary test invoking `run_claim` with a pre-existing `InvestigationCommented` queue checkpoint would close this gap.
2. **Test `run_investigation_finalize` directly** — current integration test replays the sequence manually rather than calling the new function. A `tests/daemon/` test exercising `run_investigation_finalize` end-to-end would catch internal stage-ordering mistakes.
3. **Optimize investigation resume to skip worktree creation** — `run_resume_finalization` creates a Git worktree for investigation resumes even though investigation finalization is comment-only. Pre-existing, harmless, but wasteful. Tracked as a separate optimization.

Closes #120