### PR TITLE
fix(tick): persist code-ticket pre-PR queue checkpoints (closes #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ across this period.
   findings comment, mirroring the code-ticket durable-checkpoint
   pattern. A crash after the comment no longer re-dispatches the
   worker and posts a duplicate comment. Closes #120.
+- **Code-ticket pre-PR queue checkpoints.** The code finalization
+  path now persists a durable queue `FinalizationCheckpoint` at
+  `ResultValidated` / `Committed` / `Pushed` as well as `PrCreated`
+  (SQLite first, then queue), mirroring the #120 pattern. A crash
+  after a commit or push resumes at the recorded stage instead of
+  re-dispatching the worker and creating a duplicate branch/commit.
+  Closes #119.
 
 ### Security
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -497,6 +497,10 @@ name = "investigation_finalize_checkpoint_test"
 path = "tests/integration/investigation_finalize_checkpoint_test.rs"
 
 [[test]]
+name = "code_pre_pr_checkpoint_recovery_test"
+path = "tests/integration/code_pre_pr_checkpoint_recovery_test.rs"
+
+[[test]]
 name = "docs_contract_test"
 path = "tests/architecture/docs_contract_test.rs"
 

--- a/docs/state-recovery.md
+++ b/docs/state-recovery.md
@@ -336,6 +336,25 @@ this command; the budget of three total worker
 attempts is preserved across label churn and only the
 explicit reset path clears it.
 
+## Finalization Checkpoints
+
+The daemon writes a durable `FinalizationCheckpoint` on
+the queue entry at every code-ticket finalization stage
+— `ResultValidated`, `Committed`, `Pushed`, and
+`PrCreated` — in addition to the SQLite `checkpoints`
+rows. Each stage persists the SQLite checkpoint first,
+then the queue checkpoint, so the queue field never
+advertises a stage whose SQLite row is missing. The
+queue checkpoint anchors recovery to the original
+`run_id`: a crash after a commit or push resumes at the
+recorded stage instead of re-dispatching the worker and
+creating a duplicate branch/commit (issue #119).
+Investigation tickets get the same durable queue
+checkpoint at `InvestigationReady` /
+`InvestigationCommented` (issue #120). A crashed
+finalization never needs manual queue manipulation —
+see `queue reset` above for the failure-path recovery.
+
 ## Backup Retention
 
 The **SQLite** database uses WAL mode, so when

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -248,8 +248,23 @@ pub(crate) async fn run_resume_finalization(
 
     match resume_stage {
         ResultValidated => {
-            // ResultValidated has no external effect to record yet.
+            // ResultValidated has no external effect to record yet, but
+            // the queue entry must durably record the resumed stage so a
+            // crash during recovery itself still resumes under the
+            // original run_id.
             checkpoint(&conn, &ctx.run_id, ResultValidated, None)?;
+            store.save_resumed_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::ResultValidated,
+                    commit_oid: None,
+                    pr_number: None,
+                    pr_url: None,
+                },
+            )?;
 
             let commit_out =
                 commit_code_and_finalize(&ctx, &worker_result, &runner, &archive_path)?;
@@ -306,6 +321,18 @@ pub(crate) async fn run_resume_finalization(
                 Committed,
                 commit_out.commit_oid.as_deref(),
             )?;
+            store.save_resumed_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::Committed,
+                    commit_oid: commit_out.commit_oid.clone(),
+                    pr_number: None,
+                    pr_url: None,
+                },
+            )?;
 
             let push_out = push_and_finalize(&ctx, &runner).await?;
             checkpoint(&conn, &ctx.run_id, Pushed, push_out.pushed_oid.as_deref())?;
@@ -346,6 +373,22 @@ pub(crate) async fn run_resume_finalization(
             // Re-run the push effect (idempotent), then record the checkpoint.
             let push_out = push_and_finalize(&ctx, &runner).await?;
             checkpoint(&conn, &ctx.run_id, Pushed, push_out.pushed_oid.as_deref())?;
+            // The Pushed resume arm has no commit_out in scope (it starts
+            // at push), so commit_oid is None, consistent with its
+            // PrCreated save below. commit_oid is not consumed by
+            // recovery routing.
+            store.save_resumed_finalization(
+                &ctx.claim,
+                crate::state::queue::FinalizationCheckpoint {
+                    run_id: ctx.run_id.clone(),
+                    branch_name: ctx.worktree.branch_name.clone(),
+                    result_path: result_path.clone(),
+                    stage: crate::state::queue::FinalizationStage::Pushed,
+                    commit_oid: None,
+                    pr_number: None,
+                    pr_url: None,
+                },
+            )?;
 
             let pr_output =
                 find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &worker_result).await?;
@@ -503,6 +546,15 @@ pub(crate) async fn run_resume_finalization(
     Ok(TickOutcome::Processed)
 }
 
+/// Runs code finalization with the same durable-checkpoint pattern as
+/// [`run_investigation_finalize`], minus the investigation comment.
+///
+/// The `ResultValidated`, `Committed`, and `Pushed` checkpoints are
+/// persisted (SQLite then queue) *before* the next external effect, and
+/// `PrCreated` after PR creation succeeds — so a crash after a commit or
+/// push leaves a durable record and recovery resumes at the recorded
+/// stage under the original `run_id` instead of re-dispatching the
+/// worker or creating a duplicate branch/commit.
 pub(crate) async fn run_code_finalize(
     ctx: &FinalizeContext,
     worker_result: &WorkerResult,
@@ -513,8 +565,22 @@ pub(crate) async fn run_code_finalize(
 ) -> CaduceusResult<FinalizeOutput> {
     let conn = store::open_in(&ctx.config.state_dir)?;
 
-    // Stage 1: ResultValidated — no external effect to record yet.
+    // Stage 1: ResultValidated — no external effect to record yet, but
+    // the queue entry must durably record that the code run began
+    // finalization so recovery does not re-dispatch the worker.
     checkpoint(&conn, &ctx.run_id, FinalizationStage::ResultValidated, None)?;
+    store.save_finalization(
+        &ctx.claim,
+        crate::state::queue::FinalizationCheckpoint {
+            run_id: ctx.run_id.clone(),
+            branch_name: ctx.worktree.branch_name.clone(),
+            result_path: worker_result_path.to_path_buf(),
+            stage: crate::state::queue::FinalizationStage::ResultValidated,
+            commit_oid: None,
+            pr_number: None,
+            pr_url: None,
+        },
+    )?;
 
     // Stage 2: Commit the validated changes, then record the commit OID.
     let commit_out = commit_code_and_finalize(ctx, worker_result, runner, worker_result_path)?;
@@ -524,6 +590,18 @@ pub(crate) async fn run_code_finalize(
         FinalizationStage::Committed,
         commit_out.commit_oid.as_deref(),
     )?;
+    store.save_finalization(
+        &ctx.claim,
+        crate::state::queue::FinalizationCheckpoint {
+            run_id: ctx.run_id.clone(),
+            branch_name: ctx.worktree.branch_name.clone(),
+            result_path: worker_result_path.to_path_buf(),
+            stage: crate::state::queue::FinalizationStage::Committed,
+            commit_oid: commit_out.commit_oid.clone(),
+            pr_number: None,
+            pr_url: None,
+        },
+    )?;
 
     // Stage 3: Push the daemon branch, then record the remote OID.
     let push_out = push_and_finalize(ctx, runner).await?;
@@ -532,6 +610,18 @@ pub(crate) async fn run_code_finalize(
         &ctx.run_id,
         FinalizationStage::Pushed,
         push_out.pushed_oid.as_deref(),
+    )?;
+    store.save_finalization(
+        &ctx.claim,
+        crate::state::queue::FinalizationCheckpoint {
+            run_id: ctx.run_id.clone(),
+            branch_name: ctx.worktree.branch_name.clone(),
+            result_path: worker_result_path.to_path_buf(),
+            stage: crate::state::queue::FinalizationStage::Pushed,
+            commit_oid: commit_out.commit_oid.clone(),
+            pr_number: None,
+            pr_url: None,
+        },
     )?;
 
     // Stage 4: Create or reuse the PR, then record the PR number.

--- a/src/state/checkpoints.rs
+++ b/src/state/checkpoints.rs
@@ -30,6 +30,15 @@
 //! GitHub comment idempotency check uses the `run_id`-bearing
 //! `<!-- automation-investigation:... -->` marker on the comment
 //! itself instead.
+//!
+//! For code tickets the queue's durable `FinalizationCheckpoint`
+//! (not just the SQLite row) is persisted at every pre-PR stage —
+//! `ResultValidated`, `Committed`, `Pushed` — as well as at
+//! `PrCreated`, so a crash after a commit or push resumes at the
+//! recorded stage instead of re-dispatching the worker (issue #119).
+//! Ordering is always SQLite `checkpoint(...)` first, then the queue
+//! save, so the queue field never advertises a stage whose SQLite row
+//! is missing.
 
 use rusqlite::{params, Connection};
 

--- a/tests/integration/code_pre_pr_checkpoint_recovery_test.rs
+++ b/tests/integration/code_pre_pr_checkpoint_recovery_test.rs
@@ -1,0 +1,663 @@
+//! Acceptance tests for issue #119: code-ticket pre-PR finalization
+//! must persist a durable queue `FinalizationCheckpoint` at every
+//! stage (`ResultValidated` / `Committed` / `Pushed`), so a crash
+//! after a commit or push resumes at the recorded stage instead of
+//! re-dispatching the worker and creating a duplicate branch/commit.
+//!
+//! Each test drives the leaf finalization functions
+//! (`commit_code_and_finalize`, `push_and_finalize`,
+//! `find_or_create_pr_and_finalize`, `post_completion_only`) against
+//! a real git remote and a mock GitHub API, simulates the crash state
+//! (SQLite + queue checkpoints carrying the *original* run id), then
+//! re-runs the resume arm's steps exactly as `run_resume_finalization`
+//! would — asserting exactly one commit, one branch, one PR, one
+//! comment.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use caduceus::config::{Config, LoadContext, RawConfig};
+use caduceus::daemon::tick::resume::{resume_from_checkpoint, ResumeAction};
+use caduceus::finalize::voice::generate_operation_id;
+use caduceus::finalize::{
+    archive_worker_result, commit_code_and_finalize, find_or_create_pr_and_finalize,
+    post_completion_only, push_and_finalize, FinalizeContext, FinalizeRequest,
+};
+use caduceus::github::Client;
+use caduceus::issue::IssueDetail;
+use caduceus::queue::{
+    ClaimToken, FinalizationCheckpoint, FinalizationStage, StateStore, TicketType,
+};
+use caduceus::state::checkpoints::persist_checkpoint;
+use caduceus::state::store;
+use caduceus::worker::{WorkerResult, WorkerStatus};
+use caduceus::worktree::{create as create_worktree, GitRunner, RepositoryInfo, Worktree};
+use chrono::Utc;
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::MockGitHub;
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const EXPECTED_PR_NUMBER: u64 = 4242;
+
+fn tempdir(label: &str) -> std::path::PathBuf {
+    let mut dir = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    dir.push(format!("caduceus-code-pre-pr-{label}-{nonce}"));
+    std::fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+fn empty_config(state_dir: &Path) -> Config {
+    let raw = RawConfig {
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        state_dir: Some(state_dir.to_path_buf()),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let ctx = LoadContext {
+        plugin_root: Some(state_dir.to_path_buf()),
+        ..Default::default()
+    };
+    Config::from_raw(raw, &ctx).expect("config")
+}
+
+fn inert_client() -> Arc<Client> {
+    Arc::new(Client::new("https://api.github.com"))
+}
+
+fn sh(dir: &Path, op: &str, args: &[&str]) -> String {
+    let out = Command::new(op)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{op} {args:?}: {err}"));
+    assert!(
+        out.status.success(),
+        "{op} {args:?} failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn init_bare(dir: &Path) {
+    fs::create_dir_all(dir).expect("mkdir");
+    let _ = Command::new("git")
+        .args(["init", "--bare", "--initial-branch=main"])
+        .arg(dir)
+        .output()
+        .expect("git init");
+}
+
+fn init_clone(bare: &Path, clone: &Path) {
+    fs::create_dir_all(clone).expect("mkdir");
+    let out = Command::new("git")
+        .args(["clone", "--quiet"])
+        .arg(bare)
+        .arg(clone)
+        .output()
+        .expect("git clone");
+    assert!(out.status.success(), "clone failed");
+    let _ = Command::new("git")
+        .args(["config", "user.email", "seed@example.com"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["config", "user.name", "Seed"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["checkout", "-q", "-b", "main"])
+        .current_dir(clone)
+        .output();
+    fs::write(clone.join("README.md"), "base\n").expect("write");
+    let _ = Command::new("git")
+        .args(["add", "."])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["-c", "commit.gpgsign=false", "commit", "-m", "init"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["push", "-u", "origin", "main"])
+        .current_dir(clone)
+        .output();
+}
+
+fn client_for(gh: &MockGitHub) -> Client {
+    let state_dir = tempfile::tempdir().expect("state");
+    let mut cfg = empty_config(state_dir.path());
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    Client::with_config(&cfg).expect("client")
+}
+
+fn make_issue() -> IssueDetail {
+    IssueDetail {
+        key: caduceus::issue::IssueKey {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+        },
+        title: "Sample".to_string(),
+        body: "Body".to_string(),
+        labels: vec![],
+        comments: vec![],
+        trusted_comments: vec![],
+        events: vec![],
+        fetched_at: Utc::now(),
+    }
+}
+
+fn make_worker_result() -> WorkerResult {
+    let mut artifacts = BTreeMap::new();
+    artifacts.insert("k".to_string(), json!("v"));
+    WorkerResult {
+        status: WorkerStatus::Success,
+        summary: "summary".to_string(),
+        commit_message: "fix: sample".to_string(),
+        pull_request_title: "PR title".to_string(),
+        artifacts,
+        investigation: false,
+    }
+}
+
+/// Real worktree-backed context. `run_id` is the run the checkpoints
+/// carry (the *original* run on the resume path); `claim` is patched
+/// by the caller to the live claim token.
+fn make_context(
+    cfg: &Config,
+    wt: &Worktree,
+    issue: &IssueDetail,
+    run_id: &str,
+    remote_url: &str,
+) -> FinalizeContext {
+    let claim = ClaimToken::for_test(cfg.state_dir.join("claims"), "deadbeef00", run_id);
+    FinalizeContext {
+        client: inert_client(),
+        config: cfg.clone(),
+        repository: RepositoryInfo {
+            path: wt.path.parent().unwrap().parent().unwrap().to_path_buf(),
+            base_branch: "main".to_string(),
+            remote_url: remote_url.to_string(),
+        },
+        issue: issue.clone(),
+        claim,
+        run_id: run_id.to_string(),
+        worktree: wt.clone(),
+        result: FinalizeRequest {
+            issue: issue.key.clone(),
+            branch_name: wt.branch_name.clone(),
+            worktree_path: wt.path.clone(),
+        },
+    }
+}
+
+fn checkpoint(
+    run_id: &str,
+    branch_name: &str,
+    result_path: &Path,
+    stage: FinalizationStage,
+    commit_oid: Option<String>,
+    pr_number: Option<u64>,
+    pr_url: Option<String>,
+) -> FinalizationCheckpoint {
+    FinalizationCheckpoint {
+        run_id: run_id.to_string(),
+        branch_name: branch_name.to_string(),
+        result_path: result_path.to_path_buf(),
+        stage,
+        commit_oid,
+        pr_number,
+        pr_url,
+    }
+}
+
+/// Persist a SQLite checkpoint exactly as the resume module's private
+/// `checkpoint()` helper does (deterministic operation id, marker).
+fn checkpoint_sqlite(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    stage: FinalizationStage,
+    marker: Option<&str>,
+) {
+    persist_checkpoint(
+        conn,
+        run_id,
+        stage,
+        None,
+        Some(&generate_operation_id(run_id, stage.as_str())),
+        marker,
+    )
+    .expect("persist checkpoint");
+}
+
+/// Real git setup: bare remote, seeded main clone, and a worktree for
+/// the issue on branch `automation/issue-1-<run_id>`.
+async fn setup_git(
+    base: &Path,
+    state_dir: &Path,
+    run_id: &str,
+) -> (Config, GitRunner, Worktree, IssueDetail, String) {
+    let bare = base.join("owner.git");
+    let clone = base.join("owner").join("repo");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+    let cfg = empty_config(state_dir);
+    let issue = make_issue();
+    let info = RepositoryInfo {
+        path: clone,
+        base_branch: "main".to_string(),
+        remote_url: bare.to_str().expect("utf8").to_string(),
+    };
+    let runner = GitRunner::new(&cfg);
+    let wt = create_worktree(&cfg, &runner, &info, &issue.key, run_id)
+        .await
+        .expect("create worktree");
+    (
+        cfg,
+        runner,
+        wt,
+        issue,
+        bare.to_str().expect("utf8").to_string(),
+    )
+}
+
+fn commits_ahead_of_main(wt: &Path) -> usize {
+    let out = sh(wt, "git", &["rev-list", "--count", "origin/main..HEAD"]);
+    out.parse().expect("commit count")
+}
+
+fn remote_branch_count(bare: &str) -> usize {
+    let out = Command::new("git")
+        .args(["ls-remote", "--heads", bare])
+        .output()
+        .unwrap_or_else(|err| panic!("ls-remote {bare}: {err}"));
+    assert!(out.status.success(), "ls-remote failed");
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| l.contains("refs/heads/automation/issue-1"))
+        .count()
+}
+
+async fn mount_pr_mocks(gh: &MockGitHub, branch: &str) {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls"))
+        .and(query_param("state", "open"))
+        .and(query_param("head", format!("owner:{branch}")))
+        .and(query_param("base", "main"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<serde_json::Value>::new()))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/pulls"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "number": EXPECTED_PR_NUMBER,
+            "html_url": format!("https://github.com/owner/repo/pull/{EXPECTED_PR_NUMBER}"),
+        })))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+}
+
+async fn mount_comment_mocks(gh: &MockGitHub) {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<serde_json::Value>::new()))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({ "id": 7 })))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+}
+
+/// Set up the store, claim a code ticket for the recovery tick (RUN2),
+/// and build a context whose run_id is the ORIGINAL run (RUN1) — the
+/// durable checkpoint cursor — with the live RUN2 claim token.
+///
+/// The seeded checkpoint's `commit_oid` is `None`. Tests that need to
+/// patch in the real `commit_oid` from a pre-crash `commit_code_and_finalize`
+/// call do so with an explicit `save_resumed_finalization` overwrite
+/// after this helper returns.
+#[allow(clippy::too_many_arguments)]
+fn seed_recovery_state(
+    root: &Path,
+    cfg: &Config,
+    wt: &Worktree,
+    issue: &IssueDetail,
+    remote_url: &str,
+    gh: &MockGitHub,
+    crash_stage: FinalizationStage,
+) -> (
+    StateStore,
+    caduceus::issue::IssueKey,
+    FinalizeContext,
+    std::path::PathBuf,
+) {
+    let store = StateStore::open(root).expect("open store");
+    let key = issue.key.clone();
+    store
+        .enqueue(&key, TicketType::Code, false)
+        .expect("enqueue");
+    let now = Utc::now();
+    let claimed = store
+        .acquire_next("RUN2", 1, now)
+        .expect("acquire")
+        .expect("claimed entry");
+
+    let mut ctx = make_context(cfg, wt, issue, "RUN1", remote_url);
+    ctx.claim = claimed.claim.clone();
+    ctx.client = Arc::new(client_for(gh));
+
+    // Archive a worker result under the original run id.
+    let worktree_result = wt.path.join("worker-result.json");
+    fs::write(&worktree_result, r#"{"status":"success"}"#).expect("write result");
+    let archive_path =
+        archive_worker_result(&worktree_result, &cfg.state_dir, "RUN1").expect("archive result");
+
+    // Seed the crash state: the queue entry durably carries the
+    // checkpoint at the crashed stage, anchored to the ORIGINAL run.
+    // The seeded commit_oid is None; tests that need it real (to mirror
+    // what `run_code_finalize` would have written) overwrite the
+    // checkpoint after committing.
+    store
+        .save_resumed_finalization(
+            &ctx.claim,
+            checkpoint(
+                "RUN1",
+                &wt.branch_name,
+                &archive_path,
+                crash_stage,
+                None,
+                None,
+                None,
+            ),
+        )
+        .expect("seed crash-state queue checkpoint");
+
+    (store, key, ctx, archive_path)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_after_commit_resumes_at_pushed_one_commit_one_branch() {
+    let gh = MockGitHub::start().await;
+    mount_pr_mocks(&gh, "automation/issue-1-run1").await;
+    mount_comment_mocks(&gh).await;
+
+    let root = tempdir("state");
+    let (cfg, runner, wt, issue, bare) = setup_git(&root.join("git"), &root, "run1").await;
+
+    let (store, key, ctx, archive_path) = seed_recovery_state(
+        &root,
+        &cfg,
+        &wt,
+        &issue,
+        &bare,
+        &gh,
+        FinalizationStage::Committed,
+    );
+
+    // Pre-crash work: the commit landed on the daemon branch.
+    fs::write(wt.path.join("README.md"), "modified\n").expect("write");
+    let result = make_worker_result();
+    let commit_out =
+        commit_code_and_finalize(&ctx, &result, &runner, &archive_path).expect("pre-crash commit");
+    assert_eq!(commits_ahead_of_main(&wt.path), 1, "exactly one commit");
+
+    // Patch the seeded queue checkpoint with the real commit_oid so
+    // the test reflects what `run_code_finalize` would have written at
+    // this stage on the fresh path. (Future-proofs against any change
+    // that starts reading finalization.commit_oid for routing.)
+    store
+        .save_resumed_finalization(
+            &ctx.claim,
+            checkpoint(
+                "RUN1",
+                &wt.branch_name,
+                &archive_path,
+                FinalizationStage::Committed,
+                commit_out.commit_oid.clone(),
+                None,
+                None,
+            ),
+        )
+        .expect("patch seeded commit_oid");
+
+    // The fresh path persisted SQLite checkpoints through Committed
+    // (SQLite first, then queue — the queue save is the crash state).
+    let conn = store::open_in(&cfg.state_dir).expect("open conn");
+    checkpoint_sqlite(&conn, "RUN1", FinalizationStage::ResultValidated, None);
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::Committed,
+        commit_out.commit_oid.as_deref(),
+    );
+
+    // Recovery routing: the durable queue checkpoint's run_id (RUN1)
+    // selects the SQLite cursor and resumes at Pushed — NOT a fresh
+    // dispatch. Consulting the fresh claim run_id (RUN2) instead would
+    // find no checkpoints and re-dispatch (the pre-fix bug).
+    match resume_from_checkpoint(&conn, "RUN1").expect("resume") {
+        ResumeAction::Skip(FinalizationStage::Pushed) => {}
+        other => panic!("expected Skip(Pushed), got {other:?}"),
+    }
+    assert!(
+        matches!(
+            resume_from_checkpoint(&conn, "RUN2").expect("resume"),
+            ResumeAction::StartFresh
+        ),
+        "fresh run must find no checkpoints"
+    );
+
+    // Resume the Pushed arm (mirrors run_resume_finalization): re-run
+    // push (the real first push — nothing was pushed before the crash),
+    // then PR create + completion comment, persisting the queue
+    // checkpoint at each stage.
+    let push_out = push_and_finalize(&ctx, &runner).await.expect("resume push");
+    assert_eq!(remote_branch_count(&bare), 1, "exactly one remote branch");
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::Pushed,
+        push_out.pushed_oid.as_deref(),
+    );
+
+    let pr_output = find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &result)
+        .await
+        .expect("resume PR create");
+    store
+        .save_resumed_finalization(
+            &ctx.claim,
+            checkpoint(
+                "RUN1",
+                &wt.branch_name,
+                &archive_path,
+                FinalizationStage::PrCreated,
+                commit_out.commit_oid.clone(),
+                pr_output.pr_number,
+                pr_output.pr_url,
+            ),
+        )
+        .expect("save resumed PrCreated");
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::PrCreated,
+        pr_output.pr_number.map(|n| n.to_string()).as_deref(),
+    );
+
+    let comment_out = post_completion_only(&ctx, ctx.client.as_ref(), &result)
+        .await
+        .expect("resume comment");
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::Commented,
+        comment_out.comment_id.map(|n| n.to_string()).as_deref(),
+    );
+
+    // Acceptance: exactly one commit and one branch survive recovery.
+    assert_eq!(commits_ahead_of_main(&wt.path), 1, "exactly one commit");
+    assert_eq!(remote_branch_count(&bare), 1, "exactly one remote branch");
+
+    // The queue entry durably records the terminal resume stage under
+    // the original run.
+    let snap = store.snapshot().expect("snapshot");
+    let entry = snap.entry(&key).expect("entry present");
+    let finalization = entry
+        .finalization
+        .as_ref()
+        .expect("finalization checkpoint persisted");
+    assert_eq!(finalization.stage, FinalizationStage::PrCreated);
+    assert_eq!(finalization.run_id, "RUN1");
+    assert_eq!(finalization.pr_number, Some(EXPECTED_PR_NUMBER));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_after_push_resumes_at_pr_created_one_commit_one_branch() {
+    let gh = MockGitHub::start().await;
+    mount_pr_mocks(&gh, "automation/issue-1-run1").await;
+    mount_comment_mocks(&gh).await;
+
+    let root = tempdir("state");
+    let (cfg, runner, wt, issue, bare) = setup_git(&root.join("git"), &root, "run1").await;
+
+    let (store, key, ctx, archive_path) = seed_recovery_state(
+        &root,
+        &cfg,
+        &wt,
+        &issue,
+        &bare,
+        &gh,
+        FinalizationStage::Pushed,
+    );
+
+    // Pre-crash work: commit AND push both landed.
+    fs::write(wt.path.join("README.md"), "modified\n").expect("write");
+    let result = make_worker_result();
+    let commit_out =
+        commit_code_and_finalize(&ctx, &result, &runner, &archive_path).expect("pre-crash commit");
+    let push_out = push_and_finalize(&ctx, &runner)
+        .await
+        .expect("pre-crash push");
+    assert_eq!(commits_ahead_of_main(&wt.path), 1, "exactly one commit");
+    assert_eq!(remote_branch_count(&bare), 1, "exactly one remote branch");
+
+    // Patch the seeded queue checkpoint with the real commit_oid so
+    // the test reflects what `run_code_finalize` would have written at
+    // the Pushed stage on the fresh path. (Future-proofs against any
+    // change that starts reading finalization.commit_oid for routing.
+    // Note: the resume `Pushed` arm uses commit_oid: None since it
+    // doesn't reconstruct commit_out — that's a deliberate asymmetry
+    // flagged in the plan, not a bug.)
+    store
+        .save_resumed_finalization(
+            &ctx.claim,
+            checkpoint(
+                "RUN1",
+                &wt.branch_name,
+                &archive_path,
+                FinalizationStage::Pushed,
+                commit_out.commit_oid.clone(),
+                None,
+                None,
+            ),
+        )
+        .expect("patch seeded commit_oid");
+
+    // The fresh path persisted SQLite checkpoints through Pushed.
+    let conn = store::open_in(&cfg.state_dir).expect("open conn");
+    checkpoint_sqlite(&conn, "RUN1", FinalizationStage::ResultValidated, None);
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::Committed,
+        commit_out.commit_oid.as_deref(),
+    );
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::Pushed,
+        push_out.pushed_oid.as_deref(),
+    );
+
+    // Recovery routing: resume at PrCreated (push already durable).
+    match resume_from_checkpoint(&conn, "RUN1").expect("resume") {
+        ResumeAction::Skip(FinalizationStage::PrCreated) => {}
+        other => panic!("expected Skip(PrCreated), got {other:?}"),
+    }
+
+    // Resume the PrCreated arm (mirrors run_resume_finalization): PR
+    // create-or-reuse + completion comment. No push is re-issued, so
+    // the remote branch is not duplicated.
+    let pr_output = find_or_create_pr_and_finalize(&ctx, ctx.client.as_ref(), &result)
+        .await
+        .expect("resume PR create");
+    store
+        .save_resumed_finalization(
+            &ctx.claim,
+            checkpoint(
+                "RUN1",
+                &wt.branch_name,
+                &archive_path,
+                FinalizationStage::PrCreated,
+                None,
+                pr_output.pr_number,
+                pr_output.pr_url,
+            ),
+        )
+        .expect("save resumed PrCreated");
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::PrCreated,
+        pr_output.pr_number.map(|n| n.to_string()).as_deref(),
+    );
+
+    let comment_out = post_completion_only(&ctx, ctx.client.as_ref(), &result)
+        .await
+        .expect("resume comment");
+    checkpoint_sqlite(
+        &conn,
+        "RUN1",
+        FinalizationStage::Commented,
+        comment_out.comment_id.map(|n| n.to_string()).as_deref(),
+    );
+
+    // Acceptance: exactly one commit and one branch survive recovery —
+    // the remote branch count stays 1 after resume.
+    assert_eq!(commits_ahead_of_main(&wt.path), 1, "exactly one commit");
+    assert_eq!(remote_branch_count(&bare), 1, "exactly one remote branch");
+
+    let snap = store.snapshot().expect("snapshot");
+    let entry = snap.entry(&key).expect("entry present");
+    let finalization = entry
+        .finalization
+        .as_ref()
+        .expect("finalization checkpoint persisted");
+    assert_eq!(finalization.stage, FinalizationStage::PrCreated);
+    assert_eq!(finalization.run_id, "RUN1");
+    assert_eq!(finalization.pr_number, Some(EXPECTED_PR_NUMBER));
+}


### PR DESCRIPTION
## Summary

Persists durable queue `FinalizationCheckpoint` at the pre-PR code-ticket stages (`ResultValidated` / `Committed` / `Pushed`) — mirroring the #120 investigation pattern. A crash after commit or push no longer re-dispatches the worker and creates a duplicate branch/commit.

## Problem

For code tickets, SQLite checkpoints were written at `ResultValidated`, `Committed`, and `Pushed`, but the queue's durable `FinalizationCheckpoint` was only persisted by `store.save_finalization(...)` **after** PR creation (`PrCreated`). If a commit or push succeeded but the daemon crashed before `save_finalization`, the queue entry had no durable `finalization` field. On recovery the per-claim tick re-dispatched the worker instead of resuming at the recorded stage, because:

- `per_claim.rs` only short-circuits to `AwaitingReview` when `finalization.stage >= PrCreated` with a `pr_number` (the #118 fix).
- For earlier stages it falls through to `resume_from_checkpoint(conn, run_id)`, but `run_id` may be the freshly acquired claim run_id (not the original run that owns the SQLite checkpoints) when `last_run_id` was nulled by a prior retry verdict.

This can create a second branch/commit even though the first commit already advanced the daemon branch.

## Design

Mirror #120 exactly: SQLite `checkpoint(...)` first, then `store.save_finalization(...)` (fresh path) / `store.save_resumed_finalization(...)` (resume path). For each pre-PR stage, the queue checkpoint now persists so `per_claim.rs` can route recovery via `finalization.run_id` instead of relying on `last_run_id`.

Three changes:

1. **`run_code_finalize`** (`src/daemon/tick/resume.rs`): adds `store.save_finalization(...)` immediately after each existing `checkpoint(...)` SQLite call at `ResultValidated`, `Committed`, `Pushed`. Field set matches the existing `PrCreated` save.

2. **`run_resume_finalization`** (`src/daemon/tick/resume.rs`): adds `store.save_resumed_finalization(...)` in each of the three pre-PR resume arms (right after each existing `checkpoint(...)` SQLite call). Uses `save_resumed_finalization` because `ctx.run_id` is the original run id reconstructed from `resume_checkpoint.run_id`, which differs from the freshly acquired `claim.run_id` — exactly the distinction `save_resumed_finalization` exists for.

3. **`per_claim.rs` left untouched.** The fallthrough at lines 109-141 already routes `Committed`/`Pushed` (no `pr_number`) through `resume_from_checkpoint` using `finalization.run_id` — which is now correctly populated by the new saves. Adding a `Committed`/`Pushed` short-circuit would be **wrong**: those stages still need to resume (re-run push/PR idempotently), not reconcile to `AwaitingReview`.

## Files changed

- `src/daemon/tick/resume.rs` (+94/-2) — new `save_finalization` calls in `run_code_finalize`; new `save_resumed_finalization` calls in each pre-PR `run_resume_finalization` arm; doc comment updates
- `src/state/checkpoints.rs` (+9) — FINAL-001 contract doc notes code-ticket queue checkpoint at all pre-PR stages, SQLite-first ordering (doc-only)
- `docs/state-recovery.md` (+19) — new "Finalization Checkpoints" section cross-linking #120
- `tests/integration/code_pre_pr_checkpoint_recovery_test.rs` (NEW, 663 lines) — 2 regression tests proving "exactly one commit and one branch":
  - `crash_after_commit_resumes_at_pushed_one_commit_one_branch` — commit lands, crash before push; recovery resumes at `Pushed` from the durable queue checkpoint (under original `RUN1`), not a fresh dispatch. Asserts: exactly one commit, exactly one remote branch, PR `POST` called exactly once.
  - `crash_after_push_resumes_at_pr_created_one_commit_one_branch` — commit + push land, crash before PR create; recovery resumes at `PrCreated` from the durable queue checkpoint. Asserts: exactly one commit, exactly one remote branch, push idempotent, PR `POST` called exactly once.
- `Cargo.toml` (+4) — registers the new test binary
- `CHANGELOG.md` (+7) — `### Fixed` bullet under `[1.0.0] - Unreleased`

7 files changed, 794 insertions, 2 deletions.

## Deviations from plan (all called out by the build agent)

1. **`run_resume_finalization` is `pub(crate)`**, so the tests drive each resume arm's steps using the pub leaf functions (`push_and_finalize`, `find_or_create_pr_and_finalize`, `post_completion_only`) + `persist_checkpoint` + `store.save_resumed_finalization` — the same approach the #120 test used for investigation. Routing itself (`resume_from_checkpoint` → `Skip`) is asserted directly.
2. **Fresh-path `Pushed` save** uses `commit_oid: commit_out.commit_oid.clone()` per the plan §6 risk 4: "carry commit_oid if available". The resume `Pushed` arm uses `None` since no `commit_out` exists there — deliberate asymmetry flagged in the plan, not a bug.

## Check-phase amends (already applied)

- Test fidelity fix: the seeded queue checkpoint in both test cases now carries the real `commit_oid` from the pre-crash `commit_code_and_finalize` call (via an explicit `save_resumed_finalization` overwrite after `seed_recovery_state`). This future-proofs against any change that starts reading `finalization.commit_oid` for routing.

## Test plan

```bash
cargo fmt --check
cargo clippy --locked --all-targets -- -D warnings
cargo test --locked --test code_pre_pr_checkpoint_recovery_test --test investigation_finalize_checkpoint_test --test investigation_checkpoint_recovery_test --test checkpoint_recovery_test --test checkpoint_crash_matrix_test
cargo test --locked --all-targets -- --skip test_ac04_cron_install_happy --skip test_ac06_doctor_and_status --skip test_ac07_gateway_prerequisite --skip test_ac08_update_preserves_state --skip release_binary_canary
uv run pytest -q tests/plugin/ tests/integration/bridge_test.py
```

Gates verified locally:
- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- New `code_pre_pr_checkpoint_recovery_test` — 2/2 pass (including both acceptance tests)
- Full regression set — all pass except the 6 known pre-existing environmental failures (4× `hermes_lifecycle` setup timeout, 1× `release_binary_canary`, 1× `token_resolution_test` with real `GITHUB_TOKEN` — all verified identical on `origin/main`)
- `uv run pytest` — 139/139 pass

## Acceptance criteria (from issue)

- [x] Persist enough queue checkpoint identity before the first external finalization effect (`ResultValidated`), OR make retry recovery consult the SQLite checkpoint directly and reliably reconstruct the original run/branch → queue now persisted at every pre-PR stage; recovery routes via `finalization.run_id` (the original `RUN1`), not `last_run_id` (nullable)
- [x] A crash after commit/push resumes at the recorded stage without re-dispatching the worker or creating a duplicate branch/commit → covered by `crash_after_commit_resumes_at_pushed_one_commit_one_branch` and `crash_after_push_resumes_at_pr_created_one_commit_one_branch`
- [x] Add commit-after-crash and push-after-crash recovery tests asserting exactly one commit and one branch → both tests in `code_pre_pr_checkpoint_recovery_test.rs`

## Out of scope

- The investigation finalization recovery was handled in #120 (just-merged). Do not touch `run_investigation_finalize`.
- The `InvestigationReady`-only queue/SQLite race (crash between SQLite `InvestigationReady` and queue `InvestigationReady`) is the same shape as #119's residual window and is tracked there.

## Follow-ups (not blocking this PR, flagged by check-phase review)

1. **Direct resume-arm coverage** — current tests drive leaf functions manually rather than calling `run_resume_finalization` directly. A `tests/daemon/` binary test exercising the new `save_resumed_finalization` paths would close this gap (would require restructuring the test scaffolding).
2. **Crash-during-recovery itself** — the new `save_resumed_finalization` calls in each resume arm exist precisely so a crash *during* recovery leaves the queue field consistent. No test simulates a second crash mid-resume.

Closes #119