### PR TITLE
fix(supervisor): drain DONE before cleanup cancel (closes #130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ across this period.
 
 ### Fixed
 
+- **Supervisor cancel/DONE race.** The daemon-side protocol loop drains
+  the worker's `DONE` frame before firing the cleanup cancel, so a
+  worker that exits 0 cleanly is no longer reported as cancelled. The
+  cancel path still wins when fired while the worker is alive and no
+  DONE is pending. Closes #130. Part of #94.
 - **Status exit codes.** Every status call now exits with the documented
   code instead of always returning 0.
 - **GitHub auth token resolution.** The daemon now resolves the GitHub

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,6 +405,10 @@ name = "supervisor_frame_allocation_test"
 path = "tests/worker/supervisor_frame_allocation_test.rs"
 
 [[test]]
+name = "supervisor_cancel_vs_done_test"
+path = "tests/worker/supervisor_cancel_vs_done_test.rs"
+
+[[test]]
 name = "worker_transcript_test"
 path = "tests/worker/worker_transcript_test.rs"
 

--- a/src/worker/supervisor/dispatch.rs
+++ b/src/worker/supervisor/dispatch.rs
@@ -398,12 +398,25 @@ pub(crate) async fn run_supervisor(
         stderr: format!("wait: {err}"),
     })?;
 
+    // Drain the protocol task before firing the cleanup cancel. The
+    // supervisor child is already dead, so its stdout closes and the
+    // task's pending `read_frame_async` resolves to either the buffered
+    // `DONE` frame or EOF. Cancelling first would race that buffered
+    // `DONE`: the `biased` select! polls the cancel arm first, so a
+    // worker that exited 0 was reported as `status: 130, cancelled:
+    // true`. Firing the cancel after the join keeps it a no-op cleanup
+    // signal while the protocol task still reports the real outcome.
+    //
+    // Cleanup (cancel + heartbeat abort) runs before the `?` so a
+    // panicked protocol task still tears down the heartbeat loop
+    // instead of leaking it until process exit.
+    let outcome_result = protocol_task.await;
     cancellation.cancel();
-    let outcome = protocol_task.await.map_err(|err| CaduceusError::Worker {
+    heartbeat_task.abort();
+    let outcome = outcome_result.map_err(|err| CaduceusError::Worker {
         context: "supervisor:join",
         stderr: format!("join protocol task: {err}"),
     })?;
-    heartbeat_task.abort();
 
     let signaled = supervisor_status.code().is_none();
     let _ = signaled;

--- a/tests/worker/supervisor_cancel_vs_done_test.rs
+++ b/tests/worker/supervisor_cancel_vs_done_test.rs
@@ -1,0 +1,125 @@
+//! Regression test for the supervisor cancel/DONE race (#130, part of
+//! #94).
+//!
+//! The daemon-side protocol loop used a `biased` `tokio::select!` with a
+//! cancel arm and a done-frame arm. After the supervisor child exited,
+//! `dispatch::run_supervisor` fired `cancellation.cancel()` *before*
+//! awaiting the protocol task, so the cancel arm won over a `DONE` frame
+//! already buffered on stdout. A worker that exited 0 was reported as
+//! `status: 130, cancelled: true`.
+//!
+//! The fix awaits the protocol task (which drains the `DONE` frame or
+//! EOF from the now-dead supervisor) before firing the cleanup cancel.
+//! These tests drive the real `caduceus` binary end-to-end through
+//! `supervise`, the same path the daemon's `TrustedHostExecutor` uses.
+
+#![cfg(target_os = "linux")]
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use caduceus::github::issue::IssueKey;
+use caduceus::infra::config::Config;
+use caduceus::worker_supervisor::supervise;
+use tokio_util::sync::CancellationToken;
+
+fn tempdir(label: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    dir.push(format!("caduceus-cancel-vs-done-{label}-{nonce}"));
+    fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+fn find_self_exe() -> PathBuf {
+    fixtures::ReleaseBinary::locate()
+}
+
+fn issue_key() -> IssueKey {
+    IssueKey::parse("test-owner/test-repo#130").expect("valid key")
+}
+
+fn cfg_for(root: &std::path::Path) -> Config {
+    Config::test_defaults(root)
+}
+
+fn worker_command(args: &[&str]) -> Vec<String> {
+    args.iter().map(|s| s.to_string()).collect()
+}
+
+/// A worker that exits 0 cleanly must be reported `cancelled: false`,
+/// `status: 0`. Before the fix, the cleanup cancel fired before the
+/// protocol task drained the buffered `DONE` frame, and the `biased`
+/// select! let the cancel arm report `status: 130, cancelled: true`.
+#[tokio::test]
+async fn clean_exit_reports_status_not_cancelled() {
+    let dir = tempdir("clean");
+    let worktree = dir.join("wt");
+    fs::create_dir_all(&worktree).expect("worktree");
+
+    let outcome = supervise(
+        &find_self_exe(),
+        &cfg_for(&dir),
+        &issue_key(),
+        &worktree,
+        "RUN_CLEAN_130",
+        r#"{}"#,
+        &worker_command(&["sh", "-c", "exit 0"]),
+        CancellationToken::new(),
+        "title",
+        "body",
+        &[],
+        "automation/issue-130",
+    )
+    .await
+    .expect("supervise ok");
+
+    assert_eq!(outcome.status, 0, "clean exit must report status 0");
+    assert!(!outcome.cancelled, "clean exit must not report cancelled");
+    assert!(!outcome.timed_out, "clean exit must not report timed out");
+    assert!(!outcome.signaled, "clean exit must not report signaled");
+}
+
+/// A genuinely cancelled worker (the token is fired externally while the
+/// worker is alive) must still report `cancelled: true`, `status: 130`.
+/// Guards that the fix did not break the cancel path.
+#[tokio::test]
+async fn genuine_cancel_still_reports_cancelled() {
+    let dir = tempdir("cancel");
+    let worktree = dir.join("wt");
+    fs::create_dir_all(&worktree).expect("worktree");
+
+    let cancellation = CancellationToken::new();
+    let cancel_fire = cancellation.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        cancel_fire.cancel();
+    });
+
+    let outcome = supervise(
+        &find_self_exe(),
+        &cfg_for(&dir),
+        &issue_key(),
+        &worktree,
+        "RUN_CANCEL_130",
+        r#"{}"#,
+        &worker_command(&["sh", "-c", "sleep 30"]),
+        cancellation,
+        "title",
+        "body",
+        &[],
+        "automation/issue-130",
+    )
+    .await
+    .expect("supervise ok");
+
+    assert!(outcome.cancelled, "external cancel must report cancelled");
+    assert_eq!(outcome.status, 130, "cancelled worker must report 130");
+}


### PR DESCRIPTION
## Summary

Moves the supervisor's cleanup `cancellation.cancel()` to AFTER awaiting the protocol task, so a worker that exits 0 cleanly is no longer reported as `cancelled: true, status: 130`. Defect 6 of #94.

## Problem

`src/worker/supervisor/dispatch.rs` used `tokio::select!{ biased; ... }` with a cancel arm and a done-frame arm. With `biased`, the cancel arm was polled first whenever both were ready. The cleanup `cancellation.cancel()` at the original line 401 fired immediately after `child.wait()` returned, racing any `DONE` frame buffered on the supervisor's stdout.

When a worker exited 0 cleanly, the `DONE` frame sat in the pipe buffer, the cancel arm won the biased poll, and the daemon reported `status: 130, cancelled: true` — silently misreporting successful work as cancelled.

## Design

Two-statement reorder in `run_supervisor`:
- **BEFORE:** `child.wait()` → `cancellation.cancel()` → `protocol_task.await` → `heartbeat_task.abort()`
- **AFTER:** `child.wait()` → `protocol_task.await` → `cancellation.cancel()` → `heartbeat_task.abort()`

Once the supervisor child is dead, its stdout write end closes. The protocol task's pending `read_frame_async` resolves immediately to either the buffered `DONE` or EOF — whichever is in the pipe. The `biased` select! becomes irrelevant because the protocol task has already terminated by the time cleanup runs.

The cleanup sequence runs **before** the `?` on `protocol_task.await` so a panicked protocol task still tears down the heartbeat loop (instead of leaking it until process exit). The semantic fix is preserved.

## Why not drop `biased`

`tokio::select!` polling semantics:
- **With `biased;`**: arms polled top-to-bottom in declared order. The cancel arm (line 200) is declared before the frame arm (line 275), so when both are ready, cancel wins.
- **Without `biased;`**: tokio picks a pseudo-random starting arm. When both cancel and the buffered DONE frame are ready, cancel still wins ~50% of the time — converting a deterministic bug into a flaky one.

Dropping `biased` is **cosmetic-only** once the reorder is in place (the cancel arm is unreachable during teardown). Keeping it minimizes the diff. A follow-up ticket can evaluate dropping `biased` and reordering the cancel-vs-timeout arm priority at line 200.

## Files changed

- `src/worker/supervisor/dispatch.rs` (+14/-3) — 2-statement reorder + rationale comment + panic-safe cleanup ordering
- `tests/worker/supervisor_cancel_vs_done_test.rs` (NEW, 125 lines) — 2 regression tests:
  - **`clean_exit_reports_status_not_cancelled`** — supervisor spawns a real worker that exits 0; after `supervise(...)` returns, assert `outcome.cancelled == false` and `outcome.status == 0`. Pins the bug regression.
  - **`genuine_cancel_still_reports_cancelled`** — supervisor spawns a `sleep 30` worker; cancel token fires ~100ms later. Asserts `outcome.cancelled == true` and `outcome.status == 130`. Guards that the cancel arm still works for genuinely-cancelled workers.
- `Cargo.toml` (+4) — registers the new test binary
- `CHANGELOG.md` (+5) — `### Fixed` entry, Closes #130, Part of #94

4 files changed, 149 insertions, 2 deletions.

## Acceptance criteria

- [x] A worker that exits 0 cleanly is reported `cancelled: false` and `status: 0` — `clean_exit_reports_status_not_cancelled` pins this
- [x] The supervisor's exit code is what reaches the daemon's tick outcome — the new order awaits the protocol task's actual frame parse before reporting
- [x] The cancel arm still works for genuinely-cancelled workers — `genuine_cancel_still_reports_cancelled` pins this

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- New `supervisor_cancel_vs_done_test` — 2/2 pass
- Regression set (7 supervisor binaries) — 41/41 pass
- `uv run pytest` — 139/139 pass

Kimi K2.7 Code thinking check confirmed the fix is solid; the only amend was the panic-safe cleanup ordering (now applied).

## Pre-existing follow-ups (not blocking)

- **Drop `biased`** — now cosmetic-only; deferred to a follow-up ticket.
- **EOF/signal path** — a supervisor killed without sending `DONE` returns `status: 0, cancelled: false, signaled: false`. This is pre-existing weird behavior, not introduced here.
- **Unused `supervisor_status`** — `signaled` variable is computed and discarded. Pre-existing.

Closes #130. Part of #94.