### PR TITLE
fix(supervisor): capture worker stdout into transcript (closes #126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ across this period.
 
 ### Fixed
 
+- **Supervisor stdout capture.** The supervisor now pipes worker stdout
+  into the bounded transcript alongside stderr (byte-interleaved, one
+  shared writer) instead of discarding it. Previously worker stdout was
+  sent to `/dev/null` and only stderr was captured. Closes #126. Part
+  of #94.
 - **Supervisor cancel/DONE race.** The daemon-side protocol loop drains
   the worker's `DONE` frame before firing the cleanup cancel, so a
   worker that exits 0 cleanly is no longer reported as cancelled. The

--- a/README.md
+++ b/README.md
@@ -243,6 +243,17 @@ front door; the manual is in `docs/`:
   and the actual fix.
 - [`docs/faq.md`](docs/faq.md) — short.
 
+### Transcripts
+
+Each worker run produces one bounded transcript file at
+`<state-dir>/runs/<run-id>.log`. The supervisor captures
+both the worker's stdout and stderr into it,
+byte-interleaved without stream markers, up to
+`transcript_max_bytes`; output past the cap is dropped
+behind a truncation marker line. See
+[`docs/configuration.md`](docs/configuration.md) for the
+limit and retention knobs.
+
 ## Replacing a prior install
 
 If your state directory contains a JSON state file instead

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,10 +162,10 @@ retry-budget cost).
 **Type:** `u64`. **Default:** `10485760` (10 MiB).
 
 Maximum transcript bytes retained per run. The daemon
-drains output continuously and writes the cap-aware
-transcript to the per-run log; output past the cap is
-dropped with a marker line. Cron never sees transcript
-output.
+drains worker stdout and stderr continuously and writes
+the cap-aware transcript to the per-run log; output past
+the cap is dropped with a marker line. Cron never sees
+transcript output.
 
 ### `run_retention_days`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> ExitCode {
 ///    - `Terminate` frame → clean cancel, no worker spawned
 ///    - timeout → emit FATAL, exit 124
 /// 4. on `ACK`: build `Command`, set process_group(0), spawn worker
-/// 5. start stdin-killer + stderr-drain threads, wait, write `DONE`
+/// 5. start stdin-killer + stdout/stderr-drain threads, wait, write `DONE`
 ///
 /// Until step 4 the daemon has not confirmed the PGID and no child
 /// process exists. On EOF, KILL, or TERM after spawn, the worker
@@ -282,12 +282,12 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
     }
     cmd.current_dir(&worktree);
     cmd.stdin(std::process::Stdio::null());
-    // The worker's stdout is forwarded to the daemon over
-    // the supervisor's stderr (which the daemon captures into
-    // the transcript). The supervisor's stdout carries the
-    // framed control protocol only — this keeps the protocol
-    // bytes and the worker bytes from interleaving.
-    cmd.stdout(std::process::Stdio::null());
+    // The worker's stdout and stderr are piped and drained into
+    // the bounded transcript (see the drain block below). The
+    // supervisor's own stdout carries the framed control protocol
+    // only — this keeps the protocol bytes and the worker bytes
+    // from interleaving.
+    cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
     // When the daemon supplied the new issue-context flags,
@@ -393,27 +393,54 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
         }
     });
 
-    // Forward worker stderr to the bounded transcript writer.
+    // Forward worker stdout and stderr to the bounded transcript
+    // writer, byte-interleaved into the one shared file. Two drain
+    // threads share the writer through an `Arc<Mutex<>>`, the same
+    // pattern the daemon-side transcript capture uses in
+    // `dispatch.rs`. Both streams compete for the single
+    // `transcript_max_bytes` budget; a flood drops bytes behind the
+    // truncation marker, identical to the old stderr-only drain.
+    let worker_stdout = child.stdout.take();
     let worker_stderr = child.stderr.take();
-    let mut writer = BoundedTranscriptWriter::new(transcript_path.clone(), transcript_max_bytes)
-        .map_err(|err| {
-            tracing::warn!(error = %err, "failed to open transcript");
-            err
-        })?;
+    let writer = std::sync::Arc::new(std::sync::Mutex::new(
+        BoundedTranscriptWriter::new(transcript_path.clone(), transcript_max_bytes).map_err(
+            |err| {
+                tracing::warn!(error = %err, "failed to open transcript");
+                err
+            },
+        )?,
+    ));
 
-    let tx_err = std::thread::spawn(move || {
-        let mut buf = [0u8; 4096];
-        if let Some(mut s) = worker_stderr {
-            loop {
-                match s.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => writer.write_bytes(&buf[..n]),
-                    Err(_) => break,
+    let tx_out = {
+        let writer = std::sync::Arc::clone(&writer);
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            if let Some(mut s) = worker_stdout {
+                loop {
+                    match s.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => writer.lock().unwrap().write_bytes(&buf[..n]),
+                        Err(_) => break,
+                    }
                 }
             }
-        }
-        writer
-    });
+        })
+    };
+    let tx_err = {
+        let writer = std::sync::Arc::clone(&writer);
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            if let Some(mut s) = worker_stderr {
+                loop {
+                    match s.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => writer.lock().unwrap().write_bytes(&buf[..n]),
+                        Err(_) => break,
+                    }
+                }
+            }
+        })
+    };
 
     // Wait for the worker.
     let status = child
@@ -422,11 +449,26 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
             context: "supervisor:worker_wait",
             stderr: format!("wait: {err}"),
         })?;
-    // Join the stderr drain thread and get the writer back.
-    let writer = tx_err.join().map_err(|_| caduceus::CaduceusError::Worker {
+    // Join both drain threads, then recover the writer. The threads
+    // drop their `Arc` clones on exit, so `try_unwrap` succeeds.
+    tx_out.join().map_err(|_| caduceus::CaduceusError::Worker {
         context: "supervisor",
-        stderr: "transcript writer thread panicked".to_string(),
+        stderr: "stdout drain thread panicked".to_string(),
     })?;
+    tx_err.join().map_err(|_| caduceus::CaduceusError::Worker {
+        context: "supervisor",
+        stderr: "stderr drain thread panicked".to_string(),
+    })?;
+    let writer = std::sync::Arc::try_unwrap(writer)
+        .map_err(|_| caduceus::CaduceusError::Worker {
+            context: "supervisor",
+            stderr: "transcript writer still referenced".to_string(),
+        })?
+        .into_inner()
+        .map_err(|_| caduceus::CaduceusError::Worker {
+            context: "supervisor",
+            stderr: "transcript writer lock poisoned".to_string(),
+        })?;
 
     // Finalize transcript — report truncation/write failures.
     // This must happen before DONE so a failed write is reported as a

--- a/src/worker/supervisor/outcome_transcript.rs
+++ b/src/worker/supervisor/outcome_transcript.rs
@@ -161,7 +161,7 @@ pub fn truncate_transcript(path: &Path, max_bytes: u64) -> CaduceusResult<bool> 
     Ok(true)
 }
 
-// BoundedTranscriptWriter — bounded stderr capture
+// BoundedTranscriptWriter — bounded worker output capture
 
 /// Bounded writer that wraps a transcript file with a byte cap.
 /// Writes that would exceed the cap trigger truncation; subsequent

--- a/tests/worker/worker_transcript_test.rs
+++ b/tests/worker/worker_transcript_test.rs
@@ -235,3 +235,108 @@ fn test_transcript_exact_fit_succeeds() {
     let exit_code = run_transcript_test(100, 100);
     assert_eq!(exit_code, 0, "exact fit should exit 0");
 }
+
+/// Run the supervisor with a worker that writes a marker to *stdout*
+/// (fd 1, not fd 2). Drives the control protocol (READY → ACK → DONE)
+/// and returns the supervisor exit code plus the final transcript file
+/// contents.
+fn run_stdout_transcript_test() -> (i32, String) {
+    let tree = ProcessTree::start("stdout_transcript");
+    let workdir = tree.workdir().to_path_buf();
+
+    let helper = write_worker_script(
+        &workdir,
+        "stdout_worker.sh",
+        r#"#!/bin/sh
+printf 'STDOUT_TOKEN_%s' "$$" >&1
+exit 0
+"#,
+    );
+
+    fs::create_dir_all(workdir.join("wt")).expect("create worktree");
+    let transcript = workdir.join("transcript.log");
+    let heartbeat = workdir.join("hbeat");
+    fs::File::create(&transcript).expect("create transcript");
+    fs::File::create(&heartbeat).expect("create heartbeat");
+
+    let exe = fixtures::ReleaseBinary::locate();
+    let mut cmd = Command::new(&exe);
+    cmd.arg("__worker-supervisor");
+    cmd.arg("--worktree").arg(workdir.join("wt"));
+    cmd.arg("--run-id").arg("RUN_STDOUT_CAPTURE");
+    cmd.arg("--issue").arg("owner/repo#1");
+    cmd.arg("--context-json").arg("{}");
+    cmd.arg("--transcript").arg(&transcript);
+    cmd.arg("--heartbeat").arg(&heartbeat);
+    cmd.arg("--timeout").arg("10");
+    cmd.arg("--transcript-max-bytes").arg("1048576");
+    cmd.arg("--").arg(&helper);
+    cmd.env_clear();
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn supervisor");
+    let mut stdin = child.stdin.take().expect("stdin");
+    let mut stdout = make_nonblocking(&mut child);
+
+    // READY frame.
+    let deadline = Instant::now() + std::time::Duration::from_secs(5);
+    let ready = read_frame_with_deadline(&mut stdout, deadline).expect("expected READY frame");
+    assert!(
+        matches!(ready, (ControlFrame::Ready { .. }, _)),
+        "expected READY, got {ready:?}"
+    );
+
+    // Send ACK.
+    let ack = worker_supervisor::encode_frame(&ControlFrame::Ack).expect("encode ack");
+    stdin.write_all(&ack).expect("write ack");
+    stdin.flush().ok();
+    // Keep stdin open — dropping it would trigger the killer thread.
+
+    // Wait for DONE frame OR process exit.
+    let done_deadline = Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if child.try_wait().ok().flatten().is_some() {
+            break; // process exited (success or finalize error)
+        }
+        #[allow(clippy::collapsible_match)]
+        if let Some((frame, _)) = read_frame_with_deadline(&mut stdout, done_deadline) {
+            if matches!(
+                frame,
+                ControlFrame::Done { .. } | ControlFrame::Fatal { .. }
+            ) {
+                break;
+            }
+        }
+        if Instant::now() >= done_deadline {
+            panic!("timeout waiting for supervisor exit");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // Now close stdin so the supervisor can exit.
+    std::mem::drop(stdin);
+    std::mem::drop(stdout);
+
+    let output = child.wait_with_output().expect("wait for supervisor");
+    let su_stderr = String::from_utf8_lossy(&output.stderr);
+    if !su_stderr.is_empty() {
+        eprintln!("supervisor stderr: {su_stderr}");
+    }
+    let contents = fs::read_to_string(&transcript).expect("read transcript");
+    (output.status.code().unwrap_or(1), contents)
+}
+
+// 9.5 — Worker stdout (fd 1) is captured into the transcript alongside
+// stderr (regression for #126: stdout was previously sent to /dev/null)
+
+#[test]
+fn test_transcript_captures_worker_stdout() {
+    let (exit_code, contents) = run_stdout_transcript_test();
+    assert_eq!(exit_code, 0, "stdout write under limit should exit 0");
+    assert!(
+        contents.contains("STDOUT_TOKEN_"),
+        "transcript should contain worker stdout bytes, got: {contents:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Captures worker stdout into the bounded transcript alongside stderr. Previously worker stdout was sent to `/dev/null` (defect 2 of #94 — the transcript contract promised stdout + stderr, only stderr was captured).

## Problem

`src/main.rs` used `cmd.stdout(Stdio::null())` — worker stdout was silently discarded. The transcript contract (README + `docs/configuration.md`) promised both streams.

## Design

**Plain byte-interleave, no stream markers.** `BoundedTranscriptWriter` has no per-stream concept and no consumer parses markers; the transcript is operator-facing opaque text. This matches how a terminal captures a process.

- `Stdio::null()` → `Stdio::piped()` at `src/main.rs:290`
- ONE `Arc<Mutex<BoundedTranscriptWriter>>` shared between TWO drain threads (stdout + stderr) — mirrors the existing daemon-side pattern in `dispatch.rs:339`
- Both threads joined before `Arc::try_unwrap(writer)` → `finalize()` (unchanged error semantics)
- Drain-thread panics mapped to `Worker` errors before finalize (with distinct "stdout/stderr drain thread panicked" messages + a lock-poison guard)
- The supervisor's OWN stdout still carries only the framed control protocol (READY/FATAL/DONE) — verified: no raw worker bytes touch it

## Files changed

- `src/main.rs` (+82/-26) — piped stdout, two drain threads, updated step-5 comment
- `src/worker/supervisor/outcome_transcript.rs` (+1/-1) — module doc: "bounded stderr capture" → "bounded worker output capture"
- `README.md` (+11) — new "Transcripts" subsection under The Operator's Manual
- `docs/configuration.md` (±4) — `transcript_max_bytes`: "drains worker stdout and stderr"
- `CHANGELOG.md` (+5) — Fixed entry, Closes #126, Part of #94
- `tests/worker/worker_transcript_test.rs` (+105) — new `test_transcript_captures_worker_stdout` + `run_stdout_transcript_test` helper

6 files changed, 195 insertions, 32 deletions.

## Acceptance criteria

- [x] Worker writing to stdout → bytes persisted in transcript file — `test_transcript_captures_worker_stdout` writes `STDOUT_TOKEN_$$` to fd 1 and asserts the transcript file contains it
- [x] `caduceus status` exposes worker stdout alongside stderr — status prints `transcript_path`; the file at that path now contains both streams (no status-command change needed)
- [x] Transcript module doc + README reflect both streams captured — both updated

## Scope decisions (call-outs)

1. **Plain interleave vs marker lines** — chose plain byte-interleave. No transcript reader exists in the codebase; markers would add format risk for zero benefit. README documents the choice.
2. **`caduceus status` "exposes both streams"** — interpreted as "the file at the printed path contains both streams," not "status command prints both." Status already only prints the path.
3. **Latent dual-writer truncation race** — `main.rs` (supervisor) AND `dispatch.rs` (daemon) both open the same transcript with `truncate(true)`. Pre-existing, NOT introduced here. **Filed as #134** — the supervisor should become the single owner of the transcript file.

## Verification

Two independent OpenCode plan-mode passes:
- **GLM-5.2** (correctness): PASS — point-by-point vs plan, threading/race analysis clean, test fidelity confirmed
- **Kimi K2.7 Code** (maintainability): PASS — approve as-is, optional style notes only

Gates (run by build agent):
- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- Targeted transcript/supervisor binaries — all pass (5/5)
- Full suite — green except pre-existing/environmental failures (`with_config_falls_back_to_none_when_env_var_dropped` verified failing on clean base; `loop01b` flaky under parallel load, passes in isolation)
- `uv run pytest` — 139/139 pass

Closes #126. Part of #94.