### PR TITLE
fix(supervisor): match hidden-mode token only as first argv (closes #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,11 @@ across this period.
   worker that exits 0 cleanly is no longer reported as cancelled. The
   cancel path still wins when fired while the worker is alive and no
   DONE is pending. Closes #130. Part of #94.
+- **Supervisor hidden-command dispatch.** The hidden
+  `__worker-supervisor` token is now matched only as the first argument
+  after the binary name, not anywhere in `argv`, so a copy-pasted
+  debugging recipe can no longer accidentally drop a normal CLI
+  invocation into supervisor mode. Closes #129. Part of #94.
 - **Status exit codes.** Every status call now exits with the documented
   code instead of always returning 0.
 - **GitHub auth token resolution.** The daemon now resolves the GitHub

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,12 @@
 //! diagnostics go to stderr.
 //!
 //! The hidden `__worker-supervisor` mode is dispatched before public
-//! command parsing — the token is never shown in `--help` output and is
-//! never accepted from cron / plugin configuration. The supervisor
-//! executes the worker in its own Unix session and talks to the daemon
-//! over the inherited `stdin` / `stdout` file descriptors using the
-//! framed control protocol.
+//! command parsing — the token is matched only as the first argument
+//! after the binary name (`argv[1]`), is never shown in `--help`
+//! output, and is never accepted from cron / plugin configuration.
+//! The supervisor executes the worker in its own Unix session and
+//! talks to the daemon over the inherited `stdin` / `stdout` file
+//! descriptors using the framed control protocol.
 
 use std::os::unix::process::CommandExt;
 use std::process::ExitCode;
@@ -26,9 +27,15 @@ mod cli;
 fn main() -> ExitCode {
     // Hidden `__worker-supervisor` mode is dispatched first; the
     // token is reserved and never accepted from cron or plugin
-    // configuration. The supervisor runs the worker under
-    // supervision and exits once the worker session is reaped.
-    if std::env::args_os().any(|arg| arg == caduceus::worker_supervisor::HIDDEN_COMMAND) {
+    // configuration. The token is matched only as the first argument
+    // after the binary name (`argv[1]`), exactly how
+    // `build_supervisor_command` constructs the child argv. The
+    // supervisor runs the worker under supervision and exits once
+    // the worker session is reaped.
+    if std::env::args_os()
+        .nth(1)
+        .is_some_and(|arg| arg == caduceus::worker_supervisor::HIDDEN_COMMAND)
+    {
         return match run_supervisor_mode() {
             Ok(()) => ExitCode::from(0),
             Err(err) => {

--- a/src/worker/supervisor/process_lifecycle.rs
+++ b/src/worker/supervisor/process_lifecycle.rs
@@ -18,8 +18,9 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 // Hidden command name
 
 /// Hidden command name that the binary recognises before public
-/// Clap parsing. The token is reserved and must never appear in
-/// `--help` output or be accepted from cron / plugin
+/// Clap parsing, matched only as the first argument after the
+/// binary name (`argv[1]`). The token is reserved and must never
+/// appear in `--help` output or be accepted from cron / plugin
 /// configuration.
 pub const HIDDEN_COMMAND: &str = "__worker-supervisor";
 

--- a/tests/worker/worker_process_test.rs
+++ b/tests/worker/worker_process_test.rs
@@ -353,7 +353,43 @@ ps -o pid=,pgid= -p $$ 1>&2
 }
 
 #[test]
+fn supervisor_hidden_command_must_be_first_arg() {
+    // The token must be matched only as the first argument after the
+    // binary name. `--help` at position 1 short-circuits inside clap;
+    // the token at position 2 must NOT trigger supervisor mode.
+    let exe = find_self_exe();
+    let output = Command::new(&exe)
+        .arg("--help")
+        .arg("__worker-supervisor")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run --help with trailing token");
+    assert!(
+        output.status.success(),
+        "should not enter supervisor mode, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Usage:") || stdout.contains("caduceus"),
+        "expected help output, got: {stdout}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("--worktree"),
+        "supervisor mode must not be entered"
+    );
+}
+
+#[test]
 fn supervisor_handles_missing_required_argument() {
+    // This test also serves as the position-1 dispatch guard for the
+    // hidden `__worker-supervisor` token (defect 5 of #94 / issue
+    // #129): the token must be matched as argv[1]. Missing --worktree
+    // means supervisor mode was entered; if a future refactor broke
+    // position-1 dispatch, this test would either exit 0 (clap
+    // handled --transcript etc.) or fail with a different error.
     let dir = tempdir("missing_args");
     let transcript = dir.join("t.log");
     let heartbeat = dir.join("hbeat");


### PR DESCRIPTION
## Summary

Matches the hidden `__worker-supervisor` token only as `argv[1]`, not anywhere in `argv`. Defect 5 of #94 (last of six).

## Problem

`src/main.rs:31` used `args_os().any(|arg| arg == HIDDEN_COMMAND)` — the supervisor token matched anywhere in argv. A copy-pasted debugging recipe like:

```
caduceus --some-flag __worker-supervisor /worktree
```

would unintentionally drop into supervisor mode. The contract at `process_lifecycle.rs:20-24` describes the token as a child-process invocation contract, implying first-position matching.

## Design

`std::env::args_os().any(|arg| arg == HIDDEN_COMMAND)` → `std::env::args_os().nth(1).is_some_and(|arg| arg == HIDDEN_COMMAND)`. The `is_some_and` closure reuses the **exact same** `OsString == &str` comparison the old `.any()` closure used — no semantics drift on non-UTF8 argv.

**No legitimate invocation affected.** `build_supervisor_command` (`process_lifecycle.rs:219-220`) does `Command::new(self_exe)` then immediately `cmd.arg(HIDDEN_COMMAND)` — the token is always position 1. First-position match is a strict superset of legitimate supervisor runs.

**Edge cases confirmed:**
- A worker script's argv can legitimately contain `__worker-supervisor` (e.g. `caduceus __worker-supervisor ... -- some-script __worker-supervisor`); `nth(1)` ignores everything after position 1.
- Empty / binary-only argv → `nth(1)` returns `None` → falls through to `cli::run()`, which inserts `run` (no-arg behavior).
- `--help` short-circuits inside clap before any later arg is consulted — the token at position 2 is irrelevant.

## Files changed

- `src/main.rs` (+17/-6) — `.any(...)` → `.nth(1).is_some_and(...)` at the dispatch site; surrounding comment updated.
- `src/worker/supervisor/process_lifecycle.rs` (+3/-2) — `HIDDEN_COMMAND` contract doc now says "matched only as the first argument after the binary name (`argv[1]`)".
- `tests/worker/worker_process_test.rs` (+35) — new negative regression test `supervisor_hidden_command_must_be_first_arg` (asserts `caduceus --help __worker-supervisor` exits 0 with help text, NOT supervisor mode). The existing positive-dispatch guard is `supervisor_handles_missing_required_argument` — a clarifying comment now notes that this test also pins position-1 dispatch (no duplicate test added; the existing assertion would already fail if position-1 dispatch broke).
- `CHANGELOG.md` (+5) — Fixed entry, Closes #129, Part of #94.

4 files changed, 59 insertions, 10 deletions.

## Acceptance criteria

- [x] `caduceus --something __worker-supervisor /worktree` does NOT enter supervisor mode — `supervisor_hidden_command_must_be_first_arg` (`--help __worker-supervisor` variant) pins the contract; clap handles `--help` before the trailing token is even consulted.
- [x] `caduceus __worker-supervisor /worktree` DOES enter supervisor mode — `supervisor_handles_missing_required_argument` exercises position-1 dispatch.
- [x] A regression test asserts both behaviors — both are pinned.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --test worker_process_test` — 17/17 pass
- `cargo test --locked --all-targets` (with 5 named skips) — all green except `token_resolution_test::with_config_falls_back_to_none_when_env_var_dropped`, a pre-existing environmental failure (host has `GITHUB_TOKEN`/`AUTO_ISSUE_GITHUB_TOKEN` set; verified failing on base `a66e97d` without this change).
- `uv run pytest` — 139/139 pass

Two independent OpenCode plan-mode passes:
- **GLM-5.2** (correctness): PASS — all five verification points confirmed against source, including no-semantics-drift on `OsString == &str` comparison.
- **Kimi K2.7 Code** (maintainability): PASS — flagged that the new positive test was a byte-for-byte duplicate of an existing one; amended to remove the duplicate and clarify the existing test's dispatch-guard role via a comment (saves 21 lines of test code).

Closes #129. Part of #94.