### PR TITLE
fix(supervisor): daemon stops clobbering worker transcript (closes #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,13 @@ across this period.
 
 ### Fixed
 
+- **Dual-writer transcript race.** The daemon no longer opens the run
+  transcript; the supervisor is the sole writer of
+  `<state-dir>/runs/<run-id>.log` (worker stdout+stderr). Previously
+  the daemon re-opened the same path with `truncate(true)` to capture
+  supervisor diagnostics, silently clobbering worker bytes written
+  before its open. Supervisor stderr now inherits to the daemon's
+  stderr. Closes #134. Part of #94.
 - **Supervisor stdout capture.** The supervisor now pipes worker stdout
   into the bounded transcript alongside stderr (byte-interleaved, one
   shared writer) instead of discarding it. Previously worker stdout was

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -409,6 +409,10 @@ name = "supervisor_cancel_vs_done_test"
 path = "tests/worker/supervisor_cancel_vs_done_test.rs"
 
 [[test]]
+name = "supervisor_transcript_ownership_test"
+path = "tests/worker/supervisor_transcript_ownership_test.rs"
+
+[[test]]
 name = "worker_transcript_test"
 path = "tests/worker/worker_transcript_test.rs"
 

--- a/src/worker/supervisor/dispatch.rs
+++ b/src/worker/supervisor/dispatch.rs
@@ -32,12 +32,13 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 /// 4. Read `READY(pgid)` from the supervisor's stdout, send
 ///    `ACK` over its stdin so the supervisor opens the exec
 ///    gate.
-/// 5. Drain supervisor `stderr` into the transcript, bounded
-///    by `cfg.transcript_max_bytes`, with a single truncation
-///    marker and continuing drain/discard after truncation.
-/// 6. Await supervisor exit, both readers, and writer.
-/// 7. Remove the heartbeat, return the parsed
+/// 5. Await supervisor exit and the protocol reader.
+/// 6. Remove the heartbeat, return the parsed
 ///    [`SupervisorOutcome`].
+///
+/// The supervisor owns the transcript (worker stdout+stderr); the
+/// daemon does not open it. Supervisor diagnostics inherit to the
+/// daemon's stderr.
 ///
 /// `cancellation` is the daemon's
 /// `tokio_util::sync::CancellationToken`. When triggered, the
@@ -176,7 +177,6 @@ pub(crate) async fn run_supervisor(
         context: "supervisor:spawn",
         stderr: "supervisor stdout was not piped".to_string(),
     })?;
-    let stderr = child.stderr.take();
     // Capture the worker timeout into an owned value so the
     // `'static` protocol task can read it without borrowing `cfg`.
     let worker_timeout_seconds = cfg.worker_timeout_seconds;
@@ -327,42 +327,6 @@ pub(crate) async fn run_supervisor(
             }
         })
     };
-
-    // Stderr drain — write into the transcript, bounded by
-    // cfg.transcript_max_bytes.
-    if let Some(mut stderr) = stderr {
-        let path = paths.transcript_path.clone();
-        let max_bytes = cfg.transcript_max_bytes;
-        let _drain_task = tokio::spawn(async move {
-            let mut buf = vec![0u8; 4096];
-            let writer = match BoundedTranscriptWriter::new(path.clone(), max_bytes) {
-                Ok(w) => std::sync::Arc::new(std::sync::Mutex::new(w)),
-                Err(_) => return,
-            };
-            loop {
-                match stderr.read(&mut buf).await {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        let chunk = buf[..n].to_vec();
-                        let w = writer.clone();
-                        let _ = tokio::task::spawn_blocking(move || {
-                            let mut guard = w.lock().unwrap();
-                            guard.write_bytes(&chunk);
-                        })
-                        .await;
-                    }
-                    Err(_) => break,
-                }
-            }
-            let guard = std::sync::Arc::try_unwrap(writer)
-                .unwrap_or_else(|_| panic!("writer arc still referenced"))
-                .into_inner()
-                .unwrap_or_else(|e| e.into_inner());
-            if let Err(err) = guard.finalize() {
-                tracing::warn!(error = %err, "transcript finalize");
-            }
-        });
-    }
 
     // Heartbeat refresh: every 5s while the worker is alive.
     let hb_path = paths.heartbeat_path.clone();

--- a/src/worker/supervisor/process_lifecycle.rs
+++ b/src/worker/supervisor/process_lifecycle.rs
@@ -237,11 +237,13 @@ pub fn build_supervisor_command(
     for arg in worker_command {
         cmd.arg(arg);
     }
-    // The supervisor's stdin/stdout/stderr are the daemon's
-    // control/status pipes. Stderr is captured separately so a
-    // misbehaving supervisor can log to disk.
+    // The supervisor's stdin/stdout are the daemon's control/status
+    // pipes. The supervisor owns the transcript file (worker
+    // stdout+stderr); its own diagnostics inherit to the daemon's
+    // stderr so they reach the operator/journald without contending
+    // for the transcript.
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
+    cmd.stderr(Stdio::inherit());
     cmd
 }

--- a/tests/worker/supervisor_transcript_ownership_test.rs
+++ b/tests/worker/supervisor_transcript_ownership_test.rs
@@ -1,0 +1,95 @@
+//! Regression test for the dual-writer transcript race (#134, part of
+//! #94).
+//!
+//! Both the supervisor (`main.rs` `run_supervisor_mode`) and the daemon
+//! (`dispatch::run_supervisor`) opened the same run transcript with
+//! `truncate(true)`. Whichever opened second truncated the first's
+//! bytes. In production the supervisor opens first, so the daemon's
+//! later open silently discarded worker output written before it.
+//!
+//! The fix makes the supervisor the sole owner of the transcript; the
+//! daemon no longer opens it. These tests drive the real `caduceus`
+//! binary end-to-end through `supervise`, the same path the daemon's
+//! `TrustedHostExecutor` uses, and assert that both worker streams
+//! survive the full daemon -> supervisor -> worker handshake.
+
+#![cfg(target_os = "linux")]
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use std::fs;
+use std::path::PathBuf;
+
+use caduceus::github::issue::IssueKey;
+use caduceus::infra::config::Config;
+use caduceus::worker_supervisor::supervise;
+use tokio_util::sync::CancellationToken;
+
+fn tempdir(label: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    dir.push(format!("caduceus-transcript-owner-{label}-{nonce}"));
+    fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+fn find_self_exe() -> PathBuf {
+    fixtures::ReleaseBinary::locate()
+}
+
+fn issue_key() -> IssueKey {
+    IssueKey::parse("test-owner/test-repo#134").expect("valid key")
+}
+
+fn cfg_for(root: &std::path::Path) -> Config {
+    Config::test_defaults(root)
+}
+
+fn worker_command(args: &[&str]) -> Vec<String> {
+    args.iter().map(|s| s.to_string()).collect()
+}
+
+/// A worker that writes distinct markers to stdout and stderr must have
+/// BOTH markers in the transcript after the full daemon -> supervisor
+/// -> worker handshake. Before the fix, the daemon's second
+/// `truncate(true)` open of the same path could discard the worker's
+/// stdout bytes. Regression for #134.
+#[tokio::test]
+async fn transcript_keeps_worker_output_after_daemon_handshake() {
+    let dir = tempdir("owner");
+    let worktree = dir.join("wt");
+    fs::create_dir_all(&worktree).expect("worktree");
+    let cfg = cfg_for(&dir);
+    let run_id = "RUN_OWNER_134";
+
+    let outcome = supervise(
+        &find_self_exe(),
+        &cfg,
+        &issue_key(),
+        &worktree,
+        run_id,
+        r#"{}"#,
+        &worker_command(&[
+            "sh",
+            "-c",
+            "echo STDOUT_MARKER_134; echo STDERR_MARKER_134 1>&2; exit 0",
+        ]),
+        CancellationToken::new(),
+        "title",
+        "body",
+        &[],
+        "automation/issue-134",
+    )
+    .await
+    .expect("supervise ok");
+
+    assert_eq!(outcome.status, 0, "worker must exit 0");
+    let transcript = cfg.state_dir.join("runs").join(format!("{run_id}.log"));
+    let body = fs::read_to_string(&transcript).expect("read transcript");
+    assert!(body.contains("STDOUT_MARKER_134"), "stdout lost: {body:?}");
+    assert!(body.contains("STDERR_MARKER_134"), "stderr lost: {body:?}");
+}


### PR DESCRIPTION
## Summary

The daemon no longer opens the run transcript. The supervisor is the sole writer; the redundant daemon-side `BoundedTranscriptWriter` drain is removed and supervisor diagnostics inherit to the daemon's stderr.

## Problem

Two writers targeted the same `transcript_path` (`<state-dir>/runs/<run-id>.log`):

1. **`src/main.rs` (supervisor side)** — captured worker stdout+stderr via the two drain threads added by #126.
2. **`src/worker/supervisor/dispatch.rs` (daemon side)** — opened the SAME path with `truncate(true)` to capture the supervisor's own stderr.

Whichever opened second truncated the first's bytes. In practice the supervisor opened first and wrote worker output; the daemon opened later and wrote supervisor-stderr — so worker stdout+stderr bytes written before the daemon's open could be silently lost. #126 made this worse: worker stdout now also flows into the contended file.

## Design

**Option (a)**: the supervisor is the sole owner. The daemon's transcript writer and its stderr drain block are removed. The supervisor's own stderr is changed from `Stdio::piped()` to `Stdio::inherit()` in `build_supervisor_command`, so supervisor diagnostics flow to the daemon's stderr → operator/journald. No information is lost; the destination changes.

Why not (b) (append-instead-of-truncate): leaves two writers contending on a bounded file — race risk remains.
Why not (c) (separate supervisor-stderr file): larger change, marginal value (supervisor stderr is mostly diagnostics; the worker's output is the contract).

## Files changed

- `src/worker/supervisor/process_lifecycle.rs` (+10/-2) — `cmd.stderr(Stdio::inherit())` in `build_supervisor_command`; new comment explains the single-owner contract.
- `src/worker/supervisor/dispatch.rs` (-46/+2) — deleted `let stderr = child.stderr.take();` and the entire stderr-drain block (~35 lines of the second `BoundedTranscriptWriter::new` + drain task); updated the doc comment from "Drain supervisor stderr into the transcript" to "The supervisor owns the transcript (worker stdout+stderr); the daemon does not open it. Supervisor diagnostics inherit to the daemon's stderr."
- `tests/worker/supervisor_transcript_ownership_test.rs` (NEW, 95 lines) — Linux-only. `transcript_keeps_worker_output_after_daemon_handshake` calls the full `supervise()` (via `find_self_exe()` → `ReleaseBinary::locate()`), spawns a worker that writes distinct markers to BOTH stdout and stderr, then asserts both markers are present in `<cfg.state_dir>/runs/<run-id>.log`. This is the bug regression: before the fix, the daemon's truncating open would clobber worker bytes; after the fix, both streams survive.
- `Cargo.toml` (+4) — registers the new test binary.
- `CHANGELOG.md` (+7) — Fixed entry: dual-writer transcript race, supervisor sole owner, supervisor stderr inherits.

5 files changed, 118 insertions, 46 deletions.

## Acceptance criteria

- [x] Supervisor + daemon together assert worker output in transcript (no truncation by daemon-side open) — `transcript_keeps_worker_output_after_daemon_handshake` pins both stdout+stderr markers end-to-end
- [x] Transcript file format unchanged (single file at `<state-dir>/runs/<run-id>.log`) — verified, only the supervisor touches it now

## Verification

Two independent OpenCode plan-mode passes:
- **GLM-5.2** (correctness): PASS — single-writer guarantee verified by `git grep` for all production `BoundedTranscriptWriter::new` calls; test exercises full handshake via `supervise()`; no broken references to supervisor stderr from transcript anywhere in the codebase (`src/daemon/status.rs` only prints `transcript_path` as a string, never reads content; `dry_run_archive.rs` uses a separate path under the worktree).
- **Kimi K2.7 Code** (maintainability): PASS — no amends, no deviations.

Gates:
- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- Targeted supervisor/worker tests (9 binaries, 59 tests) — all pass
- `cargo test --locked --all-targets` (with 5 named skips) — all green except `token_resolution_test::with_config_falls_back_to_none_when_env_var_dropped`, one of the 6 known pre-existing environmental failures (token resolution, untouched code; verified on base without this change)
- `uv run pytest` — 139/139 pass

## Follow-ups (out of scope)

- **Structured supervisor diagnostics.** The supervisor's bare `eprintln!` output inherits to the daemon's stderr; converting to `tracing` would give journald structured fields. File as separate ticket if desired.
- **AGENTS.md guardrail.** Consider a `grep` step in CI to ensure `BoundedTranscriptWriter::new` only appears in one production location, preventing regression of the dual-writer pattern. Optional.

Closes #134. Part of #94.