### PR TITLE
chore(docs): fix queue.json refs in skills doc (closes #138)

### DIFF
--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -98,10 +98,10 @@ work on tick exit; the cap only stops claiming new entries.
 
 ## State Recovery Procedure
 
-Both `queue.json` and `state_meta.json` use temp-file + `fsync` +
+Both `state.json` and `state_meta.json` use temp-file + `fsync` +
 atomic rename and are never silently truncated:
 
-- **Corrupt `queue.json`** → daemon exits 1, file preserved. Inspect
+- **Corrupt `state.json`** → daemon exits 1, file preserved. Inspect
   and repair manually or use `caduceus migrate-state --from <path>
   [--dry-run]`.
 - **Corrupt `state_meta.json`** → same behavior. Exit 1, file preserved.


### PR DESCRIPTION
Sub-issue of #97 (defect 6). Two `queue.json` references in the skill doc's State Recovery Procedure pointed at a filename that doesn't exist — the queue state file is `state.json` (src/state/queue/mod.rs:61). `state_meta.json` refs untouched (correct).

Plan (GLM-5.2) → Build (DeepSeek-V4-Flash-0731) → Check (Kimi K2.7) all green; acceptance grep 0 hits.