### PR TITLE
chore(plugin): bump plugin manifest to v1.0.0 (closes #139)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-"""Caduceus v0.1 — Hermes plugin adapter (stdlib-only).
+"""Caduceus v1.0.0 — Hermes plugin adapter (stdlib-only).
 
 This module is the Hermes-facing surface for Caduceus. It exposes a single
 ``register(ctx)`` entry point. Importing this module is intentionally
@@ -12,7 +12,7 @@ and enable it before any Rust binary has been built. The reference bridge
 template lives under ``plugin-assets/`` and is *not* imported here.
 
 Three registrations are wired up at ``register`` time, per the Hermes
-plugin compatibility contract in ``planning/caduceus-v0.1/CONTRACTS.md``:
+plugin compatibility contract:
 
 1. ``ctx.register_skill("caduceus", <root>/skills/caduceus/SKILL.md, ...)``,
    resolvable as ``caduceus:caduceus``.
@@ -265,7 +265,7 @@ def register(ctx: Any) -> None:
     )
     ctx.register_cli_command(
         name=PLUGIN_NAME,
-        help="Caduceus v0.1 lifecycle (setup, doctor, status, cron).",
+        help="Caduceus v1.0.0 lifecycle (setup, doctor, status, cron).",
         setup_fn=_register_caduceus_cli,
         handler_fn=_caduceus_cli_command,
         description=(

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,4 +1,4 @@
-# Caduceus v0.1 — Hermes plugin manifest
+# Caduceus v1.0 — Hermes plugin manifest
 #
 # Field set is restricted to the ones the Hermes Agent v0.18.2
 # directory-plugin loader actually consumes (see
@@ -19,7 +19,7 @@
 # tests/fixtures/negative_plugin.yaml locks this rule.
 manifest_version: 1
 name: caduceus
-version: 0.1.0
+version: 1.0.0
 description: >-
   Hermes-managed Unix daemon that polls GitHub for labeled issues, runs a
   user-configured AI harness in isolated worktrees under a hard timeout,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,7 +16,7 @@ use caduceus::issue::IssueKey;
 use caduceus::queue::StateStore;
 use caduceus::DaemonLock;
 
-/// Caduceus v0.1: poll GitHub, queue one unit of work per tick, finalise
+/// Caduceus v1.0.0: poll GitHub, queue one unit of work per tick, finalise
 /// code or investigation results.
 #[derive(Debug, Parser)]
 #[command(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Caduceus v0.1
+//! Caduceus v1.0.0
 //!
 //! Unix single-host, one-shot Rust daemon. This crate ships the `caduceus`
 //! binary plus its library surface. Modules expose their canonical paths;


### PR DESCRIPTION
Sub-issue of #97 (defect 5). Version drift cleanup: Cargo.toml says 1.0.0, the plugin surface and crate docs still said v0.1.

- plugin.yaml header comment + the real manifest `version:` field (0.1.0 → 1.0.0) — the field Hermes actually reads, so the issue-body-literal comment-only bump was extended per plan recommendation
- __init__.py docstring + argparse help
- dead `planning/caduceus-v0.1/CONTRACTS.md` path dropped
- src/lib.rs + src/cli/mod.rs crate/cli doc comments
- host-version refs (Hermes v0.18.2/v0.19.0) and era-prose untouched

Plan (GLM-5.2) → Build (DeepSeek-V4-Flash-0731) → Check (Kimi K2.7) green; fmt/clippy clean; pytest 139/139.