### PR TITLE
chore(docs): re-point dead CONTRACTS and MIGRATION refs (closes #140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Canonical CI matrix for the Caduceus v1.0 plan.
 #
-# Implements CONTRACTS.md CI-001 and CI-002. Runs on every pull
+# Implements the CI contract (CI-001, CI-002). Runs on every pull
 # request and every push to main. The matrix runs on stable Rust
 # with --locked. The MSRV is documented in Cargo.toml
 # (rust-version = "1.97") and enforced at compile time — no
@@ -35,7 +35,6 @@ on:
       - 'SECURITY.md'
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
-      - 'MIGRATION.md'
   # Option C: a weekly schedule trigger keeps the cargo and
   # target caches warm so the next human push does not pay the
   # cold-cache build cost (5-10 minutes on ubuntu-24.04 with a

--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -1,4 +1,4 @@
-# Conventional Commits subject check (CONTRACTS.md CI-003).
+# Conventional Commits subject check (CI-003).
 #
 # Validates that every commit on the PR (or the squash title,
 # when the repo enforces squash merge) follows the
@@ -28,7 +28,6 @@ on:
       - 'SECURITY.md'
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
-      - 'MIGRATION.md'
 
 concurrency:
   group: commit-policy-${{ github.ref }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -50,7 +50,7 @@ Both workflows use `paths-ignore` so docs-only pushes do not
 pay the full Rust+Python build cost. A push that touches only
 `docs/`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`,
 `AGENTS.md`, `RELEASING.md`, `SECURITY.md`, `LICENSE`,
-`.github/ISSUE_TEMPLATE/**`, or `MIGRATION.md` skips the build
+`.github/ISSUE_TEMPLATE/**` skips the build
 entirely.
 
 A change to anything else — Rust source, Python tests,

--- a/docs/state-recovery.md
+++ b/docs/state-recovery.md
@@ -7,8 +7,8 @@ lock and atomic-write discipline only hold for the
 programmatic API. This doc is the API.
 
 The migration procedure from a prior installation is
-in [`../MIGRATION.md`](../MIGRATION.md) at the
-repository root. This doc covers in-place recovery,
+in the README's ["Replacing a prior install"
+section](../README.md). This doc covers in-place recovery,
 which is different: state has become corrupt
 in-place and the daemon is refusing to start.
 
@@ -94,7 +94,7 @@ skip steps.
    If you don't know how to write that by hand, the
    easiest path is to run `caduceus migrate-state
    --from <file>` against a prior-state JSON file
-   (see `MIGRATION.md`).
+   (see [The migrate-state Subcommand](#the-migrate-state-subcommand)).
 5. **Apply the repaired file.** There are two paths
    here; pick the one that fits the situation:
    - **Library API:** if you have a Rust binary at
@@ -305,7 +305,8 @@ Two modes (mutually exclusive):
   updated to `sqlite`.
 - **`--from <file>`** — imports a JSON-formatted state
   file from a different state directory into the current
-  schema. Documented in detail in `MIGRATION.md`.
+  schema. Documented in detail in
+  [The migrate-state Subcommand](#the-migrate-state-subcommand).
 
 This is *not* the same as recovery; recovery is for
 in-place corruption, migration is for cross-format

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,8 +1,8 @@
 //! Command-line entry point used by `src/main.rs`.
 //!
 //! The exact public surface (subcommands, flags, and no-argument rewriting)
-//! is documented in `CONTRACTS.md` under "CLI contract". This file holds the
-//! CLI parser and the entry-point function. Implementation of the
+//! is documented in the CLI contract. This file holds the CLI parser and the
+//! entry-point function. Implementation of the
 //! individual subcommand bodies lives in the relevant module; `caduceus run`
 //! ultimately delegates to `caduceus::tick::run_blocking`.
 
@@ -115,7 +115,7 @@ pub enum QueueAction {
 /// Drive the CLI from `main`.
 ///
 /// A bare `caduceus` invocation is rewritten to `caduceus run` before
-/// Clap parsing. The rewrite uses `args_os()` per `CONTRACTS.md`,
+/// Clap parsing. The rewrite uses `args_os()` per the CLI contract,
 /// "Implement no-argument behavior by inspecting `args_os` and inserting
 /// `run` before Clap parsing"; a `--version` / `--help` flag is *not*
 /// considered a bare invocation and is dispatched normally.
@@ -477,8 +477,8 @@ fn resolve_config_path_for_write() -> Option<std::path::PathBuf> {
 /// under `<state_dir>/state.json`. The import path is
 /// idempotent: a second invocation with the same input
 /// against an unchanged live state is a no-op. See
-/// `MIGRATION.md` for the rollout, rollback, and recovery
-/// procedures.
+/// "The migrate-state Subcommand" in `docs/state-recovery.md` for the
+/// rollout, rollback, and recovery procedures.
 fn run_migrate_state(from: &std::path::Path, dry_run: bool) -> CaduceusResult<()> {
     let config = match std::env::var_os("CADUCEUS_CONFIG") {
         Some(path) => Config::load_from(std::path::Path::new(&path))?,

--- a/src/daemon/signals.rs
+++ b/src/daemon/signals.rs
@@ -21,8 +21,8 @@
 //! When the daemon has not yet entered a worker session — e.g.
 //! the state directory is empty, the queue is idle, or the
 //! cadence gate has skipped the tick — the first signal returns
-//! `TickOutcome::Cancelled` / exit 0 per the Cron model in
-//! `CONTRACTS.md`. The state files are not mutated by the
+//! `TickOutcome::Cancelled` / exit 0 per the Cron model. The
+//! state files are not mutated by the
 //! listener itself.
 
 use std::sync::Arc;

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -1,7 +1,7 @@
 //! The single canonical tick.
 //!
 //! [`run`], [`run_with_config`], and [`tick`] together implement
-//! the per-tick controller described in `CONTRACTS.md`. The
+//! the per-tick controller. The
 //! controller is the only entry point the daemon's CLI exposes:
 //! a no-argument `caduceus` invocation, the explicit `caduceus run`,
 //! and the cron tick all funnel through [`run`].

--- a/src/finalize/mod.rs
+++ b/src/finalize/mod.rs
@@ -1,7 +1,6 @@
 //! Finalization: commit, push, PR, comment/close, investigation comment.
 //!
-//! Idempotency across partial failures is the hard requirement — see
-//! `CONTRACTS.md` "Finalization contract".
+//! Idempotency across partial failures is the hard requirement.
 //!
 //! This module owns the public-voice validator that every outbound
 //! comment, PR title, and PR body must pass before the

--- a/src/github/client/client_core.rs
+++ b/src/github/client/client_core.rs
@@ -585,7 +585,7 @@ impl Client {
     /// this method first — it always returns an error.
     ///
     /// The returned error carries the contract message from
-    /// CONTRACTS.md FINAL-001 AC-04.
+    /// FINAL-001 AC-04 (see `src/state/checkpoints.rs`).
     pub fn enable_auto_merge(&self) -> CaduceusResult<()> {
         crate::runtime::audit::refuse_auto_merge()
     }

--- a/src/github/client/http_helpers.rs
+++ b/src/github/client/http_helpers.rs
@@ -23,7 +23,7 @@ use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
 
 /// HTTP header name for the GitHub API version pin.
 pub const GITHUB_API_VERSION_HEADER: &str = "X-GitHub-Api-Version";
-/// Value of the API version pin per `CONTRACTS.md` "Polling contract".
+/// Value of the API version pin per the polling contract in `src/github/poll.rs`.
 pub const GITHUB_API_VERSION_VALUE: &str = "2022-11-28";
 /// Accept header for the GitHub JSON API.
 pub const ACCEPT_VALUE: &str = "application/vnd.github+json";

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -1,6 +1,5 @@
 //! Typed issue identity and detail schema. The shape is normative and is
-//! re-exported from `lib.rs`. Validation rules live in this module per
-//! `CONTRACTS.md` "Issue identity and queue schema".
+//! re-exported from `lib.rs`. Validation rules live in this module.
 //!
 //! The detail fetcher issues three concurrent GitHub requests — the
 //! issue, its comments, and its timeline — and cancels the other two
@@ -77,7 +76,7 @@ impl IssueKey {
         Ok(key)
     }
 
-    /// Validate identifier components per `CONTRACTS.md`.
+    /// Validate identifier components.
     pub fn validate(&self) -> CaduceusResult<()> {
         validate_owner(&self.owner)?;
         validate_repo(&self.repo)?;
@@ -104,7 +103,7 @@ pub const MAX_RETAINED_COMMENTS: usize = 100;
 /// the comments cap.
 pub const MAX_RETAINED_EVENTS: usize = 100;
 /// Comments and events pages are capped at 20 per endpoint
-/// (matches the GitHub-side hard limit; CONTRACTS.md).
+/// (matches the GitHub-side hard limit).
 pub const MAX_PAGES: usize = 20;
 /// Per-page row count. GitHub's documented maximum.
 pub const COMMENTS_PER_PAGE: u32 = 100;

--- a/src/github/poll.rs
+++ b/src/github/poll.rs
@@ -55,9 +55,8 @@ pub struct IssueSummary {
 /// why.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IssuePollDiagnostic {
-    /// The issue matched both trigger labels. Per
-    /// `CONTRACTS.md` "Polling contract" it is not enqueued
-    /// until a human removes one.
+    /// The issue matched both trigger labels. Per the polling
+    /// contract it is not enqueued until a human removes one.
     Ambiguous {
         key: IssueKey,
         title: String,
@@ -121,7 +120,7 @@ pub async fn discover_watched_repos(client: &Client, cfg: &Config) -> CaduceusRe
 }
 
 fn validated_configured_repos(configured: &[String]) -> Vec<String> {
-    // Per CONTRACTS.md "Issue identity and queue schema":
+    // Per the queue schema in `src/state/queue/mod.rs`:
     // configured repositories deduplicate case-insensitively.
     let mut seen: BTreeSet<String> = BTreeSet::new();
     let mut out: Vec<String> = Vec::new();

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -1,5 +1,5 @@
 //! Configuration: typed loader for the YAML configuration file and the
-//! env-variable overrides listed in `CONTRACTS.md` under "Configuration".
+//! env-variable overrides.
 //!
 //! The public [`Config`] is the daemon's canonical view. It is built
 //! from a private [`RawConfig`] deserialisation layer that keeps
@@ -12,10 +12,10 @@
 //!
 //! Tests must use [`Config::test_defaults`] rooted at a temp dir; the
 //! daemon never relies on a host-dependent `Config::defaults()`
-//! constructor (CONTRACTS.md "Configuration").
+//! constructor.
 //!
-//! Public field list, semantics, and defaults are pinned by
-//! `CONTRACTS.md` — every field documented there must be present.
+//! Public field list, semantics, and defaults are pinned here —
+//! every field documented must be present.
 
 #![allow(unused_imports)]
 
@@ -29,7 +29,7 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 
 /// GitHub credential variable names that must never appear in the
 /// worker environment allowlist, even if the operator explicitly adds
-/// them. Source: CONTRACTS.md "Worker environment and result".
+/// them. Source: the worker-result contract in `src/worker/worker_contract.rs`.
 pub const DENIED_ENV_VARS: &[&str] = &["GITHUB_TOKEN", "CADUCEUS_GITHUB_TOKEN", "GH_TOKEN"];
 
 /// Worker command tokens that are always rejected as interpolation.
@@ -39,7 +39,7 @@ const FORBIDDEN_INTERPOLATION_TOKENS: &[&str] = &["$HOME", "${HOME}", "~", "$USE
 pub const PLUGIN_ROOT_TOKEN: &str = "${plugin_root}";
 
 /// Default values the daemon falls back to when an operator omits a
-/// field. Defaults match the block-quoted values in CONTRACTS.md "Configuration".
+/// field.
 pub const DEFAULT_POLL_INTERVAL_SECONDS: u64 = 120;
 pub const DEFAULT_WORKER_TIMEOUT_SECONDS: u64 = 3600;
 pub const DEFAULT_HTTP_TIMEOUT_SECONDS: u64 = 60;
@@ -87,7 +87,7 @@ pub const DEFAULT_OCI_STOP_TIMEOUT_SECONDS: u64 = 30;
 pub const DEFAULT_OCI_KILL_TIMEOUT_SECONDS: u64 = 10;
 pub const DEFAULT_OCI_RECONCILE_TIMEOUT_SECONDS: u64 = 60;
 
-/// Caduceus configuration. Field semantics are pinned in `CONTRACTS.md`.
+/// Caduceus configuration. Field semantics are pinned here.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -847,7 +847,7 @@ impl Config {
 
     /// Deterministic root-anchored defaults for tests. Avoids any
     /// host-dependent `Config::defaults()` constructor that would make
-    /// tests flake (CONTRACTS.md "Configuration").
+    /// tests flake.
     pub fn test_defaults(root: &Path) -> Self {
         let state_dir = root.join("state");
         let log_path = state_dir.join("processor.log");
@@ -1094,7 +1094,7 @@ impl Config {
 
     /// Resolve the GitHub authentication token for this configuration.
     ///
-    /// Hierarchy per `CONTRACTS.md` "Configuration":
+    /// Hierarchy:
     ///
     /// 1. Explicit `github_token` field, when non-empty.
     /// 2. `$CADUCEUS_GITHUB_TOKEN` environment variable, when non-empty.

--- a/src/infra/config/setup.rs
+++ b/src/infra/config/setup.rs
@@ -11,7 +11,7 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 // Path / interpolation helpers
 
 /// Expand a single leading ``~`` to the user's home directory. No
-/// other shell expansion is performed (CONTRACTS.md "Configuration").
+/// other shell expansion is performed.
 pub fn expand_leading_tilde(path: PathBuf) -> PathBuf {
     if let Ok(rest) = path.strip_prefix("~") {
         if let Some(home) = home_dir() {
@@ -195,7 +195,7 @@ pub fn is_valid_repo_slug(repo: &str) -> bool {
 
 /// Positive allowlist validator for the `api_base` configuration value.
 ///
-/// Per `CONTRACTS.md` GH-001, `api_base` MUST be either the literal
+/// Per the GH-001 contract (api_base rules below), `api_base` MUST be either the literal
 /// `https://api.github.com` or an `https://` URL whose path is
 /// `/api/v3` (or `/api/v3/...`). Anything else — `http://`,
 /// `bitbucket.example.com`, custom path-prefixed proxies, malformed

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -2,8 +2,7 @@
 //!
 //! [`CaduceusError`] is the canonical cross-cutting error type. It is
 //! re-exported from `lib.rs` and used by every module. The variant
-//! set and the field semantics are pinned by `CONTRACTS.md`
-//! "Error contract".
+//! set and the field semantics are pinned by the error contract.
 //!
 //! [`VoiceError`] is a separate type used by the public-voice
 //! validator. It is intentionally separate from
@@ -602,7 +601,7 @@ impl CaduceusError {
     }
 
     /// Map a daemon error to the process exit code announced in
-    /// `CONTRACTS.md` "CLI contract".
+    /// the CLI contract in `src/cli/mod.rs`.
     ///
     /// `run` returns 0 for processed/idle/concurrent/cadence/
     /// rate-limit/cancelled outcomes and 1 for configuration,

--- a/src/infra/fixtures.rs
+++ b/src/infra/fixtures.rs
@@ -76,8 +76,8 @@ pub const CANONICAL_WORKER_ENV_VARS: &[&str] = &[
     "CADUCEUS_WORKTREE_PATH",
 ];
 
-/// Default allowlist for the worker environment (CONTRACTS.md "Worker
-/// environment and result"). Operators may extend
+/// Default allowlist for the worker environment (the worker-result
+/// contract in `src/worker/worker_contract.rs`). Operators may extend
 /// `worker_env_allowlist`; the daemon's `validate_worker_env_allowlist`
 /// rejects partial matches and credential names. The bridge never reads
 /// or writes these — they describe what the daemon *preserves* from the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 //! re-exported here so downstream consumers and integration tests can reach
 //! them without depending on the internal module layout.
 //!
-//! See [`CONTRACTS.md`] for the normative scope of every module in this
-//! crate.
+//! See `docs/architecture.md` and the module docstrings for the normative
+//! scope of every module in this crate.
 
 #![forbid(unsafe_code)]
 #![warn(missing_debug_implementations)]
@@ -79,7 +79,7 @@ pub use crate::daemon::signals;
 pub use crate::daemon::status;
 pub use crate::daemon::tick;
 
-// Bounded symbol re-exports per CONTRACTS.md.
+// Bounded symbol re-exports.
 
 pub use crate::daemon::orchestration::{
     ActiveRunGuard, Clock, FailureClass, FakeClock, FinishOutcome, Git, GithubClient, Services,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
 //! `caduceus` binary entry point.
 //!
-//! The CLI parses the canonical subcommands listed in `CONTRACTS.md` under
-//! "CLI contract": `run`, `status`, `worktree-gc`, `queue reset`, and
+//! The CLI parses the canonical subcommands listed in the CLI contract in
+//! `src/cli/mod.rs`: `run`, `status`, `worktree-gc`, `queue reset`, and
 //! `migrate-state`. A no-argument invocation is equivalent to `caduceus run`
 //! — that rewriting happens inside the CLI parser, before Clap dispatches,
 //! so a bare cron tick never prints help or version output.
 //!
-//! `run` is silent on success (per the Cron model in `CONTRACTS.md`); all
-//! diagnostics go to stderr.
+//! `run` is silent on success; all diagnostics go to stderr.
 //!
 //! The hidden `__worker-supervisor` mode is dispatched before public
 //! command parsing — the token is matched only as the first argument
@@ -47,8 +46,9 @@ fn main() -> ExitCode {
 
     // The CLI router inspects `args_os` and inserts `run` when the user
     // invoked `caduceus` with no arguments, before Clap parsing. This is
-    // the contractually documented behaviour (CONTRACTS.md, "Implement
-    // no-argument behavior by inspecting `args_os`...").
+    // the contractually documented behaviour (the CLI contract in
+    // `src/cli/mod.rs`: "Implement no-argument behavior by inspecting
+    // `args_os`...").
     match cli::run() {
         Ok(()) => ExitCode::from(0),
         Err(err) => {

--- a/src/runtime/audit.rs
+++ b/src/runtime/audit.rs
@@ -23,7 +23,7 @@ use crate::scheduler::circuit::{CircuitState, ExhaustedEntry};
 pub fn refuse_auto_merge() -> CaduceusResult<()> {
     Err(CaduceusError::Other(
         "auto-merge is refused: human review is required for all PR merges \
-  (CONTRACTS.md FINAL-001 AC-04)"
+  (FINAL-001 AC-04; see src/state/checkpoints.rs)"
             .to_string(),
     ))
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,5 @@
 //! Runtime lifecycle hooks that the daemon invokes at fixed
 //! checkpoints. This module owns the audit hook that enforces
-//! the "never auto-merge" contract (CONTRACTS.md FINAL-001).
+//! the "never auto-merge" contract (FINAL-001; see `src/state/checkpoints.rs`).
 
 pub mod audit;

--- a/src/state/meta.rs
+++ b/src/state/meta.rs
@@ -69,8 +69,8 @@ pub const META_FILENAME: &str = "state_meta.json";
 /// Marker filename written when corruption is detected.
 pub const CORRUPT_MARKER_FILENAME: &str = "state_meta.corrupt";
 
-/// Persisted tick metadata. Field semantics are pinned by
-/// `CONTRACTS.md` under "State metadata and status".
+/// Persisted tick metadata. Field semantics are pinned by the
+/// StateMeta contract.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StateMeta {
@@ -164,8 +164,8 @@ impl RateLimitObservation {
     }
 }
 
-/// One diagnostic entry. Field semantics are pinned by
-/// `CONTRACTS.md`.
+/// One diagnostic entry. Field semantics are pinned by the
+/// StateMeta contract.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DaemonDiagnostic {
     pub timestamp: DateTime<Utc>,

--- a/src/state/queue/claim.rs
+++ b/src/state/queue/claim.rs
@@ -131,7 +131,7 @@ pub(crate) fn write_and_sync_claim(file: &File, body: &[u8]) -> CaduceusResult<(
     let mut writer = file;
     writer.write_all(body)?;
     writer.sync_all()?;
-    // CONTRACTS.md "Filesystem permissions": claim files are
+    // Claim files are
     // written with mode 0600. OpenOptions + create_new respects
     // the process umask, which on some distros lets group-read
     // through (mode 0o640 or 0o660). Force 0600 here so the
@@ -274,7 +274,7 @@ pub fn unlink_claim_best_effort(claims_dir: &Path, claim: &ClaimToken) {
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
         Err(err) => {
-            // Per CONTRACTS.md: a claim-unlink failure is reported
+            // A claim-unlink failure is reported
             // without rolling back the durable phase and is repaired
             // idempotently by the reaper. We log and continue; the
             // reaper will pick it up.

--- a/src/state/queue/mod.rs
+++ b/src/state/queue/mod.rs
@@ -1,7 +1,6 @@
 //! Queue state, claim token, and the crash-safe [`StateStore`]. The
 //! `IssueKey` type lives in [`crate::issue`] but its parsing and the
-//! queue's versioned envelope are owned by this module per
-//! `CONTRACTS.md` "Issue identity and queue schema".
+//! queue's versioned envelope are owned by this module.
 //!
 //! Serialization is schema-stable:
 //!
@@ -64,15 +63,15 @@ pub const STATE_FILENAME: &str = "state.json";
 pub const CLAIMS_DIRNAME: &str = "claims";
 
 /// Name of the `flock` used to serialise mutating [`StateStore`]
-/// operations. Distinct from the daemon-wide `daemon.lock` declared
-/// in CONTRACTS.md invariant #1, which covers a whole tick.
+/// operations. Distinct from the daemon-wide `daemon.lock`, which
+/// covers a whole tick.
 pub const STATE_LOCK_FILENAME: &str = "state.lock";
 
 /// Name of the claim file's on-disk format. Bumping it is a breaking
 /// change — older files are quarantined by the reaper.
 pub const CLAIM_FILE_VERSION: u32 = 1;
 
-/// Phase of one issue in the queue. See `CONTRACTS.md`.
+/// Phase of one issue in the queue.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
@@ -104,7 +103,7 @@ pub enum TicketType {
 }
 
 /// Finalization stage. Persisted atomically after every idempotent side
-/// effect (see `CONTRACTS.md` "Finalization contract").
+/// effect (see the FINAL-001 contract in `src/state/checkpoints.rs`).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]

--- a/src/state/queue/store.rs
+++ b/src/state/queue/store.rs
@@ -309,7 +309,7 @@ impl StateStore {
     /// Terminal transition for a successful dry-run preview. The
     /// entry moves to `Previewed`; on the next non-dry tick the
     /// polling loop will atomically promote it to `Queued` (see
-    /// [`StateStore::enqueue`] and CONTRACTS.md "Dry-run").
+    /// [`StateStore::enqueue`]).
     pub fn complete_preview(&self, claim: ClaimToken) -> CaduceusResult<()> {
         self.complete_with(claim, Phase::Previewed)
     }
@@ -411,7 +411,7 @@ impl StateStore {
     /// allowed attempts the convention is: attempts 1..budget-1
     /// return to ``Queued`` with ``next_attempt_at = now +
     /// retry_backoff_seconds``; attempt ``budget`` transitions to
-    /// ``Failed``. See CONTRACTS.md "Retry semantics".
+    /// ``Failed``.
     ///
     /// Returns the new phase so callers can log without re-reading
     /// state.

--- a/src/worker/context.rs
+++ b/src/worker/context.rs
@@ -1,6 +1,5 @@
 //! Stable context JSON. The shape and the serialized form are pinned by
-//! `CONTRACTS.md` under "Worker environment and result" / "build stable
-//! context JSON".
+//! the worker-result contract in `src/worker/worker_contract.rs`.
 //!
 //! The context document is the worker's authoritative view of the
 //! issue. It carries:
@@ -168,7 +167,7 @@ pub fn build_context(inputs: BuildInputs<'_>) -> CaduceusResult<WorkerContext> {
     // already populated `trusted_comments` from
     // `feedback_author_allowlist`; here we extend the trust
     // filter to *also* exclude anyone matched by any ignore
-    // pattern, per CONTRACTS.md "comment_ignore_patterns".
+    // pattern.
     let allowlist = &config.feedback_author_allowlist;
     let ignored_authors = comments_matched_by_any_ignore(config, detail);
     let trust_set: std::collections::HashSet<&str> = allowlist.iter().map(String::as_str).collect();

--- a/src/worker/prompt.rs
+++ b/src/worker/prompt.rs
@@ -27,8 +27,8 @@
 //! the bridge is launched.
 //!
 //! The file write is atomic: same-directory temp file,
-//! `fsync`, atomic rename — the contract pin in `CONTRACTS.md`
-//! "Finalization contract".
+//! `fsync`, atomic rename — the contract pin in
+//! `src/finalize/mod.rs` (the finalization contract).
 
 #![allow(dead_code)]
 

--- a/src/worker/supervisor/mod.rs
+++ b/src/worker/supervisor/mod.rs
@@ -2,8 +2,7 @@
 //!
 //! This module owns the in-process supervisor that the daemon
 //! uses to spawn and tear down the bridge. The contract is
-//! pinned by `CONTRACTS.md` "Worker environment and result" and
-//! "Hermes plugin compatibility contract".
+//! pinned by the worker-result contract in `src/worker/worker_contract.rs`.
 //!
 //! * The public daemon never spawns the bridge directly. It
 //!   re-execs the same `caduceus` binary in a hidden

--- a/src/worker/worker_contract.rs
+++ b/src/worker/worker_contract.rs
@@ -48,8 +48,7 @@ use serde::{Deserialize, Serialize};
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 
-/// Hard cap on the worker-result file size per `CONTRACTS.md`
-/// "Worker environment and result".
+/// Hard cap on the worker-result file size.
 pub const MAX_RESULT_FILE_BYTES: u64 = 1 << 20; // 1 MiB
 
 /// Maximum size of the `summary` field.
@@ -64,8 +63,8 @@ pub const MAX_ARTIFACT_KEY_LEN: usize = 128;
 /// Maximum number of artifact entries.
 pub const MAX_ARTIFACTS: usize = 100;
 
-/// Default allowlist entries preserved from the parent environment
-/// (CONTRACTS.md "Worker environment and result"). Each entry is
+/// Default allowlist entries preserved from the parent environment.
+/// Each entry is
 /// an exact portable variable name; the daemon never expands
 /// partial matches here — the matching allowlist below carries
 /// the documented prefix patterns.
@@ -82,7 +81,6 @@ pub const DEFAULT_ALLOWLIST_PREFIXES: &[&str] =
 
 /// Hard-deny list: exact variable names that never reach the
 /// worker even when an operator adds them to the allowlist.
-/// Source: CONTRACTS.md "Worker environment and result".
 const DENIED_EXACT_VARS: &[&str] = &[
     "GITHUB_TOKEN",
     "GH_TOKEN",
@@ -98,8 +96,7 @@ const INTERNAL_SECRET_MARKERS: &[&str] = &["SECRET", "TOKEN"];
 
 /// Result the bridge writes to `<worktree>/worker-result.json`.
 ///
-/// Field semantics and size limits are pinned in `CONTRACTS.md`
-/// under "Worker environment and result".
+/// Field semantics and size limits are pinned.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkerResult {

--- a/src/worktree/git_runner.rs
+++ b/src/worktree/git_runner.rs
@@ -32,11 +32,11 @@ const DEFAULT_GIT_TIMEOUT_SECONDS: u64 = 300;
 
 /// Variables the runner scrubs from the inherited environment
 /// before launching any git subprocess. These are the three
-/// canonical GitHub-credential names from CONTRACTS.md "Worker
-/// environment and result". The daemon never injects these into
-/// the child; the daemon also actively removes them from the
-/// inherited environment so a misconfigured credential helper
-/// can't surface them via `git credential fill`.
+/// canonical GitHub-credential names from the worker-result
+/// contract in `src/worker/worker_contract.rs`. The daemon never
+/// injects these into the child; the daemon also actively removes
+/// them from the inherited environment so a misconfigured
+/// credential helper can't surface them via `git credential fill`.
 pub const DENIED_INHERITED_VARS: &[&str] = &["GITHUB_TOKEN", "CADUCEUS_GITHUB_TOKEN", "GH_TOKEN"];
 
 /// Default variables preserved across `env_clear()` when the


### PR DESCRIPTION
Sub-issue of #97 (defect 4). 56 dead references to the removed CONTRACTS.md / MIGRATION.md across src/, docs/, and .github/workflows/ re-pointed to their replacement locations — module docstrings that now own each contract (FINAL-001 → src/state/checkpoints.rs, CLI contract → src/cli/mod.rs, configuration → src/infra/config/mod.rs, worker-result → src/worker/worker_contract.rs, polling → src/github/poll.rs, MIGRATION.md → docs/state-recovery.md §The migrate-state Subcommand) or dropped where the contract is described inline. Contract labels survive; only dead file mentions changed. D2 fold-in approved (4 workflow-comment refs, same defect class).

Plan (GLM-5.2) → Build (DeepSeek-V4-Flash-0731) → Check (Kimi K2.7) green; acceptance grep 0 hits; fmt/clippy clean.