### PR TITLE
chore(repo): re-baseline README and CHANGELOG claims (closes #141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,17 @@ Caduceus has grown from a single-host worker into a multi-component
 daemon with structured crash recovery, bounded concurrency, daemon-owned
 repository storage, an OCI executor, and a broad test suite. The CLI
 surface, state format, and worker process model are deliberately stable
-across this period.
+across this period. (OCI isolation end-to-end pending #88.)
 
 ### Added
 
 - **Scheduler leadership.** A single leader is elected per host with
   TTL-based leases. Followers defer to the leader's tick, eliminating
-  the dual-tick race that v0.1.0 silently tolerated.
+  the dual-tick race that v0.1.0 silently tolerated. Part of #97.
 - **Bounded concurrency.** Up to N workers run in flight at once per
   cron tick (bounded-across-the-tick), and a single repository never
   runs two workers concurrently. Replaces the host-wide tick lock.
+  Closes #107. Closes #109. Part of #97.
 - **Circuit breakers.** Per-destination breakers trip after consecutive
   failures and cool down on a configured schedule, bounding the blast
   radius of an upstream outage.
@@ -41,15 +42,20 @@ across this period.
 - **Reconciler for ambiguous side effects.** When the daemon restarts
   mid-PR, it queries GitHub for the current state and only re-runs the
   side effects that didn't land.
+- **SQLite state backend switch.** migrate-state --to-sqlite imports
+  the JSON queue into the SQLite store and flips state_backend to
+  sqlite in the operator's config. Closes #110. Part of #97.
 - **Human-review lifecycle.** Pull requests can be placed in a
   human-review-required state that pauses auto-merge and records the
   operator's review decision.
 - **OCI executor.** A trait-shaped executor seam with an OCI-backed
   implementation handling mount configuration, secrets, network policy,
   and lifecycle. Replaces the v0.1.0 in-process command runner.
+  (end-to-end isolation pending #88; argv-placement fix landed in #111)
 - **Isolation policy enforcement.** The executor enforces a read-only
   root filesystem, an explicit secret allowlist, a deny-by-default
-  network policy, and a baseline image.
+  network policy, and a baseline image. (end-to-end isolation pending
+  #88; argv-placement fix landed in #111)
 - **Production configuration bootstrap.** `caduceus setup` generates a
   non-secret configuration with a deterministic token resolution chain.
 - **Transactional Hermes scheduling.** The cron-side dispatcher uses a
@@ -166,6 +172,8 @@ across this period.
   allowlist-only by default.
 - **Mount and secret allowlist.** The executor refuses to mount
   non-allowlisted paths or load secrets outside the explicit allowlist.
+  The isolation policy and adversarial tests above cover the policy
+  layer only; end-to-end OCI isolation is pending #88.
 
 ### Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ you either.
    [GitHub]◀───▶│       Caduceus daemon       │◀─── `caduceus run`
    (outbound    │  (Rust · single binary)     │     every 2 min,
     only)       │  · ETag-aware 304 polling   │      cron-driven
-                │  · whole-tick flock         │
+                │  · scheduler leadership     │
                 │  · per-issue claim files    │
                 │  · isolated git worktrees   │
                 │  · hard worker timeout      │
@@ -83,7 +83,8 @@ you either.
 ```
 
 The daemon polls, picks one or more issues per tick, claims each
-under a host-wide flock, provisions a worktree, spawns
+under a per-issue lease (bounded by `worker_parallelism`),
+provisions a worktree, spawns
 the bridge as a child of a Rust worker supervisor (not
 systemd, not a shell), waits for exit, then finalizes:
 commit, push, find-or-create the PR, post the completion
@@ -256,12 +257,17 @@ limit and retention knobs.
 
 ## Replacing a prior install
 
-If your state directory contains a JSON state file instead
-of the current SQLite format, use the `migrate-state`
+JSON is the default state backend; SQLite is opt-in. If
+your state directory contains a JSON state file and you
+want the SQLite backend (optional), use the `migrate-state`
 command to import existing entries:
 
 ```text
 caduceus migrate-state --from <path-to-legacy.json> [--dry-run]
+```
+
+```text
+caduceus migrate-state --to-sqlite [--dry-run]
 ```
 
 **Do not edit daemon state, metadata, claim files, or
@@ -286,6 +292,7 @@ input, and install changes atomically.
 
 ### Import
 
+The flow in this section is the `--from` JSON importer.
 Run a dry run first:
 
 ```text
@@ -312,6 +319,12 @@ timestamped backup in the state directory.
 Running the same import again is idempotent: already-present
 entries are reported as skipped and are not duplicated.
 
+To switch to the SQLite backend instead, run
+`caduceus migrate-state --to-sqlite`. It imports the JSON
+queue into the SQLite store and flips `state_backend` to
+`sqlite` in the operator's config; validate it the same way
+afterwards.
+
 ### Validate
 
 1. Run `caduceus status` and review the reported state.
@@ -335,8 +348,8 @@ healthy installation.
 ### Rollback
 
 If validation fails, stop scheduling before changing
-state. The import command preserves prior content as
-`<state_dir>/state.json.bak-<timestamp>`. A typical
+state. The `--from` import command preserves prior content
+as `<state_dir>/state.json.bak-<timestamp>`. A typical
 rollback:
 
 ```text
@@ -344,6 +357,10 @@ rollback:
 cp <state_dir>/state.json.bak-<timestamp> <state_dir>/state.json
 # Restart the known-good installation.
 ```
+
+Rollback after `--to-sqlite` is config-side: set
+`state_backend` back to `json` and restart; the JSON file
+is preserved alongside the SQLite store.
 
 Use this only while the daemon is stopped. When Caduceus
 detects malformed state, it preserves the rejected bytes


### PR DESCRIPTION
Sub-issue of #97 (defect 7). README + CHANGELOG reconciled against the landed fix set: #91/#92/#94 landed since the issue was filed, so most over-claims are now true — the residue (whole-tick flock diagram, host-wide flock prose, SQLite-as-default framing) is corrected, the missing SQLite backend-switch CHANGELOG entry is added, and remaining OCI claims are annotated pending #88 (per the issue's acceptance).

Plan (GLM-5.2) → Build (DeepSeek-V4-Flash-0731) → Check (Kimi K2.7) green.