### PR TITLE
chore(src): drop module-level dead_code suppressions (closes #142)

### DIFF
--- a/src/daemon/orchestration/active_run.rs
+++ b/src/daemon/orchestration/active_run.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -8,13 +7,15 @@ use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use crate::github::issue::IssueKey;
-use crate::github::Client;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult};
-use crate::scheduler::Pool;
-use crate::state::queue::{ClaimToken, Phase, QueueEntry, StateStore};
+use crate::infra::error::CaduceusResult;
+use crate::state::queue::{ClaimToken, Phase, StateStore};
 use crate::worker::supervisor::SupervisorOutcome;
-use crate::worktree::{GitRunner, Worktree};
+use crate::worktree::Worktree;
+
+// test-only: used by the inline test module in this file; remove when
+// inline tests move to tests/ (see #144)
+#[allow(unused_imports)]
+use crate::infra::error::CaduceusError;
 
 // ActiveRunGuard — async cleanup primitive
 
@@ -349,31 +350,6 @@ impl Drop for ActiveRunGuard {
                 run_id = %run_id,
                 "ActiveRunGuard dropped while finish_* lock was contended"
             );
-        }
-    }
-}
-
-/// Read-only view of an entry the orchestrator might want to
-/// surface to structured logs before transitioning it. Wraps a
-/// [`QueueEntry`] reference so the caller does not need to
-/// import the queue module directly.
-#[derive(Clone, Debug)]
-pub struct EntrySnapshot {
-    pub key: IssueKey,
-    pub phase: Phase,
-    pub attempts: u32,
-    pub last_error: Option<String>,
-    pub last_run_id: Option<String>,
-}
-
-impl From<&QueueEntry> for EntrySnapshot {
-    fn from(entry: &QueueEntry) -> Self {
-        Self {
-            key: entry.key.clone(),
-            phase: entry.phase,
-            attempts: entry.attempts,
-            last_error: entry.last_error.clone(),
-            last_run_id: entry.last_run_id.clone(),
         }
     }
 }

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -1,20 +1,4 @@
-#![allow(dead_code, unused_imports)]
-use super::*;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-
-use chrono::{DateTime, Utc};
-use tokio::sync::Mutex;
-use tracing::{info, warn};
-
-use crate::github::issue::IssueKey;
-use crate::github::Client;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult};
-use crate::scheduler::Pool;
-use crate::state::queue::{ClaimToken, Phase, QueueEntry, StateStore};
-use crate::worker::supervisor::SupervisorOutcome;
-use crate::worktree::{GitRunner, Worktree};
+use crate::infra::error::CaduceusError;
 
 // FailureClass and classify_error
 

--- a/src/daemon/orchestration/mod.rs
+++ b/src/daemon/orchestration/mod.rs
@@ -27,24 +27,6 @@
 //! `ActiveRunGuard` calls them by reference and never duplicates
 //! their signatures.
 
-#![allow(dead_code, unused_imports)]
-
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-
-use chrono::{DateTime, Utc};
-use tokio::sync::Mutex;
-use tracing::{info, warn};
-
-use crate::github::issue::IssueKey;
-use crate::github::Client;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult};
-use crate::scheduler::Pool;
-use crate::state::queue::{ClaimToken, Phase, QueueEntry, StateStore};
-use crate::worker::supervisor::SupervisorOutcome;
-use crate::worktree::{GitRunner, Worktree};
-
 // Submodule declarations and re-exports. These preserve the historical
 // `crate::daemon::orchestration` public surface used by `lib.rs`.
 

--- a/src/daemon/orchestration/services.rs
+++ b/src/daemon/orchestration/services.rs
@@ -1,20 +1,11 @@
-#![allow(dead_code, unused_imports)]
-use super::*;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use tokio::sync::Mutex;
-use tracing::{info, warn};
 
-use crate::github::issue::IssueKey;
 use crate::github::Client;
 use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::scheduler::Pool;
-use crate::state::queue::{ClaimToken, Phase, QueueEntry, StateStore};
-use crate::worker::supervisor::SupervisorOutcome;
-use crate::worktree::{GitRunner, Worktree};
+use crate::worktree::GitRunner;
 
 // Services — the dependency-injection surface the orchestrator uses
 

--- a/src/daemon/tick/awaiting_review.rs
+++ b/src/daemon/tick/awaiting_review.rs
@@ -1,36 +1,15 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use tokio_util::sync::CancellationToken;
 use tracing::info;
-use ulid::Ulid;
 
-use crate::daemon::orchestration::{
-    classify_error, ActiveRunGuard, FailureClass, Services, SystemClock,
-};
-use crate::finalize::{
-    archive_worker_result, commit_code_and_finalize, dry_run_finalize,
-    find_or_create_pr_and_finalize, post_completion_only, post_investigation_comment_and_finalize,
-    push_and_finalize, FinalizeContext, FinalizeOutput, FinalizeRequest,
-};
-use crate::github::poll::{discover_watched_repos, merge_outcomes, poll_code, poll_investigation};
+use crate::daemon::orchestration::{ActiveRunGuard, FailureClass};
+use crate::github::poll::{merge_outcomes, poll_code, poll_investigation};
 use crate::github::{Client, RateLimitInfo};
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
-use crate::logging;
-use crate::scheduler::circuit::{AdmissionResult, CircuitConfig, CircuitStore};
-use crate::scheduler::{DrainConfig, LeaderToken, Pool};
-use crate::signals;
-use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
-use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
-use crate::state::queue::{ClaimedEntry, Phase, QueueEntry, StateStore, TicketType};
-use crate::state::store;
-use crate::worker::context::{build_context, encode_context, BuildInputs};
-use crate::worker::prompt::{build_prompt, write_prompt};
-use crate::worker::WorkerResult;
-use crate::worktree::{create as create_worktree, find_main_clone, GitRunner};
+use crate::state::meta::{CadenceGate, MetaStore, TickOutcome};
+use crate::state::queue::{Phase, QueueEntry, StateStore};
 
 // Awaiting-review poller — checks PR merge status for entries in
 // AwaitingReview phase and applies transitions.

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -33,39 +33,24 @@
 //!    finalization; teardown always runs.
 //! 10. Persist `last_tick_finished` and the final outcome.
 
-#![allow(dead_code, unused_imports)]
-
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use ulid::Ulid;
 
-use crate::daemon::orchestration::{
-    classify_error, ActiveRunGuard, FailureClass, Services, SystemClock,
-};
-use crate::finalize::{
-    archive_worker_result, commit_code_and_finalize, dry_run_finalize,
-    find_or_create_pr_and_finalize, post_completion_only, post_investigation_comment_and_finalize,
-    push_and_finalize, FinalizeContext, FinalizeOutput, FinalizeRequest,
-};
-use crate::github::poll::{discover_watched_repos, merge_outcomes, poll_code, poll_investigation};
-use crate::github::{Client, RateLimitInfo, Response};
+use crate::daemon::orchestration::{classify_error, ActiveRunGuard, Services, SystemClock};
+use crate::github::poll::discover_watched_repos;
+use crate::github::Client;
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::logging;
 use crate::scheduler::circuit::{AdmissionResult, CircuitConfig, CircuitStore};
-use crate::scheduler::{Admission, DrainConfig, LeaderToken, Pool};
+use crate::scheduler::{DrainConfig, LeaderToken, Pool};
 use crate::signals;
-use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
 use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
-use crate::state::queue::{ClaimedEntry, Phase, QueueEntry, StateStore, TicketType};
-use crate::state::store;
-use crate::worker::context::{build_context, encode_context, BuildInputs};
-use crate::worker::prompt::{build_prompt, write_prompt};
-use crate::worker::WorkerResult;
-use crate::worktree::{create as create_worktree, find_main_clone, GitRunner};
+use crate::state::queue::StateStore;
+use crate::worktree::GitRunner;
 
 use tokio::task::JoinSet;
 

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -1,38 +1,22 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
-use ulid::Ulid;
 
-use crate::daemon::orchestration::{
-    classify_error, ActiveRunGuard, FailureClass, Services, SystemClock,
-};
-use crate::finalize::{
-    archive_worker_result, commit_code_and_finalize, dry_run_finalize,
-    find_or_create_pr_and_finalize, post_completion_only, push_and_finalize, FinalizeContext,
-    FinalizeOutput, FinalizeRequest,
-};
-use crate::github::poll::{discover_watched_repos, merge_outcomes, poll_code, poll_investigation};
-use crate::github::{Client, RateLimitInfo, Response};
+use crate::daemon::orchestration::{classify_error, ActiveRunGuard, Services};
+use crate::finalize::{archive_worker_result, dry_run_finalize, FinalizeContext, FinalizeRequest};
+use crate::github::Client;
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
-use crate::logging;
-use crate::scheduler::circuit::{AdmissionResult, CircuitConfig, CircuitStore};
-use crate::scheduler::{Admission, DrainConfig, LeaderToken, Pool};
-use crate::signals;
-use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
-use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
-use crate::state::queue::{
-    ClaimedEntry, FinalizationStage, Phase, QueueEntry, StateStore, TicketType,
-};
+use crate::scheduler::{Admission, Pool};
+use crate::state::meta::{MetaStore, TickOutcome};
+use crate::state::queue::{ClaimedEntry, FinalizationStage, StateStore, TicketType};
 use crate::state::store;
 use crate::worker::context::{build_context, encode_context, BuildInputs};
 use crate::worker::prompt::{build_prompt, write_prompt};
-use crate::worker::{WorkerResult, WorkerStatus};
-use crate::worktree::{create as create_worktree, find_main_clone, GitRunner};
+use crate::worker::WorkerStatus;
+use crate::worktree::{create as create_worktree, find_main_clone};
 
 // Per-claim work loop
 

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -1,37 +1,21 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
-use ulid::Ulid;
 
-use crate::daemon::orchestration::{
-    classify_error, ActiveRunGuard, FailureClass, Services, SystemClock,
-};
+use crate::daemon::orchestration::{classify_error, ActiveRunGuard, Services};
 use crate::finalize::{
-    archive_worker_result, commit_code_and_finalize, dry_run_finalize,
-    find_or_create_pr_and_finalize, generate_operation_id, post_completion_only,
-    post_investigation_comment_and_finalize, push_and_finalize, FinalizeContext, FinalizeOutput,
-    FinalizeRequest,
+    archive_worker_result, commit_code_and_finalize, find_or_create_pr_and_finalize,
+    generate_operation_id, post_completion_only, post_investigation_comment_and_finalize,
+    push_and_finalize, FinalizeContext, FinalizeOutput, FinalizeRequest,
 };
-use crate::github::poll::{discover_watched_repos, merge_outcomes, poll_code, poll_investigation};
-use crate::github::{Client, RateLimitInfo, Response};
+use crate::github::Client;
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
-use crate::logging;
-use crate::scheduler::circuit::{AdmissionResult, CircuitConfig, CircuitStore};
-use crate::scheduler::{DrainConfig, LeaderToken, Pool};
-use crate::signals;
 use crate::state::checkpoints::{last_checkpoint_for_run, persist_checkpoint};
-use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
-use crate::state::queue::{
-    ClaimedEntry, FinalizationStage, Phase, QueueEntry, StateStore, TicketType,
-};
+use crate::state::meta::{MetaStore, TickOutcome};
+use crate::state::queue::{ClaimedEntry, FinalizationStage, StateStore, TicketType};
 use crate::state::store;
-use crate::worker::context::{build_context, encode_context, BuildInputs};
-use crate::worker::prompt::{build_prompt, write_prompt};
 use crate::worker::{WorkerResult, WorkerStatus};
 use crate::worktree::{create as create_worktree, find_main_clone, GitRunner};
 

--- a/src/finalize/comment_close.rs
+++ b/src/finalize/comment_close.rs
@@ -1,19 +1,7 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::path::PathBuf;
-use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
-use crate::github::Client;
-
-use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;
-use crate::worktree::GitRunner;
-
-use sha2::{Digest, Sha256};
 
 // Post completion and close idempotently
 

--- a/src/finalize/commit.rs
+++ b/src/finalize/commit.rs
@@ -1,19 +1,11 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::github::Client;
-
-use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;
 use crate::worktree::GitRunner;
-
-use sha2::{Digest, Sha256};
 
 // Code result finalization: inspect, validate, commit
 
@@ -211,13 +203,6 @@ fn drive_block_on<F: std::future::Future>(f: F) -> F::Output {
 /// we only carry the fields the daemon needs.
 #[derive(Clone, Debug)]
 struct GitStatusEntry {
-    /// 1-character kind: `M` (modified in index), ` `
-    /// (modified in worktree), `?` (untracked), `!`
-    /// (ignored), `s` (sparse). For untracked entries the
-    /// v2 header is `? <path>` and the worktree did not
-    /// include the symlink test in v2; we synthesise
-    /// `kind = "untracked"` for those.
-    kind: String,
     /// Path relative to the worktree root.
     path: String,
 }
@@ -279,8 +264,7 @@ fn git_status_v2(
                     });
                 }
                 let path = fields[8].to_string();
-                let xy = fields[1].chars().next().unwrap_or(' ').to_string();
-                entries.push(GitStatusEntry { kind: xy, path });
+                entries.push(GitStatusEntry { path });
                 i += 1;
             }
             Some('2') => {
@@ -292,18 +276,14 @@ fn git_status_v2(
                     });
                 }
                 let path = fields[9].to_string();
-                let xy = fields[1].chars().next().unwrap_or(' ').to_string();
-                entries.push(GitStatusEntry { kind: xy, path });
+                entries.push(GitStatusEntry { path });
                 // The renamed entry's orig path is the
                 // next NUL record; skip it.
                 i += 2;
             }
             Some('?') => {
                 let path = header_str[2..].to_string();
-                entries.push(GitStatusEntry {
-                    kind: "untracked".to_string(),
-                    path,
-                });
+                entries.push(GitStatusEntry { path });
                 i += 1;
             }
             Some('!') => {

--- a/src/finalize/dry_run_archive.rs
+++ b/src/finalize/dry_run_archive.rs
@@ -1,19 +1,11 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::github::Client;
-
 use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;
-use crate::worktree::GitRunner;
-
-use sha2::{Digest, Sha256};
 
 /// Atomic report written under `<state_dir>/runs/<run_id>.preview.json`
 /// when the daemon runs a dry-run. The report is the

--- a/src/finalize/failure_investigation.rs
+++ b/src/finalize/failure_investigation.rs
@@ -1,19 +1,7 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::path::PathBuf;
-use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
-use crate::github::Client;
-
-use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;
-use crate::worktree::GitRunner;
-
-use sha2::{Digest, Sha256};
 
 // Failure / investigation finalization
 

--- a/src/finalize/pr.rs
+++ b/src/finalize/pr.rs
@@ -1,19 +1,7 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::path::PathBuf;
-use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
-use crate::github::Client;
-
-use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;
-use crate::worktree::GitRunner;
-
-use sha2::{Digest, Sha256};
 
 // Pull request: find or create, idempotent
 

--- a/src/finalize/push.rs
+++ b/src/finalize/push.rs
@@ -1,19 +1,10 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::github::Client;
-
-use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
-use crate::worker::WorkerResult;
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worktree::GitRunner;
-
-use sha2::{Digest, Sha256};
 
 // Push: idempotent, credential-scoped, remote-aware
 

--- a/src/finalize/reconcile.rs
+++ b/src/finalize/reconcile.rs
@@ -1,19 +1,9 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::path::PathBuf;
-use std::sync::Arc;
-
-use serde::{Deserialize, Serialize};
 
 use crate::github::Client;
 
-use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
-use crate::worker::WorkerResult;
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worktree::GitRunner;
-
-use sha2::{Digest, Sha256};
 
 /// Reconcile a push effect against remote state. Queries the
 /// remote branch via `ls-remote` and compares the OID against

--- a/src/finalize/voice.rs
+++ b/src/finalize/voice.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, unused_imports)]
-use super::*;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -11,7 +9,6 @@ use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
 use crate::worker::WorkerResult;
-use crate::worktree::GitRunner;
 
 use sha2::{Digest, Sha256};
 

--- a/src/github/client/cache.rs
+++ b/src/github/client/cache.rs
@@ -1,25 +1,13 @@
 //! Persistent conditional ETag cache for the GitHub API client.
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
+use std::sync::{Mutex, OnceLock};
 
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
-use reqwest::redirect::Policy;
 use serde::{Deserialize, Serialize};
-use url::Url;
 
-use crate::finalize::{
-    validate_comment, validate_pr_body, validate_pr_title, validate_public_text,
-};
-use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 
 use super::http_helpers::HTTP_CACHE_FILENAME;
 /// One cached response keyed by full URL + Accept header. The

--- a/src/github/client/client_core.rs
+++ b/src/github/client/client_core.rs
@@ -1,33 +1,22 @@
 //! Typed GitHub API HTTP client and request methods.
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
-use std::collections::BTreeMap;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
 use reqwest::redirect::Policy;
-use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::finalize::{
-    validate_comment, validate_pr_body, validate_pr_title, validate_public_text,
-};
-use crate::github::issue::IssueKey;
 use crate::infra::config::{Config, OsEnv};
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 
 use super::cache::{cache_key, inert_cache, is_valid_etag, CacheEntry, HttpCache};
 use super::http_helpers::{
-    header_value, join_path, map_status, read_bounded_body, same_origin, split_query, ACCEPT_VALUE,
-    BODY_TOO_LARGE_SENTINEL, CONNECT_TIMEOUT_SECONDS, GITHUB_API_VERSION_HEADER,
-    GITHUB_API_VERSION_VALUE, MAX_BODY_BYTES, MAX_REDIRECTS, USER_AGENT_PREFIX,
+    header_value, join_path, map_status, read_bounded_body, same_origin, split_query,
+    BODY_TOO_LARGE_SENTINEL, CONNECT_TIMEOUT_SECONDS, GITHUB_API_VERSION_VALUE, MAX_BODY_BYTES,
+    MAX_REDIRECTS, USER_AGENT_PREFIX,
 };
-use super::response::{RateLimitInfo, Response};
+use super::response::Response;
 /// Typed HTTP client. Owns the underlying reqwest::Client, the
 /// resolved token, the persistent ETag cache, and the
 /// redirect/timeout policies.

--- a/src/github/client/http_helpers.rs
+++ b/src/github/client/http_helpers.rs
@@ -1,25 +1,9 @@
 //! HTTP helper functions and constants used by the GitHub API client.
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
-use std::collections::BTreeMap;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
-
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
-use reqwest::redirect::Policy;
-use serde::{Deserialize, Serialize};
+use reqwest::header::HeaderValue;
 use url::Url;
 
-use crate::finalize::{
-    validate_comment, validate_pr_body, validate_pr_title, validate_public_text,
-};
-use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 
 /// HTTP header name for the GitHub API version pin.
 pub const GITHUB_API_VERSION_HEADER: &str = "X-GitHub-Api-Version";

--- a/src/github/client/mod.rs
+++ b/src/github/client/mod.rs
@@ -7,8 +7,6 @@
 //! entry point for the public-voice rule; nothing else in the
 //! crate bypasses it.
 
-#![allow(dead_code)]
-
 // Submodule declarations and re-exports.
 
 pub mod cache;

--- a/src/github/client/response.rs
+++ b/src/github/client/response.rs
@@ -1,25 +1,8 @@
 //! Typed GitHub API response and rate-limit observation.
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
+use reqwest::header::HeaderMap;
 
-use std::collections::BTreeMap;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
-
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
-use reqwest::redirect::Policy;
-use serde::{Deserialize, Serialize};
-use url::Url;
-
-use crate::finalize::{
-    validate_comment, validate_pr_body, validate_pr_title, validate_public_text,
-};
-use crate::github::issue::IssueKey;
-use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult, VoiceError};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 
 /// Result of a typed HTTP GET. ``final_url`` captures the URL after
 /// any allowed redirects so issue verification can detect a

--- a/src/github/client/voice.rs
+++ b/src/github/client/voice.rs
@@ -1,19 +1,5 @@
 //! Public-voice validation and outbound text helpers for GitHub mutations.
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
-use std::collections::BTreeMap;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
-
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
-use reqwest::redirect::Policy;
-use serde::{Deserialize, Serialize};
-use url::Url;
-
 use crate::finalize::{
     validate_comment, validate_pr_body, validate_pr_title, validate_public_text,
 };

--- a/src/infra/config/load.rs
+++ b/src/infra/config/load.rs
@@ -1,10 +1,5 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
-
-use regex::Regex;
-use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
 

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -17,9 +17,7 @@
 //! Public field list, semantics, and defaults are pinned here —
 //! every field documented must be present.
 
-#![allow(unused_imports)]
-
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use regex::Regex;
@@ -1145,6 +1143,8 @@ use self::load::*;
 use self::setup::*;
 use self::token::*;
 
-pub use load::*;
+// `load` exposes only `pub(crate)` items, so its names are brought in
+// with a private glob; `setup` and `token` also export `pub` items and
+// are re-exported to keep `crate::infra::config::*` reachable.
 pub use setup::*;
 pub use token::*;

--- a/src/infra/config/setup.rs
+++ b/src/infra/config/setup.rs
@@ -1,10 +1,8 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
 

--- a/src/infra/config/token.rs
+++ b/src/infra/config/token.rs
@@ -1,10 +1,4 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
-
-use regex::Regex;
-use serde::{Deserialize, Serialize};
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
 

--- a/src/infra/validate.rs
+++ b/src/infra/validate.rs
@@ -21,8 +21,6 @@
 //! drive [`preflight`] directly with a controlled PATH and
 //! temp directories; the daemon's main loop wraps the same call.
 
-#![allow(dead_code)]
-
 use std::path::{Path, PathBuf};
 
 use crate::infra::config::Config;

--- a/src/state/meta.rs
+++ b/src/state/meta.rs
@@ -34,8 +34,6 @@
 //! observation with an older one. The check is by
 //! `reset_at` timestamp.
 
-#![allow(dead_code)]
-
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fs::{self, OpenOptions};
@@ -675,10 +673,6 @@ fn quarantine_corrupt(meta_path: &Path, reason: &str) -> CaduceusResult<()> {
 
 fn take_meta_tx_conn() -> Option<Connection> {
     META_TX_CONN.with(|cell| cell.borrow_mut().take())
-}
-
-fn is_in_meta_tx() -> bool {
-    META_TX_CONN.with(|cell| cell.borrow().is_some())
 }
 
 fn load_sqlite(conn: &Connection, state_dir: &Path) -> CaduceusResult<StateMeta> {

--- a/src/state/migrate.rs
+++ b/src/state/migrate.rs
@@ -25,8 +25,6 @@
 //! the lock short-circuit just as they do for every other
 //! state-mutating command.
 
-#![allow(dead_code)]
-
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/src/state/queue/claim.rs
+++ b/src/state/queue/claim.rs
@@ -1,16 +1,11 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use fs2::FileExt;
-use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 
 pub(crate) fn acquire_next_locked(
@@ -179,39 +174,6 @@ pub(crate) fn claim_mismatch(claim: &ClaimToken) -> CaduceusError {
 
 pub(crate) fn into_lock_error(err: std::io::Error) -> CaduceusError {
     CaduceusError::Io(err)
-}
-
-pub(crate) fn scrub(value: &str) -> String {
-    // Local scrub — duplicated here so the queue module doesn't
-    // pull in the error module's redaction helper purely for a
-    // single debug log.
-    if value.is_empty() {
-        return value.to_string();
-    }
-    let mut scrubbed = value.to_string();
-    for needle in ["GITHUB_TOKEN", "CADUCEUS_GITHUB_TOKEN", "GH_TOKEN"] {
-        if let Some(pos) = scrubbed.find(needle) {
-            let abs = pos + needle.len();
-            let value_end = advance_to_end_of_value(&scrubbed, abs);
-            scrubbed.replace_range(abs..value_end, "<redacted>");
-        }
-    }
-    scrubbed
-}
-
-pub(crate) fn advance_to_end_of_value(s: &str, start: usize) -> usize {
-    let bytes = s.as_bytes();
-    if start >= bytes.len() {
-        return start;
-    }
-    let mut i = start;
-    while i < bytes.len() {
-        match bytes[i] {
-            b' ' | b'\t' | b'\n' | b'\r' | b',' | b';' | b'}' | b']' => break,
-            _ => i += 1,
-        }
-    }
-    i
 }
 
 /// SHA-256 hex digest of the lowercase display key. This is the

--- a/src/state/queue/daemon_lock.rs
+++ b/src/state/queue/daemon_lock.rs
@@ -1,17 +1,9 @@
-#![allow(dead_code, unused_imports)]
-use super::*;
-use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use chrono::{DateTime, Utc};
 use fs2::FileExt;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
-use crate::github::issue::IssueKey;
-use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::infra::error::CaduceusResult;
 
 /// Filename of the daemon-wide tick lock. Distinct from
 /// `STATE_LOCK_FILENAME` (which guards state-store mutations); the

--- a/src/state/queue/mod.rs
+++ b/src/state/queue/mod.rs
@@ -34,19 +34,13 @@
 //! the caller but does not roll back the durable phase change — the
 //! reaper cleans up orphaned claims idempotently.
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 use std::collections::BTreeMap;
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::fs;
+use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
-use fs2::FileExt;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
@@ -428,9 +422,7 @@ pub mod store;
 use self::claim::*;
 use self::daemon_lock::*;
 use self::reaper::*;
-use self::store::*;
 
 pub use claim::*;
 pub use daemon_lock::*;
 pub use reaper::*;
-pub use store::*;

--- a/src/state/queue/reaper.rs
+++ b/src/state/queue/reaper.rs
@@ -1,16 +1,10 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::collections::BTreeMap;
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::fs::{self, OpenOptions};
+use std::path::Path;
 
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 
 /// Directory under `<state_dir>/claims` where malformed/future-stamped
@@ -381,7 +375,7 @@ impl StateStore {
     /// not take any flock — the reaper runs under the daemon
     /// tick's `DaemonLock`, which serialises the whole tick.
     #[doc(hidden)]
-    pub fn open_for_reap_only(state_dir: &Path) -> CaduceusResult<Self> {
+    pub(crate) fn open_for_reap_only(state_dir: &Path) -> CaduceusResult<Self> {
         let claims_dir = state_dir.join(CLAIMS_DIRNAME);
         fs::create_dir_all(&claims_dir).map_err(|err| CaduceusError::Queue {
             context: "state_open",
@@ -401,7 +395,7 @@ impl StateStore {
     /// Acquire the state lock for the duration of a callback
     /// in the reaper. The lock is released on return.
     #[doc(hidden)]
-    pub fn with_exclusive_reap_only<F, T>(&self, f: F) -> CaduceusResult<T>
+    pub(crate) fn with_exclusive_reap_only<F, T>(&self, f: F) -> CaduceusResult<T>
     where
         F: FnOnce(&Self) -> CaduceusResult<T>,
     {

--- a/src/state/queue/store.rs
+++ b/src/state/queue/store.rs
@@ -1,16 +1,12 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
 use rusqlite::params;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::github::issue::IssueKey;
 use crate::infra::error::{scrub, CaduceusError, CaduceusResult};

--- a/src/worker/prompt.rs
+++ b/src/worker/prompt.rs
@@ -30,8 +30,6 @@
 //! `fsync`, atomic rename — the contract pin in
 //! `src/finalize/mod.rs` (the finalization contract).
 
-#![allow(dead_code)]
-
 use std::fmt::Write as _;
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;

--- a/src/worker/supervisor/dispatch.rs
+++ b/src/worker/supervisor/dispatch.rs
@@ -1,19 +1,19 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::path::Path;
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use chrono::Utc;
 use tokio::process::{Child, Command as TokioCommand};
 
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
+
+// test-only: used by the inline test module in this file; remove when
+// inline tests move to tests/ (see #144)
+#[allow(unused_imports)]
+use std::io::Write;
+#[allow(unused_imports)]
+use std::os::unix::fs::PermissionsExt;
 
 // Public spawn orchestrator
 

--- a/src/worker/supervisor/framing.rs
+++ b/src/worker/supervisor/framing.rs
@@ -1,18 +1,7 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::Duration;
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, Command as TokioCommand};
 
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 
 // Control pipe protocol

--- a/src/worker/supervisor/heartbeat.rs
+++ b/src/worker/supervisor/heartbeat.rs
@@ -1,16 +1,11 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, Command as TokioCommand};
 
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};

--- a/src/worker/supervisor/mod.rs
+++ b/src/worker/supervisor/mod.rs
@@ -51,23 +51,6 @@
 //! so the inherited-FD contract is satisfied without explicit
 //! `unsafe`.
 
-#![allow(dead_code, unused_imports)]
-
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::Duration;
-
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, Command as TokioCommand};
-
-use crate::github::issue::IssueKey;
-use crate::infra::error::{CaduceusError, CaduceusResult};
-
 // Submodule declarations and re-exports. These preserve the historical
 // `crate::worker::supervisor` public surface.
 

--- a/src/worker/supervisor/outcome_transcript.rs
+++ b/src/worker/supervisor/outcome_transcript.rs
@@ -1,18 +1,8 @@
-#![allow(dead_code, unused_imports)]
-use super::*;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::Duration;
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, Command as TokioCommand};
-
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 
 // Worker outcome + transcript

--- a/src/worker/supervisor/process_lifecycle.rs
+++ b/src/worker/supervisor/process_lifecycle.rs
@@ -1,16 +1,5 @@
-#![allow(dead_code, unused_imports)]
-use super::*;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
-use std::time::Duration;
-
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, Command as TokioCommand};
 
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
@@ -35,19 +24,6 @@ pub const PROTOCOL_VERSION: u32 = 1;
 /// envelope.
 pub const MAX_FRAME_BYTES: usize = 64 * 1024;
 // Subreaper + setsid + signal helpers (safe wrappers via nix)
-
-#[cfg(target_os = "linux")]
-fn try_set_subreaper() -> CaduceusResult<()> {
-    nix::sys::prctl::set_child_subreaper(true).map_err(|err| CaduceusError::Worker {
-        context: "supervisor:subreaper",
-        stderr: format!("prctl(PR_SET_CHILD_SUBREAPER) failed: {err}"),
-    })
-}
-
-#[cfg(not(target_os = "linux"))]
-fn try_set_subreaper() -> CaduceusResult<()> {
-    Ok(())
-}
 
 /// `setsid` the calling process into a new session.
 ///

--- a/src/worktree/gc.rs
+++ b/src/worktree/gc.rs
@@ -1,22 +1,10 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::ffi::OsStr;
-use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use fs2::FileExt;
-use nix::unistd::pipe;
-use tokio::process::Command as TokioCommand;
-use url::Url;
 
-use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
-use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 
 /// Worktree GC entry point shared by both `caduceus worktree-gc`
 /// `caduceus worktree-gc` — sweep stale worktrees across the

--- a/src/worktree/git_runner.rs
+++ b/src/worktree/git_runner.rs
@@ -1,20 +1,13 @@
-#![allow(dead_code, unused_imports)]
-use super::*;
 use std::ffi::OsStr;
-use std::fs::{self, OpenOptions};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
-use fs2::FileExt;
 use nix::unistd::pipe;
 use tokio::process::Command as TokioCommand;
-use url::Url;
 
-use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
 use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
 
@@ -109,7 +102,6 @@ pub struct GitRunner {
 struct GitRunnerInner {
     timeout: Duration,
     env_allowlist: Vec<String>,
-    api_base: String,
     /// Anonymous pipe read-fd for the GIT_ASKPASS credential
     /// helper. When set, `build_command` sets `GIT_ASKPASS` and
     /// `GIT_ASKPASS_FD` so the helper reads the PAT from this
@@ -158,7 +150,6 @@ impl GitRunner {
             inner: Arc::new(GitRunnerInner {
                 timeout: Duration::from_secs(timeout_seconds),
                 env_allowlist: extras,
-                api_base: cfg.api_base.clone(),
                 #[cfg(unix)]
                 credential_helper_fd,
                 cancelled: Arc::new(AtomicBool::new(false)),

--- a/src/worktree/repository.rs
+++ b/src/worktree/repository.rs
@@ -1,23 +1,14 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
 use std::collections::HashSet;
 use std::ffi::OsStr;
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
-use chrono::{DateTime, Utc};
-use fs2::FileExt;
-use nix::unistd::pipe;
-use tokio::process::Command as TokioCommand;
 use url::Url;
 
 use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
-use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 
 /// Outcome of [`find_main_clone`]: the resolved on-disk clone
 /// plus the metadata the daemon needs to create worktrees off

--- a/src/worktree/testing.rs
+++ b/src/worktree/testing.rs
@@ -1,22 +1,15 @@
-#![allow(dead_code, unused_imports)]
+// test-only: used by the inline test module in this file; remove when
+// inline tests move to tests/ (see #144)
+#[allow(unused_imports)]
 use super::*;
-use std::ffi::OsStr;
-use std::fs::{self, OpenOptions};
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::path::PathBuf;
 
-use chrono::{DateTime, Utc};
-use fs2::FileExt;
-use nix::unistd::pipe;
-use tokio::process::Command as TokioCommand;
-use url::Url;
-
-use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
-use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
+
+// test-only: used by the inline test module in this file; remove when
+// inline tests move to tests/ (see #144)
+#[allow(unused_imports)]
+use crate::github::issue::IssueKey;
 
 // Test-only Config helper. `Config::test_defaults` is documented as the
 // canonical root-anchored builder, but `find_main_clone` and the runner
@@ -24,6 +17,9 @@ use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
 // pure logic.
 
 impl Config {
+    // test-only: used by the inline tests in this file; remove when
+    // inline tests move to tests/ (see #144)
+    #[allow(dead_code)]
     fn minimal_workdir_for_runner_tests() -> Self {
         Self {
             poll_interval_seconds: 0,
@@ -84,6 +80,9 @@ impl Config {
     }
 }
 
+// test-only: used by the inline tests in this file; remove when
+// inline tests move to tests/ (see #144)
+#[allow(dead_code)]
 const DEFAULT_API_BASE: &str = "https://api.github.com";
 
 #[cfg(test)]

--- a/src/worktree/worktree.rs
+++ b/src/worktree/worktree.rs
@@ -1,22 +1,13 @@
-#![allow(dead_code, unused_imports)]
 use super::*;
-use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
-use nix::unistd::pipe;
-use tokio::process::Command as TokioCommand;
-use url::Url;
 
 use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
-use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
+use crate::infra::error::{CaduceusError, CaduceusResult};
 
 /// Outcome of creating one daemon-owned worktree + branch. The
 /// daemon owns the branch name (invariant #5) and the canonical


### PR DESCRIPTION
Sub-issue of #97 (defect 1). Removed every module-level `#![allow(dead_code, unused_imports)]` (and split-form variants) across 36 files; deleted the ~490 lines of dead imports and dead items they were hiding (EntrySnapshot, GitStatusEntry.kind, GitRunnerInner.api_base, try_set_subreaper, scrub, advance_to_end_of_value, is_in_meta_tx); downgraded reaper-only StateStore methods to pub(crate); added narrow test-only inline allows referencing #144 where inline test modules consume imports.

Plan (GLM-5.2) → Build (DeepSeek-V4-Flash-0731, 2 attempts: 1st hit /tmp wall, retry clean) → Check (Kimi K2.7, flagged split-form allows) → Amend (retry) → Re-check (LGTM). Gates: clippy -D warnings clean, fmt clean, 121/121 test suites (env-unset for the documented GITHUB_TOKEN environmental test).