### PR TITLE
chore(src): replace use super glob with explicit imports (closes #143)

### DIFF
--- a/src/daemon/orchestration/active_run.rs
+++ b/src/daemon/orchestration/active_run.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::Clock;
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -438,7 +439,8 @@ impl Clock for FakeClock {
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::super::{classify_error, Clock, FailureClass, SystemClock};
+    use super::{Arc, CaduceusError, DateTime, FakeClock, IssueKey, PathBuf, Utc};
     use crate::infra::config::Config;
     use crate::state::queue::{ClaimFileBody, ClaimToken, CLAIM_FILE_VERSION};
 

--- a/src/daemon/signals.rs
+++ b/src/daemon/signals.rs
@@ -181,7 +181,7 @@ pub fn outcome_from_signal(kind: SignalKind) -> SignalOutcome {
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::{Duration, SignalKind, ESCALATE_GRACE};
 
     #[test]
     fn signal_kind_labels_match_libc_names() {

--- a/src/daemon/tick/awaiting_review.rs
+++ b/src/daemon/tick/awaiting_review.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Outcome304;
 
 use chrono::{DateTime, Utc};
 use tracing::info;
@@ -295,7 +295,10 @@ pub fn exit_code_for_tests(outcome: &TickOutcome) -> u8 {
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::{
+        exit_code_for, extract_http_status, map_phase_to_outcome, outcome_for_class, CaduceusError,
+        FailureClass, Phase, TickOutcome,
+    };
 
     #[test]
     pub(crate) fn exit_code_for_outcome_table() {

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    extract_http_status, handle_infra_or_retry, resume_from_checkpoint, run_code_finalize,
+    run_investigation_finalize, run_resume_finalization, ResumeAction,
+};
+
 use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::handle_infra_or_retry;
+
 use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;

--- a/src/executor/oci_lifecycle.rs
+++ b/src/executor/oci_lifecycle.rs
@@ -485,9 +485,8 @@ fn parse_exit_code(output: &str) -> i32 {
 
 #[cfg(test)]
 mod inline_tests {
+    use super::{derive_daemon_id, parse_exit_code, CancellationToken, Config, ExecutorSpec};
     use std::path::Path;
-
-    use super::*;
 
     #[test]
     fn parse_exit_code_parses_number() {

--- a/src/executor/secret_transport.rs
+++ b/src/executor/secret_transport.rs
@@ -100,7 +100,7 @@ impl Drop for SecretHandle {
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::EphemeralSecretFile;
     use std::panic;
 
     #[test]

--- a/src/finalize/comment_close.rs
+++ b/src/finalize/comment_close.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{FinalizeAction, FinalizeContext, FinalizeOutput};
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;

--- a/src/finalize/commit.rs
+++ b/src/finalize/commit.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{FinalizeAction, FinalizeContext, FinalizeOutput};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/finalize/dry_run_archive.rs
+++ b/src/finalize/dry_run_archive.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    build_pr_body, build_pr_title, FinalizeAction, FinalizeContext, FinalizeOutput,
+    IDEMPOTENCY_MARKER_PREFIX,
+};
+
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};

--- a/src/finalize/failure_investigation.rs
+++ b/src/finalize/failure_investigation.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{render_artifacts_with_escape, FinalizeAction, FinalizeContext, FinalizeOutput};
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;

--- a/src/finalize/pr.rs
+++ b/src/finalize/pr.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{FinalizeAction, FinalizeContext, FinalizeOutput};
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::WorkerResult;

--- a/src/finalize/push.rs
+++ b/src/finalize/push.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{git_rev_in_async, FinalizeAction, FinalizeContext, FinalizeOutput};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/finalize/reconcile.rs
+++ b/src/finalize/reconcile.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{ls_remote_branch, urlencode, ReconcileResult};
 
 use crate::github::Client;
 

--- a/src/infra/config/load.rs
+++ b/src/infra/config/load.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{expand_leading_tilde, Config, RawConfig};
+
 use std::path::Path;
 
 use crate::infra::error::{CaduceusError, CaduceusResult};

--- a/src/infra/config/setup.rs
+++ b/src/infra/config/setup.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{LoadContext, DENIED_ENV_VARS, FORBIDDEN_INTERPOLATION_TOKENS, PLUGIN_ROOT_TOKEN};
+
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 

--- a/src/infra/config/token.rs
+++ b/src/infra/config/token.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Config;
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
 

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -746,7 +746,7 @@ fn advance_to_end_of_value(s: &str, start: usize) -> usize {
 // Tests live in `tests/state/error_test.rs`.
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::scrub;
 
     #[test]
     fn scrub_redacts_token_in_value() {

--- a/src/infra/install.rs
+++ b/src/infra/install.rs
@@ -166,7 +166,7 @@ pub fn recover_temp_artifacts(dir: &Path) -> CaduceusResult<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{atomic_write, recover_temp_artifacts};
     use std::fs;
 
     #[test]

--- a/src/scheduler/circuit.rs
+++ b/src/scheduler/circuit.rs
@@ -492,7 +492,9 @@ impl CircuitStore {
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::{
+        AdmissionResult, CircuitConfig, CircuitScope, CircuitState, CircuitStore, Connection,
+    };
     use crate::daemon::orchestration::FakeClock;
 
     fn circuit_store() -> (CircuitStore, FakeClock) {

--- a/src/state/checkpoints.rs
+++ b/src/state/checkpoints.rs
@@ -228,7 +228,10 @@ pub fn delete_checkpoint(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        checkpoint_for_run, last_checkpoint_for_run, persist_checkpoint, CheckpointRow,
+        FinalizationStage,
+    };
     use crate::state::store;
 
     #[test]

--- a/src/state/migrate.rs
+++ b/src/state/migrate.rs
@@ -574,7 +574,7 @@ pub fn recover_sqlite_state(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{recover_sqlite_state, store, PathBuf};
     use std::fs;
 
     fn state_dir() -> PathBuf {

--- a/src/state/migrate_to_sqlite.rs
+++ b/src/state/migrate_to_sqlite.rs
@@ -315,7 +315,7 @@ pub(crate) fn write_state_backend_config(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{migrate_to_sqlite, params, store, LockPolicy, Path, SqliteMigrationOutcome};
     use std::fs;
 
     fn state_dir() -> std::path::PathBuf {

--- a/src/state/queue/claim.rs
+++ b/src/state/queue/claim.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    process_start_identity, ClaimFileBody, ClaimToken, ClaimedEntry, Phase, QueueEntry, StateStore,
+    CLAIM_FILE_VERSION,
+};
+
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::Path;

--- a/src/state/queue/reaper.rs
+++ b/src/state/queue/reaper.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    atomic_write, process_start_identity, sync_dir, ClaimFileBody, Phase, StateStore,
+    StateStoreBackend, CLAIMS_DIRNAME, CLAIM_FILE_VERSION, STATE_FILENAME, STATE_LOCK_FILENAME,
+};
+
 use std::fs::{self, OpenOptions};
 use std::path::Path;
 

--- a/src/state/queue/store.rs
+++ b/src/state/queue/store.rs
@@ -1,4 +1,12 @@
-use super::*;
+use super::{
+    acquire_next_locked, atomic_write, claim_mismatch, display_digest, into_lock_error,
+    matches_token, parse_queue_state, serialize_queue_state, sync_dir, unlink_claim_best_effort,
+    update_claim_worktree, ClaimToken, ClaimedEntry, Connection, EnqueueOutcome,
+    FinalizationCheckpoint, Phase, QueueEntry, QueueState, ResetOutcome, StateStore,
+    StateStoreBackend, TicketType, CLAIMS_DIRNAME, QUEUE_FILE_VERSION, STATE_FILENAME,
+    STATE_LOCK_FILENAME,
+};
+
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fs::{self, OpenOptions};

--- a/src/state/retention.rs
+++ b/src/state/retention.rs
@@ -77,7 +77,7 @@ pub fn prune_backups(state_dir: &Path, retention_days: u64) -> CaduceusResult<u6
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{prune_backups, PathBuf};
     use std::fs;
 
     fn dir() -> PathBuf {

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -346,7 +346,7 @@ pub fn open_in(state_dir: &Path) -> CaduceusResult<Connection> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{open, open_in, params, Connection, PathBuf, DB_FILENAME, SCHEMA_VERSION};
     use std::fs;
 
     fn db_path() -> PathBuf {

--- a/src/worker/context.rs
+++ b/src/worker/context.rs
@@ -520,7 +520,11 @@ fn approx_json_array_len<T: Serialize + Clone>(key: &str, items: &[T]) -> Caduce
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::{
+        build_context, decode_context, encode_context, truncate_body, BuildInputs, Config,
+        IssueDetail, IssueKey, Utc, CONTEXT_SCHEMA_VERSION, MAX_COMMENT_BODY_BYTES,
+        TRUNCATION_MARKER,
+    };
     use crate::github::issue::{IssueComment, IssueEvent};
     use regex::Regex;
 

--- a/src/worker/prompt.rs
+++ b/src/worker/prompt.rs
@@ -400,7 +400,7 @@ fn ticket_type_label(t: TicketType) -> &'static str {
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::{build_prompt, write_prompt, IssueDetail, TicketType, MAX_PROMPT_BYTES};
     use crate::github::issue::IssueKey;
     use crate::github::issue::{IssueComment, IssueEvent};
     use chrono::{TimeZone, Utc};

--- a/src/worker/supervisor/dispatch.rs
+++ b/src/worker/supervisor/dispatch.rs
@@ -1,4 +1,9 @@
-use super::*;
+use super::{
+    build_supervisor_command, clear_heartbeat, read_frame_async, read_proc_starttime,
+    verify_identity, write_frame_async, write_heartbeat_record, ControlFrame, Heartbeat,
+    SupervisorOutcome, WorkerRunPaths, HEARTBEAT_FILE_VERSION, MAX_FRAME_BYTES,
+};
+
 use std::path::Path;
 use std::time::Duration;
 
@@ -408,7 +413,12 @@ impl IntoOutcome for CaduceusError {
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::super::{
+        clear_heartbeat, decode_frame, encode_frame, open_transcript, parse_starttime_from_stat,
+        read_heartbeat, read_proc_starttime, truncate_transcript, verify_identity, write_heartbeat,
+        BoundedTranscriptWriter, ControlFrame, WorkerRunPaths, MAX_FRAME_BYTES,
+    };
+    use super::{PermissionsExt, Write};
 
     #[test]
     fn frame_round_trip() {

--- a/src/worker/supervisor/framing.rs
+++ b/src/worker/supervisor/framing.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{MAX_FRAME_BYTES, PROTOCOL_VERSION};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/src/worker/supervisor/heartbeat.rs
+++ b/src/worker/supervisor/heartbeat.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::set_mode;
+
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::fs::OpenOptionsExt;

--- a/src/worktree/gc.rs
+++ b/src/worktree/gc.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{build_runner, remove, runner_inner_cfg, runner_run_in_std, Worktree};
+
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};

--- a/src/worktree/repository.rs
+++ b/src/worktree/repository.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::GitRunner;
+
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;

--- a/src/worktree/testing.rs
+++ b/src/worktree/testing.rs
@@ -1,7 +1,3 @@
-// test-only: used by the inline test module in this file; remove when
-// inline tests move to tests/ (see #144)
-#[allow(unused_imports)]
-use super::*;
 use std::path::PathBuf;
 
 use crate::infra::config::Config;
@@ -87,7 +83,11 @@ const DEFAULT_API_BASE: &str = "https://api.github.com";
 
 #[cfg(test)]
 mod inline_tests {
-    use super::*;
+    use super::super::{
+        cap_text, clone_path, parse_origin, redact_and_cap, validate_origin_host,
+        GIT_OUTPUT_BYTE_CAP,
+    };
+    use super::{Config, IssueKey, PathBuf, DEFAULT_API_BASE};
 
     #[test]
     fn parse_origin_handles_https_form() {

--- a/src/worktree/worktree.rs
+++ b/src/worktree/worktree.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{runner_inner_cfg, GitOutput, GitRunner, RepositoryInfo};
+
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Sub-issue of #97 (defect 2). Replaced all 41 `use super::*;` sites across 37 files (incl. inside #[cfg(test)] modules) with explicit `use super::{...}` lists, compiler-guided. Plan (GLM-5.2) → Build (DeepSeek-V4-Flash-0731; final report turn hit a provider stream error after gates passed — operator verified globs=0, fmt, clippy and committed) → Check (Kimi K2.7, LGTM).