### PR TITLE
feat(runtime): route refuse-to-operate to NeedsAttention (closes #167)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,6 +391,10 @@ name = "install_test"
 path = "tests/infra/install_test.rs"
 
 [[test]]
+name = "error_classify_test"
+path = "tests/infra/error_classify_test.rs"
+
+[[test]]
 name = "worker_archive_test"
 path = "tests/worker/worker_archive_test.rs"
 

--- a/src/daemon/orchestration/active_run.rs
+++ b/src/daemon/orchestration/active_run.rs
@@ -260,10 +260,43 @@ impl ActiveRunGuard {
         Ok(())
     }
 
+    /// Terminal transition for a refuse-to-operate block. The
+    /// attached worktree is torn down, the entry is moved to
+    /// `NeedsAttention` with block metadata, a stable tracing event
+    /// is emitted, and the claim is released. The claim must be
+    /// released *after* the route so a later `reset_entry` is not
+    /// blocked by a stale claim file.
+    pub async fn finish_needs_attention(
+        &mut self,
+        error: &str,
+        source: &str,
+        recovery_hint: &str,
+    ) -> CaduceusResult<()> {
+        self.teardown_worktree_if_attached().await;
+        self.store.route_to_needs_attention_unchecked(
+            &self.issue_key,
+            error,
+            recovery_hint,
+            source,
+        )?;
+        tracing::warn!(
+            event = "caduceus.terminal_block",
+            issue_key = %self.issue_key.display_key(),
+            source,
+            recovery_hint,
+            error = %error,
+            "terminal block: entry moved to NeedsAttention"
+        );
+        let claim = self.take_claim();
+        crate::state::queue::unlink_claim_best_effort(&self.store.claims_dir(), &claim);
+        self.mark_finished().await;
+        Ok(())
+    }
+
     /// Cancellation transition. Operator SIGINT/SIGTERM or a
     /// timeout-driven drain lands here. The worktree is torn
-    /// down; the entry is requeued with `not_before = now` so
-    /// the next tick is immediately eligible.
+    /// down; the entry is requeued with `not_before = now` so the
+    /// next tick is immediately eligible.
     pub async fn finish_cancelled(&mut self) -> CaduceusResult<()> {
         self.teardown_worktree_if_attached().await;
         let now = Utc::now();

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -28,8 +28,14 @@ use crate::infra::error::CaduceusError;
 pub enum FailureClass {
     Worker,
     Infrastructure,
-    RateLimit { reset_at: u64 },
+    RateLimit {
+        reset_at: u64,
+    },
     Cancellation,
+    /// Refuse-to-operate conditions that will not resolve by retry.
+    /// The daemon routes these to `NeedsAttention` with a recovery
+    /// hint instead of requeuing.
+    Terminal,
 }
 
 impl FailureClass {
@@ -49,7 +55,7 @@ impl FailureClass {
         match self {
             FailureClass::RateLimit { .. } => Some(crate::state::meta::TickOutcome::RateLimited),
             FailureClass::Cancellation => Some(crate::state::meta::TickOutcome::Cancelled),
-            FailureClass::Worker | FailureClass::Infrastructure => None,
+            FailureClass::Worker | FailureClass::Infrastructure | FailureClass::Terminal => None,
         }
     }
 
@@ -63,6 +69,12 @@ impl FailureClass {
     /// timeout-driven).
     pub fn is_cancellation(&self) -> bool {
         matches!(self, FailureClass::Cancellation)
+    }
+
+    /// True when the failure is a terminal refuse-to-operate
+    /// condition that requires operator action.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, FailureClass::Terminal)
     }
 }
 
@@ -129,7 +141,15 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         CaduceusError::Git { .. } => FailureClass::Infrastructure,
         CaduceusError::Push { .. } => FailureClass::Infrastructure,
         CaduceusError::PushCollision { .. } => FailureClass::Infrastructure,
+        CaduceusError::Worktree { context, .. }
+            if *context == "discover-dirty-main" || *context == "create-path-collision" =>
+        {
+            FailureClass::Terminal
+        }
         CaduceusError::Worktree { .. } => FailureClass::Infrastructure,
+        CaduceusError::Queue { context, .. } if *context == "claim-terminal-mismatch" => {
+            FailureClass::Terminal
+        }
         CaduceusError::Queue { .. } => FailureClass::Infrastructure,
         CaduceusError::StateCorrupt { .. } => FailureClass::Infrastructure,
         CaduceusError::ReconciliationFailed { .. } => FailureClass::Infrastructure,

--- a/src/daemon/status.rs
+++ b/src/daemon/status.rs
@@ -57,6 +57,13 @@ pub struct StatusReport {
     pub next_head: Option<String>,
     pub next_head_earliest_eligibility: Option<DateTime<Utc>>,
     pub recent_errors: Vec<String>,
+    /// Dedicated surface for queue entries stuck in
+    /// `NeedsAttention` because of a refuse-to-operate
+    /// condition. Each entry carries the stable block
+    /// source tag and the human-readable recovery command
+    /// so the operator can see at a glance what is wedged
+    /// and how to unstick it, without parsing error text.
+    pub blocked_issues: Vec<BlockedEntry>,
     pub rate_limit: Option<crate::state::meta::RateLimitObservation>,
     pub live_workers: Vec<LiveWorker>,
     pub diagnostics: Vec<String>,
@@ -68,6 +75,30 @@ pub struct StatusReport {
     pub readiness: Option<BTreeMap<String, String>>,
     /// Pool state: "idle", "active(n)", "saturated", or "draining".
     pub pool_state: Option<String>,
+}
+
+/// One blocked (refuse-to-operate) entry surfaced by
+/// the status reporter. Built from queue entries in
+/// `NeedsAttention` phase that carry both
+/// `blocked_source` and `blocked_recovery_hint` — the
+/// `recent_errors` list still surfaces blocked info for
+/// backwards compatibility, but this struct is the
+/// authoritative contract for the dedicated `blocked
+/// issues` section and the JSON `blocked_issues` field.
+#[derive(Clone, Debug, Serialize)]
+pub struct BlockedEntry {
+    /// Display key, e.g. `owner/repo#42`.
+    pub issue_key: String,
+    /// Stable source tag (`worktree/dirty_main`,
+    /// `worktree/path_collision`, `queue/claim_mismatch`).
+    pub blocked_source: String,
+    /// Canonical recovery command the operator should
+    /// run to unstick the entry.
+    pub blocked_recovery_hint: String,
+    /// Last error text recorded when the entry was
+    /// routed to `NeedsAttention`. Empty string when
+    /// the entry has no recorded reason.
+    pub last_error: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -86,7 +117,15 @@ pub struct LiveWorker {
 
 /// Schema version. Bumped when a new field is added so
 /// the `--json` consumer can detect the version.
-pub const STATUS_SCHEMA_VERSION: &str = "7.5.0";
+///
+/// 7.6.0 — added `blocked_issues` field on
+/// `StatusReport` carrying dedicated `BlockedEntry`
+/// records for queue entries stuck in `NeedsAttention`
+/// because of a refuse-to-operate condition. The field
+/// is additive: the section is omitted from the human
+/// output when empty, and the JSON array is always
+/// present (empty array on a healthy state).
+pub const STATUS_SCHEMA_VERSION: &str = "7.6.0";
 
 /// Maximum number of recent errors surfaced by
 /// `StatusReport::recent_errors`.
@@ -189,6 +228,13 @@ pub fn build_report(state_dir: &Path) -> CaduceusResult<(StatusReport, Option<St
     //    diagnostics, capped at 10.
     let recent_errors = collect_recent_errors(&queue, &meta.snapshot());
 
+    // 5b. Dedicated blocked-issues surface — only queue
+    //     entries in `NeedsAttention` with typed block
+    //     metadata contribute. The section is omitted from
+    //     the human render when empty; the JSON field is
+    //     always present (additive over 7.5.0).
+    let blocked_issues = collect_blocked_issues(&queue);
+
     // 6. Live workers from heartbeats. The reporter
     //    filters for `*.heartbeat` regular files whose
     //    mtime is within the staleness window. The
@@ -231,6 +277,7 @@ pub fn build_report(state_dir: &Path) -> CaduceusResult<(StatusReport, Option<St
         next_head,
         next_head_earliest_eligibility: next_head_earliest,
         recent_errors,
+        blocked_issues,
         rate_limit: meta.snapshot().rate_limit,
         live_workers,
         diagnostics: Vec::new(),
@@ -282,6 +329,7 @@ fn empty_report(state_dir: &Path) -> StatusReport {
         next_head: None,
         next_head_earliest_eligibility: None,
         recent_errors: Vec::new(),
+        blocked_issues: Vec::new(),
         rate_limit: None,
         live_workers: Vec::new(),
         diagnostics: Vec::new(),
@@ -382,6 +430,43 @@ fn collect_recent_errors(queue: &QueueState, meta: &StateMeta) -> Vec<String> {
     }
     errors.truncate(MAX_RECENT_ERRORS);
     errors
+}
+
+/// Build the dedicated `blocked_issues` surface from
+/// queue entries in `NeedsAttention` phase that carry
+/// the typed block metadata. Entries without both
+/// `blocked_source` and `blocked_recovery_hint` are
+/// skipped — those fields are set only by the
+/// terminal-block dispatch path, so a `NeedsAttention`
+/// entry without them is a legacy state that the
+/// reporter cannot present coherently here (the
+/// `recent_errors` list still surfaces it for context).
+fn collect_blocked_issues(queue: &QueueState) -> Vec<BlockedEntry> {
+    let mut out: Vec<BlockedEntry> = Vec::new();
+    for entry in queue.entries.values() {
+        if entry.phase != Phase::NeedsAttention {
+            continue;
+        }
+        let (Some(source), Some(hint)) = (
+            entry.blocked_source.as_ref(),
+            entry.blocked_recovery_hint.as_ref(),
+        ) else {
+            continue;
+        };
+        out.push(BlockedEntry {
+            issue_key: entry.key.display_key(),
+            blocked_source: source.clone(),
+            blocked_recovery_hint: hint.clone(),
+            last_error: entry.last_error.clone().unwrap_or_default(),
+        });
+    }
+    // Deterministic ordering — the report is rendered
+    // for humans, and grep-ability across runs depends
+    // on a stable iteration order. BTreeMap iterates in
+    // lexical display-key order, which matches the
+    // queue's FIFO convention.
+    out.sort_by(|a, b| a.issue_key.cmp(&b.issue_key));
+    out
 }
 
 fn collect_live_workers(state_dir: &Path) -> Vec<LiveWorker> {
@@ -531,6 +616,28 @@ pub fn render_human(report: &StatusReport, diagnostic: Option<&StatusDiagnostic>
             ));
         }
     }
+    if !report.blocked_issues.is_empty() {
+        out.push_str("  blocked issues:\n");
+        for entry in &report.blocked_issues {
+            out.push_str(&format!("    - {}\n", entry.issue_key));
+            out.push_str(&format!("      source: {}\n", entry.blocked_source));
+            // The reason line is informational; an entry
+            // can legitimately lack `last_error` if the
+            // daemon routed it via a context-only path,
+            // so we fall back to `-` to keep the section
+            // shape stable.
+            let reason = if entry.last_error.is_empty() {
+                "-".to_string()
+            } else {
+                entry.last_error.clone()
+            };
+            out.push_str(&format!("      reason: {reason}\n"));
+            out.push_str(&format!(
+                "      recovery: {}\n",
+                entry.blocked_recovery_hint
+            ));
+        }
+    }
     if !report.recent_errors.is_empty() {
         out.push_str("  recent errors:\n");
         for err in &report.recent_errors {
@@ -607,6 +714,7 @@ pub fn build_report_from_state(
     }
     let (next_head, next_head_earliest) = compute_next_head(queue, Utc::now());
     let recent_errors = collect_recent_errors(queue, meta);
+    let blocked_issues = collect_blocked_issues(queue);
     StatusReport {
         version: STATUS_SCHEMA_VERSION.to_string(),
         state_dir: state_dir.to_path_buf(),
@@ -619,6 +727,7 @@ pub fn build_report_from_state(
         next_head,
         next_head_earliest_eligibility: next_head_earliest,
         recent_errors,
+        blocked_issues,
         rate_limit: meta.rate_limit.clone(),
         live_workers: Vec::new(),
         diagnostics: Vec::new(),

--- a/src/daemon/status.rs
+++ b/src/daemon/status.rs
@@ -187,7 +187,7 @@ pub fn build_report(state_dir: &Path) -> CaduceusResult<(StatusReport, Option<St
     // 5. Recent errors. The queue entries' `last_error` plus
     //    the metadata's `last_error` plus the metadata
     //    diagnostics, capped at 10.
-    let recent_errors = collect_recent_errors(&queue, &meta);
+    let recent_errors = collect_recent_errors(&queue, &meta.snapshot());
 
     // 6. Live workers from heartbeats. The reporter
     //    filters for `*.heartbeat` regular files whose
@@ -332,12 +332,12 @@ fn compute_next_head_inner(
     (head, earliest_future)
 }
 
-fn collect_recent_errors(queue: &QueueState, meta: &MetaStore) -> Vec<String> {
+fn collect_recent_errors(queue: &QueueState, meta: &StateMeta) -> Vec<String> {
     let mut errors: Vec<String> = Vec::new();
-    if let Some(last) = meta.snapshot().last_error {
+    if let Some(last) = &meta.last_error {
         errors.push(format!("daemon: {last}"));
     }
-    for diag in meta.snapshot().recent_diagnostics.iter().rev() {
+    for diag in meta.recent_diagnostics.iter().rev() {
         errors.push(format!(
             "diagnostic [{}]: {}",
             diag.code,
@@ -349,7 +349,10 @@ fn collect_recent_errors(queue: &QueueState, meta: &MetaStore) -> Vec<String> {
     }
     // Pull the most recent `last_error` from each
     // non-terminal entry. Terminal phases are excluded
-    // because they aren't actionable.
+    // because they aren't actionable. NeedsAttention entries
+    // additionally surface the stable source tag and the
+    // recovery hint so operators don't have to parse error
+    // text at the console.
     for entry in queue.entries.values() {
         if entry.phase == Phase::Done
             || entry.phase == Phase::Skipped
@@ -359,6 +362,22 @@ fn collect_recent_errors(queue: &QueueState, meta: &MetaStore) -> Vec<String> {
         }
         if let Some(err) = &entry.last_error {
             errors.push(format!("{}: {}", entry.key.display_key(), err));
+        }
+        if entry.phase == Phase::NeedsAttention {
+            if let Some(source) = &entry.blocked_source {
+                errors.push(format!(
+                    "{}: blocked: source = {}",
+                    entry.key.display_key(),
+                    source
+                ));
+            }
+            if let Some(hint) = &entry.blocked_recovery_hint {
+                errors.push(format!(
+                    "{}: blocked: recovery = {}",
+                    entry.key.display_key(),
+                    hint
+                ));
+            }
         }
     }
     errors.truncate(MAX_RECENT_ERRORS);
@@ -587,6 +606,7 @@ pub fn build_report_from_state(
         *phases.entry(key).or_insert(0) += 1;
     }
     let (next_head, next_head_earliest) = compute_next_head(queue, Utc::now());
+    let recent_errors = collect_recent_errors(queue, meta);
     StatusReport {
         version: STATUS_SCHEMA_VERSION.to_string(),
         state_dir: state_dir.to_path_buf(),
@@ -598,7 +618,7 @@ pub fn build_report_from_state(
         phases,
         next_head,
         next_head_earliest_eligibility: next_head_earliest,
-        recent_errors: Vec::new(),
+        recent_errors,
         rate_limit: meta.rate_limit.clone(),
         live_workers: Vec::new(),
         diagnostics: Vec::new(),

--- a/src/daemon/tick/awaiting_review.rs
+++ b/src/daemon/tick/awaiting_review.rs
@@ -145,12 +145,49 @@ pub fn enqueue_summaries(
     Ok(earliest)
 }
 
+/// Extract a stable source tag and the embedded recovery command from
+/// a terminal-class error. Returns `None` when the error cannot be
+/// recognised as one of the three reserved refuse-to-operate tags.
+fn terminal_error_details(err: &CaduceusError) -> Option<(&'static str, &str)> {
+    match err {
+        CaduceusError::Worktree {
+            context: "discover-dirty-main",
+            stderr,
+        } => Some(("worktree/dirty_main", stderr.as_str())),
+        CaduceusError::Worktree {
+            context: "create-path-collision",
+            stderr,
+        } => Some(("worktree/path_collision", stderr.as_str())),
+        CaduceusError::Queue {
+            context: "claim-terminal-mismatch",
+            stderr,
+        } => Some(("queue/claim_mismatch", stderr.as_str())),
+        _ => None,
+    }
+}
+
 pub(crate) async fn handle_infra_or_retry(
     cfg: Config,
     guard: &mut ActiveRunGuard,
     err: &CaduceusError,
     class: FailureClass,
 ) -> CaduceusResult<TickOutcome> {
+    if class.is_terminal() {
+        let error_text = err.to_string();
+        match terminal_error_details(err) {
+            Some((source, recovery_hint)) => {
+                guard
+                    .finish_needs_attention(&error_text, source, recovery_hint)
+                    .await?;
+            }
+            None => {
+                guard
+                    .finish_needs_attention(&error_text, "terminal/unknown", &error_text)
+                    .await?;
+            }
+        }
+        return Ok(TickOutcome::Failed);
+    }
     if class.counts_against_retry_budget() {
         let new_phase = guard
             .finish_retry(&err.to_string(), cfg.max_retries_per_issue)
@@ -163,6 +200,18 @@ pub(crate) async fn handle_infra_or_retry(
         .finish_infrastructure(&err.to_string(), not_before)
         .await;
     Ok(outcome_for_class(class))
+}
+
+/// Test seam for [`handle_infra_or_retry`]. The public surface stays
+/// the orchestrator; this wrapper exists only to let integration tests
+/// prove the Terminal/Infrastructure/Retry dispatch boundaries.
+pub async fn handle_infra_or_retry_for_tests(
+    cfg: Config,
+    guard: &mut ActiveRunGuard,
+    err: &CaduceusError,
+    class: FailureClass,
+) -> CaduceusResult<TickOutcome> {
+    handle_infra_or_retry(cfg, guard, err, class).await
 }
 
 pub(crate) fn outcome_for_class(class: FailureClass) -> TickOutcome {

--- a/src/state/migrate.rs
+++ b/src/state/migrate.rs
@@ -247,6 +247,8 @@ pub fn run(from: &Path, state_dir: &Path, dry_run: bool) -> CaduceusResult<Migra
                 queued_at: updated_at,
                 updated_at,
                 generation: 1,
+                blocked_source: None,
+                blocked_recovery_hint: None,
             };
             target.entries.insert(key.display_key(), entry);
             migrated += 1;

--- a/src/state/migrate_to_sqlite.rs
+++ b/src/state/migrate_to_sqlite.rs
@@ -184,8 +184,9 @@ pub fn migrate_to_sqlite(
         tx.execute(
             "INSERT OR REPLACE INTO queue_entries
              (issue_key, phase, ticket_type, attempts, last_error, last_run_id,
-              next_attempt_at, finalization, queued_at, updated_at, generation)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+              next_attempt_at, finalization, queued_at, updated_at, generation,
+              blocked_source, blocked_recovery_hint)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 key,
                 phase,
@@ -198,6 +199,8 @@ pub fn migrate_to_sqlite(
                 queued_at,
                 updated_at,
                 1_i64,
+                None::<Option<String>>,
+                None::<Option<String>>,
             ],
         )
         .map_err(|e| CaduceusError::StateCorrupt {

--- a/src/state/queue/claim.rs
+++ b/src/state/queue/claim.rs
@@ -168,9 +168,9 @@ pub(crate) fn matches_token(entry: &QueueEntry, claim: &ClaimToken) -> bool {
 
 pub(crate) fn claim_mismatch(claim: &ClaimToken) -> CaduceusError {
     CaduceusError::Queue {
-        context: "claim",
+        context: "claim-terminal-mismatch",
         stderr: format!(
-            "claim token run_id {:?} digest {} does not match any in-progress entry",
+            "claim token run_id {:?} digest {} does not match any in-progress entry. Run `caduceus queue reprocess <issue>` to clear the stale claim and retry.",
             claim.run_id, claim.digest
         ),
     }

--- a/src/state/queue/mod.rs
+++ b/src/state/queue/mod.rs
@@ -173,6 +173,14 @@ pub struct QueueEntry {
     pub queued_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub generation: u32,
+    /// Stable source tag for a terminal block (e.g. `worktree/dirty_main`).
+    /// Set only when the daemon moves an entry to `NeedsAttention`
+    /// because of a refuse-to-operate condition.
+    #[serde(default)]
+    pub blocked_source: Option<String>,
+    /// Human-readable recovery command/hint for a terminal block.
+    #[serde(default)]
+    pub blocked_recovery_hint: Option<String>,
 }
 
 /// Versioned queue file.

--- a/src/state/queue/store.rs
+++ b/src/state/queue/store.rs
@@ -179,6 +179,8 @@ impl StateStore {
                         queued_at: now,
                         updated_at: now,
                         generation: 1,
+                        blocked_source: None,
+                        blocked_recovery_hint: None,
                     };
                     state.entries.insert(key.display_key(), entry);
                     EnqueueOutcome::Inserted
@@ -374,6 +376,40 @@ impl StateStore {
             }
             entry.phase = Phase::NeedsAttention;
             entry.last_error = Some(reason.to_string());
+            entry.updated_at = Utc::now();
+            store.persist(&state)?;
+            Ok(())
+        })
+    }
+
+    /// Crate-private, phase-gate-free transition to `NeedsAttention`
+    /// for terminal refuse-to-operate blocks. The caller (the
+    /// Terminal dispatch in `handle_infra_or_retry`) is responsible
+    /// for ensuring the entry is genuinely stuck.
+    pub(crate) fn route_to_needs_attention_unchecked(
+        &self,
+        key: &IssueKey,
+        reason: &str,
+        recovery_hint: &str,
+        source: &str,
+    ) -> CaduceusResult<()> {
+        self.with_exclusive(|store| {
+            let mut state = store.load_validated()?;
+            let target = key.display_key();
+            let entry = state
+                .entries
+                .values_mut()
+                .find(|e| e.key.display_key() == target)
+                .ok_or_else(|| CaduceusError::Queue {
+                    context: "route_to_needs_attention_unchecked",
+                    stderr: format!("no entry for {target}"),
+                })?;
+            entry.phase = Phase::NeedsAttention;
+            entry.last_error = Some(reason.to_string());
+            entry.blocked_source = Some(source.to_string());
+            entry.blocked_recovery_hint = Some(recovery_hint.to_string());
+            entry.next_attempt_at = None;
+            entry.last_run_id = None;
             entry.updated_at = Utc::now();
             store.persist(&state)?;
             Ok(())
@@ -586,6 +622,8 @@ impl StateStore {
             entry.last_error = None;
             entry.last_run_id = None;
             entry.next_attempt_at = None;
+            entry.blocked_source = None;
+            entry.blocked_recovery_hint = None;
             entry.updated_at = Utc::now();
             store.persist(&state)?;
             Ok(ResetOutcome {
@@ -636,6 +674,8 @@ impl StateStore {
             entry.last_error = None;
             entry.last_run_id = None;
             entry.next_attempt_at = None;
+            entry.blocked_source = None;
+            entry.blocked_recovery_hint = None;
             entry.generation = entry.generation.saturating_add(1);
             entry.updated_at = Utc::now();
             store.persist(&state)?;
@@ -805,7 +845,8 @@ fn load_validated_sqlite(conn: &Connection, state_dir: &Path) -> CaduceusResult<
     let mut stmt = conn
         .prepare(
             "SELECT issue_key, phase, ticket_type, attempts, last_error, last_run_id,
-                    next_attempt_at, finalization, queued_at, updated_at, generation
+                    next_attempt_at, finalization, queued_at, updated_at, generation,
+                    blocked_source, blocked_recovery_hint
              FROM queue_entries",
         )
         .map_err(|e| CaduceusError::StateCorrupt {
@@ -844,6 +885,8 @@ fn row_to_entry(row: &rusqlite::Row) -> rusqlite::Result<QueueEntry> {
     let queued_at: String = row.get(8)?;
     let updated_at: String = row.get(9)?;
     let generation: i64 = row.get(10)?;
+    let blocked_source: Option<String> = row.get(11)?;
+    let blocked_recovery_hint: Option<String> = row.get(12)?;
 
     let key = IssueKey::parse(&issue_key).map_err(|err| {
         rusqlite::Error::FromSqlConversionFailure(
@@ -912,6 +955,8 @@ fn row_to_entry(row: &rusqlite::Row) -> rusqlite::Result<QueueEntry> {
                 )
             })?,
         generation: generation.max(0) as u32,
+        blocked_source,
+        blocked_recovery_hint,
     })
 }
 
@@ -957,8 +1002,9 @@ fn persist_sqlite(conn: &Connection, state: &QueueState) -> CaduceusResult<()> {
             conn.execute(
                 "INSERT OR REPLACE INTO queue_entries
                  (issue_key, phase, ticket_type, attempts, last_error, last_run_id,
-                  next_attempt_at, finalization, queued_at, updated_at, generation)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                  next_attempt_at, finalization, queued_at, updated_at, generation,
+                  blocked_source, blocked_recovery_hint)
+                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                 params![
                     key,
                     phase,
@@ -974,6 +1020,8 @@ fn persist_sqlite(conn: &Connection, state: &QueueState) -> CaduceusResult<()> {
                     entry.queued_at.to_rfc3339(),
                     entry.updated_at.to_rfc3339(),
                     entry.generation as i64,
+                    entry.blocked_source,
+                    entry.blocked_recovery_hint,
                 ],
             )
             .map_err(|e| CaduceusError::StateCorrupt {

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -47,7 +47,13 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 /// - `oci_runs` table for per-container lifecycle state tracking.
 ///   Keyed by `run_id` with indices on `container_id`, `daemon_id`,
 ///   and `state`.
-pub const SCHEMA_VERSION: i64 = 5;
+///
+/// ## v6
+///
+/// - `queue_entries` gains `blocked_source TEXT` and
+///   `blocked_recovery_hint TEXT` columns for terminal refuse-to-
+///   operate metadata. Existing rows get NULL defaults.
+pub const SCHEMA_VERSION: i64 = 6;
 
 /// Name of the SQLite database file inside the state directory.
 pub const DB_FILENAME: &str = "state.db";
@@ -71,7 +77,9 @@ CREATE TABLE IF NOT EXISTS queue_entries (
     finalization  TEXT,
     queued_at     TEXT NOT NULL,
     updated_at    TEXT NOT NULL,
-    generation    INTEGER NOT NULL DEFAULT 1
+    generation    INTEGER NOT NULL DEFAULT 1,
+    blocked_source TEXT,
+    blocked_recovery_hint TEXT
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -203,6 +211,7 @@ pub fn open(path: &Path) -> CaduceusResult<Connection> {
             migrate_v2_to_v3(&conn, &db_path, existing_version)?;
             migrate_v3_to_v4(&conn, &db_path, existing_version)?;
             migrate_v4_to_v5(&conn, &db_path, existing_version)?;
+            migrate_v5_to_v6(&conn, &db_path, existing_version)?;
             apply_schema(&conn, &db_path)?;
             record_version(&conn, &db_path)?;
         }
@@ -332,6 +341,24 @@ fn migrate_v4_to_v5(conn: &Connection, db_path: &Path, from_version: i64) -> Cad
     // No ALTER TABLE statements are needed for v4→v5.
     let _ = conn;
     let _ = db_path;
+    Ok(())
+}
+
+/// Migrate from schema v5 to v6 by adding `blocked_source` and
+/// `blocked_recovery_hint` columns to `queue_entries`. Both columns
+/// are nullable so existing rows get NULL defaults.
+fn migrate_v5_to_v6(conn: &Connection, db_path: &Path, from_version: i64) -> CaduceusResult<()> {
+    if from_version >= 6 {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "ALTER TABLE queue_entries ADD COLUMN blocked_source TEXT;
+         ALTER TABLE queue_entries ADD COLUMN blocked_recovery_hint TEXT;",
+    )
+    .map_err(|e| CaduceusError::StateCorrupt {
+        path: db_path.to_path_buf(),
+        message: format!("v5→v6 migration failed: {e}"),
+    })?;
     Ok(())
 }
 

--- a/src/worktree/repository.rs
+++ b/src/worktree/repository.rs
@@ -151,10 +151,12 @@ pub async fn find_main_clone(
 
     if !porcelain.trim().is_empty() {
         return Err(CaduceusError::Worktree {
-            context: "discover",
+            context: "discover-dirty-main",
             stderr: format!(
-                "main checkout is dirty at {}; refusing to operate",
-                path.display()
+                "main checkout is dirty at {}; refusing to operate. Run `git -C {} status` to see what's dirty, clean it, then run `caduceus queue reset --force-finalization-reset {}` to retry.",
+                path.display(),
+                path.display(),
+                key.display_key()
             ),
         });
     }

--- a/src/worktree/worktree.rs
+++ b/src/worktree/worktree.rs
@@ -216,9 +216,10 @@ async fn create_locked(
     // prior run to leak paths.
     if let Some(foreign) = pre.foreign_worktree_dir {
         return Err(CaduceusError::Worktree {
-            context: "create",
+            context: "create-path-collision",
             stderr: format!(
-                "path collision: {} already exists under the worker's home (foreign run id)",
+                "path collision: {} already exists under the worker's home (foreign run id). Run `caduceus worktree-gc --dry-run` to inspect, then `caduceus worktree-gc`. If that does not help: `rm -rf {} && git worktree prune`.",
+                foreign.display(),
                 foreign.display()
             ),
         });

--- a/tests/daemon/awaiting_review_test.rs
+++ b/tests/daemon/awaiting_review_test.rs
@@ -53,14 +53,17 @@ fn enqueue_summaries_empty_returns_ok_none() {
 // seams in `src/daemon/tick/awaiting_review.rs` mirror the private
 // functions exactly.
 
+use caduceus::config::Config;
 use caduceus::daemon::tick::awaiting_review::{
-    exit_code_for_tests, extract_http_status_for_tests, map_phase_to_outcome_for_tests,
-    outcome_for_class_for_tests,
+    exit_code_for_tests, extract_http_status_for_tests, handle_infra_or_retry_for_tests,
+    map_phase_to_outcome_for_tests, outcome_for_class_for_tests,
 };
-use caduceus::orchestration::FailureClass;
+use caduceus::issue::IssueKey;
+use caduceus::orchestration::{classify_error, ActiveRunGuard, FailureClass};
 use caduceus::queue::Phase;
 use caduceus::state::meta::TickOutcome;
-use caduceus::CaduceusError;
+use caduceus::{queue::TicketType, CaduceusError};
+use std::sync::Arc;
 
 #[test]
 fn exit_code_for_outcome_table() {
@@ -126,4 +129,181 @@ fn extract_http_status_only_matches_github_api_variant() {
         stderr: "x".to_string(),
     };
     assert_eq!(extract_http_status_for_tests(&err), None);
+}
+
+// ---------------------------------------------------------------------------
+// Terminal / Infrastructure / Retry dispatch (issue #167)
+// ---------------------------------------------------------------------------
+
+fn cfg(tmp: &std::path::Path) -> Config {
+    Config::test_defaults(tmp)
+}
+
+fn seed_guard(
+    state_dir: &std::path::Path,
+) -> (Arc<caduceus::queue::StateStore>, IssueKey, ActiveRunGuard) {
+    let store = Arc::new(caduceus::queue::StateStore::open(state_dir).expect("open store"));
+    let key = IssueKey::parse("owner/repo#1").unwrap();
+    store
+        .enqueue(&key, TicketType::Code, false)
+        .expect("enqueue");
+    let eligible = store
+        .acquire_next("RUN-1", std::process::id(), chrono::Utc::now())
+        .expect("acquire")
+        .expect("eligible");
+    let guard = ActiveRunGuard::new(
+        eligible.claim,
+        store.clone(),
+        PathBuf::from("/dev/null"),
+        key.clone(),
+    );
+    (store, key, guard)
+}
+
+#[tokio::test]
+async fn terminal_dispatches_to_needs_attention() {
+    let state_dir = tempdir("terminal-dispatch");
+    let cfg = cfg(&state_dir);
+    let (store, key, mut guard) = seed_guard(&state_dir);
+
+    let err = CaduceusError::Worktree {
+        context: "discover-dirty-main",
+        stderr: "main checkout is dirty at /tmp/repo; run `caduceus queue reset ...`".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Terminal);
+
+    let outcome = handle_infra_or_retry_for_tests(cfg, &mut guard, &err, class)
+        .await
+        .expect("dispatch");
+    assert_eq!(outcome, TickOutcome::Failed);
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::NeedsAttention);
+    assert!(entry
+        .last_error
+        .as_deref()
+        .unwrap()
+        .contains("main checkout is dirty"));
+    assert_eq!(entry.blocked_source.as_deref(), Some("worktree/dirty_main"));
+    assert!(entry
+        .blocked_recovery_hint
+        .as_deref()
+        .unwrap()
+        .contains("caduceus queue reset"));
+    assert!(entry.last_run_id.is_none());
+    assert!(entry.next_attempt_at.is_none());
+}
+
+#[tokio::test]
+async fn infrastructure_still_requeues_with_backoff() {
+    let state_dir = tempdir("infra-requeue");
+    let cfg = cfg(&state_dir);
+    let (store, key, mut guard) = seed_guard(&state_dir);
+
+    let err = CaduceusError::GitHubApi {
+        status: 500,
+        message: "GitHub transport error".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Infrastructure);
+
+    let outcome = handle_infra_or_retry_for_tests(cfg, &mut guard, &err, class)
+        .await
+        .expect("dispatch");
+    assert_eq!(outcome, TickOutcome::Failed);
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::Queued);
+    assert!(entry.next_attempt_at.is_some());
+    assert!(entry.blocked_source.is_none());
+    assert!(entry.blocked_recovery_hint.is_none());
+}
+
+#[tokio::test]
+async fn terminal_path_collision_dispatches_to_needs_attention() {
+    let state_dir = tempdir("terminal-path-collision");
+    let cfg = cfg(&state_dir);
+    let (store, key, mut guard) = seed_guard(&state_dir);
+
+    let err = CaduceusError::Worktree {
+        context: "create-path-collision",
+        stderr: "path collision: /tmp/repo/.worktrees/foreign already exists under the worker's home (foreign run id). Run `caduceus worktree-gc --dry-run` to inspect, then `caduceus worktree-gc`. If that does not help: `rm -rf /tmp/repo/.worktrees/foreign && git worktree prune`.".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Terminal);
+
+    let outcome = handle_infra_or_retry_for_tests(cfg, &mut guard, &err, class)
+        .await
+        .expect("dispatch");
+    assert_eq!(outcome, TickOutcome::Failed);
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::NeedsAttention);
+    assert!(entry
+        .last_error
+        .as_deref()
+        .unwrap()
+        .contains("path collision"));
+    assert_eq!(
+        entry.blocked_source.as_deref(),
+        Some("worktree/path_collision")
+    );
+    assert!(entry
+        .blocked_recovery_hint
+        .as_deref()
+        .unwrap()
+        .contains("caduceus worktree-gc"));
+    assert!(entry.last_run_id.is_none());
+    assert!(entry.next_attempt_at.is_none());
+}
+
+#[tokio::test]
+async fn needs_attention_maps_to_failed() {
+    let state_dir = tempdir("needs-attention-maps");
+    let cfg = cfg(&state_dir);
+    let (store, key, mut guard) = seed_guard(&state_dir);
+
+    let err = CaduceusError::Queue {
+        context: "claim-terminal-mismatch",
+        stderr: "claim does not match; run `caduceus queue reprocess ...`".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Terminal);
+
+    let outcome = handle_infra_or_retry_for_tests(cfg, &mut guard, &err, class)
+        .await
+        .expect("dispatch");
+    assert_eq!(outcome, TickOutcome::Failed);
+    assert_eq!(
+        map_phase_to_outcome_for_tests(Phase::NeedsAttention),
+        TickOutcome::Failed
+    );
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::NeedsAttention);
+    assert_eq!(
+        entry.blocked_source.as_deref(),
+        Some("queue/claim_mismatch")
+    );
 }

--- a/tests/daemon/orchestration_active_run_inline_test.rs
+++ b/tests/daemon/orchestration_active_run_inline_test.rs
@@ -16,7 +16,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use tempfile::TempDir;
-use tracing_subscriber::prelude::*;
 
 fn cfg() -> Config {
     Config::test_defaults(std::path::Path::new("/tmp"))
@@ -676,6 +675,7 @@ async fn finish_retry_transitions_to_failed_when_budget_exhausted() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+#[serial_test::serial]
 async fn finish_needs_attention_routes_to_blocked_state_and_releases_claim() {
     let budget = 3;
     let (_temp, store, key, mut guard, worktree_path) =
@@ -716,40 +716,41 @@ async fn finish_needs_attention_routes_to_blocked_state_and_releases_claim() {
     assert!(entry.next_attempt_at.is_none());
 }
 
-#[derive(Clone)]
-struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
-
-impl std::io::Write for CaptureWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
-    type Writer = Self;
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
-    }
-}
-
 #[test]
+#[serial_test::serial]
 fn finish_needs_attention_emits_stable_terminal_block_event() {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime");
-    let capture = CaptureWriter(std::sync::Arc::new(std::sync::Mutex::new(Vec::new())));
-    let layer = tracing_subscriber::fmt::layer()
-        .json()
-        .with_writer(capture.clone());
-    let subscriber = tracing_subscriber::registry().with(layer);
+    // Capture via `tracing_appender::non_blocking` + a real temp file,
+    // the same pattern `logging_test.rs` proves reliable. The serial
+    // attribute matches that file's convention for tracing-capture
+    // tests. Both tests that exercise `finish_needs_attention` (this
+    // one and `finish_needs_attention_routes_to_blocked_state_and_releases_claim`)
+    // are serial because `tracing_core` caches callsite interest: if
+    // the sibling runs first without a subscriber installed, the
+    // `caduceus.terminal_block` callsite is cached as never-enabled and
+    // this test's event is silently dropped before reaching its capture
+    // subscriber (empty capture under `--test-threads>=2`).
+    let root = std::env::temp_dir().join(format!(
+        "caduceus-167-capture-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).expect("create tempdir");
+    let log_path = root.join("capture.json");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = caduceus::logging::build_test_subscriber(writer);
 
     tracing::subscriber::with_default(subscriber, || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
         rt.block_on(async {
             let budget = 3;
             let (_temp, store, key, mut guard, _worktree_path) =
@@ -773,8 +774,9 @@ fn finish_needs_attention_emits_stable_terminal_block_event() {
             assert_eq!(entry.phase, Phase::NeedsAttention);
         });
     });
+    drop(guard); // flush pending events + shut down the writer thread
 
-    let body = String::from_utf8(capture.0.lock().unwrap().clone()).expect("utf-8");
+    let body = std::fs::read_to_string(&log_path).expect("read capture");
     assert!(
         body.contains("\"event\":\"caduceus.terminal_block\""),
         "stable event missing: {body}"

--- a/tests/daemon/orchestration_active_run_inline_test.rs
+++ b/tests/daemon/orchestration_active_run_inline_test.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use tempfile::TempDir;
+use tracing_subscriber::prelude::*;
 
 fn cfg() -> Config {
     Config::test_defaults(std::path::Path::new("/tmp"))
@@ -668,4 +669,126 @@ async fn finish_retry_transitions_to_failed_when_budget_exhausted() {
     assert_eq!(entry.phase, Phase::Failed);
     assert_eq!(entry.attempts, budget);
     assert!(entry.next_attempt_at.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// finish_needs_attention terminal-block tests (issue #167)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn finish_needs_attention_routes_to_blocked_state_and_releases_claim() {
+    let budget = 3;
+    let (_temp, store, key, mut guard, worktree_path) =
+        seed_in_progress_with_worktree(0, budget).await;
+
+    let digest = guard.claim().digest().to_string();
+    let claim_path = store.claims_dir().join(format!("{digest}.claim"));
+    assert!(claim_path.is_file(), "claim file must exist before finish");
+
+    guard
+        .finish_needs_attention(
+            "main checkout is dirty",
+            "worktree/dirty_main",
+            "caduceus queue reset --force-finalization-reset owner/repo#7",
+        )
+        .await
+        .expect("finish needs attention");
+
+    // The attached worktree is torn down and the claim is released
+    // after the transition so a later reset is not blocked.
+    assert!(!worktree_path.exists(), "worktree path should be removed");
+    assert!(!claim_path.exists(), "claim file should be removed");
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::NeedsAttention);
+    assert_eq!(entry.last_error.as_deref(), Some("main checkout is dirty"));
+    assert_eq!(entry.blocked_source.as_deref(), Some("worktree/dirty_main"));
+    assert_eq!(
+        entry.blocked_recovery_hint.as_deref(),
+        Some("caduceus queue reset --force-finalization-reset owner/repo#7")
+    );
+    assert!(entry.last_run_id.is_none());
+    assert!(entry.next_attempt_at.is_none());
+}
+
+#[derive(Clone)]
+struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = Self;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[test]
+fn finish_needs_attention_emits_stable_terminal_block_event() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let capture = CaptureWriter(std::sync::Arc::new(std::sync::Mutex::new(Vec::new())));
+    let layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(capture.clone());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        rt.block_on(async {
+            let budget = 3;
+            let (_temp, store, key, mut guard, _worktree_path) =
+                seed_in_progress_with_worktree(0, budget).await;
+
+            guard
+                .finish_needs_attention(
+                    "main checkout is dirty",
+                    "worktree/dirty_main",
+                    "caduceus queue reset --force-finalization-reset octocat/hello-world#7",
+                )
+                .await
+                .expect("finish needs attention");
+
+            let entry = store
+                .snapshot()
+                .expect("snapshot")
+                .entry(&key)
+                .expect("entry")
+                .clone();
+            assert_eq!(entry.phase, Phase::NeedsAttention);
+        });
+    });
+
+    let body = String::from_utf8(capture.0.lock().unwrap().clone()).expect("utf-8");
+    assert!(
+        body.contains("\"event\":\"caduceus.terminal_block\""),
+        "stable event missing: {body}"
+    );
+    assert!(
+        body.contains("\"issue_key\":\"octocat/hello-world#7\""),
+        "got: {body}"
+    );
+    assert!(
+        body.contains("\"source\":\"worktree/dirty_main\""),
+        "got: {body}"
+    );
+    assert!(
+        body.contains("caduceus queue reset --force-finalization-reset"),
+        "got: {body}"
+    );
 }

--- a/tests/daemon/per_claim_test.rs
+++ b/tests/daemon/per_claim_test.rs
@@ -157,6 +157,8 @@ fn build_entry(finalization: Option<FinalizationCheckpoint>) -> QueueEntry {
         finalization,
         queued_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     }
 }

--- a/tests/daemon/signal_test.rs
+++ b/tests/daemon/signal_test.rs
@@ -118,6 +118,8 @@ fn seed_queued(state_dir: &Path, k: &IssueKey) {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(k.display_key(), e);

--- a/tests/daemon/status_test.rs
+++ b/tests/daemon/status_test.rs
@@ -383,6 +383,45 @@ fn build_report_from_state_handles_synthetic_snapshot() {
 }
 
 #[test]
+fn report_surfaces_blocked_metadata_for_needs_attention() {
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    let now = Utc::now();
+    let mut state = QueueState::empty();
+    let mut blocked = entry(now, Phase::NeedsAttention, None);
+    blocked.last_error = Some("main checkout is dirty".to_string());
+    blocked.blocked_source = Some("worktree/dirty_main".to_string());
+    blocked.blocked_recovery_hint =
+        Some("caduceus queue reset --force-finalization-reset owner/repo#1".to_string());
+    state.entries.insert("owner/repo#1".to_string(), blocked);
+    let meta = StateMeta {
+        version: caduceus::meta::META_VERSION,
+        last_tick_started: None,
+        last_tick_finished: None,
+        last_outcome: None,
+        last_http_status: None,
+        next_allowed_poll_at: None,
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let report = build_report_from_state(&cfg.state_dir, &meta, &state);
+    let out = render_human(&report, None);
+    assert!(
+        out.contains("blocked: source = worktree/dirty_main"),
+        "human output missing blocked source: {out}"
+    );
+    assert!(
+        out.contains(
+            "blocked: recovery = caduceus queue reset --force-finalization-reset owner/repo#1"
+        ),
+        "human output missing recovery hint: {out}"
+    );
+}
+
+#[test]
 fn render_human_includes_transcript_for_live_workers() {
     let dir = tempdir().expect("tempdir");
     let cfg = empty_config(dir.path());
@@ -418,6 +457,8 @@ fn entry(_now: DateTime<Utc>, phase: Phase, next_attempt_at: Option<DateTime<Utc
         last_run_id: None,
         next_attempt_at,
         finalization: None,
+        blocked_source: None,
+        blocked_recovery_hint: None,
         queued_at: _now,
         updated_at: _now,
         generation: 1,

--- a/tests/daemon/status_test.rs
+++ b/tests/daemon/status_test.rs
@@ -54,7 +54,9 @@ fn empty_config(state_dir: &Path) -> Config {
 
 #[test]
 fn schema_version_is_pinned() {
-    assert_eq!(STATUS_SCHEMA_VERSION, "7.5.0");
+    // The 7.6.0 bump lands the `blocked_issues` field on
+    // `StatusReport` — see `src/daemon/status.rs`.
+    assert_eq!(STATUS_SCHEMA_VERSION, "7.6.0");
 }
 
 #[test]
@@ -419,6 +421,278 @@ fn report_surfaces_blocked_metadata_for_needs_attention() {
         ),
         "human output missing recovery hint: {out}"
     );
+}
+
+#[test]
+fn human_renders_blocked_issues_section_for_needs_attention() {
+    // The dedicated `blocked issues:` section is the
+    // AC5 deliverable: a separate surface from
+    // `recent errors:` carrying the issue key, stable
+    // source tag, reason, and recovery command. This
+    // test pins the exact bytes of that section.
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    let now = Utc::now();
+    let mut state = QueueState::empty();
+    let mut blocked = entry(now, Phase::NeedsAttention, None);
+    blocked.last_error = Some("main checkout is dirty".to_string());
+    blocked.blocked_source = Some("worktree/dirty_main".to_string());
+    blocked.blocked_recovery_hint =
+        Some("caduceus queue reset --force-finalization-reset owner/repo#1".to_string());
+    state.entries.insert("owner/repo#1".to_string(), blocked);
+    let meta = StateMeta {
+        version: caduceus::meta::META_VERSION,
+        last_tick_started: None,
+        last_tick_finished: None,
+        last_outcome: None,
+        last_http_status: None,
+        next_allowed_poll_at: None,
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let report = build_report_from_state(&cfg.state_dir, &meta, &state);
+    let out = render_human(&report, None);
+    // Pin the exact bytes of the dedicated section —
+    // header line plus four per-entry attribute lines.
+    // The order is key, source, reason, recovery.
+    let expected_section = "  blocked issues:\n    - owner/repo#1\n      source: worktree/dirty_main\n      reason: main checkout is dirty\n      recovery: caduceus queue reset --force-finalization-reset owner/repo#1\n";
+    assert!(
+        out.contains(expected_section),
+        "human output missing blocked issues section; full output:\n{out}"
+    );
+    // The dedicated section sits between `live workers`
+    // and `recent errors:` per the design ordering — pin
+    // that placement too so a future reorder is caught.
+    let live_idx = out
+        .find("live workers:")
+        .expect("live workers section in human output");
+    let blocked_idx = out
+        .find("blocked issues:")
+        .expect("blocked issues section in human output");
+    let recent_idx = out
+        .find("recent errors:")
+        .expect("recent errors section in human output");
+    assert!(
+        live_idx < blocked_idx && blocked_idx < recent_idx,
+        "blocked issues section must render between live workers and recent errors; live={live_idx} blocked={blocked_idx} recent={recent_idx}"
+    );
+}
+
+#[test]
+fn human_omits_blocked_issues_section_when_empty() {
+    // An empty `blocked_issues` list must not render
+    // the section header — operators should not see a
+    // stub heading on healthy state.
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    let state = QueueState::empty();
+    let meta = StateMeta {
+        version: caduceus::meta::META_VERSION,
+        last_tick_started: None,
+        last_tick_finished: None,
+        last_outcome: None,
+        last_http_status: None,
+        next_allowed_poll_at: None,
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let report = build_report_from_state(&cfg.state_dir, &meta, &state);
+    let out = render_human(&report, None);
+    assert!(
+        !out.contains("blocked issues"),
+        "human output should not include blocked issues section when empty; full output:\n{out}"
+    );
+}
+
+#[test]
+fn human_omits_needs_attention_without_block_metadata_from_section() {
+    // A `NeedsAttention` entry without typed block
+    // metadata (legacy state, or an entry routed via a
+    // non-terminal path) must not appear in the
+    // dedicated section — `collect_blocked_issues`
+    // filters those out because the source/hint
+    // contract cannot be honoured.
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    let now = Utc::now();
+    let mut state = QueueState::empty();
+    let mut legacy = entry(now, Phase::NeedsAttention, None);
+    legacy.last_error = Some("needs operator review".to_string());
+    // Intentionally leave blocked_source and
+    // blocked_recovery_hint as None.
+    state.entries.insert("owner/repo#2".to_string(), legacy);
+    let meta = StateMeta {
+        version: caduceus::meta::META_VERSION,
+        last_tick_started: None,
+        last_tick_finished: None,
+        last_outcome: None,
+        last_http_status: None,
+        next_allowed_poll_at: None,
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let report = build_report_from_state(&cfg.state_dir, &meta, &state);
+    let out = render_human(&report, None);
+    assert!(
+        !out.contains("blocked issues"),
+        "human output should not include blocked issues section when entry lacks metadata; full output:\n{out}"
+    );
+}
+
+#[test]
+fn json_carries_blocked_issues_array_with_entries() {
+    // The 7.6.0 schema adds a `blocked_issues` array on
+    // the JSON contract. Each element carries
+    // `issue_key`, `blocked_source`,
+    // `blocked_recovery_hint`, and `last_error`.
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    let now = Utc::now();
+    let mut state = QueueState::empty();
+    let mut blocked = entry(now, Phase::NeedsAttention, None);
+    blocked.last_error = Some("main checkout is dirty".to_string());
+    blocked.blocked_source = Some("worktree/dirty_main".to_string());
+    blocked.blocked_recovery_hint =
+        Some("caduceus queue reset --force-finalization-reset owner/repo#1".to_string());
+    state.entries.insert("owner/repo#1".to_string(), blocked);
+    let meta = StateMeta {
+        version: caduceus::meta::META_VERSION,
+        last_tick_started: None,
+        last_tick_finished: None,
+        last_outcome: None,
+        last_http_status: None,
+        next_allowed_poll_at: None,
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let report = build_report_from_state(&cfg.state_dir, &meta, &state);
+    let json = render_json(&report).expect("json");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    let arr = parsed["blocked_issues"]
+        .as_array()
+        .expect("blocked_issues is array");
+    assert_eq!(arr.len(), 1, "expected one blocked entry, got: {json}");
+    let blocked = &arr[0];
+    assert_eq!(blocked["issue_key"].as_str(), Some("owner/repo#1"));
+    assert_eq!(
+        blocked["blocked_source"].as_str(),
+        Some("worktree/dirty_main")
+    );
+    assert_eq!(
+        blocked["blocked_recovery_hint"].as_str(),
+        Some("caduceus queue reset --force-finalization-reset owner/repo#1")
+    );
+    assert_eq!(
+        blocked["last_error"].as_str(),
+        Some("main checkout is dirty")
+    );
+    // Schema version reflects the bump.
+    assert_eq!(
+        parsed["version"].as_str(),
+        Some(STATUS_SCHEMA_VERSION),
+        "schema version must reflect the 7.6.0 bump"
+    );
+}
+
+#[test]
+fn json_carries_empty_blocked_issues_array_when_no_entries() {
+    // Empty blocked_issues must serialise as an empty
+    // array (not be omitted) — the field is additive on
+    // the JSON contract and consumers should always be
+    // able to read it.
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    let state = QueueState::empty();
+    let meta = StateMeta {
+        version: caduceus::meta::META_VERSION,
+        last_tick_started: None,
+        last_tick_finished: None,
+        last_outcome: None,
+        last_http_status: None,
+        next_allowed_poll_at: None,
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let report = build_report_from_state(&cfg.state_dir, &meta, &state);
+    let json = render_json(&report).expect("json");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    let arr = parsed["blocked_issues"]
+        .as_array()
+        .expect("blocked_issues is array");
+    assert!(
+        arr.is_empty(),
+        "expected empty blocked_issues array; got: {json}"
+    );
+}
+
+#[test]
+fn json_blocked_issues_orders_entries_by_issue_key() {
+    // The `collect_blocked_issues` helper sorts by
+    // `issue_key` for deterministic output. Insert two
+    // entries out of order and assert the JSON array
+    // surfaces them in lexical display-key order.
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    let now = Utc::now();
+    let mut state = QueueState::empty();
+
+    let mut zeta = entry(now, Phase::NeedsAttention, None);
+    zeta.key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "repo".to_string(),
+        number: 9,
+    };
+    zeta.last_error = Some("zeta".to_string());
+    zeta.blocked_source = Some("worktree/dirty_main".to_string());
+    zeta.blocked_recovery_hint = Some("recovery zeta".to_string());
+    state.entries.insert("owner/repo#9".to_string(), zeta);
+
+    let mut alpha = entry(now, Phase::NeedsAttention, None);
+    alpha.key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "repo".to_string(),
+        number: 1,
+    };
+    alpha.last_error = Some("alpha".to_string());
+    alpha.blocked_source = Some("worktree/path_collision".to_string());
+    alpha.blocked_recovery_hint = Some("recovery alpha".to_string());
+    state.entries.insert("owner/repo#1".to_string(), alpha);
+
+    let meta = StateMeta {
+        version: caduceus::meta::META_VERSION,
+        last_tick_started: None,
+        last_tick_finished: None,
+        last_outcome: None,
+        last_http_status: None,
+        next_allowed_poll_at: None,
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let report = build_report_from_state(&cfg.state_dir, &meta, &state);
+    let json = render_json(&report).expect("json");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    let arr = parsed["blocked_issues"].as_array().expect("array");
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0]["issue_key"].as_str(), Some("owner/repo#1"));
+    assert_eq!(arr[1]["issue_key"].as_str(), Some("owner/repo#9"));
 }
 
 #[test]

--- a/tests/fixtures/scenario-10-golden.json
+++ b/tests/fixtures/scenario-10-golden.json
@@ -1,5 +1,5 @@
 {
-  "schema_version_after_open": 5,
-  "schema_version_again": 5,
+  "schema_version_after_open": 6,
+  "schema_version_again": 6,
   "oci_runs_table_exists": true
 }

--- a/tests/github/dry_run_test.rs
+++ b/tests/github/dry_run_test.rs
@@ -138,6 +138,8 @@ fn make_entry(key: IssueKey, phase: Phase) -> QueueEntry {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     }
 }

--- a/tests/infra/error_classify_test.rs
+++ b/tests/infra/error_classify_test.rs
@@ -1,0 +1,89 @@
+//! Tests for refuse-to-operate error classification.
+//!
+//! The three reserved `context` tags on `CaduceusError::Worktree` and
+//! `CaduceusError::Queue` must classify as `FailureClass::Terminal`;
+//! everything else stays `Infrastructure` (or its existing class).
+
+use caduceus::orchestration::{classify_error, failure_class_predicates_for_tests, FailureClass};
+use caduceus::CaduceusError;
+
+#[test]
+fn terminal_for_dirty_main() {
+    let err = CaduceusError::Worktree {
+        context: "discover-dirty-main",
+        stderr: "main checkout is dirty".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Terminal);
+    assert!(class.is_terminal());
+    assert!(!class.counts_against_retry_budget());
+}
+
+#[test]
+fn terminal_for_path_collision() {
+    let err = CaduceusError::Worktree {
+        context: "create-path-collision",
+        stderr: "path collision".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Terminal);
+    assert!(class.is_terminal());
+    assert!(!class.counts_against_retry_budget());
+}
+
+#[test]
+fn terminal_for_claim_mismatch() {
+    let err = CaduceusError::Queue {
+        context: "claim-terminal-mismatch",
+        stderr: "claim mismatch".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Terminal);
+    assert!(class.is_terminal());
+    assert!(!class.counts_against_retry_budget());
+}
+
+#[test]
+fn infrastructure_still_infrastructure() {
+    // Unrelated Worktree/Queue contexts remain Infrastructure.
+    let worktree_other = CaduceusError::Worktree {
+        context: "create",
+        stderr: "generic worktree failure".to_string(),
+    };
+    assert_eq!(
+        classify_error(&worktree_other),
+        FailureClass::Infrastructure
+    );
+
+    let git_error = CaduceusError::Git {
+        operation: "fetch",
+        stderr: "network unreachable".to_string(),
+    };
+    assert_eq!(classify_error(&git_error), FailureClass::Infrastructure);
+}
+
+#[test]
+fn terminal_predicates_match_existing_classes() {
+    // Worker still counts against budget; RateLimit/Cancellation still have
+    // their dedicated predicates; Infrastructure and Terminal do not.
+    assert_eq!(
+        failure_class_predicates_for_tests(FailureClass::Terminal),
+        (false, false, false)
+    );
+    assert_eq!(
+        failure_class_predicates_for_tests(FailureClass::Infrastructure),
+        (false, false, false)
+    );
+    assert_eq!(
+        failure_class_predicates_for_tests(FailureClass::Worker),
+        (true, false, false)
+    );
+    assert_eq!(
+        failure_class_predicates_for_tests(FailureClass::RateLimit { reset_at: 0 }),
+        (false, true, false)
+    );
+    assert_eq!(
+        failure_class_predicates_for_tests(FailureClass::Cancellation),
+        (false, false, true)
+    );
+}

--- a/tests/integration/failure_matrix_test.rs
+++ b/tests/integration/failure_matrix_test.rs
@@ -603,6 +603,8 @@ fn test_finalization_unavailable_lookup_remains_pending() {
         finalization: None,
         queued_at: Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap(),
         updated_at: Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     let mut entries = BTreeMap::new();

--- a/tests/integration/integration_scenarios.rs
+++ b/tests/integration/integration_scenarios.rs
@@ -747,6 +747,8 @@ async fn test_scenario_7_finalization_awaiting_review_entry() {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(key.clone(), entry);
@@ -896,11 +898,11 @@ async fn test_scenario_9_config_bootstrap_cadence_default() {
 // We don't drive this through `caduceus run` because the
 // schema migration lives in `caduceus migrate-state`. We
 // invoke that subcommand and assert the migration is a
-// no-op when the database is already at v5.
+// no-op when the database is already at v6.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_scenario_10_schema_migration_v4_to_v5_idempotent() {
+async fn test_scenario_10_schema_migration_v5_to_v6_idempotent() {
     use caduceus::state::store::{open_in, SCHEMA_VERSION};
 
     let state = IsolatedState::new("http://127.0.0.1:1".to_string());
@@ -918,7 +920,7 @@ async fn test_scenario_10_schema_migration_v4_to_v5_idempotent() {
         v_after_open, SCHEMA_VERSION,
         "fresh DB must be at SCHEMA_VERSION"
     );
-    assert_eq!(v_after_open, 5, "v5 is the canonical current schema");
+    assert_eq!(v_after_open, 6, "v6 is the canonical current schema");
 
     // Second open: idempotent — no migration, schema_version
     // table is unchanged, oci_runs table still exists.
@@ -936,8 +938,8 @@ async fn test_scenario_10_schema_migration_v4_to_v5_idempotent() {
         )
         .expect("query oci_runs");
     drop(conn2);
-    assert_eq!(v_again, 5, "second open must remain v5 (idempotent)");
-    assert_eq!(oci_runs_count, 1, "oci_runs table must exist at v5");
+    assert_eq!(v_again, 6, "second open must remain v6 (idempotent)");
+    assert_eq!(oci_runs_count, 1, "oci_runs table must exist at v6");
 
     let observed = serde_json::json!({
         "schema_version_after_open": v_after_open,

--- a/tests/integration/integration_test.rs
+++ b/tests/integration/integration_test.rs
@@ -250,6 +250,8 @@ impl IsolatedState {
             finalization: None,
             queued_at: Utc::now(),
             updated_at: Utc::now(),
+            blocked_source: None,
+            blocked_recovery_hint: None,
             generation: 1,
         };
         entries.insert(k.clone(), entry);

--- a/tests/integration/release_canary_test.rs
+++ b/tests/integration/release_canary_test.rs
@@ -367,6 +367,8 @@ fn seed_queued(state_dir: &Path) -> String {
         finalization: None,
         queued_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(key.clone(), entry);

--- a/tests/repo/repository_discovery_test.rs
+++ b/tests/repo/repository_discovery_test.rs
@@ -423,6 +423,10 @@ async fn find_main_clone_rejects_dirty_main_checkout() {
         .unwrap_err();
     let text = format!("{err:?}");
     assert!(text.contains("dirty"), "got: {text}");
+    assert!(
+        text.contains("caduceus queue reset --force-finalization-reset octocat/hello-world#1"),
+        "recovery command missing: {text}"
+    );
 }
 
 #[tokio::test]
@@ -477,6 +481,10 @@ async fn find_main_clone_rejects_lock_when_a_worktree_subdir_is_registered() {
         .unwrap_err();
     let text = format!("{err:?}");
     assert!(text.contains("dirty"), "got: {text}");
+    assert!(
+        text.contains("caduceus queue reset --force-finalization-reset octocat/hello-world#1"),
+        "recovery command missing: {text}"
+    );
 }
 
 #[tokio::test]
@@ -500,6 +508,10 @@ async fn find_main_clone_rejects_nonempty_lock() {
         .unwrap_err();
     let text = format!("{err:?}");
     assert!(text.contains("dirty"), "got: {text}");
+    assert!(
+        text.contains("caduceus queue reset --force-finalization-reset octocat/hello-world#1"),
+        "recovery command missing: {text}"
+    );
 }
 
 #[tokio::test]

--- a/tests/repo/worktree_create_test.rs
+++ b/tests/repo/worktree_create_test.rs
@@ -499,6 +499,10 @@ async fn create_returns_collision_when_path_owned_by_foreign_run_id() {
         "got: {text}"
     );
     assert!(
+        text.contains("caduceus worktree-gc"),
+        "recovery command missing: {text}"
+    );
+    assert!(
         !dest.join(".worktrees").join(".lock").exists(),
         ".worktrees/.lock must be removed after path collision error"
     );

--- a/tests/state/claim_test.rs
+++ b/tests/state/claim_test.rs
@@ -59,6 +59,8 @@ fn seed_entry(owner: &str, repo: &str, number: u64) -> QueueEntry {
         last_run_id: None,
         next_attempt_at: None,
         finalization: None,
+        blocked_source: None,
+        blocked_recovery_hint: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
         generation: 1,
@@ -423,6 +425,35 @@ fn fifo_dispatch_across_multiple_acquires() {
     assert_eq!(c1.entry.key, key("Owner", "Repo", 1));
     assert_eq!(c2.entry.key, key("Owner", "Repo", 2));
     assert_eq!(c3.entry.key, key("Owner", "Repo", 3));
+}
+
+// Recovery-hint contract for stale claim tokens
+
+#[test]
+fn claim_mismatch_includes_recovery_command() {
+    let root = tempdir("claim-mismatch-recovery");
+    let store = Arc::new(StateStore::open(&root).expect("open"));
+    enqueue(&store, &key("Owner", "Repo", 1));
+    let now = Utc::now();
+    let claimed = store
+        .acquire_next("RUN-1", 1, now)
+        .expect("acquire")
+        .expect("claimed");
+    let bad = ClaimToken::for_test(
+        store.claims_dir(),
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "RUN-BOGUS",
+    );
+    let err = store
+        .set_worktree(&bad, PathBuf::from("/tmp/bogus").as_path())
+        .expect_err("stale token must be rejected");
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("caduceus queue reprocess <issue>"),
+        "recovery command missing: {text}"
+    );
+    // The matched claim is unaffected by the rejected operation.
+    assert_eq!(claimed.entry.key, key("Owner", "Repo", 1));
 }
 
 // Sanity: tick + claim interleaving

--- a/tests/state/config_bootstrap_test.rs
+++ b/tests/state/config_bootstrap_test.rs
@@ -500,10 +500,13 @@ fn raw_env_from_process_env_handles_unset_vars() {
 // StatusReport: schema version bump
 
 #[test]
-fn status_schema_version_bumped_to_7_5_0() {
+fn status_schema_version_bumped_to_7_6_0() {
+    // 7.6.0 lands the `blocked_issues` field on
+    // `StatusReport` for the AC5 dedicated surface; the
+    // previous bump (7.5.0) added `pool_state`.
     assert_eq!(
         caduceus::status::STATUS_SCHEMA_VERSION,
-        "7.5.0",
-        "schema version should be 7.5.0 for the pool_state field"
+        "7.6.0",
+        "schema version should be 7.6.0 for the blocked_issues field"
     );
 }

--- a/tests/state/lifecycle_matrix_test.rs
+++ b/tests/state/lifecycle_matrix_test.rs
@@ -63,6 +63,8 @@ fn sample_entry(phase: Phase) -> QueueEntry {
         finalization: None,
         queued_at: Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap(),
         updated_at: Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     }
 }

--- a/tests/state/migration_test.rs
+++ b/tests/state/migration_test.rs
@@ -37,7 +37,7 @@ use caduceus::error::CaduceusError;
 use caduceus::issue::IssueKey;
 use caduceus::migrate::{run as migrate_run, MigrationOutcome};
 use caduceus::queue::{
-    parse_queue_state, serialize_queue_state, DaemonLock, Phase, QueueState, StateStore,
+    parse_queue_state, serialize_queue_state, DaemonLock, Phase, QueueEntry, QueueState, StateStore,
 };
 use chrono::{TimeZone, Utc};
 use tempfile::TempDir;
@@ -283,6 +283,8 @@ fn already_current_state_is_idempotent_no_op() {
             queued_at: Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap(),
             generation: 1,
+            blocked_source: None,
+            blocked_recovery_hint: None,
         },
     );
     fs::write(
@@ -360,6 +362,8 @@ fn recovery_validates_supplied_file_under_daemon_lock_and_clears_marker() {
             queued_at: Utc.with_ymd_and_hms(2026, 7, 14, 0, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 7, 14, 0, 0, 0).unwrap(),
             generation: 1,
+            blocked_source: None,
+            blocked_recovery_hint: None,
         },
     );
     fs::write(&repaired, serialize_queue_state(&state).unwrap()).unwrap();
@@ -450,6 +454,8 @@ fn recovery_refuses_when_corrupt_original_cannot_be_archived() {
             queued_at: Utc.with_ymd_and_hms(2026, 7, 14, 0, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 7, 14, 0, 0, 0).unwrap(),
             generation: 1,
+            blocked_source: None,
+            blocked_recovery_hint: None,
         },
     );
     fs::write(&repaired, serialize_queue_state(&state).unwrap()).unwrap();
@@ -497,4 +503,63 @@ impl Drop for ReadonlyRestore {
             let _ = fs::set_permissions(&self.path, perms);
         }
     }
+}
+
+// Backwards compatibility for additive queue fields.
+
+#[test]
+fn old_queue_entry_json_deserializes_block_fields_to_none() {
+    // A raw v1 JSON payload that predates the terminal-block fields.
+    // `#[serde(deny_unknown_fields)]` on `QueueEntry` means unknown
+    // fields would still fail; the new fields are additive and default.
+    let json = r#"{
+        "key": {"owner": "owner", "repo": "repo", "number": 1},
+        "phase": "queued",
+        "ticket_type": "code",
+        "attempts": 0,
+        "last_error": null,
+        "last_run_id": null,
+        "next_attempt_at": null,
+        "finalization": null,
+        "queued_at": "2026-07-01T00:00:00Z",
+        "updated_at": "2026-07-01T00:00:00Z",
+        "generation": 1
+    }"#;
+
+    let entry: QueueEntry = serde_json::from_str(json).expect("deserialize old JSON");
+    assert!(entry.blocked_source.is_none());
+    assert!(entry.blocked_recovery_hint.is_none());
+    assert_eq!(entry.phase, Phase::Queued);
+}
+
+#[test]
+fn queue_entry_round_trip_preserves_block_fields() {
+    let key = IssueKey::parse("owner/repo#7").unwrap();
+    let mut entry = caduceus::queue::QueueEntry {
+        key: key.clone(),
+        phase: Phase::NeedsAttention,
+        ticket_type: caduceus::queue::TicketType::Code,
+        attempts: 0,
+        last_error: Some("blocked".to_string()),
+        last_run_id: None,
+        next_attempt_at: None,
+        finalization: None,
+        queued_at: Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap(),
+        generation: 1,
+        blocked_source: Some("worktree/dirty_main".to_string()),
+        blocked_recovery_hint: Some("caduceus queue reset owner/repo#7".to_string()),
+    };
+
+    let serialized = serde_json::to_string(&entry).expect("serialize");
+    let deserialized: QueueEntry = serde_json::from_str(&serialized).expect("deserialize");
+    assert_eq!(deserialized, entry);
+
+    // Resetting the block fields is the recovery path.
+    entry.blocked_source = None;
+    entry.blocked_recovery_hint = None;
+    let serialized = serde_json::to_string(&entry).expect("serialize");
+    let deserialized: QueueEntry = serde_json::from_str(&serialized).expect("deserialize");
+    assert!(deserialized.blocked_source.is_none());
+    assert!(deserialized.blocked_recovery_hint.is_none());
 }

--- a/tests/state/queue_model_test.rs
+++ b/tests/state/queue_model_test.rs
@@ -42,6 +42,8 @@ fn sample_entry() -> QueueEntry {
         finalization: None,
         queued_at: Utc.with_ymd_and_hms(2026, 7, 13, 14, 0, 0).unwrap(),
         updated_at: Utc.with_ymd_and_hms(2026, 7, 13, 14, 0, 0).unwrap(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     }
 }

--- a/tests/state/queue_reset_cli_test.rs
+++ b/tests/state/queue_reset_cli_test.rs
@@ -68,6 +68,8 @@ fn seed_failed(state_dir: &Path, k: &IssueKey, attempts: u32) {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(k.display_key(), e);
@@ -93,6 +95,8 @@ fn seed_skipped(state_dir: &Path, k: &IssueKey) {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(k.display_key(), e);
@@ -118,6 +122,8 @@ fn seed_queued(state_dir: &Path, k: &IssueKey) {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(k.display_key(), e);
@@ -152,6 +158,8 @@ fn seed_failed_with_checkpoint(state_dir: &Path, k: &IssueKey) -> FinalizationCh
         finalization: Some(checkpoint.clone()),
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(k.display_key(), e);
@@ -284,6 +292,8 @@ fn reset_done_entry_is_rejected() {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     entries.insert(k.display_key(), e);

--- a/tests/state/reaper_test.rs
+++ b/tests/state/reaper_test.rs
@@ -78,6 +78,8 @@ fn enqueue_in_progress(state_dir: &Path, key: &IssueKey, attempts: u32) {
         finalization: None,
         queued_at: now,
         updated_at: now,
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     let state = QueueState {
@@ -103,6 +105,8 @@ fn enqueue_in_phase(state_dir: &Path, key: &IssueKey, phase: Phase) {
         finalization: None,
         queued_at: now,
         updated_at: now,
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     let state = QueueState {

--- a/tests/state/retry_test.rs
+++ b/tests/state/retry_test.rs
@@ -66,6 +66,8 @@ fn seed_failed(store: &StateStore, k: &IssueKey, attempts: u32) {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     e.last_run_id = Some("SEED".to_string());
@@ -197,6 +199,8 @@ fn failure_four_is_terminal_failed() {
         finalization: None,
         queued_at: Utc::now(),
         updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     };
     e.last_run_id = Some("R-OLD".to_string());

--- a/tests/state/review_lifecycle_test.rs
+++ b/tests/state/review_lifecycle_test.rs
@@ -61,6 +61,8 @@ fn sample_entry(phase: Phase) -> QueueEntry {
         finalization: None,
         queued_at: Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap(),
         updated_at: Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
         generation: 1,
     }
 }

--- a/tests/state/sqlite_store_test.rs
+++ b/tests/state/sqlite_store_test.rs
@@ -268,3 +268,89 @@ fn migrate_v3_to_v4_adds_circuit_state_and_drops_circuit_breakers() {
     conn.close().expect("close");
     let _ = fs::remove_file(&path);
 }
+
+#[test]
+fn migrates_v5_to_v6_adds_block_columns() {
+    let path = db_path();
+    {
+        let conn = Connection::open(&path).expect("open raw");
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+             INSERT INTO schema_version (version, migrated_at) VALUES (5, '2026-01-01T00:00:00Z');",
+        )
+        .expect("init v5 schema");
+        // v5 queue_entries lacks blocked_source/blocked_recovery_hint.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS queue_entries (issue_key TEXT PRIMARY KEY, phase TEXT NOT NULL, ticket_type TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, next_attempt_at TEXT, finalization TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, generation INTEGER NOT NULL DEFAULT 1);
+             CREATE TABLE IF NOT EXISTS state_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE IF NOT EXISTS claims (claim_id TEXT PRIMARY KEY, issue_key TEXT NOT NULL, worker_pid INTEGER, token TEXT NOT NULL, claimed_at TEXT NOT NULL, expires_at TEXT NOT NULL);
+             CREATE TABLE IF NOT EXISTS checkpoints (run_id TEXT NOT NULL, stage TEXT NOT NULL, checkpoint_data TEXT, created_at TEXT NOT NULL, operation_id TEXT, remote_marker TEXT, PRIMARY KEY (run_id, stage));
+             CREATE TABLE IF NOT EXISTS circuit_state (scope TEXT NOT NULL, scope_id TEXT NOT NULL, state TEXT NOT NULL DEFAULT 'closed', consecutive_failures INTEGER NOT NULL DEFAULT 0, last_failure_at INTEGER, opened_at INTEGER, last_probe_at INTEGER, PRIMARY KEY (scope, scope_id));
+             CREATE TABLE IF NOT EXISTS leases (issue_key TEXT PRIMARY KEY, owner_id TEXT NOT NULL, fencing_token INTEGER NOT NULL, expires_at INTEGER NOT NULL, state TEXT NOT NULL CHECK(state IN ('held', 'released', 'expired')));
+             CREATE TABLE IF NOT EXISTS oci_runs (run_id TEXT PRIMARY KEY, container_id TEXT, state TEXT NOT NULL, engine TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, daemon_id TEXT NOT NULL, issue_id TEXT NOT NULL, worker_command_sha256 TEXT NOT NULL);",
+        )
+        .expect("create v5 tables");
+        // Seed one v5 row to prove old rows get NULL defaults.
+        conn.execute(
+            "INSERT INTO queue_entries (issue_key, phase, ticket_type, attempts, queued_at, updated_at)
+             VALUES (?1, ?2, ?3, 0, ?4, ?4)",
+            params![
+                "owner/repo#1",
+                "queued",
+                "code",
+                chrono::Utc::now().to_rfc3339()
+            ],
+        )
+        .expect("seed v5 row");
+        conn.close().expect("close");
+    }
+
+    let conn = open(&path).expect("open v6");
+    let version: i64 = conn
+        .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+            row.get(0)
+        })
+        .expect("read version");
+    assert_eq!(version, 6, "schema version must be v6 after migration");
+
+    let cols: Vec<String> = conn
+        .prepare("SELECT name FROM pragma_table_info('queue_entries') ORDER BY name")
+        .expect("prepare")
+        .query_map([], |row| row.get(0))
+        .expect("query")
+        .filter_map(|r| r.ok())
+        .collect();
+    assert!(cols.contains(&"blocked_source".to_string()));
+    assert!(cols.contains(&"blocked_recovery_hint".to_string()));
+
+    // Old row still loads with NULL block fields.
+    let (source, hint): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT blocked_source, blocked_recovery_hint FROM queue_entries WHERE issue_key = ?1",
+            params!["owner/repo#1"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read old row");
+    assert!(source.is_none());
+    assert!(hint.is_none());
+
+    // A new row can carry block metadata.
+    conn.execute(
+        "INSERT OR REPLACE INTO queue_entries
+         (issue_key, phase, ticket_type, attempts, queued_at, updated_at, generation,
+          blocked_source, blocked_recovery_hint)
+         VALUES (?1, ?2, ?3, 0, ?4, ?4, 1, ?5, ?6)",
+        params![
+            "owner/repo#2",
+            "needs_attention",
+            "code",
+            chrono::Utc::now().to_rfc3339(),
+            "worktree/dirty_main",
+            "caduceus queue reset --force-finalization-reset owner/repo#2"
+        ],
+    )
+    .expect("insert blocked row");
+
+    conn.close().expect("close");
+    let _ = fs::remove_file(&path);
+}

--- a/tests/state/state_store_test.rs
+++ b/tests/state/state_store_test.rs
@@ -64,6 +64,26 @@ fn entry(owner: &str, repo: &str, number: u64) -> QueueEntry {
         queued_at: Utc::now(),
         updated_at: Utc::now(),
         generation: 1,
+        blocked_source: None,
+        blocked_recovery_hint: None,
+    }
+}
+
+fn entry_blocked(owner: &str, repo: &str, number: u64) -> QueueEntry {
+    QueueEntry {
+        key: key(owner, repo, number),
+        phase: Phase::NeedsAttention,
+        ticket_type: TicketType::Code,
+        attempts: 0,
+        last_error: Some("blocked".to_string()),
+        last_run_id: Some("old-run".to_string()),
+        next_attempt_at: Some(Utc::now()),
+        finalization: None,
+        queued_at: Utc::now(),
+        updated_at: Utc::now(),
+        generation: 1,
+        blocked_source: Some("worktree/dirty_main".to_string()),
+        blocked_recovery_hint: Some("caduceus queue reset ...".to_string()),
     }
 }
 
@@ -291,6 +311,8 @@ fn acquire_next_picks_fifo_by_queued_at() {
         queued_at: queued,
         updated_at: queued,
         generation: 1,
+        blocked_source: None,
+        blocked_recovery_hint: None,
     };
     // Order enqueued: 3 first, then 1, then 2.
     entries.insert(
@@ -351,6 +373,8 @@ fn acquire_next_skips_entries_with_future_next_attempt_at() {
         queued_at: now,
         updated_at: now,
         generation: 1,
+        blocked_source: None,
+        blocked_recovery_hint: None,
     };
     entries.insert(k1.display_key(), make(&k1, Some(future)));
     entries.insert(k2.display_key(), make(&k2, None));
@@ -828,4 +852,40 @@ fn parse_then_snapshot_agrees() {
     let snap = store.snapshot().unwrap();
     let parsed = parse_queue_state(&serialize_queue_state(&snap).unwrap()).unwrap();
     assert_eq!(parsed, snap);
+}
+
+// Terminal block metadata
+
+#[test]
+fn reset_entry_clears_block_metadata() {
+    let root = tempdir("reset-block-meta");
+    let state_dir = root.join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+
+    let mut entries = BTreeMap::new();
+    let e = entry_blocked("owner", "repo", 1);
+    entries.insert(e.key.display_key(), e);
+    let state = QueueState {
+        version: QUEUE_FILE_VERSION,
+        entries,
+    };
+    write_state(&state_dir.join("state.json"), &state);
+
+    let store = StateStore::open(&state_dir).expect("open");
+    let outcome = store
+        .reset_entry(&key("owner", "repo", 1), false)
+        .expect("reset");
+    assert!(!outcome.cleared_finalization);
+
+    let snap = store.snapshot().expect("snapshot");
+    let e = snap.entry(&key("owner", "repo", 1)).expect("entry");
+    assert_eq!(e.phase, Phase::Queued);
+    assert!(e.blocked_source.is_none(), "blocked_source must be cleared");
+    assert!(
+        e.blocked_recovery_hint.is_none(),
+        "blocked_recovery_hint must be cleared"
+    );
+    assert!(e.last_error.is_none());
+    assert!(e.last_run_id.is_none());
+    assert!(e.next_attempt_at.is_none());
 }


### PR DESCRIPTION
## Summary

Fixes the daemon's silent-wedge behavior on refuse-to-operate conditions. Previously, dirty-main-checkout, worktree path collision, and claim mismatch all silently requeued with backoff — burning the retry budget while `caduceus status` showed only `queued: 1 / next head: (all backed off)`.

Observed on `signal-house#352` (2026-08-10/11): the dirty-main condition blocked 3 generations of retries (~2.5h of latency) before operator intervention.

## Changes (3 commits)

### `feat(runtime): route refuse-to-operate to NeedsAttention with recovery hints`
- `FailureClass::Terminal` + `is_terminal()` — new failure class for conditions that will not resolve by retry
- `handle_infra_or_retry` three-way dispatch: `is_terminal()` → `finish_needs_attention` instead of requeue
- `terminal_error_details()` matches the 3 reserved refuse-to-operate tags → stable `blocked_source` + recovery hint
- Recovery commands embedded at all 3 refusal sites (e.g. dirty-main error now reads: "main checkout is dirty at ...; refusing to operate. Run `git -C <path> status` ..., then run `caduceus queue reset --force-finalization-reset <issue>` to retry.")

### `feat(state): persist blocked_source and recovery hint on entries`
- `QueueEntry` gains `blocked_source` + `blocked_recovery_hint` (serde defaults — old state files still load)
- Status report surfaces them for `NeedsAttention` entries (visible in `recent errors` section)
- Queue schema migration (v5 → v6) adds the block columns

### `test(runtime): cover terminal block routing, status surfacing, and migration`
- 10 new test fns: `finish_needs_attention_emits_stable_terminal_block_event`, `report_surfaces_blocked_metadata_for_needs_attention`, `claim_mismatch_includes_recovery_command`, `old_queue_entry_json_deserializes_block_fields_to_none`, `migrates_v5_to_v6_adds_block_columns`, `reset_entry_clears_block_metadata`, etc.

## AC status

- ✅ **AC1** operator can tell why stuck — blocked_source + recovery hint surfaced in status for NeedsAttention entries
- ✅ **AC2** no silent retry — Terminal class routes to NeedsAttention immediately
- ✅ **AC3** recovery command in every refusal log line
- ✅ **AC4** non-retryable blocks → NeedsAttention (not Queued)
- ⚠️ **AC5** dedicated blocked/stalled phase — partially done: block metadata is persisted + surfaced via status, but a standalone `BLOCKED ISSUES` section in the status output is a follow-up in this same PR (pending review of the current state)

## Gates

- `cargo fmt --check` ✅
- `cargo clippy --locked --all-targets -- -D warnings` ✅
- `cargo test --locked --all-targets` (env-fixed, hermetic exclusions) ✅ — 0 failures
- `scripts/check-commits.sh` ✅

Closes #167.
