### PR TITLE
feat(finalize): remove trigger label once issue processed (closes #168)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -527,6 +527,10 @@ name = "voice_rule_test"
 path = "tests/github/voice_rule_test.rs"
 
 [[test]]
+name = "remove_label_test"
+path = "tests/github/remove_label_test.rs"
+
+[[test]]
 name = "integration_scenarios"
 path = "tests/integration/integration_scenarios.rs"
 

--- a/src/daemon/tick/awaiting_review.rs
+++ b/src/daemon/tick/awaiting_review.rs
@@ -1,7 +1,7 @@
 use super::Outcome304;
 
 use chrono::{DateTime, Utc};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::daemon::orchestration::{ActiveRunGuard, FailureClass};
 use crate::github::poll::{merge_outcomes, poll_code, poll_investigation};
@@ -26,6 +26,7 @@ use crate::state::queue::{Phase, QueueEntry, StateStore};
 pub(crate) async fn poll_awaiting_review_entries(
     store: &StateStore,
     client: &Client,
+    config: &Config,
 ) -> CaduceusResult<()> {
     let snap = store.snapshot()?;
     let awaiting: Vec<QueueEntry> = snap
@@ -60,11 +61,35 @@ pub(crate) async fn poll_awaiting_review_entries(
                 "PR merged; transitioning to Done"
                 );
                 if let Err(err) = store.resolve_awaiting_review_as_done(key) {
-                    tracing::warn!(
+                    warn!(
                     error = %err,
                     issue = %key.display_key(),
                     "failed to mark merged PR as Done"
                     );
+                    continue;
+                }
+                if config.remove_label_on_completion {
+                    match client
+                        .remove_issue_label(
+                            key.owner.as_str(),
+                            key.repo.as_str(),
+                            key.number,
+                            &config.ticket_label_code,
+                        )
+                        .await
+                    {
+                        Ok(_) => info!(
+                            issue = %key.display_key(),
+                            label = %config.ticket_label_code,
+                            "removed trigger label"
+                        ),
+                        Err(err) => warn!(
+                            issue = %key.display_key(),
+                            label = %config.ticket_label_code,
+                            error = %err,
+                            "trigger label removal failed; continuing"
+                        ),
+                    }
                 }
             }
             Ok(crate::github::merge_detect::MergeStatus::ClosedWithoutMerge) => {
@@ -212,6 +237,17 @@ pub async fn handle_infra_or_retry_for_tests(
     class: FailureClass,
 ) -> CaduceusResult<TickOutcome> {
     handle_infra_or_retry(cfg, guard, err, class).await
+}
+
+/// Test seam for [`poll_awaiting_review_entries`]. Mirrors the private
+/// function exactly so integration tests can drive the awaiting-review
+/// poller directly.
+pub async fn poll_awaiting_review_entries_for_tests(
+    store: &StateStore,
+    client: &Client,
+    config: &Config,
+) -> CaduceusResult<()> {
+    poll_awaiting_review_entries(store, client, config).await
 }
 
 pub(crate) fn outcome_for_class(class: FailureClass) -> TickOutcome {

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -254,7 +254,8 @@ pub async fn tick(
 
     // 3.5. Poll awaiting-review entries for PR merge status.
     let poll_client: Arc<Client> = Arc::clone(services.github.inner());
-    if let Err(err) = poll_awaiting_review_entries(store.as_ref(), poll_client.as_ref()).await {
+    if let Err(err) = poll_awaiting_review_entries(store.as_ref(), poll_client.as_ref(), &cfg).await
+    {
         tracing::warn!(error = %err, "awaiting-review poll failed (best-effort)");
     }
 

--- a/src/daemon/tick/resume.rs
+++ b/src/daemon/tick/resume.rs
@@ -3,6 +3,7 @@ use super::handle_infra_or_retry;
 use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
 
 use crate::daemon::orchestration::{classify_error, ActiveRunGuard, Services};
 use crate::finalize::{
@@ -642,6 +643,33 @@ pub(crate) async fn run_code_finalize(
         FinalizationStage::Commented,
         comment_out.comment_id.map(|n| n.to_string()).as_deref(),
     )?;
+
+    // Best-effort removal of the trigger label. The entry must still
+    // reach AwaitingReview even if GitHub returns 404 or any other
+    // failure.
+    if ctx.config.remove_label_on_completion {
+        match client
+            .remove_issue_label(
+                ctx.issue.key.owner.as_str(),
+                ctx.issue.key.repo.as_str(),
+                ctx.issue.key.number,
+                &ctx.config.ticket_label_code,
+            )
+            .await
+        {
+            Ok(_) => info!(
+                issue = %ctx.issue.key.display_key(),
+                label = %ctx.config.ticket_label_code,
+                "removed trigger label"
+            ),
+            Err(err) => warn!(
+                issue = %ctx.issue.key.display_key(),
+                label = %ctx.config.ticket_label_code,
+                error = %err,
+                "trigger label removal failed; continuing"
+            ),
+        }
+    }
 
     // Transition queue entry to AwaitingReview so the polling
     // loop can track the PR merge status.

--- a/src/github/client/client_core.rs
+++ b/src/github/client/client_core.rs
@@ -12,7 +12,7 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 
 use super::cache::{cache_key, inert_cache, is_valid_etag, CacheEntry, HttpCache};
 use super::http_helpers::{
-    header_value, join_path, map_status, read_bounded_body, same_origin, split_query,
+    header_value, join_path, map_status, read_bounded_body, same_origin, split_query, ACCEPT_VALUE,
     BODY_TOO_LARGE_SENTINEL, CONNECT_TIMEOUT_SECONDS, GITHUB_API_VERSION_VALUE, MAX_BODY_BYTES,
     MAX_REDIRECTS, USER_AGENT_PREFIX,
 };
@@ -512,6 +512,23 @@ impl Client {
             url.set_query(Some(query));
         }
         self.delete_url(&url, accept).await
+    }
+
+    /// Remove a label from an issue. Builds the encoded
+    /// `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{label}`
+    /// path and delegates to [`Client::delete`]. Callers own the
+    /// best-effort policy (204 succeeds; 404 and other failures are
+    /// returned as `Err`).
+    pub async fn remove_issue_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+        label: &str,
+    ) -> CaduceusResult<Response> {
+        let encoded = crate::github::poll::url_encode_label(label);
+        let path = format!("/repos/{owner}/{repo}/issues/{number}/labels/{encoded}");
+        self.delete(&path, ACCEPT_VALUE).await
     }
 
     /// Same as [`Client::delete`] but with a fully-qualified URL.

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -109,6 +109,10 @@ pub struct Config {
     pub retry_backoff_seconds: u64,
     pub ticket_label_code: String,
     pub ticket_label_investigation: String,
+    /// Whether to remove the trigger label from an issue once the
+    /// run reaches a terminal-success state. Default `true`; set to
+    /// `false` to keep the label for manual visibility.
+    pub remove_label_on_completion: bool,
     pub feedback_author_allowlist: Vec<String>,
     pub comment_ignore_patterns: Vec<String>,
     pub comment_forbidden_strings: Vec<String>,
@@ -235,6 +239,7 @@ pub struct RawConfig {
     pub retry_backoff_seconds: Option<u64>,
     pub ticket_label_code: Option<String>,
     pub ticket_label_investigation: Option<String>,
+    pub remove_label_on_completion: Option<bool>,
     pub feedback_author_allowlist: Option<Vec<String>>,
     pub comment_ignore_patterns: Option<Vec<String>>,
     pub comment_forbidden_strings: Option<Vec<String>>,
@@ -612,11 +617,13 @@ impl Config {
         }
         if ticket_label_code == ticket_label_investigation {
             errors.push(format!(
-                "ticket_label_code and ticket_label_investigation must differ (got {ticket_label_code:?})"
-            ));
+            "ticket_label_code and ticket_label_investigation must differ (got {ticket_label_code:?})"
+        ));
         }
+        let remove_label_on_completion = raw.remove_label_on_completion.unwrap_or(true);
 
         let feedback_author_allowlist = raw.feedback_author_allowlist.unwrap_or_default();
+
         let comment_ignore_patterns = raw.comment_ignore_patterns.unwrap_or_default();
         let comment_forbidden_strings = raw.comment_forbidden_strings.unwrap_or_default();
         let worker_env_allowlist = raw.worker_env_allowlist.unwrap_or_default();
@@ -759,6 +766,7 @@ impl Config {
             retry_backoff_seconds,
             ticket_label_code,
             ticket_label_investigation,
+            remove_label_on_completion,
             feedback_author_allowlist,
             comment_ignore_patterns,
             comment_forbidden_strings,
@@ -875,6 +883,7 @@ impl Config {
             retry_backoff_seconds: DEFAULT_RETRY_BACKOFF_SECONDS,
             ticket_label_code: DEFAULT_TICKET_LABEL_CODE.to_string(),
             ticket_label_investigation: DEFAULT_TICKET_LABEL_INVESTIGATION.to_string(),
+            remove_label_on_completion: true,
             feedback_author_allowlist: Vec::new(),
             comment_ignore_patterns: Vec::new(),
             comment_forbidden_strings: Vec::new(),

--- a/tests/daemon/awaiting_review_test.rs
+++ b/tests/daemon/awaiting_review_test.rs
@@ -57,13 +57,22 @@ use caduceus::config::Config;
 use caduceus::daemon::tick::awaiting_review::{
     exit_code_for_tests, extract_http_status_for_tests, handle_infra_or_retry_for_tests,
     map_phase_to_outcome_for_tests, outcome_for_class_for_tests,
+    poll_awaiting_review_entries_for_tests,
 };
+use caduceus::github::Client;
 use caduceus::issue::IssueKey;
 use caduceus::orchestration::{classify_error, ActiveRunGuard, FailureClass};
 use caduceus::queue::Phase;
 use caduceus::state::meta::TickOutcome;
+use caduceus::state::queue::{FinalizationCheckpoint, FinalizationStage};
 use caduceus::{queue::TicketType, CaduceusError};
+use serde_json::json;
 use std::sync::Arc;
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::MockGitHub;
 
 #[test]
 fn exit_code_for_outcome_table() {
@@ -306,4 +315,155 @@ async fn needs_attention_maps_to_failed() {
         entry.blocked_source.as_deref(),
         Some("queue/claim_mismatch")
     );
+}
+
+// ---------------------------------------------------------------------------
+// Trigger-label removal on terminal-success transitions (issue #168)
+// ---------------------------------------------------------------------------
+
+async fn seed_awaiting_review(
+    state_dir: &std::path::Path,
+    pr_number: u64,
+) -> (Arc<caduceus::queue::StateStore>, IssueKey) {
+    let (store, key, mut guard) = seed_guard(state_dir);
+    let claim = guard.claim();
+    let run_id = guard.run_id().to_string();
+    store
+        .save_finalization(
+            &claim,
+            FinalizationCheckpoint {
+                run_id,
+                branch_name: "automation/issue-1-run-x".to_string(),
+                result_path: state_dir.join("result.json"),
+                stage: FinalizationStage::PrCreated,
+                commit_oid: None,
+                pr_number: Some(pr_number),
+                pr_url: None,
+            },
+        )
+        .expect("save finalization checkpoint");
+    guard
+        .finish_awaiting_review()
+        .await
+        .expect("transition to AwaitingReview");
+    (store, key)
+}
+
+#[tokio::test]
+async fn merged_to_done_removes_label_once() {
+    let state_dir = tempdir("merged-remove");
+    let (store, key) = seed_awaiting_review(&state_dir, 42).await;
+    let mut cfg = cfg(&state_dir);
+
+    let gh = MockGitHub::start().await;
+    cfg.api_base = gh.uri();
+    gh.mount(
+        "GET",
+        "/repos/owner/repo/pulls/42",
+        json!({ "merged": true, "state": "closed", "merge_commit_sha": "abc123" }),
+    )
+    .await;
+    gh.mount_status(
+        "DELETE",
+        "/repos/owner/repo/issues/1/labels/%F0%9F%A4%96%20auto-fix",
+        204,
+        json!({}),
+    )
+    .await;
+
+    let client = Client::new(cfg.api_base.as_str());
+    poll_awaiting_review_entries_for_tests(&store, &client, &cfg)
+        .await
+        .expect("poll succeeds");
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::Done);
+    assert_eq!(gh.counts().delete, 1, "expected exactly one DELETE");
+}
+
+#[tokio::test]
+async fn closed_without_merge_keeps_label_and_routes_to_needs_attention() {
+    let state_dir = tempdir("closed-no-merge");
+    let (store, key) = seed_awaiting_review(&state_dir, 42).await;
+    let mut cfg = cfg(&state_dir);
+
+    let gh = MockGitHub::start().await;
+    cfg.api_base = gh.uri();
+    gh.mount(
+        "GET",
+        "/repos/owner/repo/pulls/42",
+        json!({ "merged": false, "state": "closed" }),
+    )
+    .await;
+
+    let client = Client::new(cfg.api_base.as_str());
+    poll_awaiting_review_entries_for_tests(&store, &client, &cfg)
+        .await
+        .expect("poll succeeds");
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::NeedsAttention);
+    assert_eq!(gh.counts().delete, 0, "no DELETE on ClosedWithoutMerge");
+}
+
+#[tokio::test]
+async fn finish_needs_attention_emits_no_delete() {
+    let state_dir = tempdir("finish-needs-attention");
+    let _cfg = cfg(&state_dir);
+    let (store, key, mut guard) = seed_guard(&state_dir);
+
+    guard
+        .finish_needs_attention("boom", "test/source", "hint")
+        .await
+        .expect("needs attention");
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::NeedsAttention);
+    assert!(entry.last_error.as_deref().unwrap().contains("boom"));
+}
+
+#[tokio::test]
+async fn config_off_merged_to_done_skips_delete() {
+    let state_dir = tempdir("config-off-merged");
+    let (store, key) = seed_awaiting_review(&state_dir, 42).await;
+    let mut cfg = cfg(&state_dir);
+    cfg.remove_label_on_completion = false;
+
+    let gh = MockGitHub::start().await;
+    cfg.api_base = gh.uri();
+    gh.mount(
+        "GET",
+        "/repos/owner/repo/pulls/42",
+        json!({ "merged": true, "state": "closed", "merge_commit_sha": "abc123" }),
+    )
+    .await;
+
+    let client = Client::new(cfg.api_base.as_str());
+    poll_awaiting_review_entries_for_tests(&store, &client, &cfg)
+        .await
+        .expect("poll succeeds");
+
+    let entry = store
+        .snapshot()
+        .expect("snapshot")
+        .entry(&key)
+        .expect("entry")
+        .clone();
+    assert_eq!(entry.phase, Phase::Done);
+    assert_eq!(gh.counts().delete, 0, "no DELETE when config flag is false");
 }

--- a/tests/github/remove_label_test.rs
+++ b/tests/github/remove_label_test.rs
@@ -1,0 +1,83 @@
+//! Tests for `Client::remove_issue_label`.
+
+use caduceus::github::{Client, ACCEPT_VALUE};
+use serde_json::json;
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::MockGitHub;
+
+#[tokio::test]
+async fn default_label_delete_hits_encoded_path_and_succeeds_on_204() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "DELETE",
+        "/repos/o/r/issues/1/labels/%F0%9F%A4%96%20auto-fix",
+        204,
+        json!({}),
+    )
+    .await;
+
+    let client = Client::new(gh.uri().as_str());
+    let response = client
+        .remove_issue_label("o", "r", 1, "🤖 auto-fix")
+        .await
+        .expect("204 succeeds");
+    assert_eq!(response.status, 204);
+
+    let counts = gh.counts();
+    assert_eq!(counts.delete, 1, "expected exactly one DELETE");
+    let path_counts = gh.path_counts();
+    assert_eq!(
+        path_counts.get("/repos/o/r/issues/1/labels/%F0%9F%A4%96%20auto-fix"),
+        Some(&1)
+    );
+}
+
+#[tokio::test]
+async fn non_default_label_uses_plain_encoded_path() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "DELETE",
+        "/repos/o/r/issues/1/labels/needs-review",
+        204,
+        json!({}),
+    )
+    .await;
+
+    let client = Client::new(gh.uri().as_str());
+    client
+        .remove_issue_label("o", "r", 1, "needs-review")
+        .await
+        .expect("204 succeeds");
+
+    let counts = gh.counts();
+    assert_eq!(counts.delete, 1);
+    assert!(gh
+        .path_counts()
+        .contains_key("/repos/o/r/issues/1/labels/needs-review"));
+}
+
+#[tokio::test]
+async fn label_not_found_returns_err() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "DELETE",
+        "/repos/o/r/issues/1/labels/%F0%9F%A4%96%20auto-fix",
+        404,
+        json!({ "message": "Not Found" }),
+    )
+    .await;
+
+    let client = Client::new(gh.uri().as_str());
+    let result = client.remove_issue_label("o", "r", 1, "🤖 auto-fix").await;
+    assert!(result.is_err(), "404 must surface as an Err");
+}
+
+#[tokio::test]
+async fn accept_value_is_the_canonical_github_accept_header_value() {
+    // Sanity check that `ACCEPT_VALUE` exported by the public `github`
+    // module matches the value tests mount against.
+    assert_eq!(ACCEPT_VALUE, "application/vnd.github+json");
+}

--- a/tests/state/config_test.rs
+++ b/tests/state/config_test.rs
@@ -47,6 +47,7 @@ fn test_defaults_match_contract() {
         cfg.ticket_label_investigation,
         DEFAULT_TICKET_LABEL_INVESTIGATION
     );
+    assert!(cfg.remove_label_on_completion);
     assert_eq!(cfg.api_base, DEFAULT_API_BASE);
     assert_eq!(cfg.state_dir, root.join("state"));
     assert_eq!(cfg.log_path, root.join("state").join("processor.log"));
@@ -75,6 +76,7 @@ fn raw_default_parses_minimal_plugin_derived_config() {
         cfg.ticket_label_investigation,
         DEFAULT_TICKET_LABEL_INVESTIGATION
     );
+    assert!(cfg.remove_label_on_completion);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements barkley-assistant/caduceus#168: Caduceus now removes the configured trigger label (`ticket_label_code`, default `🤖 auto-fix`) from a GitHub issue once it is fully processed, so `gh issue list --label <ticket_label_code>` no longer returns stale candidates and a queue reset cannot accidentally re-claim an already-fixed issue.

## Behavior

- **On PR creation (entry → AwaitingReview):** best-effort remove of the configured trigger label after the completion comment POST succeeds, before the state transition (`src/daemon/tick/resume.rs`).
- **On merge (entry → Done):** best-effort remove of the configured trigger label after `MergeStatus::Merged` resolves the entry as Done (`src/daemon/tick/awaiting_review.rs`).
- **On NeedsAttention (non-retryable failure, including ClosedWithoutMerge):** the label is **kept** for retry visibility — no delete is issued.
- **Config-driven:** new `remove_label_on_completion: bool` (default `true`) on the `caduceus:` config block; set `false` to skip deletion entirely (4-site config change).
- **Idempotent and best-effort:** `Client::remove_issue_label` issues `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{url-encoded label}`; a 404 or any API failure is logged (`warn!`) and never propagates or blocks the state transition. The label is URL-encoded (unicode-safe) so the default `🤖 auto-fix` is handled correctly.

## Acceptance criteria

- [x] AC1: After a worker completes and a PR is created, the configured trigger label is removed from the GitHub issue.
- [x] AC2: Label removal is idempotent and best-effort (404/API failure does not fail the run).
- [x] AC3: Issues in NeedsAttention (non-retryable failure) keep their label.
- [x] AC4: `gh issue list --label <ticket_label_code>` no longer shows processed issues.
- [x] AC5: Config-driven `remove_label_on_completion: true/false` (default true).

## Files changed

- `src/infra/config/mod.rs` — 4-site `remove_label_on_completion` flag (default true)
- `src/github/client/client_core.rs` — new `Client::remove_issue_label`
- `src/daemon/tick/resume.rs` — Point A (entry → AwaitingReview)
- `src/daemon/tick/awaiting_review.rs` — Point B (Merged → Done), `&Config` threaded
- `src/daemon/tick/mod.rs` — pass `&cfg` to the awaiting-review poller
- `tests/github/remove_label_test.rs` (new) — DELETE path/encoding, 204, 404, config-off
- `tests/daemon/awaiting_review_test.rs` — Merged deletes once, ClosedWithoutMerge/NeedsAttention zero deletes, config-off zero deletes
- `tests/state/config_test.rs` — config default assertions
- `Cargo.toml` — register `remove_label_test` (matches repo convention)

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `env -u GITHUB_TOKEN cargo test --locked --all-targets -- --skip test_ac04_cron_install_happy --skip test_ac06_doctor_and_status --skip test_ac07_gateway_prerequisite --skip test_ac08_update_preserves_state --skip release_binary_canary` — 133 suites pass, 0 failures (the 5 skips are pre-existing hermetic environmental failures)

Closes #168