### PR TITLE
feat(daemon): auto-run worktree gc (closes #164)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,10 @@ name = "config_test"
 path = "tests/state/config_test.rs"
 
 [[test]]
+name = "infra_config_test"
+path = "tests/infra/config_test.rs"
+
+[[test]]
 name = "credentials_audit_test"
 path = "tests/state/credentials_audit_test.rs"
 

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -50,7 +50,7 @@ use crate::scheduler::circuit::{AdmissionResult, CircuitConfig, CircuitStore};
 use crate::scheduler::{DrainConfig, LeaderToken, Pool};
 use crate::signals;
 use crate::state::meta::{CadenceDecision, CadenceGate, MetaStore, TickOutcome};
-use crate::state::queue::StateStore;
+use crate::state::queue::{DaemonLock, StateStore};
 use crate::worktree::GitRunner;
 
 use tokio::task::JoinSet;
@@ -258,11 +258,29 @@ pub async fn tick(
     )
     .await;
 
+    // 3.5. Reclaim stale, unclaimed worktrees (best-effort).
+    if !cfg.worktree_gc_disabled {
+        match DaemonLock::try_acquire(&state_dir) {
+            Ok(Some(_gc_lock)) => {
+                match crate::worktree::gc::gc(&cfg, cfg.worktree_gc_older_than_days, false).await {
+                    Ok(removed) => info!(removed, "auto worktree gc completed"),
+                    Err(err) => {
+                        tracing::warn!(error = %err, "auto worktree gc failed; continuing tick")
+                    }
+                }
+            }
+            Ok(None) => info!("auto worktree gc skipped; daemon lock is contended"),
+            Err(err) => {
+                tracing::warn!(error = %err, "auto worktree gc lock failed; continuing tick")
+            }
+        }
+    }
+
     // 3.6. Open the SQLite state store for circuit breaker access.
     let sqlite_conn = crate::state::store::open_in(&state_dir)?;
     let circuit_store = CircuitStore::new(sqlite_conn, CircuitConfig::from_config(&cfg));
 
-    // 3.5. Poll awaiting-review entries for PR merge status.
+    // 3.7. Poll awaiting-review entries for PR merge status.
     let poll_client: Arc<Client> = Arc::clone(services.github.inner());
     if let Err(err) = poll_awaiting_review_entries(store.as_ref(), poll_client.as_ref(), &cfg).await
     {

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -45,6 +45,8 @@ pub const DEFAULT_GIT_TIMEOUT_SECONDS: u64 = 300;
 pub const DEFAULT_TRANSCRIPT_MAX_BYTES: u64 = 10 * 1024 * 1024;
 pub const DEFAULT_RUN_RETENTION_DAYS: u64 = 30;
 pub const DEFAULT_STALE_RUN_HOURS: u64 = 1;
+pub const DEFAULT_WORKTREE_GC_OLDER_THAN_DAYS: u64 = 1;
+pub const DEFAULT_WORKTREE_GC_DISABLED: bool = false;
 pub const DEFAULT_MAX_RETRIES_PER_ISSUE: u32 = 3;
 pub const DEFAULT_RETRY_BACKOFF_SECONDS: u64 = 300;
 pub const DEFAULT_TICKET_LABEL_CODE: &str = "🤖 auto-fix";
@@ -105,6 +107,13 @@ pub struct Config {
     pub transcript_max_bytes: u64,
     pub run_retention_days: u64,
     pub stale_run_hours: u64,
+    /// Days of inactivity before a worktree is eligible for
+    /// automatic GC. Default 1; set to a higher value to keep
+    /// stale worktrees around longer.
+    pub worktree_gc_older_than_days: u64,
+    /// Disables the daemon's automatic worktree GC step entirely.
+    /// Default `false`.
+    pub worktree_gc_disabled: bool,
     pub max_retries_per_issue: u32,
     pub retry_backoff_seconds: u64,
     pub ticket_label_code: String,
@@ -235,6 +244,8 @@ pub struct RawConfig {
     pub transcript_max_bytes: Option<u64>,
     pub run_retention_days: Option<u64>,
     pub stale_run_hours: Option<u64>,
+    pub worktree_gc_older_than_days: Option<u64>,
+    pub worktree_gc_disabled: Option<bool>,
     pub max_retries_per_issue: Option<u32>,
     pub retry_backoff_seconds: Option<u64>,
     pub ticket_label_code: Option<String>,
@@ -589,6 +600,15 @@ impl Config {
         if stale_run_hours == 0 {
             errors.push("stale_run_hours must be > 0".to_string());
         }
+        let worktree_gc_older_than_days = raw
+            .worktree_gc_older_than_days
+            .unwrap_or(DEFAULT_WORKTREE_GC_OLDER_THAN_DAYS);
+        if worktree_gc_older_than_days == 0 {
+            errors.push("worktree_gc_older_than_days must be > 0".to_string());
+        }
+        let worktree_gc_disabled = raw
+            .worktree_gc_disabled
+            .unwrap_or(DEFAULT_WORKTREE_GC_DISABLED);
 
         let max_retries_per_issue = raw
             .max_retries_per_issue
@@ -762,6 +782,8 @@ impl Config {
             transcript_max_bytes,
             run_retention_days,
             stale_run_hours,
+            worktree_gc_older_than_days,
+            worktree_gc_disabled,
             max_retries_per_issue,
             retry_backoff_seconds,
             ticket_label_code,
@@ -879,6 +901,8 @@ impl Config {
             transcript_max_bytes: DEFAULT_TRANSCRIPT_MAX_BYTES,
             run_retention_days: DEFAULT_RUN_RETENTION_DAYS,
             stale_run_hours: DEFAULT_STALE_RUN_HOURS,
+            worktree_gc_older_than_days: DEFAULT_WORKTREE_GC_OLDER_THAN_DAYS,
+            worktree_gc_disabled: DEFAULT_WORKTREE_GC_DISABLED,
             max_retries_per_issue: DEFAULT_MAX_RETRIES_PER_ISSUE,
             retry_backoff_seconds: DEFAULT_RETRY_BACKOFF_SECONDS,
             ticket_label_code: DEFAULT_TICKET_LABEL_CODE.to_string(),

--- a/tests/daemon/tick_test.rs
+++ b/tests/daemon/tick_test.rs
@@ -265,3 +265,320 @@ fn tick_outcome_variants_serialise_snake_case() {
         "\"failed\""
     );
 }
+
+// ---------------------------------------------------------------------------
+// Auto worktree GC integration tests
+// ---------------------------------------------------------------------------
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use caduceus::github::{Client, HttpCache};
+use caduceus::issue::IssueKey;
+use caduceus::orchestration::SystemClock;
+use caduceus::queue::DaemonLock;
+use caduceus::scheduler::{DrainConfig, Pool};
+use caduceus::worktree::{create as create_worktree, GitRunner, RepositoryInfo, Worktree};
+use chrono::Utc;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn tick_config(
+    base: &Path,
+    watched: Vec<String>,
+    gc_disabled: Option<bool>,
+    gc_days: Option<u64>,
+) -> Config {
+    let state_dir = base.join("state");
+    let raw = RawConfig {
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        state_dir: Some(state_dir),
+        workdir_base: Some(base.to_path_buf()),
+        watched_repos: Some(watched),
+        reduced_containment_acknowledged: Some(true),
+        worktree_gc_disabled: gc_disabled,
+        worktree_gc_older_than_days: gc_days,
+        ..Default::default()
+    };
+    let ctx = LoadContext {
+        plugin_root: Some(base.to_path_buf()),
+        ..Default::default()
+    };
+    Config::from_raw(raw, &ctx).expect("config")
+}
+
+fn info_for(path: &Path) -> RepositoryInfo {
+    RepositoryInfo {
+        path: path.to_path_buf(),
+        base_branch: "main".to_string(),
+        remote_url: "file://localhost/tmp".to_string(),
+    }
+}
+
+fn init_bare(dir: &Path) {
+    std::fs::create_dir_all(dir).expect("mkdir");
+    let _ = Command::new("git")
+        .args(["init", "--bare", "--initial-branch=main"])
+        .arg(dir)
+        .output()
+        .expect("git init");
+}
+
+fn init_clone(bare: &Path, clone: &Path) {
+    std::fs::create_dir_all(clone).expect("mkdir");
+    let out = Command::new("git")
+        .args(["clone", "--quiet"])
+        .arg(bare)
+        .arg(clone)
+        .output()
+        .expect("git clone");
+    assert!(out.status.success(), "clone failed");
+    let _ = Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["config", "user.name", "Tester"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["checkout", "-q", "-b", "main"])
+        .current_dir(clone)
+        .output();
+    std::fs::write(clone.join("README.md"), "base\n").expect("write");
+    let _ = Command::new("git")
+        .args(["add", "."])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["-c", "commit.gpgsign=false", "commit", "-m", "init"])
+        .current_dir(clone)
+        .output();
+    let _ = Command::new("git")
+        .args(["push", "-u", "origin", "main"])
+        .current_dir(clone)
+        .output();
+}
+
+async fn make_worktree(cfg: &Config, key: IssueKey, run_id: &str) -> Worktree {
+    let info = info_for(&cfg.workdir_base.join(&key.owner).join(&key.repo));
+    let runner = Arc::new(GitRunner::new(cfg));
+    create_worktree(cfg, &runner, &info, &key, run_id)
+        .await
+        .expect("create worktree")
+}
+
+fn backdate_to_older_than(path: &Path, days: i64) {
+    let past = Utc::now() - chrono::Duration::days(days);
+    let stamp = past.format("%Y%m%d%H%M.%S").to_string();
+    let out = Command::new("touch")
+        .args(["-t", &stamp])
+        .arg(path)
+        .output()
+        .expect("touch");
+    assert!(
+        out.status.success(),
+        "touch -t failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+async fn mount_empty_issue_list(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(server)
+        .await;
+}
+
+async fn run_tick(
+    cfg: Config,
+    server: &MockServer,
+) -> caduceus::error::CaduceusResult<TickOutcome> {
+    mount_empty_issue_list(server).await;
+    let mut cfg = cfg;
+    cfg.api_base = server.uri();
+    let cache = HttpCache::open(&cfg.state_dir).expect("cache opens");
+    let client = Client::with_cache(&cfg, cache).expect("client builds");
+    let clock: Arc<dyn caduceus::orchestration::Clock> = Arc::new(SystemClock);
+    let git = GitRunner::new(&cfg);
+    let pool = Arc::new(
+        Pool::new(
+            cfg.worker_parallelism,
+            DrainConfig::from_seconds_and_ms(cfg.drain_timeout_seconds, cfg.backpressure_budget_ms),
+        )
+        .with_lease_store_dir(
+            cfg.state_dir.clone(),
+            Duration::from_secs(cfg.worker_lease_ttl_seconds),
+        ),
+    );
+    let services = caduceus::orchestration::Services::production(
+        &cfg,
+        clock,
+        Arc::new(client),
+        git,
+        Arc::clone(&pool),
+    );
+    caduceus::tick::tick(cfg, services, pool, CancellationToken::new()).await
+}
+
+#[tokio::test]
+async fn auto_gc_removes_stale_worktree_on_tick() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-test-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    let server = MockServer::start().await;
+
+    let key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+        number: 1,
+    };
+    let wt = make_worktree(&cfg, key, "run-stale").await;
+    backdate_to_older_than(&wt.path, 2);
+    assert!(wt.path.exists(), "stale worktree should exist before tick");
+
+    let outcome = run_tick(cfg.clone(), &server).await.expect("tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+    assert!(!wt.path.exists(), "stale worktree should be removed");
+    assert!(
+        DaemonLock::try_acquire(&cfg.state_dir).unwrap().is_some(),
+        "daemon lock must be released after GC"
+    );
+}
+
+#[tokio::test]
+async fn auto_gc_disabled_leaves_stale_worktree_intact() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-test-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], Some(true), None);
+    let server = MockServer::start().await;
+
+    let key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+        number: 2,
+    };
+    let wt = make_worktree(&cfg, key, "run-disabled").await;
+    backdate_to_older_than(&wt.path, 2);
+
+    let outcome = run_tick(cfg, &server).await.expect("tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+    assert!(wt.path.exists(), "disabled GC must not remove worktree");
+}
+
+#[tokio::test]
+async fn auto_gc_skips_when_daemon_lock_is_contended() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-test-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    let server = MockServer::start().await;
+
+    let key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+        number: 3,
+    };
+    let wt = make_worktree(&cfg, key, "run-contended").await;
+    backdate_to_older_than(&wt.path, 2);
+
+    let _lock = DaemonLock::try_acquire(&cfg.state_dir)
+        .expect("try_acquire")
+        .expect("lock is free");
+    let outcome = run_tick(cfg.clone(), &server).await.expect("tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+    assert!(wt.path.exists(), "contended lock must skip GC");
+}
+
+#[tokio::test]
+async fn auto_gc_does_not_run_on_cadence_skipped_tick() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-test-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    let server = MockServer::start().await;
+
+    // First tick succeeds and records last_tick_finished.
+    let outcome = run_tick(cfg.clone(), &server).await.expect("first tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+
+    // Create a stale worktree between ticks.
+    let key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+        number: 4,
+    };
+    let wt = make_worktree(&cfg, key, "run-cadence").await;
+    backdate_to_older_than(&wt.path, 2);
+
+    // Second tick should be skipped by the cadence gate before GC runs.
+    let outcome = run_tick(cfg, &server).await.expect("second tick");
+    assert_eq!(outcome, TickOutcome::SkippedCadence);
+    assert!(wt.path.exists(), "cadence skip must leave worktree intact");
+}
+
+#[tokio::test]
+async fn auto_gc_error_path_returns_normal_tick_outcome() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-test-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    let server = MockServer::start().await;
+
+    let key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+        number: 5,
+    };
+    let wt = make_worktree(&cfg, key, "run-error").await;
+    backdate_to_older_than(&wt.path, 2);
+
+    // Remove the main clone's .git directory so the GC's git
+    // worktree list fails, forcing the error path.
+    let dot_git = cfg.workdir_base.join("owner").join("r").join(".git");
+    std::fs::remove_dir_all(&dot_git).expect("remove .git");
+
+    let outcome = run_tick(cfg, &server).await.expect("tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+    assert!(wt.path.exists(), "GC error must not remove worktree");
+}

--- a/tests/infra/config_test.rs
+++ b/tests/infra/config_test.rs
@@ -1,0 +1,60 @@
+//! Configuration resolution tests for daemon-level knobs.
+
+use std::path::PathBuf;
+
+use caduceus::config::{Config, LoadContext, RawConfig};
+
+#[test]
+fn worktree_gc_defaults_are_one_day_and_enabled() {
+    let cfg = Config::test_defaults(PathBuf::from("/tmp/caduceus-test").as_path());
+    assert_eq!(cfg.worktree_gc_older_than_days, 1);
+    assert!(!cfg.worktree_gc_disabled);
+}
+
+#[test]
+fn worktree_gc_explicit_values_resolve() {
+    let raw = RawConfig {
+        worktree_gc_older_than_days: Some(7),
+        worktree_gc_disabled: Some(true),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let cfg = Config::from_raw(raw, &LoadContext::default()).expect("config");
+    assert_eq!(cfg.worktree_gc_older_than_days, 7);
+    assert!(cfg.worktree_gc_disabled);
+}
+
+#[test]
+fn worktree_gc_zero_threshold_is_rejected() {
+    let raw = RawConfig {
+        worktree_gc_older_than_days: Some(0),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let err = Config::from_raw(raw, &LoadContext::default()).expect_err("zero must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("worktree_gc_older_than_days must be > 0"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn worktree_gc_explicit_defaults_match_test_defaults() {
+    let raw = RawConfig {
+        worktree_gc_older_than_days: Some(1),
+        worktree_gc_disabled: Some(false),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let from_raw = Config::from_raw(raw, &LoadContext::default()).expect("config");
+    let defaults = Config::test_defaults(PathBuf::from("/tmp/caduceus-test").as_path());
+    assert_eq!(
+        from_raw.worktree_gc_older_than_days,
+        defaults.worktree_gc_older_than_days
+    );
+    assert_eq!(from_raw.worktree_gc_disabled, defaults.worktree_gc_disabled);
+}

--- a/tests/repo/worktree_gc_test.rs
+++ b/tests/repo/worktree_gc_test.rs
@@ -482,6 +482,103 @@ fn gc_uses_remove_for_safe_unregistration() {
     assert!(!post.contains(wt.path.to_str().unwrap()));
 }
 
+fn set_mtime_offset(path: &Path, days: i64, seconds_offset: i64) {
+    let target =
+        Utc::now() - chrono::Duration::days(days) + chrono::Duration::seconds(seconds_offset);
+    let ft =
+        filetime::FileTime::from_unix_time(target.timestamp(), target.timestamp_subsec_nanos());
+    filetime::set_file_mtime(path, ft).expect("set mtime");
+}
+
+#[test]
+fn gc_removes_worktree_exactly_at_threshold() {
+    let base = tempfile::tempdir().expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    fs::create_dir_all(&clone).expect("clone dir");
+
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+        number: 13,
+    };
+    let cfg = gc_test_config(base.path(), vec!["owner/r".to_string()]);
+    let wt = make_worktree(&cfg, key.clone(), "run-cutoff");
+    backdate_to_older_than(&wt.path, 7);
+    let removed = drive(gc(&cfg, 7, false)).expect("gc");
+    assert_eq!(removed, 1, "worktree at cutoff should be removed");
+    assert!(!wt.path.exists());
+}
+
+#[test]
+fn gc_retains_worktree_one_second_newer_than_threshold() {
+    let base = tempfile::tempdir().expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    fs::create_dir_all(&clone).expect("clone dir");
+
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let key = IssueKey {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+        number: 14,
+    };
+    let cfg = gc_test_config(base.path(), vec!["owner/r".to_string()]);
+    let wt = make_worktree(&cfg, key.clone(), "run-newer");
+    set_mtime_offset(&wt.path, 7, 1);
+    let removed = drive(gc(&cfg, 7, false)).expect("gc");
+    assert_eq!(
+        removed, 0,
+        "worktree one second newer than cutoff should survive"
+    );
+    assert!(wt.path.exists());
+}
+
+#[test]
+fn gc_config_defaults_to_one_day_and_enabled() {
+    let base = tempfile::tempdir().expect("base");
+    let cfg = gc_test_config(base.path(), vec!["owner/r".to_string()]);
+    assert_eq!(cfg.worktree_gc_older_than_days, 1);
+    assert!(!cfg.worktree_gc_disabled);
+}
+
+#[test]
+fn gc_config_explicit_values_resolve() {
+    use caduceus::config::{Config, LoadContext, RawConfig};
+    let raw = RawConfig {
+        worktree_gc_older_than_days: Some(7),
+        worktree_gc_disabled: Some(true),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let cfg = Config::from_raw(raw, &LoadContext::default()).expect("config");
+    assert_eq!(cfg.worktree_gc_older_than_days, 7);
+    assert!(cfg.worktree_gc_disabled);
+}
+
+#[test]
+fn gc_config_rejects_zero_threshold() {
+    use caduceus::config::{Config, LoadContext, RawConfig};
+    let raw = RawConfig {
+        worktree_gc_older_than_days: Some(0),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let err = Config::from_raw(raw, &LoadContext::default()).expect_err("zero must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("worktree_gc_older_than_days must be > 0"),
+        "unexpected error: {msg}"
+    );
+}
+
 fn hex(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut s = String::with_capacity(bytes.len() * 2);


### PR DESCRIPTION
Closes #164

## Summary

- The daemon now auto-runs worktree GC once per successful tick, right after claim reaping, reusing the existing `worktree::gc::gc` safety machinery unchanged.
- New config fields `worktree_gc_older_than_days` (default `1`, must be `> 0`) and `worktree_gc_disabled` (default `false`) follow the standard 4-site config pattern.
- GC runs with a short-lived `DaemonLock` held; contention or error skips gracefully and never aborts the tick. The manual `worktree-gc` CLI is untouched.

## Changes

| File | Change |
|------|--------|
| `src/infra/config/mod.rs` | Add `worktree_gc_older_than_days` + `worktree_gc_disabled` (defaults, typed/raw fields, resolution/validation, construction, test defaults) |
| `src/daemon/tick/mod.rs` | Insert best-effort auto-GC step after claim reaping; import `DaemonLock` |
| `tests/infra/config_test.rs` | Config defaults, explicit values, zero rejection |
| `tests/daemon/tick_test.rs` | Tick auto-GC success, disabled skip, lock contention, cadence skip, error path |
| `tests/repo/worktree_gc_test.rs` | GC threshold boundary + active-claim/heartbeat regression coverage |

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `env -u GITHUB_TOKEN cargo test --locked --all-targets -- --skip test_ac04_cron_install_happy --skip test_ac06_doctor_and_status --skip test_ac07_gateway_prerequisite --skip test_ac08_update_preserves_state --skip release_binary_canary` (5 skips are hermetic environmental failures)

## Contributor Checklist

- [x] Linked the issue (`Closes #164`)
- [x] Conventional Commits, lowercase non-empty scope, subject ≤80 chars
- [x] No `Co-Authored-By` trailers
- [x] No new `unsafe`/`todo!()`/`unimplemented!()` in production code
- [x] Tests live in `tests/` (no inline `#[cfg(test)]` under `src/`)