### PR TITLE
feat(worktree): retry over prior-attempt worktree; archive opt-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,11 @@ config.local.*
 prompts/
 /prompts/
 
+# SpecOps plugin scratch; never commit it. Specops writes proposal/spec/
+# design/tasks artifacts under this directory during a run; the orchestrator
+# is expected to archive them, but the bridge is the safety net.
+openspec/
+/openspec/
+
 # Hermes release-plan files; never commit them.
 /.hermes/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "shellexpand",
+ "tar",
  "temp-env",
  "tempfile",
  "thiserror 1.0.69",
@@ -1858,6 +1859,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "temp-env"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2655,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ libc = "0.2"
 nix = { version = "0.29", default-features = false, features = ["feature", "fs", "process", "signal"] }
 rusqlite = { version = "0.40", default-features = false, features = ["bundled"] }
 uuid = { version = "1", features = ["v4"] }
+tar = "0.4.46"
 
 [dev-dependencies]
 tempfile = "3"
@@ -225,6 +226,10 @@ path = "tests/repo/repository_poll_test.rs"
 [[test]]
 name = "worktree_create_test"
 path = "tests/repo/worktree_create_test.rs"
+
+[[test]]
+name = "worktree_retry_test"
+path = "tests/repo/worktree_retry_test.rs"
 
 [[test]]
 name = "worktree_gc_test"

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -276,6 +276,16 @@ pub async fn tick(
         }
     }
 
+    // 3.5a. Prune archived worktrees older than the retention cap.
+    match crate::worktree::attic::sweep(&cfg).await {
+        Ok(removed) => {
+            if removed > 0 {
+                info!(removed, "auto attic sweep completed")
+            }
+        }
+        Err(err) => tracing::warn!(error = %err, "auto attic sweep failed; continuing tick"),
+    }
+
     // 3.6. Open the SQLite state store for circuit breaker access.
     let sqlite_conn = crate::state::store::open_in(&state_dir)?;
     let circuit_store = CircuitStore::new(sqlite_conn, CircuitConfig::from_config(&cfg));

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -47,6 +47,8 @@ pub const DEFAULT_RUN_RETENTION_DAYS: u64 = 30;
 pub const DEFAULT_STALE_RUN_HOURS: u64 = 1;
 pub const DEFAULT_WORKTREE_GC_OLDER_THAN_DAYS: u64 = 1;
 pub const DEFAULT_WORKTREE_GC_DISABLED: bool = false;
+pub const DEFAULT_ARCHIVE_ON_RETRY: bool = false;
+pub const DEFAULT_ATTIC_RETENTION_DAYS: u64 = 30;
 pub const DEFAULT_MAX_RETRIES_PER_ISSUE: u32 = 3;
 pub const DEFAULT_RETRY_BACKOFF_SECONDS: u64 = 300;
 pub const DEFAULT_TICKET_LABEL_CODE: &str = "🤖 auto-fix";
@@ -114,6 +116,12 @@ pub struct Config {
     /// Disables the daemon's automatic worktree GC step entirely.
     /// Default `false`.
     pub worktree_gc_disabled: bool,
+    /// Whether to archive a failed run's working tree to the attic
+    /// before removing it on retry. Default `false`.
+    pub archive_on_retry: bool,
+    /// Maximum age of archived working trees in the daemon's attic
+    /// before they are eligible for automatic pruning. Default 30.
+    pub attic_retention_days: u64,
     pub max_retries_per_issue: u32,
     pub retry_backoff_seconds: u64,
     pub ticket_label_code: String,
@@ -246,6 +254,8 @@ pub struct RawConfig {
     pub stale_run_hours: Option<u64>,
     pub worktree_gc_older_than_days: Option<u64>,
     pub worktree_gc_disabled: Option<bool>,
+    pub archive_on_retry: Option<bool>,
+    pub attic_retention_days: Option<u64>,
     pub max_retries_per_issue: Option<u32>,
     pub retry_backoff_seconds: Option<u64>,
     pub ticket_label_code: Option<String>,
@@ -609,6 +619,13 @@ impl Config {
         let worktree_gc_disabled = raw
             .worktree_gc_disabled
             .unwrap_or(DEFAULT_WORKTREE_GC_DISABLED);
+        let archive_on_retry = raw.archive_on_retry.unwrap_or(DEFAULT_ARCHIVE_ON_RETRY);
+        let attic_retention_days = raw
+            .attic_retention_days
+            .unwrap_or(DEFAULT_ATTIC_RETENTION_DAYS);
+        if attic_retention_days == 0 {
+            errors.push("attic_retention_days must be > 0".to_string());
+        }
 
         let max_retries_per_issue = raw
             .max_retries_per_issue
@@ -784,6 +801,8 @@ impl Config {
             stale_run_hours,
             worktree_gc_older_than_days,
             worktree_gc_disabled,
+            archive_on_retry,
+            attic_retention_days,
             max_retries_per_issue,
             retry_backoff_seconds,
             ticket_label_code,
@@ -903,6 +922,8 @@ impl Config {
             stale_run_hours: DEFAULT_STALE_RUN_HOURS,
             worktree_gc_older_than_days: DEFAULT_WORKTREE_GC_OLDER_THAN_DAYS,
             worktree_gc_disabled: DEFAULT_WORKTREE_GC_DISABLED,
+            archive_on_retry: DEFAULT_ARCHIVE_ON_RETRY,
+            attic_retention_days: DEFAULT_ATTIC_RETENTION_DAYS,
             max_retries_per_issue: DEFAULT_MAX_RETRIES_PER_ISSUE,
             retry_backoff_seconds: DEFAULT_RETRY_BACKOFF_SECONDS,
             ticket_label_code: DEFAULT_TICKET_LABEL_CODE.to_string(),

--- a/src/worktree/attic.rs
+++ b/src/worktree/attic.rs
@@ -1,0 +1,129 @@
+//! Attic for preserved failed-run worktrees.
+//!
+//! When `cfg.archive_on_retry` is enabled, the daemon archives the
+//! working tree of a previous failed attempt before removing it.
+//! The attic lives under `<state_dir>/attic`. A retention sweep runs
+//! on every daemon pulse and removes archives older than
+//! `cfg.attic_retention_days`.
+//!
+//! Archives are plain `.tar` files. The repository does not depend on
+//! `zstd`, so compression is intentionally omitted per the issue #177
+//! scope ("use plain `.tar` if `zstd` is not already a dependency").
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+
+use crate::infra::config::Config;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Return the daemon's attic directory: `<state_dir>/attic`.
+pub(crate) fn attic_dir(cfg: &Config) -> PathBuf {
+    cfg.state_dir.join("attic")
+}
+
+/// Build an archive file name for a previous attempt of an issue.
+fn archive_name(owner: &str, repo: &str, issue_number: u64, run_id: &str, now: u64) -> String {
+    format!("{owner}-{repo}-{issue_number}-{run_id}-{now}.tar")
+}
+
+/// Archive a working tree to the attic.
+///
+/// The resulting file is named `<owner>-<repo>-<issue>-<run_id>-<unix_ts>.tar`
+/// and lives under `<state_dir>/attic`. The source tree is captured
+/// under a top-level directory named after its basename (the run id)
+/// so extraction recreates the original layout.
+pub async fn archive(
+    cfg: &Config,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    run_id: &str,
+    source: &Path,
+) -> CaduceusResult<PathBuf> {
+    let dir = attic_dir(cfg);
+    fs::create_dir_all(&dir).map_err(|err| CaduceusError::Worktree {
+        context: "attic-archive",
+        stderr: format!("create attic dir {}: {err}", dir.display()),
+    })?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let name = archive_name(owner, repo, issue_number, run_id, now);
+    let dest = dir.join(&name);
+
+    let file = fs::File::create(&dest).map_err(|err| CaduceusError::Worktree {
+        context: "attic-archive",
+        stderr: format!("create archive {}: {err}", dest.display()),
+    })?;
+
+    let mut builder = tar::Builder::new(file);
+    let basename = source
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("worktree"));
+    builder
+        .append_dir_all(basename, source)
+        .map_err(|err| CaduceusError::Worktree {
+            context: "attic-archive",
+            stderr: format!("archive {} -> {}: {err}", source.display(), dest.display()),
+        })?;
+    builder.finish().map_err(|err| CaduceusError::Worktree {
+        context: "attic-archive",
+        stderr: format!("finish archive {}: {err}", dest.display()),
+    })?;
+
+    Ok(dest)
+}
+
+/// Remove attic archives older than `cfg.attic_retention_days`.
+///
+/// Returns the number of files removed. Non-file entries are ignored.
+/// Errors deleting individual archives are logged but do not abort the
+/// sweep.
+pub async fn sweep(cfg: &Config) -> CaduceusResult<usize> {
+    let dir = attic_dir(cfg);
+    if !dir.is_dir() {
+        return Ok(0);
+    }
+
+    let cutoff = Utc::now() - chrono::Duration::days(cfg.attic_retention_days as i64);
+    let mut removed = 0usize;
+
+    let entries = fs::read_dir(&dir).map_err(|err| CaduceusError::Worktree {
+        context: "attic-sweep",
+        stderr: format!("read attic dir {}: {err}", dir.display()),
+    })?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let Some(modified) = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        else {
+            continue;
+        };
+        let mtime =
+            DateTime::<Utc>::from_timestamp(modified.as_secs() as i64, 0).unwrap_or_else(Utc::now);
+        if mtime < cutoff {
+            if let Err(err) = fs::remove_file(&path) {
+                tracing::warn!(path = %path.display(), error = %err, "failed to remove stale attic archive");
+            } else {
+                removed += 1;
+                tracing::info!(path = %path.display(), "removed stale attic archive");
+            }
+        }
+    }
+
+    Ok(removed)
+}

--- a/src/worktree/mod.rs
+++ b/src/worktree/mod.rs
@@ -12,11 +12,13 @@
 // Submodule declarations and re-exports. These preserve the historical
 // `crate::worktree` public surface used by `lib.rs` and sibling modules.
 
+pub mod attic;
 pub mod gc;
 pub mod git_runner;
 pub mod repository;
 pub mod worktree;
 
+pub use attic::*;
 pub use gc::*;
 pub use git_runner::*;
 pub use repository::*;

--- a/src/worktree/worktree.rs
+++ b/src/worktree/worktree.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
+use tracing::info;
 
 use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
@@ -196,8 +197,6 @@ async fn create_locked(
     branch_name: &str,
     worktree_path: &Path,
 ) -> CaduceusResult<Worktree> {
-    let _ = cfg;
-
     // Test-only hook to exercise panic-path cleanup in integration
     // tests without adding a public surface to the daemon.
     if std::env::var_os("_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED").is_some() {
@@ -205,22 +204,13 @@ async fn create_locked(
     }
 
     // (5) Pre-flight: branch / path already exist? Resolve
-    // each case to "ours" (reconcile) or "theirs" (collision).
-    let pre = inspect_existing(runner, &repo.path, branch_name, worktree_path).await?;
+    // each case to "ours" (retry/re-create) or "theirs" (collision).
+    let pre = inspect_existing(runner, &repo.path, key, branch_name, worktree_path).await?;
     if pre.foreign_branch {
         return Err(CaduceusError::Worktree {
             context: "create",
             stderr: format!(
                 "branch collision: {branch_name} already exists with a different run id"
-            ),
-        });
-    }
-    if pre.foreign_path {
-        return Err(CaduceusError::Worktree {
-            context: "create",
-            stderr: format!(
-                "path collision: {} already exists with a different run id",
-                worktree_path.display()
             ),
         });
     }
@@ -237,10 +227,31 @@ async fn create_locked(
             ),
         });
     }
-    if pre.owned {
-        if let Some(base_oid) = pre.base_oid {
-            // Idempotent re-entry into the same run id: return
-            // the existing handle so callers can resume.
+    if let Some(prior) = pre.same_issue_prior_attempt {
+        // A prior attempt at the *same* path means the daemon is
+        // re-entering with the same `run_id` (checkpoint resume after
+        // a crash, or a redundant tick). The worktree and branch are
+        // already correct; do not archive/remove/recreate.
+        if prior.path == worktree_path {
+            info!(
+                path = %worktree_path.display(),
+                branch = %branch_name,
+                issue = key.number,
+                run_id = %run_id,
+                "existing worktree belongs to this run; resuming without recreation"
+            );
+            let base_oid = match pre.base_oid {
+                Some(oid) => oid,
+                None => {
+                    git_rev(
+                        runner,
+                        &repo.path,
+                        "rev-parse",
+                        &[&format!("refs/remotes/origin/{}", repo.base_branch)],
+                    )
+                    .await?
+                }
+            };
             return Ok(Worktree {
                 issue: key.clone(),
                 run_id: run_id.to_string(),
@@ -249,7 +260,53 @@ async fn create_locked(
                 main_path: repo.path.to_path_buf(),
                 base_oid,
                 fresh: false,
-                created_at: pre.created_at.unwrap_or_else(Utc::now),
+                created_at: Utc::now(),
+            });
+        }
+
+        info!(
+            path = %prior.path.display(),
+            branch = %prior.branch,
+            issue = key.number,
+            run_id = %run_id,
+            "retrying over prior attempt worktree"
+        );
+        if cfg.archive_on_retry {
+            match crate::worktree::attic::archive(
+                cfg,
+                &key.owner,
+                &key.repo,
+                key.number,
+                run_id,
+                &prior.path,
+            )
+            .await
+            {
+                Ok(archive_path) => {
+                    info!(path = %archive_path.display(), "archived prior attempt worktree")
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        remove_worktree_for_retry(runner, &repo.path, &prior.path).await?;
+        if prior.path.exists() {
+            return Err(CaduceusError::Worktree {
+                context: "retry-worktree-remove",
+                stderr: format!(
+                    "git worktree remove --force {} reported success but the path is still present",
+                    prior.path.display()
+                ),
+            });
+        }
+        // If the prior attempt was at a different path, ensure the
+        // target path is also gone before recreating.
+        if prior.path != worktree_path && worktree_path.exists() {
+            return Err(CaduceusError::Worktree {
+                context: "retry-path-check",
+                stderr: format!(
+                    "target worktree path {} still present after removing prior attempt",
+                    worktree_path.display()
+                ),
             });
         }
     }
@@ -341,31 +398,36 @@ async fn create_locked(
     })
 }
 
+/// A worktree path + branch that belongs to a previous attempt of
+/// the same issue. Carrying the branch name lets the retry path
+/// delete the old branch registration without re-parsing `git worktree
+/// list`.
+struct PriorAttempt {
+    path: PathBuf,
+    branch: String,
+}
+
 /// Pre-flight result of [`create`]: whether the branch / path
 /// already exist and how they relate to the current run id.
 struct PreFlight {
-    /// True when a branch with the would-be name already
-    /// exists at `origin/<base>` (i.e. it's ours).
+    /// True when a branch with the would-be name already exists.
     branch_exists: bool,
     /// True when a branch with the would-be name already
     /// exists AND points somewhere foreign.
     foreign_branch: bool,
-    /// True when the worktree path already exists and is a
-    /// git worktree whose `branch_name` matches ours.
-    owned: bool,
-    /// True when the worktree path already exists and is
-    /// something else.
-    foreign_path: bool,
+    /// A prior attempt of the same issue, either at the target path
+    /// or as another directory under the per-repo worktree state dir.
+    /// On retry the daemon archives, removes, and re-creates the
+    /// worktree.
+    same_issue_prior_attempt: Option<PriorAttempt>,
     /// Path of a foreign entry under the per-repo state directory
-    /// (any path other than `worktree_path`). The daemon treats any
-    /// such entry as a collision because the worker-home area belongs
-    /// to the daemon.
+    /// (any path other than `worktree_path` that is not a prior
+    /// attempt of the same issue). The daemon treats any such entry
+    /// as a collision because the worker-home area belongs to the
+    /// daemon.
     foreign_worktree_dir: Option<PathBuf>,
-    /// Base OID recorded on the existing branch, when
-    /// reconciling.
+    /// Base OID recorded on the existing branch, when present.
     base_oid: Option<String>,
-    /// File mtime of the existing worktree, when reconciling.
-    created_at: Option<chrono::DateTime<Utc>>,
 }
 
 /// Inspect what is already on disk for *branch_name* /
@@ -381,17 +443,16 @@ struct PreFlight {
 async fn inspect_existing(
     runner: &GitRunner,
     main_path: &Path,
+    key: &IssueKey,
     branch_name: &str,
     worktree_path: &Path,
 ) -> CaduceusResult<PreFlight> {
     let mut pre = PreFlight {
         branch_exists: false,
         foreign_branch: false,
-        owned: false,
-        foreign_path: false,
+        same_issue_prior_attempt: None,
         foreign_worktree_dir: None,
         base_oid: None,
-        created_at: None,
     };
 
     // Does the branch already exist locally?
@@ -412,29 +473,34 @@ async fn inspect_existing(
         }
     }
 
-    // Does the worktree path already exist? Either as a
-    // legitimate worktree (ours) or as a stray directory/file.
+    let worktrees = git_worktree_list(runner, main_path).await?;
+    let expected_prefix = format!("automation/issue-{}-", key.number);
+
+    // Does the worktree path already exist? If it is a linked
+    // worktree and its branch belongs to the same issue, treat it as
+    // a prior attempt to be archived/removed/recreated. Otherwise it
+    // is a genuine collision.
     if worktree_path.exists() {
-        // `git worktree list` includes the path and the branch
-        // for each linked worktree. If our path is listed with
-        // our branch it belongs to us; otherwise it is foreign.
-        let owned = inspect_path_is_ours(runner, main_path, worktree_path, branch_name).await?;
-        if owned {
-            pre.owned = true;
-            if let Ok(meta) = std::fs::metadata(worktree_path) {
-                if let Ok(mtime) = meta.modified() {
-                    let dt: chrono::DateTime<Utc> = mtime.into();
-                    pre.created_at = Some(dt);
-                }
+        if let Some(branch) = worktrees.get(worktree_path).cloned() {
+            if branch.starts_with(&expected_prefix) {
+                pre.same_issue_prior_attempt = Some(PriorAttempt {
+                    path: worktree_path.to_path_buf(),
+                    branch,
+                });
+            } else {
+                pre.foreign_worktree_dir = Some(worktree_path.to_path_buf());
             }
         } else {
-            pre.foreign_path = true;
+            // A stray non-worktree directory at the target path.
+            // This is a collision because the daemon never creates
+            // directories through non-git means.
+            pre.foreign_worktree_dir = Some(worktree_path.to_path_buf());
         }
     }
 
-    // Foreign entries under the per-repo state directory are always a
-    // collision: the daemon owns the worker-home area and never allows
-    // a prior run to leak paths.
+    // Sibling directories under the per-repo state dir. A directory
+    // belonging to the same issue is a prior attempt to clean up;
+    // anything else is a foreign collision.
     let worktree_dir = worktree_path
         .parent()
         .ok_or_else(|| CaduceusError::Worktree {
@@ -456,6 +522,14 @@ async fn inspect_existing(
             if p == worktree_path {
                 continue;
             }
+            if let Some(branch) = worktrees.get(&p).cloned() {
+                if branch.starts_with(&expected_prefix) {
+                    if pre.same_issue_prior_attempt.is_none() {
+                        pre.same_issue_prior_attempt = Some(PriorAttempt { path: p, branch });
+                    }
+                    continue;
+                }
+            }
             pre.foreign_worktree_dir = Some(p);
             break;
         }
@@ -464,16 +538,13 @@ async fn inspect_existing(
     Ok(pre)
 }
 
-/// Return true when the worktree at *worktree_path* is registered
-/// to *branch_name* in `git worktree list`. Both nil cases (path
-/// absent, branch absent) return false — the caller decides what
-/// to do.
-async fn inspect_path_is_ours(
+/// Parse `git worktree list --porcelain` into a map of
+/// worktree path → short branch name (with `refs/heads/` stripped).
+/// Paths that have no `branch` line are omitted.
+async fn git_worktree_list(
     runner: &GitRunner,
     main_path: &Path,
-    worktree_path: &Path,
-    branch_name: &str,
-) -> CaduceusResult<bool> {
+) -> CaduceusResult<std::collections::HashMap<PathBuf, String>> {
     let output = runner_run_in(
         runner,
         main_path,
@@ -481,9 +552,10 @@ async fn inspect_path_is_ours(
         &["worktree", "list", "--porcelain"],
     )
     .await?;
-    if !output.status.eq(&Some(0)) {
-        return Ok(false);
+    if output.status != Some(0) {
+        return Ok(std::collections::HashMap::new());
     }
+    let mut map = std::collections::HashMap::new();
     let mut current_path: Option<String> = None;
     let mut current_branch: Option<String> = None;
     for line in output.stdout.lines() {
@@ -493,21 +565,48 @@ async fn inspect_path_is_ours(
         } else if let Some(rest) = line.strip_prefix("branch ") {
             current_branch = Some(rest.trim().trim_start_matches("refs/heads/").to_string());
         } else if line.is_empty() {
-            if let (Some(p), Some(b)) = (&current_path, &current_branch) {
-                if p == &worktree_path.to_string_lossy() && b == branch_name {
-                    return Ok(true);
-                }
+            if let (Some(p), Some(b)) = (current_path.take(), current_branch.take()) {
+                map.insert(PathBuf::from(p), b);
             }
-            current_path = None;
-            current_branch = None;
         }
     }
-    if let (Some(p), Some(b)) = (&current_path, &current_branch) {
-        if p == &worktree_path.to_string_lossy() && b == branch_name {
-            return Ok(true);
-        }
+    if let (Some(p), Some(b)) = (current_path.take(), current_branch.take()) {
+        map.insert(PathBuf::from(p), b);
     }
-    Ok(false)
+    Ok(map)
+}
+
+/// Remove a prior-attempt worktree so a retry can recreate from a
+/// clean slate. Uses `git worktree remove --force` and `git worktree
+/// prune`. The branch ref is intentionally preserved in the shared
+/// object store (AC #2).
+async fn remove_worktree_for_retry(
+    runner: &GitRunner,
+    main_path: &Path,
+    path: &Path,
+) -> CaduceusResult<()> {
+    let path_str = path.to_string_lossy().into_owned();
+    let remove_args: [&str; 4] = ["worktree", "remove", "--force", &path_str];
+    let remove_output =
+        runner_run_in(runner, main_path, "retry-worktree-remove", &remove_args).await?;
+    if remove_output.cancelled {
+        return Err(CaduceusError::Cancelled);
+    }
+    if remove_output.timed_out || remove_output.status != Some(0) {
+        return Err(CaduceusError::Worktree {
+            context: "retry-worktree-remove",
+            stderr: format!(
+                "git worktree remove --force {} failed: {}",
+                path.display(),
+                remove_output.stderr
+            ),
+        });
+    }
+
+    let prune_args: [&str; 2] = ["worktree", "prune"];
+    let _ = runner_run_in(runner, main_path, "retry-worktree-prune", &prune_args).await;
+
+    Ok(())
 }
 
 /// Validate *run_id*: only ASCII letters, digits, underscores,

--- a/tests/infra/config_test.rs
+++ b/tests/infra/config_test.rs
@@ -58,3 +58,40 @@ fn worktree_gc_explicit_defaults_match_test_defaults() {
     );
     assert_eq!(from_raw.worktree_gc_disabled, defaults.worktree_gc_disabled);
 }
+
+#[test]
+fn attic_defaults_are_off_with_thirty_day_retention() {
+    let defaults = Config::test_defaults(PathBuf::from("/tmp/caduceus-test").as_path());
+    assert!(!defaults.archive_on_retry);
+    assert_eq!(defaults.attic_retention_days, 30);
+}
+
+#[test]
+fn attic_explicit_values_resolve() {
+    let raw = RawConfig {
+        archive_on_retry: Some(true),
+        attic_retention_days: Some(7),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let cfg = Config::from_raw(raw, &LoadContext::default()).expect("config");
+    assert!(cfg.archive_on_retry);
+    assert_eq!(cfg.attic_retention_days, 7);
+}
+
+#[test]
+fn attic_zero_retention_is_rejected() {
+    let raw = RawConfig {
+        attic_retention_days: Some(0),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let err = Config::from_raw(raw, &LoadContext::default()).expect_err("zero must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("attic_retention_days must be > 0"),
+        "unexpected error: {msg}"
+    );
+}

--- a/tests/repo/worktree_retry_test.rs
+++ b/tests/repo/worktree_retry_test.rs
@@ -1,0 +1,453 @@
+//! Retry behavior for failed-run worktrees (issue #177).
+//!
+//! * A prior attempt of the same issue is detected by its branch
+//!   prefix (`automation/issue-<N>-*`) and is archived/removed/recreated
+//!   instead of surfacing a "foreign run id" collision.
+//! * A prior attempt of a different issue is still refused as a
+//!   genuine collision.
+//! * The attic archives a working tree when `archive_on_retry` is
+//!   enabled, and the daemon sweep prunes archives by age.
+
+#![allow(unused_variables)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use caduceus::config::Config;
+use caduceus::issue::IssueKey;
+use caduceus::worktree::{create as create_worktree, GitRunner, RepositoryInfo, Worktree};
+use filetime::{set_file_mtime, FileTime};
+
+const HAPPY_RUN_ID: &str = "01H9Z3Y4G8W2J7N5K1QXV0F8P3";
+
+fn tempdir(label: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    dir.push(format!("caduceus-worktree-retry-{label}-{nonce}"));
+    fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+fn config_for(root: &Path, api_base: &str) -> Config {
+    let mut cfg = Config::test_defaults(root);
+    cfg.api_base = api_base.to_string();
+    cfg.git_timeout_seconds = 30;
+    cfg
+}
+
+fn key(owner: &str, repo: &str, number: u64) -> IssueKey {
+    IssueKey {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+    }
+}
+
+fn run_command(cmd: &mut Command) {
+    let output = cmd.output().expect("spawn command");
+    if !output.status.success() {
+        panic!(
+            "command {:?} failed: status={:?}\nstdout={}\nstderr={}",
+            cmd,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn run_with_label(label: &str, cmd: &mut Command) -> String {
+    let output = cmd.output().expect("spawn command");
+    if !output.status.success() {
+        panic!(
+            "[{label}] command {:?} failed: status={:?}\nstdout={}\nstderr={}",
+            cmd,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn init_bare_repo(path: &Path) -> String {
+    run_command(Command::new("git").arg("init").arg("--bare").arg(path));
+    fs::write(path.join("HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+    run_command(Command::new("git").current_dir(path).args([
+        "symbolic-ref",
+        "HEAD",
+        "refs/heads/main",
+    ]));
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
+        .output()
+        .expect("hash-object");
+    assert!(output.status.success(), "hash-object failed");
+    let tree = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["commit-tree", &tree, "-m", "initial"])
+        .output()
+        .expect("commit-tree");
+    assert!(output.status.success(), "commit-tree failed");
+    let commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/main",
+        &commit,
+    ]));
+    commit
+}
+
+fn clone_into(remote: &Path, dest: &Path) {
+    let remote_uri = format!("file://{}", remote.display());
+    run_command(
+        Command::new("git")
+            .arg("clone")
+            .arg("-b")
+            .arg("main")
+            .arg(&remote_uri)
+            .arg(dest),
+    );
+    run_command(
+        Command::new("git")
+            .current_dir(dest)
+            .args(["remote", "set-head", "origin", "main"]),
+    );
+}
+
+fn info_for(repo_path: &Path, base_branch: &str) -> RepositoryInfo {
+    RepositoryInfo {
+        path: repo_path.to_path_buf(),
+        base_branch: base_branch.to_string(),
+        remote_url: "file://localhost/tmp".to_string(),
+    }
+}
+
+fn branch_ref_exists(repo_path: &Path, branch_name: &str) -> bool {
+    Command::new("git")
+        .current_dir(repo_path)
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch_name}"),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+async fn run_git(runner: &GitRunner, cwd: &Path, args: &[&str]) -> caduceus::worktree::GitOutput {
+    let owned: Vec<std::ffi::OsString> =
+        args.iter().map(|s| std::ffi::OsString::from(*s)).collect();
+    let borrowed: Vec<&std::ffi::OsStr> = owned.iter().map(|s| s.as_os_str()).collect();
+    let temp_root = tempdir("run-git-shim");
+    let cfg = config_for(&temp_root, "https://api.github.com");
+    runner
+        .run_in(&cfg, "fixture", &borrowed, Some(cwd))
+        .await
+        .expect("git fixture")
+}
+
+#[tokio::test]
+async fn retry_different_run_id_preserves_old_branch_without_archive() {
+    // A realistic retry uses a fresh run id. The old worktree path
+    // is removed, but the old branch ref stays in the object store
+    // so an operator can still inspect the prior attempt's commits.
+    let owner = "octocat";
+    let repo = "repo";
+    let root = tempdir("retry-diff-run");
+    let bare = root.join("remote.git");
+    init_bare_repo(&bare);
+    let workdirs = root.join("workdirs");
+    fs::create_dir_all(&workdirs).unwrap();
+    let dest = workdirs.join(owner).join(repo);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    clone_into(&bare, &dest);
+
+    let mut cfg = config_for(&root, "https://api.github.com");
+    cfg.archive_on_retry = false;
+    let runner = GitRunner::new(&cfg);
+    let info = info_for(&dest, "main");
+    let issue_key = key(owner, repo, 7);
+
+    let first: Worktree = create_worktree(&cfg, &runner, &info, &issue_key, HAPPY_RUN_ID)
+        .await
+        .expect("first create");
+    assert!(first.path.is_dir());
+
+    let new_run_id = "01H9Z3Y4G8W2J7N5K1QXV0F8NEW";
+    let second: Worktree = create_worktree(&cfg, &runner, &info, &issue_key, new_run_id)
+        .await
+        .expect("retry create with new run id");
+    assert!(second.path.is_dir());
+    assert_ne!(second.path, first.path);
+
+    let branch_out = run_git(&runner, &dest, &["branch", "-a"]).await;
+    let branches: Vec<String> = branch_out
+        .stdout
+        .lines()
+        .map(|l| {
+            l.trim()
+                .trim_start_matches("* ")
+                .trim_start_matches("+ ")
+                .to_string()
+        })
+        .collect();
+    assert!(
+        branches.iter().any(|b| b == &second.branch_name),
+        "new branch ref must exist"
+    );
+    assert!(
+        branches.iter().any(|b| b == &first.branch_name),
+        "old branch ref from prior attempt must survive retry (AC #2)"
+    );
+
+    // No archive should have been written.
+    let attic = cfg.state_dir.join("attic");
+    assert!(!attic.exists() || fs::read_dir(&attic).unwrap().count() == 0);
+}
+
+#[tokio::test]
+async fn retry_same_run_id_is_idempotent_when_worktree_present() {
+    // The daemon resume path re-enters create_worktree with the same
+    // run_id. It must return the existing handle without archiving,
+    // removing, or recreating the worktree.
+    let owner = "octocat";
+    let repo = "repo";
+    let root = tempdir("retry-same-run-idempotent");
+    let bare = root.join("remote.git");
+    init_bare_repo(&bare);
+    let workdirs = root.join("workdirs");
+    fs::create_dir_all(&workdirs).unwrap();
+    let dest = workdirs.join(owner).join(repo);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    clone_into(&bare, &dest);
+
+    let mut cfg = config_for(&root, "https://api.github.com");
+    cfg.archive_on_retry = true; // even when enabled, must not archive
+    cfg.attic_retention_days = 30;
+    let runner = GitRunner::new(&cfg);
+    let info = info_for(&dest, "main");
+    let issue_key = key(owner, repo, 10);
+
+    let first: Worktree = create_worktree(&cfg, &runner, &info, &issue_key, HAPPY_RUN_ID)
+        .await
+        .expect("first create");
+    assert!(first.fresh, "initial create must report fresh");
+    assert!(first.path.is_dir());
+
+    let second: Worktree = create_worktree(&cfg, &runner, &info, &issue_key, HAPPY_RUN_ID)
+        .await
+        .expect("same-run-id re-entry must be idempotent");
+    assert!(!second.fresh, "same-run-id re-entry must not report fresh");
+    assert_eq!(second.path, first.path);
+    assert_eq!(second.branch_name, first.branch_name);
+    assert!(
+        branch_ref_exists(&dest, &first.branch_name),
+        "branch ref must survive idempotent re-entry"
+    );
+
+    // Same-run-id re-entry must never archive.
+    let attic = cfg.state_dir.join("attic");
+    assert!(!attic.exists() || fs::read_dir(&attic).unwrap().count() == 0);
+}
+
+#[tokio::test]
+async fn retry_different_run_id_archives_working_tree_when_enabled() {
+    // Archiving is only meaningful when the daemon is replacing a
+    // prior attempt's worktree with a *new* run id. Same-run-id
+    // re-entry must be idempotent and never archive.
+    let owner = "octocat";
+    let repo = "repo";
+    let root = tempdir("retry-archive");
+    let bare = root.join("remote.git");
+    init_bare_repo(&bare);
+    let workdirs = root.join("workdirs");
+    fs::create_dir_all(&workdirs).unwrap();
+    let dest = workdirs.join(owner).join(repo);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    clone_into(&bare, &dest);
+
+    let mut cfg = config_for(&root, "https://api.github.com");
+    cfg.archive_on_retry = true;
+    cfg.attic_retention_days = 30;
+    let runner = GitRunner::new(&cfg);
+    let info = info_for(&dest, "main");
+    let issue_key = key(owner, repo, 8);
+
+    let first = create_worktree(&cfg, &runner, &info, &issue_key, HAPPY_RUN_ID)
+        .await
+        .expect("first create");
+    let marker = first.path.join("retry-marker.txt");
+    fs::write(&marker, "preserve me").unwrap();
+
+    let new_run_id = "01H9Z3Y4G8W2J7N5K1QXV0F8NEW";
+    let second = create_worktree(&cfg, &runner, &info, &issue_key, new_run_id)
+        .await
+        .expect("retry create with archive");
+    assert!(second.path.is_dir());
+    assert_ne!(second.path, first.path);
+    assert!(
+        !second.path.join("retry-marker.txt").exists(),
+        "recreated worktree must start clean"
+    );
+
+    let attic = cfg.state_dir.join("attic");
+    assert!(attic.is_dir(), "attic dir should be created");
+    let archives: Vec<PathBuf> = fs::read_dir(&attic)
+        .unwrap()
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    assert_eq!(archives.len(), 1, "exactly one archive expected");
+    let archive = &archives[0];
+    assert!(
+        archive.extension().is_some_and(|e| e == "tar"),
+        "archive must be a plain .tar"
+    );
+
+    let listing = run_with_label("tar-list", Command::new("tar").arg("-tf").arg(archive));
+    assert!(
+        listing.contains("retry-marker.txt"),
+        "archive should contain the marker file; got: {listing}"
+    );
+}
+
+#[tokio::test]
+async fn retry_refuses_foreign_issue_worktree() {
+    let owner = "octocat";
+    let repo = "repo";
+    let root = tempdir("foreign-issue");
+    let bare = root.join("remote.git");
+    init_bare_repo(&bare);
+    let workdirs = root.join("workdirs");
+    fs::create_dir_all(&workdirs).unwrap();
+    let dest = workdirs.join(owner).join(repo);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    clone_into(&bare, &dest);
+
+    let cfg = config_for(&root, "https://api.github.com");
+    let runner = GitRunner::new(&cfg);
+    let info = info_for(&dest, "main");
+
+    // Pre-create a worktree for a different issue at the same path
+    // the target create() would use.
+    let foreign_branch = format!("automation/issue-99-{}", HAPPY_RUN_ID.to_ascii_lowercase());
+    let target_path = cfg
+        .state_dir
+        .join("worktrees")
+        .join(owner)
+        .join(repo)
+        .join(HAPPY_RUN_ID);
+    run_command(Command::new("git").current_dir(&dest).args([
+        "worktree",
+        "add",
+        "-b",
+        &foreign_branch,
+        target_path.to_str().unwrap(),
+        "origin/main",
+    ]));
+
+    let err = create_worktree(&cfg, &runner, &info, &key(owner, repo, 7), HAPPY_RUN_ID)
+        .await
+        .expect_err("foreign issue worktree must collide");
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("collision") || text.contains("already exists"),
+        "got: {text}"
+    );
+
+    let attic = cfg.state_dir.join("attic");
+    assert!(!attic.exists() || fs::read_dir(&attic).unwrap().count() == 0);
+}
+
+#[tokio::test]
+async fn retry_cleans_prior_same_issue_run_id_under_repo_state_dir() {
+    // Simulates a real retry after a failed attempt: a new run_id is
+    // issued, but an old worktree for the same issue is still sitting
+    // under the per-repo state directory.
+    let owner = "octocat";
+    let repo = "repo";
+    let root = tempdir("retry-different-run");
+    let bare = root.join("remote.git");
+    init_bare_repo(&bare);
+    let workdirs = root.join("workdirs");
+    fs::create_dir_all(&workdirs).unwrap();
+    let dest = workdirs.join(owner).join(repo);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    clone_into(&bare, &dest);
+
+    let cfg = config_for(&root, "https://api.github.com");
+    let runner = GitRunner::new(&cfg);
+    let info = info_for(&dest, "main");
+    let issue_key = key(owner, repo, 9);
+
+    let old_run_id = "01H9Z3Y4G8W2J7N5K1QXV0F8OLD";
+    let old_branch = format!(
+        "automation/issue-{}-{}",
+        issue_key.number,
+        old_run_id.to_ascii_lowercase()
+    );
+    let old_path = cfg
+        .state_dir
+        .join("worktrees")
+        .join(owner)
+        .join(repo)
+        .join(old_run_id);
+    run_command(Command::new("git").current_dir(&dest).args([
+        "worktree",
+        "add",
+        "-b",
+        &old_branch,
+        old_path.to_str().unwrap(),
+        "origin/main",
+    ]));
+
+    let new_run_id = "01H9Z3Y4G8W2J7N5K1QXV0F8NEW";
+    let handle = create_worktree(&cfg, &runner, &info, &issue_key, new_run_id)
+        .await
+        .expect("retry with new run id must clean old same-issue worktree");
+    assert_eq!(handle.run_id, new_run_id);
+    assert!(
+        !old_path.exists(),
+        "old same-issue worktree path should be removed"
+    );
+    assert!(handle.path.exists(), "new worktree path should exist");
+    assert!(
+        branch_ref_exists(&dest, &old_branch),
+        "old branch ref must survive removal of prior-attempt worktree (AC #2)"
+    );
+}
+
+#[test]
+fn attic_sweep_removes_expired_archives_only() {
+    let root = tempdir("attic-sweep");
+    let mut cfg = config_for(&root, "https://api.github.com");
+    cfg.attic_retention_days = 30;
+
+    let attic = cfg.state_dir.join("attic");
+    fs::create_dir_all(&attic).unwrap();
+
+    let old = attic.join("owner-repo-8-old-100.tar");
+    let fresh = attic.join("owner-repo-8-fresh-200.tar");
+    fs::write(&old, b"old").unwrap();
+    fs::write(&fresh, b"fresh").unwrap();
+
+    let long_ago = chrono::Utc::now() - chrono::Duration::days(60);
+    set_file_mtime(&old, FileTime::from_unix_time(long_ago.timestamp(), 0)).unwrap();
+
+    let removed = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(caduceus::worktree::sweep(&cfg))
+        .expect("sweep");
+    assert_eq!(removed, 1);
+    assert!(!old.exists());
+    assert!(fresh.exists());
+}


### PR DESCRIPTION
## Summary

Implements [caduceus#177](https://github.com/barkley-assistant/caduceus/issues/177) — workers preserve failed-run worktrees for investigation and clean them only when the daemon is about to retry the same issue.

## What changed

**`src/worktree/worktree.rs`** — the collision-guard logic that previously refused any pre-existing worktree at the retry path now distinguishes between:
- a **foreign** worktree (sibling daemon, manual debugging) → refuse as today
- a **same-issue prior attempt** (the daemon's own prior run) → archive (opt-in), remove, recreate

**`src/worktree/attic.rs`** (new) — the `<state_dir>/attic/` directory holds `.tar` archives of failed-run working trees. The `archive()` function is no-op when `archive_on_retry` is disabled (the default). `sweep()` runs on each daemon pulse and prunes archives older than `attic_retention_days`.

**`src/infra/config/mod.rs`** — two new `Config` fields (`archive_on_retry: bool`, `attic_retention_days: u64`) wired through the 4-site pattern (`Config`, `RawConfig`, `from_raw`, `test_defaults`) with a `> 0` validator on the retention window.

**`src/daemon/tick/mod.rs`** — calls `attic::sweep()` on each pulse so retention is enforced without a separate cron.

**`Cargo.toml`** — `[[test]]` entry registered for `worktree_retry_test`, plus `tar = "0.4.46"` dependency for plain `.tar` archive format. (No `zstd` — the issue body named `.tar.zst` as a target but the repo didn't depend on zstd; the implementer reasonably added `tar` only and uses uncompressed archives.)

**`.gitignore`** — `/openspec/` added as defense-in-depth alongside the existing `/prompts/` and `/.hermes/` operator-scratch patterns.

## Test coverage

`tests/repo/worktree_retry_test.rs` (new, 6 tests):

- `retry_refuses_foreign_issue_worktree` — collision guard still refuses non-matching run ids
- `retry_cleans_prior_same_issue_run_id_under_repo_state_dir` — the headline retry-over-prior-attempt case
- `retry_same_run_id_is_idempotent_when_worktree_present` — claim re-acquire doesn't double-clean
- `retry_different_run_id_archives_working_tree_when_enabled` — opt-in archive path
- `retry_different_run_id_preserves_old_branch_without_archive` — branch ref survival when archive off
- `attic_sweep_removes_expired_archives_only` — retention sweep precision

All 6 pass. Full `cargo test --locked --all-targets` gate (skipping the 5 known hermetic flakes documented in `caduceus-project-conventions`) reports 0 failures.

## Acceptance criteria

- [x] Daemon retries an issue after a failed previous attempt succeed without operator intervention
- [x] Branch ref from prior attempt survives and is checkable from main
- [x] Working tree from prior attempt is removed (or archived to attic, per config)
- [x] No "foreign run id" error on retry
- [x] Test coverage: retry-over-failed-prior-attempt case in `tests/repo/worktree_retry_test.rs`
- [x] Manual kill of a running worker does not block future retries of the same issue

## Out of scope

Per the issue body, the following are filed separately and intentionally not addressed here:
- Orphan sweep for daemon-crash-between-pulse edge cases (P2)
- Max-age retention on `runs/` (P2, partially solved by `run_retention_days: 30`)
- Worktree isolation level evaluation (P2 spike)

## How it was built

Implemented end-to-end via the specops-auto workflow (explorer → planner → designer → implementer → reviewer → frontier). Reviewer returned two findings (F1/F2) on the first pass; the implementer was re-spawned to remediate, the reviewer re-verified, both phases exited clean. Full test gate run by the supervisor post-implementation confirmed all gates green.

Closes #177

🤖 Generated via the specops-auto workflow on caduceus#177