### PR TITLE
feat(supervisor): portable process-tree reaping via ProcessTree (closes #183)

### DIFF
--- a/src/worker/supervisor/dispatch.rs
+++ b/src/worker/supervisor/dispatch.rs
@@ -13,7 +13,7 @@ use tokio::process::{Child, Command as TokioCommand};
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::supervisor::process_lifecycle::{
-    decide_deadline_kill, DeadlineKillDecision, IDENTITY,
+    decide_deadline_kill, kill_pid, signal_number_from_str, DeadlineKillDecision, IDENTITY, TREE,
 };
 
 // Public spawn orchestrator
@@ -232,6 +232,14 @@ pub(crate) async fn run_supervisor(
                             }
                         }
 
+                        // Reap descendants that setsid-ed out of the worker
+                        // group. Best-effort: kill_pid swallows errors.
+                        if let Some(worker_pgid) = worker_pgid {
+                            for pid in TREE.list_children(worker_pgid) {
+                                kill_pid(pid, signal_number_from_str("TERM").unwrap_or(15));
+                            }
+                        }
+
                         // Wait 2 s grace period then re-verify and KILL.
                         tokio::time::sleep(Duration::from_secs(2)).await;
 
@@ -249,6 +257,22 @@ pub(crate) async fn run_supervisor(
                                     &mut stdin,
                                     &ControlFrame::Terminate { force: true },
                                 ).await.ok();
+                            }
+                        }
+
+                        // Final reap: rediscover survivors and SIGKILL them.
+                        // Bounded so a runaway session cannot stall teardown.
+                        if let Some(worker_pgid) = worker_pgid {
+                            for _ in 0..3 {
+                                let remaining = TREE.list_children(worker_pgid);
+                                if remaining.is_empty() {
+                                    break;
+                                }
+                                let sig = signal_number_from_str("KILL").unwrap_or(9);
+                                for pid in remaining {
+                                    kill_pid(pid, sig);
+                                }
+                                tokio::time::sleep(Duration::from_millis(100)).await;
                             }
                         }
 

--- a/src/worker/supervisor/mod.rs
+++ b/src/worker/supervisor/mod.rs
@@ -29,6 +29,15 @@
 //!   the original negative PGID plus every descendant, waits
 //!   two seconds, rediscovers, sends `SIGKILL`, and reaps
 //!   until no descendants remain.
+//!
+//! P5 records the wire-in-vs-delete decision: descendant reaping is wired into
+//! the production cleanup path on both Linux and macOS via `TREE.list_children`.
+//! On macOS the kernel has no subreaper analogue
+//! (`procctl(PROC_REAP_ACQUIRE)` is FreeBSD-only); POSIX process-group kill is
+//! the primary mechanism, and `proc_listchildpids`-based enumeration catches
+//! `setsid`-ed grandchildren as a best-effort safety net. Unsupported platforms
+//! fail at compile time rather than silently no-oping.
+//!
 //! * The supervisor only ever sees the cleared worker
 //!   environment — daemon credentials never appear in any
 //!   inherited descriptor or pipe frame.

--- a/src/worker/supervisor/process_lifecycle.rs
+++ b/src/worker/supervisor/process_lifecycle.rs
@@ -208,6 +208,55 @@ impl ProcessTree for LinuxProcessTree {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+pub struct MacosProcessTree;
+
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+impl ProcessTree for MacosProcessTree {
+    fn adopt_subtree(&self, _root: i32) -> std::io::Result<()> {
+        static WARNED: std::sync::Once = std::sync::Once::new();
+        WARNED.call_once(|| tracing::warn!("child subreaper is unavailable on macOS"));
+        Ok(())
+    }
+
+    fn list_children(&self, ppid: i32) -> Vec<i32> {
+        extern "C" {
+            fn proc_listchildpids(
+                ppid: libc::pid_t,
+                buffer: *mut libc::c_int,
+                buffersize: libc::c_int,
+            ) -> libc::c_int;
+        }
+
+        if ppid <= 0 {
+            return Vec::new();
+        }
+
+        let mut cap: i32 = 64;
+        let max_cap: i32 = 16_384;
+        loop {
+            let mut buf: Vec<i32> = Vec::with_capacity(cap as usize);
+            let written = unsafe { proc_listchildpids(ppid, buf.as_mut_ptr().cast(), cap) };
+            if written < 0 {
+                return Vec::new();
+            }
+            if written < cap {
+                unsafe { buf.set_len(written as usize) };
+                return buf;
+            }
+            if cap >= max_cap {
+                // Cap reached — return what we have rather than loop unboundedly.
+                // Safety: the kernel wrote `written` ints into the uninitialised buffer.
+                unsafe { buf.set_len(written as usize) };
+                return buf;
+            }
+            cap = cap.saturating_mul(2).min(max_cap);
+        }
+    }
+}
+
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 #[derive(Debug)]
 pub struct StubProcessIdentity;
@@ -227,23 +276,6 @@ impl ProcessIdentity for StubProcessIdentity {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
-#[derive(Debug)]
-pub struct StubProcessTree;
-
-#[cfg(not(target_os = "linux"))]
-impl ProcessTree for StubProcessTree {
-    fn adopt_subtree(&self, _root: i32) -> std::io::Result<()> {
-        static WARNED: std::sync::Once = std::sync::Once::new();
-        WARNED.call_once(|| tracing::warn!("child subreaper is unavailable on this platform"));
-        Ok(())
-    }
-
-    fn list_children(&self, _ppid: i32) -> Vec<i32> {
-        Vec::new()
-    }
-}
-
 #[cfg(target_os = "linux")]
 pub static IDENTITY: &dyn ProcessIdentity = &LinuxProcessIdentity;
 
@@ -256,8 +288,8 @@ pub static IDENTITY: &dyn ProcessIdentity = &StubProcessIdentity;
 #[cfg(target_os = "linux")]
 pub static TREE: &dyn ProcessTree = &LinuxProcessTree;
 
-#[cfg(not(target_os = "linux"))]
-pub static TREE: &dyn ProcessTree = &StubProcessTree;
+#[cfg(target_os = "macos")]
+pub static TREE: &dyn ProcessTree = &MacosProcessTree;
 
 // Subreaper + setsid + signal helpers (safe wrappers via nix)
 

--- a/tests/worker/process_tree_test.rs
+++ b/tests/worker/process_tree_test.rs
@@ -1,14 +1,68 @@
-use caduceus::worker_supervisor::TREE;
+use caduceus::worker::supervisor::process_lifecycle::TREE;
 
+#[serial_test::serial]
 #[test]
 fn own_process_has_no_children_at_test_start() {
     assert!(TREE.list_children(std::process::id() as i32).is_empty());
 }
 
+#[serial_test::serial]
 #[test]
 fn adopting_own_process_is_idempotent() {
     TREE.adopt_subtree(std::process::id() as i32)
         .expect("first subtree adoption should be non-fatal");
     TREE.adopt_subtree(std::process::id() as i32)
         .expect("second subtree adoption should be non-fatal");
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[serial_test::serial]
+#[test]
+fn list_children_returns_direct_children() {
+    use std::process::{Command, Stdio};
+
+    // `sleep 30 & sleep 30; wait` keeps two direct sleep children
+    // alive under the shell PID for the duration of the test.
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg("sleep 30 & sleep 30; wait")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn fixture shell");
+    let shell_pid = child.id() as i32;
+
+    // Let the shell exec the two sleeps so they appear as direct
+    // children. 50 ms is plenty for fork+exec on both platforms.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let children = TREE.list_children(shell_pid);
+    assert_eq!(
+        children.len(),
+        2,
+        "expected two sleep children, got {children:?}"
+    );
+
+    // Ground-truth cross-check via pgrep where available.
+    if let Ok(out) = Command::new("pgrep")
+        .args(["-P", &shell_pid.to_string()])
+        .output()
+    {
+        if out.status.success() {
+            let expected: Vec<i32> = String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .filter_map(|line| line.trim().parse().ok())
+                .collect();
+            assert!(
+                children.iter().all(|pid| expected.contains(pid)),
+                "list_children returned PIDs not in pgrep ground truth: {children:?} vs {expected:?}"
+            );
+        }
+    }
+
+    // Best-effort cleanup; ignore kill errors (the test may have
+    // raced a sleep exit).
+    let _ = child.kill();
+    let _ = child.wait();
 }

--- a/tests/worker/process_tree_test.rs
+++ b/tests/worker/process_tree_test.rs
@@ -21,32 +21,39 @@ fn adopting_own_process_is_idempotent() {
 fn list_children_returns_direct_children() {
     use std::process::{Command, Stdio};
 
-    // `sleep 30 & sleep 30; wait` keeps two direct sleep children
-    // alive under the shell PID for the duration of the test.
-    let mut child = Command::new("sh")
-        .arg("-c")
-        .arg("sleep 30 & sleep 30; wait")
+    // Spawn two direct sleep children of this process. Keeping them as
+    // direct children (no intermediate shell) makes cleanup deterministic:
+    // kill+wait each and no orphan can reparent here to poison the
+    // own_process_has_no_children_at_test_start assertion.
+    let mut s1 = Command::new("sleep")
+        .arg("30")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn fixture shell");
-    let shell_pid = child.id() as i32;
+        .expect("spawn sleep child 1");
+    let mut s2 = Command::new("sleep")
+        .arg("30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sleep child 2");
+    let p1 = s1.id() as i32;
+    let p2 = s2.id() as i32;
 
-    // Let the shell exec the two sleeps so they appear as direct
-    // children. 50 ms is plenty for fork+exec on both platforms.
+    // Let both fully exec before enumerating.
     std::thread::sleep(std::time::Duration::from_millis(50));
 
-    let children = TREE.list_children(shell_pid);
-    assert_eq!(
-        children.len(),
-        2,
-        "expected two sleep children, got {children:?}"
+    let children = TREE.list_children(std::process::id() as i32);
+    assert!(
+        children.contains(&p1) && children.contains(&p2),
+        "expected both sleep children {p1},{p2}, got {children:?}"
     );
 
     // Ground-truth cross-check via pgrep where available.
     if let Ok(out) = Command::new("pgrep")
-        .args(["-P", &shell_pid.to_string()])
+        .args(["-P", &std::process::id().to_string()])
         .output()
     {
         if out.status.success() {
@@ -61,8 +68,10 @@ fn list_children_returns_direct_children() {
         }
     }
 
-    // Best-effort cleanup; ignore kill errors (the test may have
-    // raced a sleep exit).
-    let _ = child.kill();
-    let _ = child.wait();
+    // Deterministic cleanup: kill+wait each direct child. Nothing is
+    // orphaned, so no reparenting can race the sibling assertion.
+    let _ = s1.kill();
+    let _ = s1.wait();
+    let _ = s2.kill();
+    let _ = s2.wait();
 }


### PR DESCRIPTION
## Summary

Controlled specops-auto run (manual, no daemon — #5 in the #60 portability chain). Adds the macOS `ProcessTree` impl and wires descendant reaping into the production cleanup path, closing S1/S2 (the coupled subreaper+descendant-collection unit, INV-03).

## Changes

- `src/worker/supervisor/process_lifecycle.rs` — `MacosProcessTree` via `proc_listchildpids` FFI + grow-on-demand buffer; `TREE` static gains macOS arm; `StubProcessTree` deleted. F1 (cap-reached branch returned `Vec::new()` instead of the populated buffer) found by reviewer, fixed at 249-254, re-verified.
- `src/worker/supervisor/dispatch.rs` — `TREE.list_children` wired into cleanup: TERM-reap + bounded post-KILL rediscovery.
- `src/worker/supervisor/mod.rs` — P5 decision paragraph.
- `tests/worker/process_tree_test.rs` — `list_children_returns_direct_children`, cfg-gated linux/macos, `pgrep` cross-check.

## Verification

- `cargo fmt --check` clean; `cargo clippy --locked --all-targets -- -D warnings` clean
- `cargo test --locked --all-targets` green (my full gate — the implementer's sandbox hit a `/tmp` quota)
- Reviewer FAIL → 1 remediation round → PASS

## Notes

- macOS `cargo check --target x86_64-apple-darwin` deferred to P7 macOS CI (target not installed locally); the macOS FFI branch is exercisable only there.
- `hermes_lifecycle` hermetic skips as documented.

Closes #183