### PR TITLE
ci(runtime): add macos-latest GitHub Actions job (ref #60)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,90 @@
+# macOS CI gate for the Caduceus v1.0 portability plan.
+#
+# Companion to ci.yml: same Rust + Python gate, but on macos-latest
+# so portability regressions surface in PR review instead of after
+# merge. The Linux runner cannot cross-compile x86_64-apple-darwin
+# because rusqlite (bundled C) and rustls (C deps) need a darwin C
+# cross-toolchain, which rustup does not provide. macOS runners are
+# free for public repos; cost is zero for this project.
+#
+# Mirrors ci.yml structure (actions/cache@v4 keyed on Cargo.lock,
+# configure git identity for tests, timeout-minutes: 30 job, 15-min
+# test step). Path filter keeps macOS runner-minute burn low — only
+# Rust crate or this workflow file changes fire the runner.
+#
+# GITHUB_TOKEN is unset for the test step so the
+# `with_config_falls_back_to_none_when_env_var_dropped` case in
+# token_resolution_test runs hermetically (the GH Actions runner's
+# auto-injected GITHUB_TOKEN would otherwise leak through
+# src/infra/config/token.rs).
+#
+# Required-check name: macos / test
+name: macos
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/macos.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/macos.yml'
+
+# Cancel in-progress runs on the same ref so a force-push does
+# not leave a stale runner burning macOS minutes.
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install stable Rust 1.97
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.97 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          rustup component add rustfmt clippy
+      - name: cache cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-macos-stable-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-macos-stable-
+      - name: configure git identity for tests
+        run: |
+          set -euo pipefail
+          git config --global user.email "ci@caduceus.local"
+          git config --global user.name "caduceus-ci"
+      - name: fmt
+        run: cargo fmt --check
+      - name: clippy
+        run: cargo clippy --locked --all-targets -- -D warnings
+      - name: build
+        run: cargo build --locked
+      - name: test
+        # hermes_lifecycle tests (ac04/ac06/ac07/ac08) each shell out
+        # to `hermes caduceus setup` which takes 2-3 minutes to
+        # compile the release binary; allow 15 min for the test
+        # step on macOS just like ci.yml.
+        timeout-minutes: 15
+        run: env -u GITHUB_TOKEN cargo test --locked --all-targets


### PR DESCRIPTION
## Summary

Controlled specops-auto run (manual — #7 in the #60 portability chain). Adds a `macos-latest` CI job so portability regressions surface in PR review instead of after merge. Without macOS CI, every portability ticket (#179, #180, #181, #182, #183, #184) is unverifiable except by an operator with a Mac and the discipline to run it locally.

## Changes

- `.github/workflows/macos.yml` (new) — mirrors `ci.yml` structure (`actions/cache@v4` keyed on `Cargo.lock`, configure git identity for tests, `timeout-minutes: 30` job, 15-min test step) but on `macos-latest`. Path filter (`src/**`, `Cargo.toml`, `Cargo.lock`, `.github/workflows/macos.yml`) keeps macOS runner-minute burn low. `GITHUB_TOKEN` unset for the test step so `token_resolution_test`'s hermetic case fires correctly.
- No other workflow files touched; no source code touched.

## Verification

- YAML parses cleanly via `python3 -c "import yaml; yaml.safe_load(...)"`
- Manually diffed against `ci.yml` for consistency: same caching action, same git-identity step, same timeout shape

## Notes

- macOS cold builds are 5-10 min, warm under 2 min via `actions/cache@v4` (no `Swatinem/rust-cache` per repo convention in `ci.yml`)
- macOS verification of `cargo test --locked --all-targets` will gate on the same hermetic class as Linux (ac04/06/07/08 setup timeouts) — `--skip` list NOT applied because the issue body's claim of a canonical `--skip` list was unfounded; `ci.yml` runs `cargo test --locked --all-targets` plain with a 15-min step timeout, same here.

Refs #60