### PR TITLE
fix(supervisor): gate linux-only test seam re-export to macOS (closes #195)

### DIFF
--- a/src/worker/supervisor/mod.rs
+++ b/src/worker/supervisor/mod.rs
@@ -84,6 +84,7 @@ pub use process_lifecycle::*;
 
 // Test seam: re-export the synthetic-stat parser so integration
 // tests can assert the field-22 contract without owning a runtime.
+#[cfg(target_os = "linux")]
 #[doc(hidden)]
 pub use self::process_lifecycle::parse_starttime_from_stat_for_tests;
 

--- a/tests/worker/supervisor_dispatch_inline_test.rs
+++ b/tests/worker/supervisor_dispatch_inline_test.rs
@@ -2,11 +2,13 @@
 //! (`src/worker/supervisor/dispatch.rs`). Moved out of the inline
 //! `#[cfg(test)]` module per AGENTS.md.
 
+#[cfg(target_os = "linux")]
+use caduceus::worker_supervisor::parse_starttime_from_stat_for_tests;
 use caduceus::worker_supervisor::{
     clear_heartbeat, decide_deadline_kill, decode_frame, encode_frame, open_transcript,
-    parse_starttime_from_stat_for_tests, read_heartbeat, read_proc_starttime, truncate_transcript,
-    verify_identity, write_heartbeat, BoundedTranscriptWriter, ControlFrame, DeadlineKillDecision,
-    ProcessIdentity, WorkerRunPaths, MAX_FRAME_BYTES,
+    read_heartbeat, read_proc_starttime, truncate_transcript, verify_identity, write_heartbeat,
+    BoundedTranscriptWriter, ControlFrame, DeadlineKillDecision, ProcessIdentity, WorkerRunPaths,
+    MAX_FRAME_BYTES,
 };
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary

Fixes the two cfg-asymmetries that broke the new `macos / test` CI job added in PR #195. Re-export at `src/worker/supervisor/mod.rs:88` was unconditional but pointed at a `#[cfg(target_os = "linux")]`-gated symbol — Linux compiled, macOS didn't. Same asymmetry at the test file's module-top import.

## Changes

- `src/worker/supervisor/mod.rs` (+1) — `#[cfg(target_os = "linux")]` above the `pub use parse_starttime_from_stat_for_tests`, matching the symbol's existing gate
- `tests/worker/supervisor_dispatch_inline_test.rs` (+5/-3) — extracted the linux-only `use` into a separate top-level statement preceded by `#[cfg(target_os = "linux")]`; removed the symbol from the unconditional `use ... { ... }` group

**macOS support maintained.** Symbol definition's linux cfg preserved. Fix shape is "make the unconditional reference conditional to match the symbol's cfg", not remove the cfg.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --locked --all-targets -- -D warnings` clean
- `cargo test --locked --all-targets` green (incl. `supervisor_dispatch_inline_test` 18/18)
- Reviewer V1–V9 PASS

## Why this PR

#185's macOS CI acceptance is "`cargo check`, `cargo build`, `cargo test` all green on macos-latest." These two unconditional references were the only asymmetries; the macOS runner is the authoritative verifier and the fix must ship for #185's contract to be met.

Closes #195