### PR TITLE
feat(plugin): one-function user harness contract (closes #201)

### DIFF
--- a/plugin-assets/caduceus_harness.py.example
+++ b/plugin-assets/caduceus_harness.py.example
@@ -1,0 +1,28 @@
+"""Caduceus user harness hook — the entire user-editable surface.
+
+Two dispatch paths exist:
+
+1. New contract (this file): when this file is copied to
+   ``~/.hermes/caduceus/harness.py``, the parent runner loads it,
+   calls ``run_task(ctx)`` with a ``Ctx`` object, and runs the
+   returned argv inside the worktree.
+
+2. Legacy full-script contract: when only ``worker-bridge.py`` exists
+   at ``~/.hermes/caduceus/worker-bridge.py``, the parent exec's it
+   as a subprocess. To migrate, copy this file to ``harness.py``
+   next to ``worker-bridge.py`` and edit ``run_task``.
+
+Verify the active path with::
+
+    cat ~/.hermes/caduceus/harness.py | head   # new contract active
+    ls ~/.hermes/caduceus/                     # otherwise legacy
+
+``ctx`` exposes every ``CADUCEUS_*`` variable the daemon exports
+(see ``Ctx`` in ``plugin-assets/worker-bridge.py``). ``ctx.dry_run``
+is best-effort: it is set if the daemon propagates
+``CADUCEUS_DRY_RUN`` to the worker, otherwise it defaults to False.
+"""
+
+
+def run_task(ctx):
+    return ["opencode", "run", "--agent", "gentle-orchestrator", "-f", str(ctx.prompt)]

--- a/plugin-assets/worker-bridge.py
+++ b/plugin-assets/worker-bridge.py
@@ -1,21 +1,16 @@
 #!/usr/bin/env python3
 """Caduceus harness bridge — canonical reference implementation.
 
-This file is the reference bridge that ``hermes caduceus setup`` seeds at
-``$HERMES_HOME/caduceus/worker-bridge.py``. It is the only part of Caduceus
-written in Python. Its job is intentionally narrow:
+This file is the parent runner that ``hermes caduceus setup`` seeds at
+``$HERMES_HOME/caduceus/worker-bridge.py``. A user-owned
+``$HERMES_HOME/caduceus/harness.py`` can provide the small ``run_task(ctx)``
+hook; the parent validates the daemon inputs, loads that hook, runs its argv,
+and synthesizes a result when the argv did not write one. If no hook exists,
+the bridge preserves the legacy full-script path.
 
-1. Read the ``CADUCEUS_*`` environment variables that the daemon exports
-   for the worker, fail with a clear diagnostic when any required value
-   is missing or malformed.
-2. Verify the worktree and the rendered prompt file exist and are usable.
-3. Invoke the configured harness through :func:`invoke_harness` and
-   return its exit code so the daemon's ``worker_timeout_seconds``,
-   transcript capture, and retry budget behave correctly.
-
-The bridge never touches the daemon state directory, never reads or writes
-a heartbeat, and never claims, queues, or finalizes anything. All of that
-work lives in the Rust core.
+The bridge never touches the daemon state directory, never reads or writes a
+heartbeat, and never claims, queues, or finalizes anything. All of that work
+lives in the Rust core.
 
 Credential hygiene
 ------------------
@@ -32,12 +27,10 @@ and it runs **before** the bridge starts.
 Harness selection
 -----------------
 
-The reference harness is OpenCode with the gentle-orchestrator agent. To
-swap harnesses, edit :func:`invoke_harness` in the *user-owned* copy at
-``$HERMES_HOME/caduceus/worker-bridge.py`` — leave the validation in
-:func:`main` alone. ``hermes caduceus setup`` will never overwrite that
-copy automatically; if the upstream template changes it writes a sibling
-``.new`` candidate and reports it, leaving your edits in place.
+The reference hook returns OpenCode with the gentle-orchestrator agent. To
+swap harnesses, copy ``plugin-assets/caduceus_harness.py.example`` to
+``$HERMES_HOME/caduceus/harness.py`` and edit its ``run_task`` function.
+Existing user-owned full bridge scripts remain valid when the hook is absent.
 
 Forbidden side effects
 ----------------------
@@ -63,16 +56,17 @@ delivered signal is the correct behavior. The Python test suite pins
 this explicitly (``test_signal_is_forwarded_to_harness``).
 """
 
-from __future__ import annotations
-
+import importlib.util
 import json
 import os
-import signal
+import signal  # noqa: F401 - preserved as a public compatibility symbol
 import subprocess
 import sys
+import unicodedata
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Mapping, Sequence, Union
-
+from types import MappingProxyType
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -105,6 +99,12 @@ EXIT_MALFORMED_LABELS = 2
 EXIT_MISSING_PROMPT = 2
 EXIT_HARNESS_NOT_FOUND = 127
 EXIT_HARNESS_UNREACHABLE = 126
+EXIT_HARNESS_CRASH = 125
+
+# Result-file limits mirror ``src/worker/worker_contract.rs``.
+MAX_RESULT_FILE_BYTES = 1 << 20
+MAX_SUMMARY_BYTES = 64 * 1024
+MAX_PULL_REQUEST_TITLE_CHARS = 256
 
 #: Patterns the bridge uses. The daemon is the source of truth for
 #: credential hygiene (see ``DENIED_ENV_VARS`` in the Rust core); the
@@ -124,7 +124,224 @@ del _DOCUMENTED_DENIED_VARS  # documented above; not enforced here
 
 
 # ---------------------------------------------------------------------------
-# Harness hook — the only function operators are expected to edit
+# Parent runner types and helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Issue:
+    """Issue details exposed to a user harness through :class:`Ctx`."""
+
+    repo: str
+    number: int
+    title: str
+    body: str
+
+
+@dataclass(frozen=True)
+class Ctx:
+    """The explicit worker context passed to ``run_task``."""
+
+    worktree: Path
+    prompt: Path
+    run_id: str
+    branch: str
+    labels: list[str]
+    issue: Issue
+    context_json: str
+    dry_run: bool
+    env: Mapping[str, str]
+
+
+def _hermes_home(env: Mapping[str, str] | None = None) -> Path:
+    """Resolve ``HERMES_HOME`` without consulting a fallback first."""
+    source = os.environ if env is None else env
+    raw = source.get("HERMES_HOME")
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path("~/.hermes").expanduser().resolve()
+
+
+def _hook_path(env: Mapping[str, str] | None = None) -> Path | None:
+    """Return the opt-in user hook path when it is a regular file."""
+    path = _hermes_home(env) / "caduceus" / "harness.py"
+    return path if path.is_file() else None
+
+
+def _legacy_bridge_path(env: Mapping[str, str] | None = None) -> Path:
+    """Return the user-owned full bridge path used by the legacy path."""
+    return _hermes_home(env) / "caduceus" / "worker-bridge.py"
+
+
+def _build_ctx(env: Mapping[str, str]) -> Ctx:
+    """Validate the daemon environment and construct the hook context."""
+    values = read_required_env(env)
+    labels = parse_labels(values["CADUCEUS_ISSUE_LABELS_JSON"])
+    worktree = resolve_worktree(env).expanduser().resolve()
+    prompt = verify_prompt(worktree / PROMPT_FILE_NAME)
+    try:
+        issue_number = int(values["CADUCEUS_ISSUE_NUMBER"])
+    except ValueError as exc:
+        print(
+            "caduceus bridge: invalid CADUCEUS_ISSUE_NUMBER: "
+            f"{exc}",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_MISSING_ENV)
+    dry_run = env.get("CADUCEUS_DRY_RUN", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    return Ctx(
+        worktree=worktree,
+        prompt=prompt,
+        run_id=values["CADUCEUS_RUN_ID"],
+        branch=values["CADUCEUS_BRANCH_NAME"],
+        labels=labels,
+        issue=Issue(
+            repo=values["CADUCEUS_ISSUE_REPO"],
+            number=issue_number,
+            title=values["CADUCEUS_ISSUE_TITLE"],
+            body=values["CADUCEUS_ISSUE_BODY"],
+        ),
+        context_json=values["CADUCEUS_CONTEXT_JSON"],
+        dry_run=dry_run,
+        env=MappingProxyType(dict(env)),
+    )
+
+
+def _load_hook(hook_path: Path) -> Callable[[Ctx], Sequence[str]]:
+    """Load and validate ``run_task`` from a user-owned hook module."""
+    spec = importlib.util.spec_from_file_location("caduceus_harness", hook_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to load harness module from {hook_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    hook = module.run_task
+    if not callable(hook):
+        raise TypeError("run_task is not callable")
+    return hook
+
+
+def _exception_line(prefix: str, exc: Exception) -> str:
+    """Format a one-line diagnostic without allowing hook output to break it."""
+    message = " ".join(str(exc).split()) or "no message"
+    return f"caduceus bridge: {prefix}: {type(exc).__name__}: {message}\n"
+
+
+def _invoke_hook(
+    hook: Callable[[Ctx], Sequence[str]], ctx: Ctx
+) -> Sequence[str] | int:
+    """Invoke a hook, mapping hook and contract errors to exit 125."""
+    try:
+        argv = hook(ctx)
+        if not isinstance(argv, list) or not all(
+            isinstance(argument, str) for argument in argv
+        ):
+            raise TypeError("run_task must return list[str]")
+        if not argv:
+            raise ValueError("run_task returned an empty argv")
+        return argv
+    except Exception as exc:  # noqa: BLE001 - hook failures map to exit 125
+        sys.stderr.write(_exception_line("harness hook crashed", exc))
+        return EXIT_HARNESS_CRASH
+
+
+def _execute_argv(argv: Sequence[str], ctx: Ctx) -> tuple[int, str, str]:
+    """Execute hook argv and return its exit code and captured output."""
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=str(ctx.worktree),
+            env=ctx.env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return completed.returncode, completed.stdout or "", completed.stderr or ""
+    except FileNotFoundError as exc:
+        program = exc.filename or argv[0]
+        return (
+            EXIT_HARNESS_NOT_FOUND,
+            "",
+            f"caduceus bridge: harness executable not found: {program}\n",
+        )
+    except OSError as exc:
+        return (
+            EXIT_HARNESS_UNREACHABLE,
+            "",
+            f"caduceus bridge: unable to start harness: {exc}\n",
+        )
+
+
+def _clean_terminal_text(value: str) -> str:
+    """Remove NUL and control characters while retaining newlines."""
+    return "".join(
+        character
+        for character in value
+        if character == "\n" or unicodedata.category(character) != "Cc"
+    )
+
+
+def _clamp_utf8(value: str, limit: int) -> str:
+    """Clamp a string by UTF-8 byte length without splitting a code point."""
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    return encoded[:limit].decode("utf-8", errors="ignore")
+
+
+def truncate_pull_request_title(title: str) -> str:
+    """Port Rust's char-counted title truncation exactly."""
+    if len(title) <= MAX_PULL_REQUEST_TITLE_CHARS:
+        return title
+    return title[: MAX_PULL_REQUEST_TITLE_CHARS - 1] + "…"
+
+
+def _result_path(worktree: Path) -> Path:
+    """Return the daemon-consumed result path for a worktree."""
+    return worktree / "worker-result.json"
+
+
+def _synthesize_worker_result(
+    worktree: Path, returncode: int, stdout: str, stderr: str
+) -> None:
+    """Atomically synthesize a schema-shaped result when none was written.
+
+    A sibling temporary file plus ``os.replace`` keeps the daemon from seeing
+    a partially written JSON document. Direct writes are an explicit bypass;
+    an existing result file is therefore left untouched.
+    """
+    result_path = _result_path(worktree)
+    if result_path.exists():
+        return
+
+    combined = _clean_terminal_text((stdout or "") + (stderr or ""))
+    lines = [line.strip() for line in combined.split("\n") if line.strip()]
+    placeholder = "Harness produced no terminal output."
+    first_line = lines[0] if lines else placeholder
+    last_line = lines[-1] if lines else placeholder
+    summary = _clamp_utf8(combined, MAX_SUMMARY_BYTES) or placeholder
+    payload = {
+        "status": "success" if returncode == EXIT_OK else "failure",
+        "summary": summary,
+        "commit_message": last_line,
+        "pull_request_title": truncate_pull_request_title(first_line),
+        "artifacts": {},
+        "investigation": False,
+    }
+    temporary_path = result_path.with_name(result_path.name + ".tmp")
+    temporary_path.write_text(
+        json.dumps(payload, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    os.replace(temporary_path, result_path)
+
+
+# ---------------------------------------------------------------------------
+# Legacy harness shim — preserved for existing full bridge copies
 # ---------------------------------------------------------------------------
 
 
@@ -162,7 +379,7 @@ def invoke_harness(
     paths containing spaces and Unicode characters reach the harness
     verbatim.
     """
-    argv: List[str] = [
+    argv: list[str] = [
         "opencode",
         "run",
         "--agent",
@@ -173,7 +390,7 @@ def invoke_harness(
     argv.extend(extra_argv)
     argv.append("--")
     argv.append("Run the workflow per the attached prompt file.")
-    completed = subprocess.run(argv, cwd=str(worktree))
+    completed = subprocess.run(argv, cwd=str(worktree), check=False)
     return completed.returncode
 
 
@@ -200,7 +417,7 @@ def read_required_env(env: Mapping[str, str]) -> dict:
     return {name: env[name] for name in REQUIRED_ENV_VARS}
 
 
-def parse_labels(raw: str) -> List[str]:
+def parse_labels(raw: str) -> list[str]:
     """Parse the JSON-encoded labels array.
 
     The daemon emits ``CADUCEUS_ISSUE_LABELS_JSON`` as a UTF-8 JSON array
@@ -262,35 +479,71 @@ def resolve_worktree(env: Mapping[str, str]) -> Path:
 
 
 def main(
-    env: Union[Mapping[str, str], None] = None,
-    argv: Union[Sequence[str], None] = None,
+    env: Mapping[str, str] | None = None,
+    argv: Sequence[str] | None = None,
 ) -> int:
     """Bridge entry point.
 
     Both parameters default to the live process environment / ``sys.argv``
     so ``python -m`` and direct ``python worker-bridge.py`` invocations
     behave identically. The test suite calls :func:`main` with explicit
-    arguments and patches :func:`invoke_harness` to assert behavior
-    without spawning OpenCode.
+    arguments for both the hook and legacy paths.
     """
     env = os.environ if env is None else env
     argv = sys.argv if argv is None else argv
 
-    values = read_required_env(env)
-    labels = parse_labels(values["CADUCEUS_ISSUE_LABELS_JSON"])
-    worktree = resolve_worktree(env)
-    prompt_file = verify_prompt(worktree / PROMPT_FILE_NAME)
+    ctx = _build_ctx(env)
+    hook_path = _hook_path(env)
+    if hook_path is not None:
+        try:
+            hook = _load_hook(hook_path)
+        except Exception as exc:  # noqa: BLE001 - load failures are exit 125
+            sys.stderr.write(_exception_line("harness hook crashed", exc))
+            return EXIT_HARNESS_CRASH
 
-    run_id = values["CADUCEUS_RUN_ID"]
-    branch_name = values["CADUCEUS_BRANCH_NAME"]
+        hook_result = _invoke_hook(hook, ctx)
+        if isinstance(hook_result, int):
+            return hook_result
+        returncode, stdout, stderr = _execute_argv(hook_result, ctx)
+        if stdout:
+            sys.stdout.write(stdout)
+        if stderr:
+            sys.stderr.write(stderr)
+        if not _result_path(ctx.worktree).exists():
+            _synthesize_worker_result(ctx.worktree, returncode, stdout, stderr)
+        return returncode
+
+    # A current parent runner may have a separate user-owned legacy bridge.
+    # Execute it as a full script, never import it into this process. When no
+    # separate copy exists, retain the direct legacy invocation so an existing
+    # 311-line installation and the historical test seam remain unchanged.
+    legacy_path = _legacy_bridge_path(env)
+    current_path = Path(__file__).resolve()
+    if legacy_path.is_file() and legacy_path.resolve() != current_path:
+        command = [sys.executable, str(legacy_path), *argv[1:]]
+        try:
+            completed = subprocess.run(command, env=dict(env), check=False)
+            return completed.returncode
+        except FileNotFoundError as exc:
+            print(
+                f"caduceus bridge: harness executable not found: {exc.filename}",
+                file=sys.stderr,
+            )
+            return EXIT_HARNESS_NOT_FOUND
+        except OSError as exc:
+            print(
+                f"caduceus bridge: unable to start harness: {exc}",
+                file=sys.stderr,
+            )
+            return EXIT_HARNESS_UNREACHABLE
 
     try:
         return invoke_harness(
-            worktree=worktree,
-            prompt_file=prompt_file,
-            run_id=run_id,
-            labels=labels,
-            branch_name=branch_name,
+            worktree=ctx.worktree,
+            prompt_file=ctx.prompt,
+            run_id=ctx.run_id,
+            labels=ctx.labels,
+            branch_name=ctx.branch,
             extra_argv=tuple(argv[1:]),  # tests pass extra args after the script path
         )
     except FileNotFoundError as exc:

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -32,11 +32,20 @@ When triggered, this skill should:
    `caduceus:` section of `~/.hermes/config.yaml`, then verify watched
    repositories exist at `<workdir_base>/<owner>/<repo>` with a matching
    noninteractive `origin`. Reference the plugin's defaults.
-4. **If the user wants to swap harnesses**: explain that they edit the
-   plugin's user-owned `worker-bridge.py` (default
-   `~/.hermes/caduceus/worker-bridge.py`) and change one function
-   (`invoke_harness`). Leave `read_required_env` / `parse_labels` /
-   `verify_prompt` alone — those enforce the daemon contract.
+4. **If the user wants to swap harnesses**: explain the new
+   one-function contract. They copy
+   `plugin-assets/caduceus_harness.py.example` to
+   `~/.hermes/caduceus/harness.py` (alongside any existing
+   `worker-bridge.py`) and edit `run_task(ctx)` to return the
+   harness argv. The parent runner in `plugin-assets/worker-bridge.py`
+   loads `harness.py` when present, calls `run_task(ctx)`, runs the
+   returned argv inside the worktree, and synthesizes
+   `worker-result.json` if the hook didn't write one. Existing
+   311-line `worker-bridge.py` copies keep working unchanged on the
+   legacy path. To verify the active path, run
+   `ls ~/.hermes/caduceus/`: a `harness.py` file means the new
+   contract; only `worker-bridge.py` means the legacy path. The parent
+   resolves this relative to `$HERMES_HOME` (default `~/.hermes`).
 5. **If something is broken**: tail `<state_dir>/processor.log` and
    `<state_dir>/runs/<run-id>.log` for the affected run. For a terminal
    failed/skipped entry, show `caduceus queue reset OWNER/REPO#N
@@ -91,15 +100,15 @@ counter.
 
 `max_issues_per_tick` (default `worker_parallelism * 4`) bounds how
 many queue entries a single tick will claim before returning. With the
-default, a tick with `worker_parallelism: 4` processes up to 16 issues
+ default, a tick with `worker_parallelism: 4` processes up to 16 issues
 and leaves the rest for the next tick. Set `0` to restore the unbounded
 drain-the-queue behavior. In-flight workers always finish their current
 work on tick exit; the cap only stops claiming new entries.
 
 ## State Recovery Procedure
 
-Both `state.json` and `state_meta.json` use temp-file + `fsync` +
-atomic rename and are never silently truncated:
+Both `state.json` and `state_meta.json` use temp-file + `fsync` + atomic
+rename and are never silently truncated:
 
 - **Corrupt `state.json`** → daemon exits 1, file preserved. Inspect
   and repair manually or use `caduceus migrate-state --from <path>
@@ -131,6 +140,10 @@ atomic rename and are never silently truncated:
   overwrites it on `setup`. If the upstream template changes, setup
   writes a sibling `.new` candidate and reports it; your edits remain
   intact.
+- The plugin (`plugin.yaml`, `__init__.py`, and this skill) does not know
+  about harness-specific shapes. To roll back the new contract, remove
+  `~/.hermes/caduceus/harness.py`; the parent runner then uses the legacy
+  `worker-bridge.py` path.
 - **The plugin does not run manifest build/hook steps.** Hermes
   installs plugin source but does not auto-build or auto-execute; you
   must run the explicit `hermes caduceus setup` step yourself.
@@ -168,7 +181,7 @@ The `hermes plugins update` step updates sources only — it does **not**
 rebuild the binary. Always re-run `hermes caduceus setup` afterwards
 to pick up the new Rust workspace. `setup` preserves the user-owned
 bridge and only writes a sibling `.new` candidate if the upstream
-template changes.
+ template changes.
 
 ### Standalone installs (no Hermes)
 

--- a/tests/fixtures/bridge_harness.py
+++ b/tests/fixtures/bridge_harness.py
@@ -7,6 +7,15 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
+
+
+def run_task(ctx):
+    """Return a configurable argv for the parent-runner contract."""
+    configured = ctx.env.get("FAKE_HARNESS_ARGV_JSON")
+    if configured:
+        return json.loads(configured)
+    return [sys.executable, str(Path(__file__).resolve())]
 
 
 def main() -> int:
@@ -50,4 +59,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/tests/integration/bridge_test.py
+++ b/tests/integration/bridge_test.py
@@ -454,6 +454,7 @@ class TestForbiddenSideEffects:
 
 
 def _make_worktree_with_prompt(tmp_path: Path) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     worktree = tmp_path
     prompt = worktree / "worker-prompt.md"
     prompt.write_text(
@@ -619,7 +620,7 @@ class TestSubprocessEndToEnd:
     def test_bridge_does_not_install_python_signal_handlers(
         self, bridge_module, monkeypatch, tmp_path
     ):
-        """The bridge is downstream of the daemon's worker supervisor,."""
+        """The bridge is downstream of the daemon's worker supervisor,"""
         # Provide a real worktree with a prompt so the bridge runs to
         # completion through invoke_harness.
         _make_worktree_with_prompt(tmp_path)
@@ -751,4 +752,312 @@ class TestSubprocessEndToEnd:
         assert "AUTO_ISSUE_GITHUB_TOKEN" not in record["env_keys"]
 
 
+def _write_hook(hermes_home: Path, body: str) -> Path:
+    hook_dir = hermes_home / "caduceus"
+    hook_dir.mkdir(parents=True, exist_ok=True)
+    hook = hook_dir / "harness.py"
+    hook.write_text(textwrap.dedent(body), encoding="utf-8")
+    return hook
 
+
+def _new_contract_env(worktree: Path, hermes_home: Path) -> dict:
+    env = _build_env(worktree)
+    env["HERMES_HOME"] = str(hermes_home)
+    return env
+
+
+class TestNewContract:
+    def test_hook_present_activates_new_contract(
+        self, bridge_module, tmp_path
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes home"
+        marker = tmp_path / "hook-ran.txt"
+        _write_hook(
+            hermes_home,
+            f"""
+            from pathlib import Path
+
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "from pathlib import Path; Path({str(marker)!r}).write_text('ran')"]
+            """,
+        )
+        env = _new_contract_env(worktree, hermes_home)
+
+        assert bridge_module.main(env=env, argv=["bridge"]) == 0
+        assert marker.read_text(encoding="utf-8") == "ran"
+
+    def test_hook_absent_falls_back_to_legacy_subprocess(
+        self, bridge_module, tmp_path
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        legacy_dir = hermes_home / "caduceus"
+        legacy_dir.mkdir(parents=True)
+        marker = tmp_path / "legacy-ran.txt"
+        legacy = legacy_dir / "worker-bridge.py"
+        legacy.write_text(
+            textwrap.dedent(
+                f"""
+                #!{sys.executable}
+                from pathlib import Path
+                Path({str(marker)!r}).write_text("legacy")
+                """
+            ),
+            encoding="utf-8",
+        )
+        legacy.chmod(0o755)
+        env = _new_contract_env(worktree, hermes_home)
+
+        assert bridge_module.main(env=env, argv=["bridge"]) == 0
+        assert marker.read_text(encoding="utf-8") == "legacy"
+
+    def test_ctx_has_all_documented_fields(
+        self, bridge_module, tmp_path
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        capture = tmp_path / "ctx.json"
+        _write_hook(
+            hermes_home,
+            f"""
+            import json
+            from pathlib import Path
+
+            def run_task(ctx):
+                Path({str(capture)!r}).write_text(json.dumps({{
+                    "worktree": str(ctx.worktree),
+                    "prompt": str(ctx.prompt),
+                    "run_id": ctx.run_id,
+                    "branch": ctx.branch,
+                    "labels": ctx.labels,
+                    "issue": {{
+                        "repo": ctx.issue.repo,
+                        "number": ctx.issue.number,
+                        "title": ctx.issue.title,
+                        "body": ctx.issue.body,
+                    }},
+                    "context_json": ctx.context_json,
+                    "dry_run": ctx.dry_run,
+                    "env_keys": sorted(ctx.env),
+                    "env_type": type(ctx.env).__name__,
+                }}), encoding="utf-8")
+                return [{sys.executable!r}, "-c", "pass"]
+            """,
+        )
+        env = _new_contract_env(worktree, hermes_home)
+
+        assert bridge_module.main(env=env, argv=["bridge"]) == 0
+        observed = json.loads(capture.read_text(encoding="utf-8"))
+        assert observed["worktree"] == str(worktree.resolve())
+        assert observed["prompt"] == str((worktree / "worker-prompt.md").resolve())
+        assert observed["run_id"] == env["CADUCEUS_RUN_ID"]
+        assert observed["branch"] == env["CADUCEUS_BRANCH_NAME"]
+        assert observed["labels"] == ["🤖 auto-fix", "good first issue"]
+        assert observed["issue"] == {
+            "repo": env["CADUCEUS_ISSUE_REPO"],
+            "number": 42,
+            "title": env["CADUCEUS_ISSUE_TITLE"],
+            "body": env["CADUCEUS_ISSUE_BODY"],
+        }
+        assert observed["context_json"] == env["CADUCEUS_CONTEXT_JSON"]
+        assert observed["dry_run"] is False
+        assert "CADUCEUS_CONTEXT_JSON" in observed["env_keys"]
+        assert observed["env_type"] == "mappingproxy"
+
+    def test_argv_with_spaces_round_trips(self, bridge_module, tmp_path):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree with spaces")
+        hermes_home = tmp_path / "hermes"
+        capture = tmp_path / "capture.py"
+        received = tmp_path / "received spaces.txt"
+        capture.write_text(
+            "from pathlib import Path; import sys; "
+            "Path(sys.argv[1]).write_text(sys.argv[2], encoding='utf-8')",
+            encoding="utf-8",
+        )
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, {str(capture)!r}, {str(received)!r}, "value with spaces"]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 0
+        assert received.read_text(encoding="utf-8") == "value with spaces"
+
+    def test_argv_with_unicode_round_trips(self, bridge_module, tmp_path):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree café 第12")
+        hermes_home = tmp_path / "hermes"
+        capture = tmp_path / "capture.py"
+        received = tmp_path / "received-unicode.txt"
+        capture.write_text(
+            "from pathlib import Path; import sys; "
+            "Path(sys.argv[1]).write_text(sys.argv[2], encoding='utf-8')",
+            encoding="utf-8",
+        )
+        argument = "café-第12-🚀"
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, {str(capture)!r}, {str(received)!r}, {argument!r}]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 0
+        assert received.read_text(encoding="utf-8") == argument
+
+    def test_exit_code_127_for_missing_argv0(
+        self, bridge_module, tmp_path, capsys
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        _write_hook(
+            hermes_home,
+            """
+            def run_task(ctx):
+                return ["nonexistent-binary-xyz"]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 127
+        assert "nonexistent-binary-xyz" in capsys.readouterr().err
+
+    def test_exit_code_126_for_unreachable_argv0(
+        self, bridge_module, tmp_path, capsys
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        program = tmp_path / "not-executable"
+        program.write_text("not executable", encoding="utf-8")
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{str(program)!r}]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 126
+        assert "unable to start harness" in capsys.readouterr().err
+
+    def test_exit_code_125_for_hook_crash(
+        self, bridge_module, tmp_path, capsys
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        _write_hook(
+            hermes_home,
+            """
+            def run_task(ctx):
+                raise KeyError("nope")
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 125
+        error = capsys.readouterr().err
+        assert "KeyError" in error
+        assert "nope" in error
+        assert len(error.splitlines()) == 1
+
+    def test_missing_run_task_is_a_harness_crash(
+        self, bridge_module, tmp_path, capsys
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        _write_hook(hermes_home, "VALUE = 1\n")
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 125
+        assert "AttributeError" in capsys.readouterr().err
+
+    def test_result_synthesis_success_exit(self, bridge_module, tmp_path):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "print('feat(plugin): synthesized title')"]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 0
+        result = json.loads(
+            (worktree / "worker-result.json").read_text(encoding="utf-8")
+        )
+        assert result["status"] == "success"
+        assert result["pull_request_title"] == "feat(plugin): synthesized title"
+        assert result["investigation"] is False
+
+    def test_result_synthesis_failure_exit(self, bridge_module, tmp_path):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "print('failure output'); raise SystemExit(1)"]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 1
+        result = json.loads(
+            (worktree / "worker-result.json").read_text(encoding="utf-8")
+        )
+        assert result["status"] == "failure"
+        assert "failure output" in result["summary"]
+
+    def test_truncate_pull_request_title_256_chars(self, bridge_module):
+        title = "x" * 400
+        truncated = bridge_module.truncate_pull_request_title(title)
+        assert len(truncated) == 256
+        assert truncated.endswith("…")
+        assert truncated == ("x" * 255) + "…"
+
+    def test_direct_write_bypass(self, bridge_module, tmp_path):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        result_path = worktree / "worker-result.json"
+        payload = {
+            "status": "success",
+            "summary": "direct write",
+            "commit_message": "feat: direct",
+            "pull_request_title": "feat: direct",
+            "artifacts": {"note": "kept"},
+            "investigation": True,
+        }
+        payload_text = json.dumps(payload, ensure_ascii=False)
+        write_command = (
+            "from pathlib import Path; "
+            f"Path({str(result_path)!r}).write_text({payload_text!r}, "
+            "encoding='utf-8')"
+        )
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", {write_command!r}]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 0
+        assert result_path.read_text(encoding="utf-8") == payload_text


### PR DESCRIPTION
## Summary

- Split `plugin-assets/worker-bridge.py` into a parent runner, hook loader, result synthesizer, and preserved legacy shim.
- Add the user-editable `plugin-assets/caduceus_harness.py.example` with a one-function `run_task(ctx) -> list[str]` contract.
- Cover hook discovery, `Ctx`, argv round-tripping, exit-code mapping, synthesis, direct-write bypass, and legacy behavior in integration tests.
- Document the opt-in hook, rollback, and legacy path in `skills/caduceus/SKILL.md`.

## Design rationale

The parent runner absorbs daemon validation and worker-result protocol details so operators edit at most one small hook file. Hook argv is executed without a shell inside the worktree with the daemon-provided environment, and synthesized results use the Rust schema limits and title truncation rule.

## Backward compatibility

Existing user-owned 311-line `worker-bridge.py` copies remain unchanged and continue through the legacy subprocess path when no `harness.py` exists. `plugin.yaml` and `__init__.py` remain harness-ignorant; the adapter does not seed the new hook automatically.

Verification: `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` (152 passed).