### PR TITLE
ci(runtime): migrate rust gate to nextest and rust-cache (closes #203)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,27 @@
+# cargo-nextest configuration for the rust-stable CI gate (issue #203).
+#
+# [profile.default] sets a per-test slow-timeout of 120s. Tests that take
+# longer than this are terminated by nextest. The 120s budget is generous
+# on purpose; tighten later from data.
+#
+# The override profile below preserves today's effective CI behavior for
+# the five hermes_lifecycle tests that self-skip into green on CI (the
+# `hermes` binary is absent; preflight_or_skip() returns None).
+# Investigation on 2026-08-23 confirmed they pass vacuously in ~1ms each
+# today. The override is declarative belt-and-suspenders: nextest 0.9 does
+# NOT support per-test env vars in config, so the CADUCEUS_SKIP_LIFECYCLE
+# signal for #205's root-cause fix is set on the test step in ci.yml.
+# The override keeps filter + platform only — no per-test slow-timeout —
+# so the default 120s applies. On CI the tests self-skip (~1ms) and the
+# slow-timeout is irrelevant; on local hermes-less runs they self-skip
+# too. Local full-suite verification should exclude these five tests with
+# a command-line filter expression to mirror CI behavior (see tasks.md).
+# When #205 lands, the override profile is the natural place to add
+# per-test settings (priority, test-group, etc.).
+
+[profile.default]
+slow-timeout = "120s"
+
+[[profile.default.overrides]]
+filter = "test(test_ac04_cron_install_happy) or test(test_ac06_doctor_and_status) or test(test_ac07_gateway_prerequisite) or test(test_ac08_update_preserves_state) or test(test_ac10_uninstall_preserves_user_state)"
+platform = "x86_64-unknown-linux-gnu"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,16 +72,12 @@ jobs:
           # install keeps the four-line gate reproducible on cold-cache
           # first runs.
           rustup component add rustfmt clippy
-      - name: cache cargo registry and target
-        uses: actions/cache@v4
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-stable-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            cargo-stable-
+          tool: cargo-nextest
+      - name: cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
       - name: configure git identity for tests
         run: |
           set -euo pipefail
@@ -92,12 +88,19 @@ jobs:
       - name: clippy
         run: cargo clippy --locked --all-targets -- -D warnings
       - name: test
+        env:
+          # Belt-and-suspenders signal for the five hermes_lifecycle
+          # tests in tests/integration/hermes_lifecycle_test.rs that
+          # self-skip into green on CI. See .config/nextest.toml for
+          # the matching override profile. #205 owns the root-cause
+          # fix; today the env var is declarative and not read.
+          CADUCEUS_SKIP_LIFECYCLE: "1"
         # hermes_lifecycle tests (ac04/ac06/ac07/ac08) each shell out to
         # `hermes caduceus setup` which takes 2-3 minutes to compile the
         # release binary; running four of them in parallel saturates the
         # 240s per-test timeout. Allow up to 15 minutes for the test step.
         timeout-minutes: 15
-        run: cargo test --locked --all-targets
+        run: cargo nextest run --locked --all-targets --retries 2
 
   python:
     name: python

--- a/tests/github/context_test.rs
+++ b/tests/github/context_test.rs
@@ -278,7 +278,7 @@ fn trusted_comment_dropped_only_after_untrusted() {
         created_at: Utc::now() - chrono::Duration::days(7),
     };
     let mut comments = vec![trusted.clone()];
-    for i in 0..800u32 {
+    for i in 0..80u32 {
         comments.push(IssueComment {
             author: format!("u{i}"),
             body: "u".repeat(2048),

--- a/tests/state/logging_test.rs
+++ b/tests/state/logging_test.rs
@@ -216,6 +216,14 @@ fn init_second_call_fails_with_clear_message() {
     let root = tempdir("init-second");
     let log_path = root.join("processor.log");
 
+    // Ensure the global subscriber is installed in THIS process before
+    // asserting that a subsequent call fast-fails. Under libtest the prior
+    // serial tests in this module would have installed it; under cargo-nextest
+    // each test runs in its own process, so we install it here.
+    if !is_initialised() {
+        let _log_guard = init(&log_path).expect("first init succeeds");
+    }
+
     let err = init(&log_path).expect_err("second init must fail");
     let msg = format!("{err:?}");
     assert!(msg.contains("already initialised"), "got: {msg}");


### PR DESCRIPTION
Closes #203

## Summary

### Measured baseline

Before this change on `rust-stable`: cache restore 87s, clippy serial 47s,
and test step 206s.

### What changed

1. `.github/workflows/ci.yml` rust-stable job installs `cargo-nextest` via
   `taiki-e/install-action@v2`, swaps `actions/cache@v4` for
   `Swatinem/rust-cache@v2`, and replaces `cargo test` with
   `cargo nextest run --locked --all-targets --retries 2`. The test step also
   sets `CADUCEUS_SKIP_LIFECYCLE=1` in its step-level env (the only place
   nextest 0.9 supports it; per-test env vars do not exist in config).
2. New `.config/nextest.toml` at repo root sets per-test
   `slow-timeout = "120s"` and documents the five hermes lifecycle-test
   override anchor.
3. In `tests/state/logging_test.rs`,
   `init_second_call_fails_with_clear_message` is now self-contained: it
   installs the global subscriber itself before asserting that a second
   `init()` call fast-fails.
4. In `tests/github/context_test.rs`, the
   `trusted_comment_dropped_only_after_untrusted` fixture shrinks from 800 to
   80 untrusted comments (~10x), targeting ~2s wall time instead of 18.2s.

### Logging-test fix rationale

cargo-nextest runs each test in its own process; libtest's shared-process
 global logger state is no longer available across tests. The fix installs the
 global within the test that needs it, making it independent of cross-test
 ordering while remaining correct under legacy libtest.

### Cache migration note

This PR's first run on `main` after landing pays one cold-cache build (~5-10
min) before the rust-cache steady state kicks in. Subsequent runs get the
pruned fast restores.

### Local hermes-lifecycle verification

Locally where `hermes` is installed, the five lifecycle tests would actually
run (and exceed the 120s slow-timeout). Use this command to mirror CI behavior:

```bash
cargo nextest run --locked --all-targets --retries 2 -E 'not (test(test_ac04_cron_install_happy) or test(test_ac06_doctor_and_status) or test(test_ac07_gateway_prerequisite) or test(test_ac08_update_preserves_state) or test(test_ac10_uninstall_preserves_user_state))'
```

On CI the tests self-skip via `preflight_or_skip()` in ~1ms because `hermes`
is absent, so the filter is not needed there.

### Scope

- Zero `src/` changes.
- Zero required-check renames; the job stays `rust-stable`.
- `.github/workflows/macos.yml` is untouched.
- Refs: closes #203. Cross-references #205 (lifecycle-test root cause, out
  of scope here).
