### PR TITLE
ci(runtime): split clippy into its own parallel job (closes #204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,6 @@ jobs:
           git config --global user.name "caduceus-ci"
       - name: fmt
         run: cargo fmt --check
-      - name: clippy
-        run: cargo clippy --locked --all-targets -- -D warnings
       - name: test
         env:
           # Belt-and-suspenders signal for the five hermes_lifecycle
@@ -101,6 +99,30 @@ jobs:
         # 240s per-test timeout. Allow up to 15 minutes for the test step.
         timeout-minutes: 15
         run: cargo nextest run --locked --all-targets --retries 2
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install stable Rust
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          rustup component add clippy
+      - name: cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+      - name: configure git identity
+        run: |
+          set -euo pipefail
+          git config --global user.email "ci@caduceus.local"
+          git config --global user.name "caduceus-ci"
+      - name: clippy
+        run: cargo clippy --locked --all-targets -- -D warnings
 
   python:
     name: python


### PR DESCRIPTION
## What

Move `cargo clippy --locked --all-targets -- -D warnings` out of the
serial `rust-stable` job and into its own parallel `clippy` job in
`.github/workflows/ci.yml`.

## Measured baseline

The clippy step runs serially before nextest on `rust-stable`. Measured
baseline: **clippy serial 47s** (issue #204). Promoting it to a parallel
job removes that latency from `rust-stable`'s critical path.

## New job shape

The new `clippy` job runs on `ubuntu-24.04` with `timeout-minutes: 15`
and contains five steps: checkout → install stable Rust → cache cargo
registry and target → configure git identity → clippy. The install step
adds only the `clippy` component — no rustfmt, no cargo-nextest.

`rust-stable` keeps its `rustup component add rustfmt clippy` line
verbatim so the install recipe is not forked across the two jobs; the
cost of installing the unused `clippy` component is negligible.

## Concurrency + cache

The workflow-level `concurrency: ci-${{ github.ref }}` block is preserved
verbatim (not duplicated per job). Both jobs share one cancel-in-progress
group, so a force-push cancels them together. Each job owns its own
`Swatinem/rust-cache@v2` step (auto-keyed on Cargo.lock + workspace
files); the two jobs' cache keys overlap by design and produce
overlapping restore hits on warm runs without thrash.

## Branch-protection context

Main is **NOT** branch-protected today (verified 2026-08-23). Adding the
new `clippy` job therefore introduces no coordination cost now and does
not change the documented required-check names (`ci / rust-stable`, `ci /
python`, `ci / planning`). If/when branch protection is enabled, the
operator setting it must add `ci / clippy` to the required-checks list at
that time.

## Expected wall-time savings

- Typical: **~30–40s** off the overall CI critical path.
- Warm runs: savings approach the full **~47s**.
- First cold run after merge warms the new `clippy` job's rust-cache slot;
  subsequent runs get warm restores. The weekly `cron: '0 6 * * 0'`
  schedule trigger keeps both slots warm.

## Files changed

- `.github/workflows/ci.yml` — removed one step from `rust-stable`,
  added one new `clippy` job.

No other files modified. Verified `git diff --name-only` shows only
`.github/workflows/ci.yml`.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — OK
- `cargo clippy --locked --all-targets -- -D warnings` — exit 0
- `cargo nextest run --locked --all-targets --retries 2 -E 'not (test(test_ac04_cron_install_happy) or test(test_ac06_doctor_and_status) or test(test_ac07_gateway_prerequisite) or test(test_ac08_update_preserves_state) or test(test_ac10_uninstall_preserves_user_state))'` — exit 0
- `bash scripts/check-commits.sh HEAD~1..HEAD` — exit 0

Closes #204.
