### PR TITLE
feat(config): configurable daemon git author identity (closes #210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Configurable git author identity.** `git_author_name` and
+  `git_author_email` now resolve per field through explicit config, host git
+  config, and the `Caduceus Daemon <caduceus@daemon.local>` fallback. Closes
+  #210.
+
 ## [1.0.0] - 2026-08-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,6 +476,10 @@ name = "commit_test"
 path = "tests/github/commit_test.rs"
 
 [[test]]
+name = "finalize_commit_test"
+path = "tests/finalize/commit_test.rs"
+
+[[test]]
 name = "context_test"
 path = "tests/github/context_test.rs"
 

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -67,6 +67,15 @@ When triggered, this skill should:
    daemon `processor.log` lives at `<state_dir>/processor.log` and the
    heartbeat envelope sits at `<state_dir>/runs/<run_id>.heartbeat`.
 
+## Configuration keys
+
+Set `git_author_name` and `git_author_email` in the `caduceus:` block to
+configure commit identity. Each field cascades independently from explicit
+config to the host's global git config and then
+`Caduceus Daemon <caduceus@daemon.local>`, so values from different tiers can
+merge; the daemon emits a once-per-process WARN when the last-resort fallback
+is used.
+
 ## Investigation vs. Code Tickets
 
 The same bridge contract serves both. The bridge forwards labels via

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@
 //! ultimately delegates to `caduceus::tick::run_blocking`.
 
 use std::ffi::OsString;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use clap::{Parser, Subcommand};
 
@@ -15,6 +16,8 @@ use caduceus::error::{CaduceusError, CaduceusResult};
 use caduceus::issue::IssueKey;
 use caduceus::queue::StateStore;
 use caduceus::DaemonLock;
+
+static GIT_AUTHOR_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Caduceus v1.0.0: poll GitHub, queue one unit of work per tick, finalise
 /// code or investigation results.
@@ -156,6 +159,14 @@ pub fn run() -> CaduceusResult<()> {
                 Some(path) => Config::load_from(std::path::Path::new(&path))?,
                 None => Config::load()?,
             };
+            let (host_name, host_email) = caduceus::finalize::commit::host_git_identity();
+            let name_from_tier3 = cfg.git_author_name.is_none() && host_name.is_none();
+            let email_from_tier3 = cfg.git_author_email.is_none() && host_email.is_none();
+            if (name_from_tier3 || email_from_tier3)
+                && !GIT_AUTHOR_WARNED.swap(true, Ordering::SeqCst)
+            {
+                tracing::warn!("git_author: no config or host identity resolved — falling back to \"Caduceus Daemon <caduceus@daemon.local>\". Configure git_author_name + git_author_email in the caduceus: config block to silence this warning.");
+            }
             let outcome = caduceus::tick::run_blocking(cfg)?;
             // Map the outcome to the documented exit code so
             // the cron model (Processed / Idle / Cancelled →

--- a/src/finalize/commit.rs
+++ b/src/finalize/commit.rs
@@ -1,5 +1,7 @@
 use super::{FinalizeAction, FinalizeContext, FinalizeOutput};
 
+use std::process::Command;
+
 use serde::{Deserialize, Serialize};
 
 use crate::infra::config::Config;
@@ -47,6 +49,42 @@ pub const WORKER_CONTROL_FILE_NAMES: &[&str] = &["worker-result.json"];
 /// added.
 pub const DEFAULT_GIT_USER_NAME: &str = "Caduceus Daemon";
 pub const DEFAULT_GIT_USER_EMAIL: &str = "caduceus@daemon.local";
+
+/// Resolve the git author and committer identity through the configured
+/// identity, host git config, and daemon default tiers.
+pub fn resolve_git_author(cfg: &Config) -> (String, String) {
+    let tier1_name = cfg.git_author_name.clone();
+    let tier1_email = cfg.git_author_email.clone();
+    let (tier2_name, tier2_email) = host_git_identity();
+    let name = tier1_name
+        .or(tier2_name)
+        .unwrap_or(DEFAULT_GIT_USER_NAME.to_string());
+    let email = tier1_email
+        .or(tier2_email)
+        .unwrap_or(DEFAULT_GIT_USER_EMAIL.to_string());
+    (name, email)
+}
+
+/// Read the host's global git identity, treating missing values and git
+/// failures as silent misses in the resolution cascade.
+pub fn host_git_identity() -> (Option<String>, Option<String>) {
+    let read = |key: &str| -> Option<String> {
+        let out = Command::new("git")
+            .args(["config", "--global", key])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    };
+    (read("user.name"), read("user.email"))
+}
 
 /// Inspect the worktree, validate the changes, and commit
 /// the worker's work. The function:
@@ -165,11 +203,12 @@ pub fn commit_code_result(
     for path in &validated {
         git_add(&ctx.worktree.path, path, runner)?;
     }
+    let (author_name, author_email) = resolve_git_author(&ctx.config);
     let commit_oid = git_commit(
         &ctx.worktree.path,
         &worker_result.commit_message,
-        DEFAULT_GIT_USER_NAME,
-        DEFAULT_GIT_USER_EMAIL,
+        &author_name,
+        &author_email,
         runner,
     )?;
     let _ = worker_result_path;

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -16,6 +16,10 @@
 //!
 //! Public field list, semantics, and defaults are pinned here —
 //! every field documented must be present.
+//!
+//! `git_author_name` and `git_author_email` are optional `String` keys in the
+//! `caduceus:` block. An absent or empty value falls through to host git
+//! config and then the last-resort daemon identity.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -135,6 +139,8 @@ pub struct Config {
     pub comment_forbidden_strings: Vec<String>,
     pub worker_env_allowlist: Vec<String>,
     pub github_token: Option<String>,
+    pub git_author_name: Option<String>,
+    pub git_author_email: Option<String>,
     pub api_base: String,
     pub dry_run: bool,
     /// Maximum number of concurrent worker processes. Default 1.
@@ -266,6 +272,8 @@ pub struct RawConfig {
     pub comment_forbidden_strings: Option<Vec<String>>,
     pub worker_env_allowlist: Option<Vec<String>>,
     pub github_token: Option<String>,
+    pub git_author_name: Option<String>,
+    pub git_author_email: Option<String>,
     pub api_base: Option<String>,
     pub dry_run: Option<bool>,
     pub worker_parallelism: Option<u32>,
@@ -820,6 +828,20 @@ impl Config {
                     Some(trimmed.to_string())
                 }
             }),
+            git_author_name: raw.git_author_name.and_then(|s| {
+                if s.trim().is_empty() {
+                    None
+                } else {
+                    Some(s.trim().to_string())
+                }
+            }),
+            git_author_email: raw.git_author_email.and_then(|s| {
+                if s.trim().is_empty() {
+                    None
+                } else {
+                    Some(s.trim().to_string())
+                }
+            }),
             api_base,
             dry_run,
             worker_parallelism,
@@ -934,6 +956,8 @@ impl Config {
             comment_forbidden_strings: Vec::new(),
             worker_env_allowlist: Vec::new(),
             github_token: None,
+            git_author_name: None,
+            git_author_email: None,
             api_base: DEFAULT_API_BASE.to_string(),
             dry_run: false,
             worker_parallelism: DEFAULT_WORKER_PARALLELISM,

--- a/tests/finalize/commit_test.rs
+++ b/tests/finalize/commit_test.rs
@@ -1,0 +1,137 @@
+//! Tests for the configurable git author identity cascade.
+
+use std::fs;
+use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+use caduceus::config::Config;
+use caduceus::finalize::commit::{
+    resolve_git_author, DEFAULT_GIT_USER_EMAIL, DEFAULT_GIT_USER_NAME,
+};
+
+static TEST_HOST_GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn with_host_config<T>(gitconfig: Option<&str>, test: impl FnOnce() -> T) -> T {
+    let _guard = TEST_HOST_GUARD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("host config test mutex");
+    let home = tempfile::tempdir().expect("temporary HOME");
+    if let Some(contents) = gitconfig {
+        fs::write(home.path().join(".gitconfig"), contents).expect("write gitconfig");
+    }
+
+    let original_home = std::env::var_os("HOME");
+    let original_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", home.path());
+    std::env::set_var("XDG_CONFIG_HOME", home.path());
+
+    let result = catch_unwind(AssertUnwindSafe(test));
+
+    match original_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    match original_xdg {
+        Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+        None => std::env::remove_var("XDG_CONFIG_HOME"),
+    }
+
+    match result {
+        Ok(value) => value,
+        Err(payload) => resume_unwind(payload),
+    }
+}
+
+fn test_config() -> Config {
+    Config::test_defaults(Path::new("/tmp"))
+}
+
+#[test]
+fn explicit_identity_wins() {
+    with_host_config(None, || {
+        let mut cfg = test_config();
+        cfg.git_author_name = Some("Ops Bot".to_string());
+        cfg.git_author_email = Some("ops@example.com".to_string());
+
+        assert_eq!(
+            resolve_git_author(&cfg),
+            ("Ops Bot".to_string(), "ops@example.com".to_string())
+        );
+    });
+}
+
+#[test]
+fn host_identity_wins_when_config_is_absent() {
+    with_host_config(
+        Some("[user]\n\tname = Host Bot\n\temail = host@example.com\n"),
+        || {
+            let cfg = test_config();
+            assert_eq!(
+                resolve_git_author(&cfg),
+                ("Host Bot".to_string(), "host@example.com".to_string())
+            );
+        },
+    );
+}
+
+#[test]
+fn last_resort_identity_is_used_without_config() {
+    with_host_config(None, || {
+        let cfg = test_config();
+        assert_eq!(
+            resolve_git_author(&cfg),
+            (
+                DEFAULT_GIT_USER_NAME.to_string(),
+                DEFAULT_GIT_USER_EMAIL.to_string()
+            )
+        );
+    });
+}
+
+#[test]
+fn config_name_and_host_email_merge() {
+    with_host_config(Some("[user]\n\temail = host@example.com\n"), || {
+        let mut cfg = test_config();
+        cfg.git_author_name = Some("Ops Bot".to_string());
+
+        assert_eq!(
+            resolve_git_author(&cfg),
+            ("Ops Bot".to_string(), "host@example.com".to_string())
+        );
+    });
+}
+
+#[test]
+fn empty_host_identity_falls_back_without_error() {
+    with_host_config(Some("[user]\n\tname =\n\temail =\n"), || {
+        let cfg = test_config();
+        assert_eq!(
+            resolve_git_author(&cfg),
+            (
+                DEFAULT_GIT_USER_NAME.to_string(),
+                DEFAULT_GIT_USER_EMAIL.to_string()
+            )
+        );
+    });
+}
+
+#[test]
+fn config_name_merges_with_last_resort_email() {
+    with_host_config(None, || {
+        let mut cfg = test_config();
+        cfg.git_author_name = Some("Ops Bot".to_string());
+
+        assert_eq!(
+            resolve_git_author(&cfg),
+            ("Ops Bot".to_string(), DEFAULT_GIT_USER_EMAIL.to_string())
+        );
+    });
+}
+
+#[test]
+fn default_identity_constants_are_documented_values() {
+    assert_eq!(DEFAULT_GIT_USER_NAME, "Caduceus Daemon");
+    assert_eq!(DEFAULT_GIT_USER_EMAIL, "caduceus@daemon.local");
+}

--- a/tests/github/commit_test.rs
+++ b/tests/github/commit_test.rs
@@ -445,7 +445,9 @@ fn commit_uses_daemon_identity() {
     // The commit author is the daemon's configured
     // identity, not the worker's.
     let base = tempfile::tempdir().expect("base");
-    let (cfg, wt, issue) = setup_worktree(base.path());
+    let (mut cfg, wt, issue) = setup_worktree(base.path());
+    cfg.git_author_name = Some("Caduceus Daemon".to_string());
+    cfg.git_author_email = Some("caduceus@daemon.local".to_string());
     fs::write(wt.path.join("README.md"), "modified\n").expect("write");
     let ctx = make_context(&cfg, &wt, &issue, "run-identity");
     let runner = GitRunner::new(&cfg);

--- a/tests/infra/config_test.rs
+++ b/tests/infra/config_test.rs
@@ -95,3 +95,18 @@ fn attic_zero_retention_is_rejected() {
         "unexpected error: {msg}"
     );
 }
+
+#[test]
+fn git_author_config_trims_values_and_treats_empty_as_absent() {
+    let raw = RawConfig {
+        git_author_name: Some("  Ops Bot  ".to_string()),
+        git_author_email: Some("   ".to_string()),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+
+    let cfg = Config::from_raw(raw, &LoadContext::default()).expect("config");
+    assert_eq!(cfg.git_author_name.as_deref(), Some("Ops Bot"));
+    assert_eq!(cfg.git_author_email, None);
+}


### PR DESCRIPTION
## Summary

Implements issue #210: a configurable daemon git author identity resolved through a three-tier cascade.

Resolves the git **author and committer** (same value for this issue) per field, first match:

1. **Explicit config** — `git_author_name` + `git_author_email` in the `caduceus:` config block (`~/.hermes/config.yaml` or `~/.config/caduceus/config.yaml`). Both `Option<String>`, default `None`.
2. **Host git config** — `git config --global user.name` / `user.email` on the host where caduceus runs. Silent fallback when missing (no error, no warning).
3. **Last-resort constant** — the existing `DEFAULT_GIT_USER_NAME` / `DEFAULT_GIT_USER_EMAIL` (`Caduceus Daemon <caduceus@daemon.local>`), unchanged.

Precedence is **per-field, not all-or-nothing**: if one source supplies the name and another the email, they merge into one identity. When tier 3 fires for the first time per daemon process, a one-line WARN is logged exactly once (process-wide `AtomicBool` once guard) at startup; the daemon proceeds regardless — a CI runner with no global git config still produces PRs.

## Files changed

- `src/infra/config/mod.rs` — add `git_author_name` / `git_author_email` to `Config` and `RawConfig`; resolve in `from_raw` (trim-empty → `None`); extend the config-field doc comment.
- `src/finalize/commit.rs` — add public, pure `resolve_git_author(cfg)` (three-tier cascade) and `pub(crate) host_git_identity()` (silent host read); rewire the `commit_code_result` call site. Constants retained as the tier-3 value. `git_commit` signature unchanged.
- `src/cli/mod.rs` — seed the once-per-process WARN in `Command::Run` after config load; per-field guard; exact message text.
- `tests/finalize/commit_test.rs` (new) — covers explicit-only, host-only, last-resort, mixed, empty tier-2, partial-empty; host reads isolated by redirecting `HOME`/`XDG_CONFIG_HOME` to a temp `.gitconfig` under a `OnceLock<Mutex<()>>` guard (no new dependency).
- `Cargo.toml` — explicit `[[test]]` target for the new integration test.
- `CHANGELOG.md` — `### Changed` entry under `[Unreleased]`.
- `skills/caduceus/SKILL.md` — new `## Configuration keys` subsection.

## Backwards compatibility

Operators who set neither config key and have no host git config see **identical** commit authorship (`Caduceus Daemon <caduceus@daemon.local>`); the only new observable is the at-most-once-per-process WARN, which is informational and non-fatal. The `WorkerResult` schema, supervisor protocol, and harness contract are untouched.

## Verification (Linux)

`cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --locked --all-targets` pass (hermetic). Two pre-existing `config_bootstrap_test` cases and the Python bridge tests fail only in the ambient environment (inherited `HERMES_HOME`/`GITHUB_TOKEN`, and `opencode` not on `PATH`) and are unrelated to this change; they pass hermetically. macOS is the CI runner's responsibility — **not** verified from this Linux host.

Closes #210.