### PR TITLE
feat(oci): workspace, .git and runtime identity isolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ hex = "0.4"
 filetime = "0.2"
 walkdir = "2"
 libc = "0.2"
-nix = { version = "0.29", default-features = false, features = ["feature", "fs", "process", "signal", "time"] }
+nix = { version = "0.29", default-features = false, features = ["feature", "fs", "process", "signal", "time", "user"] }
 rusqlite = { version = "0.40", default-features = false, features = ["bundled"] }
 uuid = { version = "1", features = ["v4"] }
 tar = "0.4.46"
@@ -162,6 +162,14 @@ path = "tests/executor/sandbox_renderer_test.rs"
 [[test]]
 name = "sandbox_resolve_test"
 path = "tests/executor/sandbox_resolve_test.rs"
+
+[[test]]
+name = "identity_resolution_test"
+path = "tests/executor/identity_resolution_test.rs"
+
+[[test]]
+name = "oci_isolation_live_test"
+path = "tests/executor/oci_isolation_live_test.rs"
 
 [[test]]
 name = "secret_grant_test"

--- a/README.md
+++ b/README.md
@@ -183,6 +183,41 @@ never publicly released. The verbatim removal list lives
 on the
 [configuration wiki page](https://github.com/barkley-assistant/caduceus/wiki/Configuration).
 
+What the worker container sees is a closed, typed spec:
+
+- **Two writable host-backed surfaces, nothing else.**
+  `/workspace` binds the per-run worktree directly (no
+  copied or `.git`-stripped second workspace) and `/output`
+  is a daemon-owned directory under the daemon state
+  directory (`<state_dir>/oci-runs/<run_id>/output`), never
+  a sibling of the worktree. `/tmp` and `/dev/shm` are the
+  only tmpfs, each bounded by the configured sizes. Any
+  other host-backed mount would be a resolution-time typed
+  error, before a container exists.
+- **A daemon-owned `.git` shadow.** A worktree's `.git` is a
+  `gitdir:` pointer into the main repo's object database, so
+  the container sees a read-only shadow at
+  `/workspace/.git` instead: a harmless sentinel file for a
+  pointer-file `.git`, an empty read-only directory for a
+  `.git` directory, and no shadow at all when `.git` is
+  absent. The worker can neither read the real gitdir nor
+  write `/workspace/.git`; repo operations belong to the
+  host-side finalize step.
+- **Dynamic runtime identity.** The container runs as the
+  worktree owner's real UID/GID, probed before container
+  start — never a hard-coded `1000:1000`. Docker rootful
+  renders `--user <owner-uid>:<owner-gid>`; Docker rootless
+  emits no `--user` (container root maps to the unprivileged
+  engine user via the rootless user namespace); Podman
+  rootless renders plain `--userns keep-id` so the
+  in-container identity equals the daemon/worktree owner;
+  Podman rootful follows the rootful rule. Unsupported
+  namespace configurations (the canonical case: a rootful
+  engine with userns-remap, or an engine whose mode cannot
+  be determined) are refused with a typed error before any
+  container is created, and `hermes caduceus doctor`
+  reports the engine/mode as unavailable.
+
 ## The 60-Second Orientation
 
 1. `git clone`, `cargo build`, `hermes caduceus setup`

--- a/__init__.py
+++ b/__init__.py
@@ -703,6 +703,136 @@ def _doctor_check_hermes_home() -> _DoctorFinding:
     )
 
 
+def _doctor_check_oci_identity() -> _DoctorFinding:
+    """Check that the OCI engine identity configuration is supported (issue #244).
+
+    Mirrors the daemon's pre-flight probe decision (the Rust-side
+    ``engine_probe``): Docker's ``{{.SecurityOptions}}`` or Podman's
+    ``{{.Host.Security.Rootless}}`` is fetched with a bounded, argument-array
+    subprocess call and parsed with the same rules the daemon applies before
+    any container start. No container is ever created and no engine state is
+    mutated — this is the read-only ``info`` surface only.
+
+    Reports ``host-capability-unavailable`` (doctor exit code 2) when the
+    daemon would refuse the run with ``OciIdentityUnsupported``:
+
+    - an engine binary is installed but its ``info`` probe fails or times
+      out (engine mode cannot be determined — fail-closed);
+    - the engine reports a rootful mode with ``userns-remap`` (the canonical
+      unsupported namespace configuration).
+
+    When neither engine binary is installed the check is not applicable (the
+    daemon runs trusted-host dispatch) and reports ``ok``.
+    """
+    category = "host-capability-unavailable"
+    probes = [
+        ("docker", ["info", "--format", "{{.SecurityOptions}}"]),
+        ("podman", ["info", "--format", "{{.Host.Security.Rootless}}"]),
+    ]
+    for binary, args in probes:
+        try:
+            proc = subprocess.run(
+                [binary] + args,
+                capture_output=True,
+                timeout=SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            # Binary missing or engine hung — try the other engine before
+            # deciding.
+            continue
+        if proc.returncode != 0:
+            # Engine installed but not usable/reachable — try the other.
+            continue
+        stdout = proc.stdout.decode("utf-8", "replace").strip()
+        if binary == "podman":
+            if stdout == "true":
+                return _DoctorFinding(
+                    category=category,
+                    status="ok",
+                    detail="Podman rootless detected; keep-id identity is supported",
+                    next_action="",
+                    internal_detail="podman info Host.Security.Rootless = true",
+                )
+            if stdout == "false":
+                return _DoctorFinding(
+                    category=category,
+                    status="ok",
+                    detail="Podman rootful detected; owner-uid identity is supported",
+                    next_action="",
+                    internal_detail="podman info Host.Security.Rootless = false",
+                )
+            return _DoctorFinding(
+                category=category,
+                status="fail",
+                detail="Podman installed but its rootful/rootless mode could not be determined",
+                next_action="verify the Podman engine is healthy (`podman info`), then re-run doctor",
+                internal_detail=f"unparseable podman info output: {stdout!r}",
+            )
+        # Docker
+        if "name=rootless" in stdout:
+            return _DoctorFinding(
+                category=category,
+                status="ok",
+                detail="Docker rootless detected; rootless user-namespace identity is supported",
+                next_action="",
+                internal_detail=f"docker info SecurityOptions: {stdout!r}",
+            )
+        if "name=userns-remap" in stdout:
+            return _DoctorFinding(
+                category=category,
+                status="fail",
+                detail="rootful Docker with userns-remap is unsupported and will be refused before container start",
+                next_action="disable userns-remap in the Docker daemon configuration, or switch to rootless mode",
+                internal_detail=f"docker info SecurityOptions: {stdout!r}",
+            )
+        if stdout == "[]" or "name=" in stdout:
+            return _DoctorFinding(
+                category=category,
+                status="ok",
+                detail="Docker rootful detected; owner-uid identity is supported",
+                next_action="",
+                internal_detail=f"docker info SecurityOptions: {stdout!r}",
+            )
+        return _DoctorFinding(
+            category=category,
+            status="fail",
+            detail="Docker installed but its rootful/rootless mode could not be determined",
+            next_action="verify the Docker engine is healthy (`docker info`), then re-run doctor",
+            internal_detail=f"unparseable docker info output: {stdout!r}",
+        )
+    # Neither engine answered. Without any OCI engine installed the daemon
+    # runs trusted-host dispatch and the identity check is not applicable;
+    # an installed-but-broken engine is a fail (fail-closed probe outcome).
+    docker_present = any(_binary_on_path(b) for b, _ in probes)
+    if not docker_present:
+        return _DoctorFinding(
+            category=category,
+            status="ok",
+            detail="no OCI engine installed; OCI identity check not applicable (trusted-host dispatch)",
+            next_action="",
+            internal_detail="",
+        )
+    return _DoctorFinding(
+        category=category,
+        status="fail",
+        detail="OCI engine installed but its info probe failed; engine mode cannot be determined",
+        next_action="verify the Docker/Podman engine is reachable, then re-run doctor",
+        internal_detail="both docker info and podman info probes failed or timed out",
+    )
+
+
+def _binary_on_path(name: str) -> bool:
+    """True when ``name`` resolves on PATH (pure stdlib, no subprocess)."""
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(directory) / name
+        try:
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _doctor_check_worktree_lock(ctx: Any) -> _DoctorFinding:
     """Detect leftover .worktrees/.lock files via non-blocking flock probe.
 
@@ -816,6 +946,7 @@ def _cli_doctor(verbose: bool = False) -> int:
         ("Cron Capability", _doctor_check_cron_capability(ctx=None)),
         ("Worktree Lock", _doctor_check_worktree_lock(ctx=None)),
         ("Hermes Home", _doctor_check_hermes_home()),
+        ("OCI Identity", _doctor_check_oci_identity()),
     ]
 
     effective_verbose = verbose

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -179,6 +179,11 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         // budget.
         CaduceusError::OciCliNotFound { .. } => FailureClass::Infrastructure,
         CaduceusError::OciEngineUnavailable { .. } => FailureClass::Infrastructure,
+        // Refused before any container exists: a host/environment
+        // capability problem (undetectable engine mode, unsupported
+        // namespace configuration, unreadable worktree) — not
+        // worker-attributable.
+        CaduceusError::OciIdentityUnsupported { .. } => FailureClass::Infrastructure,
         CaduceusError::OciMismatchedCliVersion { .. } => FailureClass::Infrastructure,
         CaduceusError::OciPullFailed { .. } => FailureClass::Infrastructure,
         CaduceusError::OciCreateFailed { .. } => FailureClass::Infrastructure,

--- a/src/executor/engine_probe.rs
+++ b/src/executor/engine_probe.rs
@@ -1,0 +1,354 @@
+//! Pre-flight I/O probe for the OCI executor.
+//!
+//! This module is the **only** new I/O surface introduced by the
+//! workspace/git-identity isolation change. It collects every
+//! filesystem- or engine-derived fact that [`resolve`](crate::executor::sandbox_spec::resolve)
+//! needs while staying pure (no `std::fs`, no `std::env` inside the
+//! resolver/renderer) and creates the daemon-owned host artifacts the
+//! container will bind-mount:
+//!
+//! 1. Worktree owner uid/gid — `std::fs::metadata` +
+//!    `MetadataExt::{uid, gid}`.
+//! 2. Host `.git` type at `<worktree>/.git` — `symlink_metadata`
+//!    → `GitShadowKind::{File, Dir, Absent}`.
+//! 3. Engine mode (rootful/rootless) + userns-remap flag — a bounded
+//!    `docker info` / `podman info` call parsed by the pure
+//!    [`parse_engine_mode`]. This is the only engine-CLI call added
+//!    here; it must NOT move into `oci_lifecycle`, which stays a
+//!    lifecycle-only boundary.
+//! 4. Daemon-owned artifacts under `cfg.state_dir`:
+//!    `<state_dir>/oci-runs/<run_id>/` (fresh per run, throwaway),
+//!    the `output` directory (mode `0700`, chowned to the resolved
+//!    identity), and the `.git` shadow artifact per kind.
+//! 5. The assembled extended [`RuntimeFacts`].
+//!
+//! Every failure is fail-closed with
+//! [`CaduceusError::OciIdentityUnsupported`]: the daemon never
+//! guesses an engine mode and never falls back to a hard-coded
+//! identity. Refusals happen **before** any `create` argv exists, so
+//! an unsupported configuration can never reach `oci_lifecycle`.
+
+use std::io;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::Path;
+use std::time::Duration;
+
+use nix::unistd::{chown, Gid, Uid};
+
+use crate::executor::sandbox_spec::{
+    derive_daemon_id, EngineMode, GitShadowKind, RuntimeFacts, SandboxEngine,
+};
+use crate::executor::ExecutorSpec;
+use crate::infra::config::Config;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Sentinel content of the `.git` shadow file. It deliberately
+/// contains no real gitdir path: git commands inside the container
+/// fail on the bogus gitdir, which is the intended outcome (repo
+/// operations belong to the host finalize step).
+pub const GIT_SHADOW_FILE_CONTENT: &str = "gitdir: /caduceus-git-shadow/unavailable\n";
+
+/// Bounded probe timeout: a hung engine CLI fails fast instead of
+/// stalling the daemon tick.
+const ENGINE_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Collect all pre-flight runtime facts and create the daemon-owned
+/// host artifacts for the run. Called by `OciExecutor::run` **before**
+/// `resolve` — nothing downstream may perform I/O.
+///
+/// Fail-closed: worktree unreadable, `.git` unprobeable, engine-mode
+/// probe failure, unsupported namespace configuration, or
+/// output-dir/shadow creation failure all return
+/// [`CaduceusError::OciIdentityUnsupported`] before any container is
+/// created.
+pub async fn probe_runtime_facts(
+    cfg: &Config,
+    spec: &ExecutorSpec,
+) -> CaduceusResult<RuntimeFacts> {
+    let engine = cfg.sandbox().engine;
+
+    // 1. Worktree owner — a missing/unreadable worktree is
+    //    fail-closed: there is no identity to run the worker as.
+    let meta = std::fs::metadata(&spec.worktree).map_err(|e| {
+        identity_unsupported(
+            engine,
+            None,
+            format!("worktree {} is not readable: {e}", spec.worktree.display()),
+        )
+    })?;
+    let worktree_uid = meta.uid();
+    let worktree_gid = meta.gid();
+
+    // 2. Host `.git` type. A symlink counts as `File` (linked
+    //    worktrees may symlink the pointer); a directory as `Dir`;
+    //    `NotFound` as `Absent`; any other probe error is
+    //    fail-closed.
+    let git_shadow_kind = match std::fs::symlink_metadata(spec.worktree.join(".git")) {
+        Ok(md) if md.is_dir() => GitShadowKind::Dir,
+        Ok(_) => GitShadowKind::File,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => GitShadowKind::Absent,
+        Err(e) => {
+            return Err(identity_unsupported(
+                engine,
+                None,
+                format!(
+                    "cannot probe .git in worktree {}: {e}",
+                    spec.worktree.display()
+                ),
+            ))
+        }
+    };
+
+    // 3. Engine-mode probe (bounded timeout; fail-closed).
+    let stdout = engine_info_output(engine).await?;
+    let (engine_mode, userns_remap) = parse_engine_mode(engine, &stdout)?;
+
+    // 4. Unsupported-namespace refusal — raised before any `create`
+    //    argv exists. userns-remap under rootful is the canonical
+    //    unsupported case; userns-remap does not occur under rootless
+    //    (rootless already implies its own user namespace).
+    if engine_mode == EngineMode::Rootful && userns_remap {
+        return Err(identity_unsupported(
+            engine,
+            Some(engine_mode),
+            "rootful engine configured with userns-remap is unsupported".to_string(),
+        ));
+    }
+
+    // 5. Daemon-owned artifacts under the state directory. The
+    //    run-scoped `oci-runs/<run_id>` subtree is created fresh per
+    //    run and is throwaway; it shares the state dir's existing
+    //    lifecycle and needs no new teardown code.
+    let state_dir = cfg.state_dir.clone();
+    let run_dir = state_dir.join("oci-runs").join(&spec.run_id);
+    std::fs::create_dir_all(&run_dir).map_err(|e| {
+        identity_unsupported(
+            engine,
+            Some(engine_mode),
+            format!("cannot create run dir {}: {e}", run_dir.display()),
+        )
+    })?;
+
+    let output_dir = run_dir.join("output");
+    create_output_dir(&output_dir, worktree_uid, worktree_gid, engine, engine_mode)?;
+
+    let git_shadow_host = run_dir.join("git-shadow");
+    create_git_shadow(&git_shadow_host, git_shadow_kind, engine, engine_mode)?;
+
+    // 6. Assemble the extended facts.
+    Ok(RuntimeFacts {
+        run_id: spec.run_id.clone(),
+        issue: spec.issue.clone(),
+        worker_command: spec.worker_command.clone(),
+        worktree: spec.worktree.clone(),
+        output_dir,
+        daemon_id: derive_daemon_id(cfg),
+        workdir_base: cfg.workdir_base.clone(),
+        state_dir,
+        worktree_uid,
+        worktree_gid,
+        engine_mode,
+        git_shadow_kind,
+        git_shadow_host,
+    })
+}
+
+/// Pure engine-mode parser. Unit-tested against the synthetic stdout
+/// shapes below; unparseable output is fail-closed
+/// (`mode: None` — the daemon never guesses).
+///
+/// - **Podman**: `podman info --format '{{.Host.Security.Rootless}}'`
+///   prints `true`/`false`.
+/// - **Docker**: `docker info --format '{{.SecurityOptions}}'`
+///   prints e.g. `[name=apparmor name=seccomp,profile=builtin]`,
+///   `[name=rootless ...]`, or `[name=userns-remap,...]`.
+///   Substring matching (not exact tokenization) is used because the
+///   `SecurityOptions` formatting varies across Docker versions.
+pub fn parse_engine_mode(
+    engine: SandboxEngine,
+    stdout: &str,
+) -> CaduceusResult<(EngineMode, bool /* userns_remap */)> {
+    let unparseable = || {
+        identity_unsupported(
+            engine,
+            None,
+            "cannot determine engine rootful/rootless mode from engine \
+             info output"
+                .to_string(),
+        )
+    };
+    let trimmed = stdout.trim();
+    match engine {
+        SandboxEngine::Podman => match trimmed {
+            "true" => Ok((EngineMode::Rootless, false)),
+            "false" => Ok((EngineMode::Rootful, false)),
+            _ => Err(unparseable()),
+        },
+        SandboxEngine::Docker => {
+            if trimmed.contains("name=rootless") {
+                Ok((EngineMode::Rootless, false))
+            } else if trimmed.contains("name=userns-remap") {
+                Ok((EngineMode::Rootful, true))
+            } else if trimmed == "[]" || trimmed.contains("name=") {
+                // A recognized (possibly empty) SecurityOptions list
+                // without rootless/userns-remap: plain rootful.
+                Ok((EngineMode::Rootful, false))
+            } else {
+                Err(unparseable())
+            }
+        }
+    }
+}
+
+/// Run the bounded engine-mode probe. The only new engine-CLI call in
+/// the crate; failure, timeout, or non-zero exit are fail-closed.
+async fn engine_info_output(engine: SandboxEngine) -> CaduceusResult<String> {
+    let mut cmd = tokio::process::Command::new(engine.binary_name());
+    cmd.arg("info").arg("--format").arg(match engine {
+        SandboxEngine::Docker => "{{.SecurityOptions}}",
+        SandboxEngine::Podman => "{{.Host.Security.Rootless}}",
+    });
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let output = tokio::time::timeout(ENGINE_PROBE_TIMEOUT, cmd.output())
+        .await
+        .map_err(|_| {
+            identity_unsupported(
+                engine,
+                None,
+                "engine info probe timed out; engine mode cannot be determined".to_string(),
+            )
+        })?
+        .map_err(|e| {
+            identity_unsupported(
+                engine,
+                None,
+                format!("engine info probe failed to spawn: {e}"),
+            )
+        })?;
+
+    if !output.status.success() {
+        return Err(identity_unsupported(
+            engine,
+            None,
+            format!("engine info probe exited with {}", output.status),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Create the daemon-owned `/output` host directory: mode `0700`,
+/// chowned to the resolved `(uid, gid)`. In the supported
+/// configurations the daemon user *is* the worktree owner (the daemon
+/// created the worktree), so the chown is normally a no-op; a rootful
+/// daemon serving a differently-owned worktree gets correct ownership
+/// via the chown. An unprivileged daemon facing a foreign-owned
+/// worktree cannot chown, and the run is refused fail-closed.
+fn create_output_dir(
+    path: &Path,
+    uid: u32,
+    gid: u32,
+    engine: SandboxEngine,
+    mode: EngineMode,
+) -> CaduceusResult<()> {
+    std::fs::create_dir_all(path).map_err(|e| {
+        identity_unsupported(
+            engine,
+            Some(mode),
+            format!("cannot create output dir {}: {e}", path.display()),
+        )
+    })?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
+        identity_unsupported(
+            engine,
+            Some(mode),
+            format!("cannot set mode on output dir {}: {e}", path.display()),
+        )
+    })?;
+    chown(path, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid))).map_err(|e| {
+        identity_unsupported(
+            engine,
+            Some(mode),
+            format!(
+                "cannot chown output dir {} to {uid}:{gid}: {e} \
+                 (the resolved identity cannot own its writable surfaces)",
+                path.display()
+            ),
+        )
+    })?;
+    Ok(())
+}
+
+/// Create the `.git` shadow host artifact per [`GitShadowKind`]:
+///
+/// - `File`: a regular file, mode `0644`, containing
+///   [`GIT_SHADOW_FILE_CONTENT`]. World-readable on purpose: the
+///   worker (arbitrary resolved uid) must be able to *read* the
+///   shadow, and the content contains no real gitdir path.
+/// - `Dir`: an empty directory, mode `0755` (readable, not writable
+///   through the read-only mount). A host-backed empty dir is chosen
+///   over a tmpfs so both engines use one uniform `-v …:ro`
+///   mechanism.
+/// - `Absent`: create nothing — the repo is unaffected.
+fn create_git_shadow(
+    path: &Path,
+    kind: GitShadowKind,
+    engine: SandboxEngine,
+    mode: EngineMode,
+) -> CaduceusResult<()> {
+    match kind {
+        GitShadowKind::File => {
+            std::fs::write(path, GIT_SHADOW_FILE_CONTENT).map_err(|e| {
+                identity_unsupported(
+                    engine,
+                    Some(mode),
+                    format!("cannot create .git shadow file {}: {e}", path.display()),
+                )
+            })?;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).map_err(
+                |e| {
+                    identity_unsupported(
+                        engine,
+                        Some(mode),
+                        format!("cannot set mode on .git shadow {}: {e}", path.display()),
+                    )
+                },
+            )?;
+        }
+        GitShadowKind::Dir => {
+            std::fs::create_dir_all(path).map_err(|e| {
+                identity_unsupported(
+                    engine,
+                    Some(mode),
+                    format!("cannot create .git shadow dir {}: {e}", path.display()),
+                )
+            })?;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).map_err(
+                |e| {
+                    identity_unsupported(
+                        engine,
+                        Some(mode),
+                        format!("cannot set mode on .git shadow {}: {e}", path.display()),
+                    )
+                },
+            )?;
+        }
+        GitShadowKind::Absent => {}
+    }
+    Ok(())
+}
+
+/// Build the typed fail-closed refusal.
+fn identity_unsupported(
+    engine: SandboxEngine,
+    mode: Option<EngineMode>,
+    reason: String,
+) -> CaduceusError {
+    CaduceusError::OciIdentityUnsupported {
+        engine,
+        mode,
+        reason,
+    }
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -31,6 +31,7 @@ use crate::worker::supervisor::SupervisorOutcome;
 use self::oci::OciExecutor;
 use self::trusted_host::TrustedHostExecutor;
 
+pub mod engine_probe;
 pub mod oci;
 pub mod oci_lifecycle;
 pub mod sandbox_renderer;
@@ -38,7 +39,9 @@ pub mod sandbox_spec;
 pub mod secret_transport;
 pub mod trusted_host;
 
-pub use sandbox_spec::{MountSpec, RuntimeFacts, SandboxEngine, SandboxSpec};
+pub use sandbox_spec::{
+    EngineMode, GitShadowKind, MountSpec, RuntimeFacts, SandboxEngine, SandboxSpec,
+};
 
 /// Arguments to [`Executor::run`]. Every field the executor needs
 /// to dispatch a worker, regardless of mode.

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -1,39 +1,30 @@
 //! OCI executor — dispatches workers via Docker or Podman CLI.
 //!
-//! The executor resolves a typed [`SandboxSpec`] from the sandbox
-//! config and runtime facts, renders the `create` argv with the pure
-//! renderer, then delegates to [`oci_lifecycle::run_with_argv`] for the
-//! five-step container lifecycle (create → start → wait → stop →
-//! remove). The state DAO is injected through the config's state
-//! directory.
+//! The executor runs the pre-flight probe (`engine_probe`) to collect
+//! the runtime facts (worktree owner, `.git` type, engine mode) and
+//! create the daemon-owned host artifacts, resolves a typed
+//! [`SandboxSpec`] from the sandbox config and those facts, renders
+//! the `create` argv with the pure renderer, then delegates to
+//! [`oci_lifecycle::run_with_argv`] for the five-step container
+//! lifecycle (create → start → wait → stop → remove). The state DAO
+//! is injected through the config's state directory.
 //!
 //! The renderer is the sole argv producer in the crate: `resolve` owns
-//! every host-path and identity decision, and `oci_lifecycle` only
-//! consumes already-rendered argv.
+//! every host-path and identity decision, `engine_probe` is the sole
+//! pre-flight I/O surface, and `oci_lifecycle` only consumes
+//! already-rendered argv.
 
 use std::future::Future;
-use std::path::PathBuf;
 use std::pin::Pin;
 
-use crate::executor::sandbox_spec::{self, RuntimeFacts};
-use crate::executor::{oci_lifecycle, sandbox_renderer, Executor, ExecutorSpec};
+use crate::executor::{
+    engine_probe, oci_lifecycle, sandbox_renderer, sandbox_spec, Executor, ExecutorSpec,
+};
 use crate::infra::config::Config;
 use crate::infra::error::CaduceusResult;
 use crate::state::oci_run::OciRunDao;
 use crate::state::store;
 use crate::worker::supervisor::SupervisorOutcome;
-
-/// Host-side output directory for a run: the sibling `result` dir of
-/// the worktree under the same parent (matches the legacy mount-path
-/// derivation shape, but now at the fixed container path `/output`).
-/// The worktree itself stays the single workspace mount — the
-/// double-RW same-host bug is gone.
-fn derive_output_dir(cfg: &Config, spec: &ExecutorSpec) -> PathBuf {
-    spec.worktree
-        .parent()
-        .map(|parent| parent.join("result"))
-        .unwrap_or_else(|| cfg.workdir_base.join("result"))
-}
 
 /// Executor that dispatches workers via Docker or Podman CLI.
 #[derive(Clone, Debug)]
@@ -54,26 +45,26 @@ impl Executor for OciExecutor {
         spec: &'a ExecutorSpec,
     ) -> Pin<Box<dyn Future<Output = CaduceusResult<SupervisorOutcome>> + Send + 'a>> {
         Box::pin(async move {
-            // 1. Resolve the closed typed spec. All host-path,
+            // 1. Pre-flight probe: collect the runtime facts (worktree
+            //    owner uid/gid, host `.git` type, engine mode) and
+            //    create the daemon-owned host artifacts. Every
+            //    unsupported-configuration refusal (typed
+            //    `OciIdentityUnsupported`) is raised here — before any
+            //    `create` argv exists, so `oci_lifecycle` is never
+            //    reached on a refusal path.
+            let runtime = engine_probe::probe_runtime_facts(&self.cfg, spec).await?;
+
+            // 2. Resolve the closed typed spec. All host-path,
             //    identity, and mount decisions happen here; the
             //    renderer invents nothing.
-            let runtime = RuntimeFacts {
-                run_id: spec.run_id.clone(),
-                issue: spec.issue.clone(),
-                worker_command: spec.worker_command.clone(),
-                worktree: spec.worktree.clone(),
-                output_dir: derive_output_dir(&self.cfg, spec),
-                daemon_id: sandbox_spec::derive_daemon_id(&self.cfg),
-                workdir_base: self.cfg.workdir_base.clone(),
-            };
             let resolved = sandbox_spec::resolve(self.cfg.sandbox(), &runtime)?;
 
-            // 2. Open the state database.
+            // 3. Open the state database.
             let db_path = self.cfg.state_dir.join(store::DB_FILENAME);
             let conn = store::open(&db_path)?;
             let dao = OciRunDao::new(conn);
 
-            // 3. Render the create argv. Secret env files are created
+            // 4. Render the create argv. Secret env files are created
             //    after resolution (`secret_transport`) and passed as
             //    renderer parameters; today the daemon writes no
             //    secrets, so the slice is empty and no `--env-file`
@@ -81,7 +72,7 @@ impl Executor for OciExecutor {
             let engine = self.cfg.sandbox().engine;
             let argv = sandbox_renderer::render_with_env_files(&resolved, engine, &[]);
 
-            // 4. Run the lifecycle with the rendered argv.
+            // 5. Run the lifecycle with the rendered argv.
             oci_lifecycle::run_with_argv(
                 &self.cfg,
                 spec,

--- a/src/executor/sandbox_renderer.rs
+++ b/src/executor/sandbox_renderer.rs
@@ -42,34 +42,32 @@ pub fn render_with_env_files(
     argv.push(engine.binary_name().to_string());
     argv.push("create".to_string());
 
-    // --- Fixed security controls (from FixedSecurityPolicy's existence).
-    argv.push("--user".to_string());
-    argv.push(format!("{}:{}", spec.identity().uid, spec.identity().gid));
+    // --- Identity, encoded entirely in the spec by `resolve`'s
+    //     (engine, engine_mode) matrix. Rootful modes emit
+    //     `--user <owner-uid>:<owner-gid>`; rootless modes emit no
+    //     `--user` (the engine's user namespace already maps the
+    //     in-container identity to the unprivileged engine user, so
+    //     no host-root privilege is granted). There is no hard-coded
+    //     identity anywhere in the renderer.
+    let identity = spec.identity();
+    if identity.emit_user {
+        argv.push("--user".to_string());
+        argv.push(format!("{}:{}", identity.uid, identity.gid));
+    }
     argv.push("--cap-drop".to_string());
     argv.push("ALL".to_string());
     argv.push("--security-opt".to_string());
     argv.push("no-new-privileges".to_string());
     argv.push("--read-only".to_string());
 
-    // --- Per-engine deltas, encoded strictly inside the match so the
-    // compiler forces both branches.
-    match engine {
-        SandboxEngine::Docker => {
-            // Default namespace: `--user 1000:1000` is exact, no
-            // userns flag needed.
-        }
-        SandboxEngine::Podman => {
-            // Rootless Podman (>= 4.3 mapping syntax): map container
-            // uid/gid 1000 to the invoking host user so `--user
-            // 1000:1000` remains meaningful. Under rootful podman the
-            // mapping is identity, so one flag is correct in both modes.
-            argv.push("--userns".to_string());
-            argv.push(format!(
-                "keep-id:uid={},gid={}",
-                spec.identity().uid,
-                spec.identity().gid
-            ));
-        }
+    // --- User namespace, also encoded in the spec: the only value
+    //     ever stored is plain `keep-id` (Podman rootless), so the
+    //     in-container identity equals the invoking user — the daemon
+    //     user, which is the worktree owner. No uid=/gid= mapping is
+    //     ever emitted.
+    if let Some(userns) = identity.userns {
+        argv.push("--userns".to_string());
+        argv.push(userns.to_string());
     }
 
     // --- Network mode.
@@ -86,17 +84,19 @@ pub fn render_with_env_files(
     argv.push(format!("{}m", spec.resources().memory_mb));
     argv.push("--pids-limit".to_string());
     argv.push(format!("{}", spec.resources().pids));
-    argv.push("--shm-size".to_string());
-    argv.push(format!("{}m", spec.resources().shm_mb));
+    // `/dev/shm` is declared via the dual tmpfs list from the spec
+    // (same bounded-size mechanism as `/tmp`); the standalone
+    // `--shm-size` flag was removed as redundant.
 
     // --- Container name.
     argv.push("--name".to_string());
     argv.push(spec.name().to_string());
 
-    // --- Mounts: exactly one workspace mount and one output mount.
-    // The container targets are the fixed canonical constants the
-    // resolver chose (`/workspace`, `/output`); the renderer formats
-    // them from the spec without inventing any path.
+    // --- Mounts: the two writable host-backed surfaces (`/workspace`,
+    //     `/output`) plus the optional read-only `.git` shadow at
+    //     `/workspace/.git`. The container targets are the fixed
+    //     canonical constants the resolver chose; the renderer
+    //     formats them from the spec without inventing any path.
     argv.push("-v".to_string());
     argv.push(format!(
         "{}:/workspace:{}",
@@ -109,6 +109,19 @@ pub fn render_with_env_files(
         spec.output_mount().host_path.display(),
         mode(spec.output_mount().read_only)
     ));
+    // The shadow is emitted after the `/workspace` bind. Docker and
+    // Podman (crun) order mounts by target depth and apply a bind
+    // whose target is nested under another bind over the parent bind
+    // — `/workspace/.git` wins over `/workspace` regardless of argv
+    // order; the deterministic ordering matches that depth rule.
+    if let Some(shadow) = spec.git_shadow() {
+        argv.push("-v".to_string());
+        argv.push(format!(
+            "{}:/workspace/.git:{}",
+            shadow.host_path.display(),
+            mode(shadow.read_only)
+        ));
+    }
 
     // --- Tmpfs mounts (in spec order).
     for mount in spec.tmpfs() {

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -8,7 +8,10 @@
 //!
 //! Pure module: no `tokio::process`, no `std::fs`, no global mutable
 //! state. The only `std::env` access is for `pass_env` filtering inside
-//! [`resolve`].
+//! [`resolve`]. Every I/O-derived fact the resolver needs (worktree
+//! owner uid/gid, host `.git` type, engine rootful/rootless mode) is
+//! gathered by the pre-flight probe (`engine_probe`) and carried in
+//! [`RuntimeFacts`].
 
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -55,6 +58,35 @@ impl SandboxEngine {
     }
 }
 
+/// Rootful vs rootless engine mode, detected by the pre-flight
+/// engine probe (`engine_probe`) and carried in [`RuntimeFacts`].
+///
+/// `resolve` stays pure: the mode is a fact gathered outside it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EngineMode {
+    /// Engine runs with host root privileges (Docker daemon as root,
+    /// Podman invoked by root).
+    Rootful,
+    /// Engine runs unprivileged (Docker rootless, Podman rootless):
+    /// container root maps to the unprivileged engine user via a
+    /// user namespace.
+    Rootless,
+}
+
+/// What `.git` is on the host worktree, probed by the pre-flight
+/// step and carried in [`RuntimeFacts`]. Determines the daemon-owned
+/// `.git` shadow form (see [`select_git_shadow`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GitShadowKind {
+    /// `.git` is a regular file or symlink (the `gitdir:` pointer
+    /// file of a linked worktree).
+    File,
+    /// `.git` is a directory (a normal checkout).
+    Dir,
+    /// `.git` does not exist.
+    Absent,
+}
+
 /// Digest-pinned image reference. The only constructor (module-private
 /// [`ImageRef::new`]) rejects any reference without `@sha256:`.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -86,16 +118,24 @@ impl AsRef<str> for ImageRef {
     }
 }
 
-/// Non-root identity inside the container. Always `1000:1000`.
+/// Resolved container runtime identity, computed by [`resolve`]
+/// from the `(engine, engine_mode, worktree-owner uid/gid)` matrix.
+///
+/// * `uid`/`gid` are the worktree owner's ids as probed by the
+///   pre-flight step — never a hard-coded constant.
+/// * `emit_user` selects whether the renderer emits
+///   `--user <uid>:<gid>` (rootful modes) or nothing (rootless
+///   modes, where the engine's user namespace already maps the
+///   in-container identity to the engine user).
+/// * `userns` carries the only supported user-namespace flag value,
+///   `Some("keep-id")` for Podman rootless.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResolvedIdentity {
     pub uid: u32,
     pub gid: u32,
+    pub emit_user: bool,
+    pub userns: Option<&'static str>,
 }
-
-/// Fixed non-root UID and GID for the worker container.
-pub const SANDBOX_UID: u32 = 1000;
-pub const SANDBOX_GID: u32 = 1000;
 
 /// A single bind-mount declaration for a container.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -152,6 +192,7 @@ pub struct SandboxSpec {
     identity: ResolvedIdentity,
     workspace_mount: MountSpec,
     output_mount: MountSpec,
+    git_shadow: Option<MountSpec>,
     tmpfs: Vec<TmpfsMount>,
     environment: Vec<(String, String)>,
     resources: ResourceLimits,
@@ -186,6 +227,12 @@ impl SandboxSpec {
     /// The single output mount (host → `/output`).
     pub fn output_mount(&self) -> &MountSpec {
         &self.output_mount
+    }
+    /// The optional daemon-owned `.git` shadow mount (host →
+    /// `/workspace/.git`, read-only). `None` when the host worktree
+    /// has no `.git` entry at all.
+    pub fn git_shadow(&self) -> Option<&MountSpec> {
+        self.git_shadow.as_ref()
     }
     /// Tmpfs mounts (ordered).
     pub fn tmpfs(&self) -> &[TmpfsMount] {
@@ -227,6 +274,7 @@ impl SandboxSpec {
         identity: ResolvedIdentity,
         workspace_mount: MountSpec,
         output_mount: MountSpec,
+        git_shadow: Option<MountSpec>,
         tmpfs: Vec<TmpfsMount>,
         environment: Vec<(String, String)>,
         resources: ResourceLimits,
@@ -241,6 +289,7 @@ impl SandboxSpec {
             identity,
             workspace_mount,
             output_mount,
+            git_shadow,
             tmpfs,
             environment,
             resources,
@@ -271,59 +320,127 @@ pub struct RuntimeFacts {
     pub worker_command: Vec<String>,
     /// Host path to the worktree root.
     pub worktree: PathBuf,
-    /// Host path to the output directory (sibling of the worktree
-    /// under the same parent, e.g. `<workdir_base>/<owner>/<repo>/result`).
+    /// Host path to the output directory. Daemon-owned:
+    /// `<state_dir>/oci-runs/<run_id>/output` (derived by the
+    /// pre-flight probe, never a worktree sibling).
     pub output_dir: PathBuf,
     /// Stable daemon identifier (state-dir basename).
     pub daemon_id: String,
     /// The declared worktree root (`Config.workdir_base`). The
-    /// host-path allow-list in `resolve` rejects mounts outside
-    /// this root.
+    /// host-path allow-list in `resolve` requires the worktree to
+    /// live under this root.
     pub workdir_base: PathBuf,
+    /// Daemon state directory. Allow-list root for the daemon-owned
+    /// surfaces (`output_dir`, `git_shadow_host`).
+    pub state_dir: PathBuf,
+    /// Worktree owner UID (pre-flight probe fact).
+    pub worktree_uid: u32,
+    /// Worktree owner GID (pre-flight probe fact).
+    pub worktree_gid: u32,
+    /// Engine mode (rootful/rootless), probed before resolution.
+    pub engine_mode: EngineMode,
+    /// Host `.git` type for the worktree (pre-flight probe fact).
+    pub git_shadow_kind: GitShadowKind,
+    /// Daemon-owned host path of the `.git` shadow artifact
+    /// (`<state_dir>/oci-runs/<run_id>/git-shadow`), created by the
+    /// pre-flight probe when `git_shadow_kind != Absent`.
+    pub git_shadow_host: PathBuf,
 }
 
 // ---------------------------------------------------------------------------
 // Resolution step
 // ---------------------------------------------------------------------------
 
+/// Type-aware `.git` shadow selection: `File` and `Dir` both yield a
+/// single read-only mount of the daemon-owned shadow artifact at
+/// `/workspace/.git`; `Absent` yields no shadow (the repo is
+/// unaffected). The kind only affects what the pre-flight creates on
+/// the host — the mount shape is uniform so both engines use one
+/// `-v …:ro` mechanism.
+///
+/// Pure — unit-testable without I/O.
+pub fn select_git_shadow(kind: GitShadowKind, shadow_host: &Path) -> Option<MountSpec> {
+    match kind {
+        GitShadowKind::File | GitShadowKind::Dir => Some(MountSpec {
+            host_path: shadow_host.to_path_buf(),
+            container_path: PathBuf::from("/workspace/.git"),
+            read_only: true,
+        }),
+        GitShadowKind::Absent => None,
+    }
+}
+
 /// Resolve a [`SandboxConfig`] plus runtime facts into a closed
 /// [`SandboxSpec`].
 ///
 /// Pure — no I/O. The only `std::env` reads are for `pass_env`
-/// filtering (task 1.13 contract).
+/// filtering (task 1.13 contract). All facts the resolver needs
+/// (owner uid/gid, `.git` type, engine mode) must already be carried
+/// in [`RuntimeFacts`] by the pre-flight probe.
 pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResult<SandboxSpec> {
-    // 1. Host-path allow-list.
-    //    Lexically normalize both paths so we can check containment
-    //    without filesystem access (resolve is pure).
+    // 1. Lexically normalize every declared path so containment can
+    //    be checked without filesystem access (resolve is pure).
+    let undeclared = |p: &Path| CaduceusError::OciUndeclaredMount {
+        path: p.display().to_string(),
+    };
     let workdir_base_norm = lexical_normalize(&runtime.workdir_base).ok_or_else(|| {
         CaduceusError::OciUndeclaredMount {
             path: runtime.workdir_base.display().to_string(),
         }
     })?;
-    if !workdir_base_norm.is_absolute() {
-        return Err(CaduceusError::OciUndeclaredMount {
-            path: workdir_base_norm.display().to_string(),
-        });
-    }
+    let state_dir_norm =
+        lexical_normalize(&runtime.state_dir).ok_or_else(|| undeclared(&runtime.state_dir))?;
+    let worktree_norm =
+        lexical_normalize(&runtime.worktree).ok_or_else(|| undeclared(&runtime.worktree))?;
+    let output_norm =
+        lexical_normalize(&runtime.output_dir).ok_or_else(|| undeclared(&runtime.output_dir))?;
+    let shadow_norm = lexical_normalize(&runtime.git_shadow_host)
+        .ok_or_else(|| undeclared(&runtime.git_shadow_host))?;
 
-    let worktree_norm = resolve_path(&runtime.worktree, &workdir_base_norm)?;
-    let output_norm = resolve_path(&runtime.output_dir, &workdir_base_norm)?;
-
-    // 2. Workspace/output overlap check — the old double-RW mount
-    //    bug (same host path at two container paths) is rejected.
-    if output_norm.starts_with(&worktree_norm) || worktree_norm.starts_with(&output_norm) {
+    // 2. Cross-root containment policy. Checked before the per-root
+    //    allow-list so the double-RW conflict stays the reported
+    //    failure when paths overlap.
+    //
+    //    2a. The daemon state directory must not live inside the
+    //        worktree root — a misconfigured `state_dir` under
+    //        `workdir_base` would put the daemon-owned `/output` and
+    //        `.git` shadow surfaces inside the tree the worker can
+    //        traverse via other runs' worktrees.
+    if state_dir_norm.starts_with(&workdir_base_norm) {
         return Err(CaduceusError::OciMountConflict {
             detail: format!(
-                "output_dir {} must not equal or contain worktree {} \
-                 (the old double-RW mount bug: each needs a distinct host path)",
-                output_norm.display(),
-                worktree_norm.display(),
+                "state_dir {} must not be inside workdir_base {} (the \
+                 daemon-owned /output and .git shadow surfaces would live \
+                 inside the worker-visible tree)",
+                state_dir_norm.display(),
+                workdir_base_norm.display(),
             ),
         });
     }
 
-    // 3. Mounts — exactly one workspace mount and one output mount,
-    //    with fixed canonical container paths.
+    //    2b. The three daemon-declared host paths must be pairwise
+    //        disjoint — the old double-RW mount bug (same host path
+    //        at two container paths) is rejected in every pairing.
+    check_disjoint(&worktree_norm, &output_norm, "worktree", "output_dir")?;
+    check_disjoint(&worktree_norm, &shadow_norm, "worktree", "git_shadow_host")?;
+    check_disjoint(&output_norm, &shadow_norm, "output_dir", "git_shadow_host")?;
+
+    // 3. Host-path allow-list: the worktree lives under
+    //    `workdir_base`; the daemon-owned output dir and `.git`
+    //    shadow live under the daemon state directory.
+    if !worktree_norm.starts_with(&workdir_base_norm) {
+        return Err(undeclared(&runtime.worktree));
+    }
+    if !output_norm.starts_with(&state_dir_norm) {
+        return Err(undeclared(&runtime.output_dir));
+    }
+    if !shadow_norm.starts_with(&state_dir_norm) {
+        return Err(undeclared(&runtime.git_shadow_host));
+    }
+
+    // 4. Mounts — exactly one workspace mount and one output mount,
+    //    with fixed canonical container paths, plus the optional
+    //    read-only `.git` shadow at `/workspace/.git`.
     let workspace_mount = MountSpec {
         host_path: worktree_norm,
         container_path: PathBuf::from("/workspace"),
@@ -334,17 +451,49 @@ pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResul
         container_path: PathBuf::from("/output"),
         read_only: false,
     };
+    let git_shadow = select_git_shadow(runtime.git_shadow_kind, &shadow_norm);
 
-    // 4. Identity — fixed non-root uid/gid.
-    let identity = ResolvedIdentity {
-        uid: SANDBOX_UID,
-        gid: SANDBOX_GID,
+    // 5. Identity — the closed 4-case matrix over
+    //    (engine, engine_mode). `uid`/`gid` are always the probed
+    //    worktree-owner facts; there is deliberately no fallback to
+    //    a hard-coded identity.
+    let identity = match (sandbox.engine, runtime.engine_mode) {
+        (SandboxEngine::Docker, EngineMode::Rootful) => ResolvedIdentity {
+            uid: runtime.worktree_uid,
+            gid: runtime.worktree_gid,
+            emit_user: true,
+            userns: None,
+        },
+        // Container root maps to the unprivileged engine user via the
+        // rootless user namespace; no `--user` is emitted.
+        (SandboxEngine::Docker, EngineMode::Rootless) => ResolvedIdentity {
+            uid: runtime.worktree_uid,
+            gid: runtime.worktree_gid,
+            emit_user: false,
+            userns: None,
+        },
+        // In-container uid/gid = the user invoking Podman = the
+        // daemon user = the worktree owner (the daemon created the
+        // worktree). Plain `keep-id` — no uid=/gid= mapping, which is
+        // what removed the hard-coded 1000 mapping.
+        (SandboxEngine::Podman, EngineMode::Rootless) => ResolvedIdentity {
+            uid: runtime.worktree_uid,
+            gid: runtime.worktree_gid,
+            emit_user: false,
+            userns: Some("keep-id"),
+        },
+        (SandboxEngine::Podman, EngineMode::Rootful) => ResolvedIdentity {
+            uid: runtime.worktree_uid,
+            gid: runtime.worktree_gid,
+            emit_user: true,
+            userns: None,
+        },
     };
 
-    // 5. Image — reject non-digest-pinned references.
+    // 6. Image — reject non-digest-pinned references.
     let image = ImageRef::new(&sandbox.image)?;
 
-    // 6. Pull policy — `Always` is incompatible with digest-pinned images.
+    // 7. Pull policy — `Always` is incompatible with digest-pinned images.
     if sandbox.pull_policy == OciPullPolicy::Always {
         return Err(CaduceusError::OciPullPolicyIncompatible {
             detail: "pull_policy 'Always' is incompatible with \
@@ -353,7 +502,7 @@ pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResul
         });
     }
 
-    // 7. Resources — mapped 1:1 from SandboxResources.
+    // 8. Resources — mapped 1:1 from SandboxResources.
     let resources = ResourceLimits {
         cpus: sandbox.resources.cpus,
         memory_mb: sandbox.resources.memory_mb,
@@ -362,13 +511,13 @@ pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResul
         shm_mb: sandbox.resources.shm_mb,
     };
 
-    // 8. Network — map from SandboxNetwork.
+    // 9. Network — map from SandboxNetwork.
     let network = match sandbox.network {
         SandboxNetwork::None => NetworkMode::None,
         SandboxNetwork::Unrestricted => NetworkMode::Unrestricted,
     };
 
-    // 9. Environment — ordered.
+    // 10. Environment — ordered.
     let mut environment: Vec<(String, String)> = vec![
         ("CADUCEUS_RUN_ID".to_string(), runtime.run_id.clone()),
         ("CADUCEUS_ISSUE_ID".to_string(), runtime.issue.display_key()),
@@ -379,39 +528,155 @@ pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResul
         }
     }
 
-    // 10. Tmpfs — one /tmp mount sized from config.
-    let tmpfs = vec![TmpfsMount {
-        target: "/tmp".to_string(),
-        size_mb: sandbox.resources.tmpfs_mb,
-    }];
+    // 11. Tmpfs — bounded ephemeral surfaces only: `/tmp` sized from
+    //     `resources.tmpfs_mb` and `/dev/shm` sized from
+    //     `resources.shm_mb` (replacing the standalone `--shm-size`
+    //     flag, which sized the same mount redundantly).
+    let tmpfs = vec![
+        TmpfsMount {
+            target: "/tmp".to_string(),
+            size_mb: sandbox.resources.tmpfs_mb,
+        },
+        TmpfsMount {
+            target: "/dev/shm".to_string(),
+            size_mb: sandbox.resources.shm_mb,
+        },
+    ];
 
-    // 11. Labels — fixed order.
+    // 12. Labels — fixed order.
     let labels = vec![
         ("caduceus.daemon_id".to_string(), runtime.daemon_id.clone()),
         ("caduceus.run_id".to_string(), runtime.run_id.clone()),
         ("caduceus.issue_id".to_string(), runtime.issue.display_key()),
     ];
 
-    // 12. Command — worker argv.
+    // 13. Command — worker argv.
     let command = runtime.worker_command.clone();
 
-    // 13. Name — container name == run_id.
+    // 14. Name — container name == run_id.
     let name = runtime.run_id.clone();
 
-    Ok(SandboxSpec::new(
+    let spec = SandboxSpec::new(
         name,
         image,
         command,
         identity,
         workspace_mount,
         output_mount,
+        git_shadow,
         tmpfs,
         environment,
         resources,
         network,
         FixedSecurityPolicy,
         labels,
-    ))
+    );
+
+    // 15. Writable-surface invariant — enforced where the closed spec
+    //     is built, so an extra writable host-backed mount can only
+    //     ever be a future regression caught at resolution time.
+    validate_mount_policy(&spec)?;
+
+    Ok(spec)
+}
+
+/// Reject two daemon-declared host paths that are equal or nested
+/// (either direction). `left`/`right` are human-readable labels used
+/// in the conflict detail.
+fn check_disjoint(
+    left: &Path,
+    right: &Path,
+    left_label: &str,
+    right_label: &str,
+) -> CaduceusResult<()> {
+    if left == right || left.starts_with(right) || right.starts_with(left) {
+        return Err(CaduceusError::OciMountConflict {
+            detail: format!(
+                "{left_label} {} and {right_label} {} must be disjoint host \
+                 paths (the old double-RW mount bug: each mount needs a \
+                 distinct host path)",
+                left.display(),
+                right.display(),
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Enforce the writable-surface invariant on a resolved spec:
+///
+/// - exactly two RW host-backed mounts: `/workspace` and `/output`;
+/// - the only extra host-backed mount is the `.git` shadow, and it
+///   is read-only at `/workspace/.git`;
+/// - the tmpfs set is exactly `[/tmp (tmpfs_mb), /dev/shm (shm_mb)]`.
+///
+/// A violation returns `OciUndeclaredMount`/`OciMountConflict` —
+/// structurally this can only fire on a future regression inside
+/// `resolve` itself, which is exactly the point.
+fn validate_mount_policy(spec: &SandboxSpec) -> CaduceusResult<()> {
+    // The two writable host-backed surfaces.
+    let writable = [
+        ("workspace", &spec.workspace_mount, "/workspace"),
+        ("output", &spec.output_mount, "/output"),
+    ];
+    for (label, mount, container_path) in writable {
+        if mount.read_only {
+            return Err(CaduceusError::OciMountConflict {
+                detail: format!("the {label} surface must be writable, but {mount:?} is read-only"),
+            });
+        }
+        if mount.container_path != Path::new(container_path) {
+            return Err(CaduceusError::OciMountConflict {
+                detail: format!(
+                    "the {label} surface must target {container_path}, but {:?} was declared",
+                    mount.container_path
+                ),
+            });
+        }
+    }
+
+    // The only extra host-backed mount is the read-only `.git` shadow.
+    if let Some(shadow) = &spec.git_shadow {
+        if !shadow.read_only {
+            return Err(CaduceusError::OciUndeclaredMount {
+                path: shadow.host_path.display().to_string(),
+            });
+        }
+        if shadow.container_path != Path::new("/workspace/.git") {
+            return Err(CaduceusError::OciMountConflict {
+                detail: format!(
+                    "the .git shadow must target /workspace/.git, but {:?} was declared",
+                    shadow.container_path
+                ),
+            });
+        }
+    }
+
+    // Tmpfs set is exactly the two bounded ephemeral surfaces.
+    let expected = [
+        ("/tmp", spec.resources.tmpfs_mb),
+        ("/dev/shm", spec.resources.shm_mb),
+    ];
+    if spec.tmpfs.len() != expected.len() {
+        return Err(CaduceusError::OciMountConflict {
+            detail: format!(
+                "tmpfs set must be exactly {expected:?}, got {:?}",
+                spec.tmpfs
+            ),
+        });
+    }
+    for (mount, (target, size_mb)) in spec.tmpfs.iter().zip(expected.iter()) {
+        if mount.target != *target || mount.size_mb != *size_mb {
+            return Err(CaduceusError::OciMountConflict {
+                detail: format!(
+                    "tmpfs set must be exactly {expected:?}, got {:?}",
+                    spec.tmpfs
+                ),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -451,19 +716,4 @@ fn lexical_normalize(path: &Path) -> Option<PathBuf> {
         }
     }
     Some(out)
-}
-
-/// Resolve a host path: lexical-normalize, check absolute, check
-/// under `workdir_base_norm`. Returns the normalized path on success
-/// or `OciUndeclaredMount` on failure.
-fn resolve_path(path: &Path, workdir_base_norm: &Path) -> CaduceusResult<PathBuf> {
-    let norm = lexical_normalize(path).ok_or_else(|| CaduceusError::OciUndeclaredMount {
-        path: path.display().to_string(),
-    })?;
-    if !norm.starts_with(workdir_base_norm) {
-        return Err(CaduceusError::OciUndeclaredMount {
-            path: path.display().to_string(),
-        });
-    }
-    Ok(norm)
 }

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -310,6 +310,19 @@ pub enum CaduceusError {
     #[error("OCI mount conflict: {detail}")]
     OciMountConflict { detail: String },
 
+    /// Unsupported namespace / identity configuration, refused
+    /// before any container is created. `mode` is `None` when the
+    /// engine mode itself could not be determined; the canonical
+    /// named case is a rootful engine configured with
+    /// userns-remap. Raised by the pre-flight engine probe, never
+    /// after `create` argv exists.
+    #[error("OCI identity unsupported for {engine:?} (mode {mode:?}): {reason}")]
+    OciIdentityUnsupported {
+        engine: crate::executor::sandbox_spec::SandboxEngine,
+        mode: Option<crate::executor::sandbox_spec::EngineMode>,
+        reason: String,
+    },
+
     /// A potential secret leak was detected in OCI output.
     #[error("OCI secret leak suspected at {path}")]
     OciSecretLeakSuspected { path: String },
@@ -544,6 +557,12 @@ impl fmt::Debug for CaduceusError {
   }
   CaduceusError::OciMountConflict { detail } => {
   format!("OciMountConflict {{ detail: {} }}", scrub(detail))
+  }
+  CaduceusError::OciIdentityUnsupported { engine, mode, reason } => {
+  format!(
+  "OciIdentityUnsupported {{ engine: {:?}, mode: {:?}, reason: {} }}",
+  engine, mode, scrub(reason)
+  )
   }
   CaduceusError::OciSecretLeakSuspected { path } => {
   format!("OciSecretLeakSuspected {{ path: {:?} }}", path)

--- a/tests/executor/executor_oci_test.rs
+++ b/tests/executor/executor_oci_test.rs
@@ -2,8 +2,11 @@
 //!
 //! Verifies that `OciExecutor::run` attempts to dispatch via the
 //! configured OCI CLI. In CI without Docker/Podman, the executor
-//! returns `OciEngineUnavailable` (via `OciCliNotFound` or similar
-//! from the subprocess path). The tests verify the typed error and
+//! returns a typed OCI error: the pre-flight engine probe fails
+//! fail-closed with `OciIdentityUnsupported` (the engine mode cannot
+//! be determined without a reachable engine), surfaced from the
+//! lifecycle path as `OciEngineUnavailable`/`OciCreateFailed` in
+//! older configurations. The tests verify the typed error and
 //! that no subprocess is spawned for config-only errors.
 
 use std::sync::Arc;
@@ -26,6 +29,15 @@ fn setup() -> (Config, TempDir) {
     std::fs::create_dir_all(&state_dir).expect("create state dir");
     let mut cfg = Config::test_defaults(tmp.path());
     cfg.state_dir = state_dir;
+    // The pre-flight probe stats the worktree, so it must exist on
+    // disk (a missing worktree would fail the probe before the
+    // engine-availability error could surface).
+    let worktree = cfg
+        .workdir_base
+        .join("test-owner")
+        .join("test-repo")
+        .join("run-1");
+    std::fs::create_dir_all(&worktree).expect("create worktree dir");
     (cfg, tmp)
 }
 
@@ -57,7 +69,9 @@ fn test_spec(cfg: &Config) -> ExecutorSpec {
 
 /// `OciExecutor::run` returns a typed `CaduceusError` (not a panic).
 /// Without Docker/Podman in CI, the error is either
-/// `OciEngineUnavailable` or `OciCreateFailed`.
+/// `OciEngineUnavailable` or the fail-closed pre-flight refusal
+/// `OciIdentityUnsupported` (mode undetectable without a reachable
+/// engine).
 #[tokio::test]
 async fn oci_executor_returns_typed_error() {
     let (cfg, _tmp) = setup();
@@ -74,6 +88,7 @@ async fn oci_executor_returns_typed_error() {
             | CaduceusError::OciCreateFailed { .. }
             | CaduceusError::OciCliNotFound { .. }
             | CaduceusError::OciPullFailed { .. }
+            | CaduceusError::OciIdentityUnsupported { .. }
     );
     assert!(
         is_oci_error,

--- a/tests/executor/identity_resolution_test.rs
+++ b/tests/executor/identity_resolution_test.rs
@@ -1,0 +1,210 @@
+//! Dynamic identity resolution tests (design D2/D3).
+//!
+//! Two layers, both pure and ungated:
+//!
+//! 1. `parse_engine_mode` — the engine-mode decision logic pinned
+//!    against the synthetic `docker info` / `podman info` stdout
+//!    shapes, including the fail-closed garbage case.
+//! 2. The 4-case identity matrix — `resolve` + `render` from
+//!    synthetic ownership facts with a non-1000 owner (`4242:4242`),
+//!    asserting the rendered argv per engine×mode and that a literal
+//!    `1000:1000` is never emitted.
+
+use caduceus::executor::sandbox_renderer::render;
+use caduceus::executor::sandbox_spec::{resolve, EngineMode, SandboxEngine};
+use caduceus::infra::config::Config;
+use caduceus::infra::error::CaduceusError;
+
+mod support;
+
+/// A config with the given engine, plus the resolved spec + rendered
+/// argv for the default fixture facts (owner `4242:4242`).
+fn rendered_for(engine: SandboxEngine, mode: EngineMode) -> (Config, Vec<String>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = Config::test_defaults(tmp.path());
+    cfg.sandbox.as_mut().expect("sandbox").engine = engine;
+    let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
+    let mut runtime = support::runtime_facts(&cfg, "run-001", &worktree);
+    runtime.engine_mode = mode;
+    let spec = resolve(cfg.sandbox(), &runtime).expect("facts must resolve");
+    (cfg, render(&spec, engine))
+}
+
+// ---------------------------------------------------------------------------
+// 4-case identity matrix (design D2)
+// ---------------------------------------------------------------------------
+
+/// Docker rootful ⇒ `--user <owner-uid>:<owner-gid>`, no userns.
+#[test]
+fn docker_rootful_uses_owner_identity() {
+    let (cfg, argv) = rendered_for(SandboxEngine::Docker, EngineMode::Rootful);
+    let user_pos = argv.iter().position(|a| a == "--user").expect("--user");
+    assert_eq!(argv[user_pos + 1], "4242:4242");
+    assert!(!argv.contains(&"--userns".to_string()));
+    let _ = cfg;
+}
+
+/// Docker rootless ⇒ no `--user` at all: container root maps to the
+/// unprivileged engine user via the rootless user namespace, granting
+/// no host-root privilege. No userns flag either.
+#[test]
+fn docker_rootless_emits_no_user() {
+    let (_, argv) = rendered_for(SandboxEngine::Docker, EngineMode::Rootless);
+    assert!(
+        !argv.contains(&"--user".to_string()),
+        "rootless docker must not emit --user, got: {argv:?}"
+    );
+    assert!(!argv.contains(&"--userns".to_string()));
+}
+
+/// Podman rootless ⇒ plain `--userns keep-id` (no uid=/gid= mapping)
+/// and no `--user`: in-container identity = the invoking user = the
+/// daemon user = the worktree owner.
+#[test]
+fn podman_rootless_uses_plain_keep_id() {
+    let (_, argv) = rendered_for(SandboxEngine::Podman, EngineMode::Rootless);
+    let pos = argv.iter().position(|a| a == "--userns").expect("--userns");
+    assert_eq!(argv[pos + 1], "keep-id");
+    assert!(
+        !argv.contains(&"--user".to_string()),
+        "podman rootless must not emit --user, got: {argv:?}"
+    );
+    assert!(
+        !argv
+            .iter()
+            .any(|a| a.contains("uid=") || a.contains("gid=")),
+        "keep-id must be plain (no hard-coded mapping), got: {argv:?}"
+    );
+}
+
+/// Podman rootful ⇒ the rootful rule: `--user U:G`, no `--userns`.
+#[test]
+fn podman_rootful_follows_rootful_rule() {
+    let (_, argv) = rendered_for(SandboxEngine::Podman, EngineMode::Rootful);
+    let user_pos = argv.iter().position(|a| a == "--user").expect("--user");
+    assert_eq!(argv[user_pos + 1], "4242:4242");
+    assert!(!argv.contains(&"--userns".to_string()));
+}
+
+/// Identity never assumes UID 1000: for every supported engine×mode,
+/// the hard-coded `1000:1000` value is never emitted anywhere in the
+/// argv, and the resolved uid/gid equal the synthetic owner facts.
+#[test]
+fn identity_never_assumes_1000() {
+    let cases = [
+        (SandboxEngine::Docker, EngineMode::Rootful),
+        (SandboxEngine::Docker, EngineMode::Rootless),
+        (SandboxEngine::Podman, EngineMode::Rootless),
+        (SandboxEngine::Podman, EngineMode::Rootful),
+    ];
+    for (engine, mode) in cases {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut cfg = Config::test_defaults(tmp.path());
+        cfg.sandbox.as_mut().expect("sandbox").engine = engine;
+        let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
+        let runtime = support::runtime_facts(&cfg, "run-001", &worktree);
+        let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+        assert_eq!(spec.identity().uid, 4242, "{engine:?}/{mode:?}");
+        assert_eq!(spec.identity().gid, 4242, "{engine:?}/{mode:?}");
+
+        let argv = render(&spec, engine);
+        assert!(
+            !argv.iter().any(|a| a.contains("1000:1000")),
+            "{engine:?}/{mode:?} must never emit the hard-coded 1000:1000, got: {argv:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine-mode parsing (design D2)
+// ---------------------------------------------------------------------------
+
+fn parse(engine: SandboxEngine, stdout: &str) -> Result<(EngineMode, bool), CaduceusError> {
+    caduceus::executor::engine_probe::parse_engine_mode(engine, stdout)
+}
+
+/// Docker rootful shapes: plain security options, and the empty list
+/// some Docker versions print.
+#[test]
+fn parse_docker_rootful() {
+    for stdout in [
+        "[name=apparmor name=seccomp,profile=builtin]",
+        "[name=seccomp,profile=builtin name=cgroupns]",
+        "[]",
+    ] {
+        let (mode, userns_remap) = parse(SandboxEngine::Docker, stdout)
+            .unwrap_or_else(|e| panic!("must parse {stdout:?}: {e:?}"));
+        assert_eq!(mode, EngineMode::Rootful, "{stdout:?}");
+        assert!(!userns_remap, "{stdout:?}");
+    }
+}
+
+/// Docker rootless: `name=rootless` in the security options.
+#[test]
+fn parse_docker_rootless() {
+    for stdout in [
+        "[name=rootless]",
+        "[name=rootless name=seccomp,profile=builtin]",
+    ] {
+        let (mode, userns_remap) = parse(SandboxEngine::Docker, stdout)
+            .unwrap_or_else(|e| panic!("must parse {stdout:?}: {e:?}"));
+        assert_eq!(mode, EngineMode::Rootless, "{stdout:?}");
+        assert!(!userns_remap, "{stdout:?}");
+    }
+}
+
+/// Docker rootful with userns-remap (with and without `=`-value):
+/// rootful + userns_remap flag set — the canonical unsupported case.
+#[test]
+fn parse_docker_userns_remap() {
+    for stdout in [
+        "[name=userns-remap]",
+        "[name=userns-remap,value=default]",
+        "[name=apparmor name=userns-remap,value=custom]",
+    ] {
+        let (mode, userns_remap) = parse(SandboxEngine::Docker, stdout)
+            .unwrap_or_else(|e| panic!("must parse {stdout:?}: {e:?}"));
+        assert_eq!(mode, EngineMode::Rootful, "{stdout:?}");
+        assert!(userns_remap, "{stdout:?}");
+    }
+}
+
+/// Podman rootless/rootful: `{{.Host.Security.Rootless}}` booleans.
+#[test]
+fn parse_podman_boolean() {
+    let (mode, userns_remap) = parse(SandboxEngine::Podman, "true").expect("must parse");
+    assert_eq!(mode, EngineMode::Rootless);
+    assert!(!userns_remap);
+
+    let (mode, userns_remap) = parse(SandboxEngine::Podman, "false\n").expect("must parse");
+    assert_eq!(mode, EngineMode::Rootful);
+    assert!(!userns_remap);
+}
+
+/// Garbage / unparseable output is fail-closed: typed refusal with
+/// `mode: None` — the daemon never guesses a mode.
+#[test]
+fn parse_garbage_is_fail_closed() {
+    for (engine, stdout) in [
+        (SandboxEngine::Docker, "not-a-security-options-list"),
+        (SandboxEngine::Docker, ""),
+        (SandboxEngine::Podman, "maybe"),
+        (SandboxEngine::Podman, ""),
+        (SandboxEngine::Podman, "[name=rootless]"),
+    ] {
+        match parse(engine, stdout) {
+            Err(CaduceusError::OciIdentityUnsupported {
+                mode: None, reason, ..
+            }) => {
+                assert!(
+                    !reason.is_empty(),
+                    "refusal must carry a reason, engine {engine:?} stdout {stdout:?}"
+                );
+            }
+            other => panic!(
+                "expected fail-closed OciIdentityUnsupported for {engine:?} \
+                 stdout {stdout:?}, got: {other:?}"
+            ),
+        }
+    }
+}

--- a/tests/executor/isolation_escape_test.rs
+++ b/tests/executor/isolation_escape_test.rs
@@ -13,22 +13,14 @@
 //! event (MountBoundaryHeld, GitLessBoundaryHeld, etc.).
 
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::Config;
+
+mod support;
 
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: "run-001".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, "run-001", &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 
@@ -64,22 +56,38 @@ fn escape_worktree_mount() {
     );
 }
 
-// escape_git_metadata — reading /workspace/.git/HEAD returns EROFS + audit
+// escape_git_metadata — reading /workspace/.git reaches only the
+// daemon-owned read-only shadow, never the real gitdir
 
 #[test]
 #[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
 fn escape_git_metadata() {
-    // The git-less worker contract ensures that .git is never mounted
-    // at all. When CADUCEUS_RUN_ISOLATION_TESTS is set, run:
+    // The gitdir pointer file at /workspace/.git is shadowed by a
+    // daemon-owned read-only mount; the real main-repo gitdir path is
+    // unreachable and the shadow is not writable. When
+    // CADUCEUS_RUN_ISOLATION_TESTS is set, run:
     //  docker run --read-only -v /tmp/worktree:/workspace:rw \
-    //  caduceus-worker sh -c 'cat /workspace/.git/HEAD'
-    // Expected: cat: /workspace/.git/HEAD: No such file or directory
-    // Daemon audit: "GitLessBoundaryHeld".
+    //    -v /state/oci-runs/run/git-shadow:/workspace/.git:ro \
+    //  caduceus-worker sh -c 'cat /workspace/.git'
+    // Expected: only the sentinel shadow content (never the real
+    // gitdir path), and writes to /workspace/.git fail.
+    // Daemon audit: "GitShadowHeld".
     let argv = rendered_argv();
-    let has_git_mount = argv.iter().any(|a| a.contains(".git"));
+    let shadow_mounts: Vec<&String> = argv
+        .iter()
+        .filter(|a| a.ends_with(":/workspace/.git:ro"))
+        .collect();
+    assert_eq!(
+        shadow_mounts.len(),
+        1,
+        "exactly one read-only shadow mount for /workspace/.git: {argv:?}"
+    );
+    // No writable .git mount anywhere.
     assert!(
-        !has_git_mount,
-        ".git must not be mounted; git-less boundary enforced"
+        !argv
+            .iter()
+            .any(|a| a.contains(".git") && a.ends_with(":rw")),
+        ".git must never be mounted writable: {argv:?}"
     );
 }
 

--- a/tests/executor/network_isolation_test.rs
+++ b/tests/executor/network_isolation_test.rs
@@ -7,22 +7,14 @@
 //! `CADUCEUS_RUN_ISOLATION_TESTS`.
 
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::{Config, SandboxNetwork};
+
+mod support;
 
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: "run-001".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, "run-001", &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 

--- a/tests/executor/oci_args_test.rs
+++ b/tests/executor/oci_args_test.rs
@@ -10,22 +10,14 @@
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::sandbox_renderer::{render, render_with_env_files};
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::Config;
+
+mod support;
 
 fn resolve_from(cfg: &Config, run_id: &str) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join(run_id);
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: run_id.to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "state".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, run_id, &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 
@@ -46,15 +38,36 @@ fn one_contract_both_clis() {
 
     assert_eq!(docker_argv[0], "docker");
     assert_eq!(podman_argv[0], "podman");
-    assert_eq!(docker_argv.len() + 2, podman_argv.len());
-    // Everything after the binary is identical except the userns pair.
-    let mut podman_without_delta: Vec<String> = podman_argv
-        .iter()
-        .filter(|a| a.as_str() != "--userns" && !a.starts_with("keep-id:"))
-        .cloned()
-        .collect();
-    podman_without_delta[0] = "docker".to_string();
-    assert_eq!(docker_argv, podman_without_delta);
+    // Rootful docker vs rootless-mode fixture facts for podman differ
+    // by the identity encoding: docker has the `--user` pair, the
+    // podman facts carry plain keep-id. Strip both identity encodings
+    // and the argvs are otherwise identical.
+    let strip_identity = |argv: &[String]| -> Vec<String> {
+        let mut out = Vec::new();
+        let mut skip_next = false;
+        for tok in argv {
+            if skip_next {
+                skip_next = false;
+                continue;
+            }
+            if tok == "--user" {
+                skip_next = true;
+                continue;
+            }
+            if tok == "--userns" {
+                skip_next = true;
+                continue;
+            }
+            out.push(tok.clone());
+        }
+        out
+    };
+    let docker_stripped = strip_identity(&docker_argv);
+    let podman_stripped = strip_identity(&podman_argv);
+    assert_eq!(docker_stripped[0], "docker");
+    let mut podman_as_docker = podman_stripped;
+    podman_as_docker[0] = "docker".to_string();
+    assert_eq!(docker_stripped, podman_as_docker);
 }
 
 // undeclared_mount_rejected (AC-02) — resolution rejects host paths
@@ -63,15 +76,7 @@ fn one_contract_both_clis() {
 #[test]
 fn undeclared_mount_rejected() {
     let cfg = default_cfg();
-    let runtime = RuntimeFacts {
-        run_id: "run-002".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree: PathBuf::from("/tmp/worktree"),
-        output_dir: PathBuf::from("/tmp/result"),
-        daemon_id: "state".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(&cfg, "run-002", Path::new("/tmp/worktree"));
     let err = resolve(cfg.sandbox(), &runtime).expect_err("undeclared worktree must be rejected");
     assert!(
         matches!(
@@ -185,7 +190,7 @@ fn renderer_reads_spec_not_argv() {
     let cfg = default_cfg();
     let spec = resolve_from(&cfg, "run-004");
     let argv = render(&spec, SandboxEngine::Docker);
-    assert!(argv.iter().any(|a| a == "1000:1000"));
+    assert!(argv.iter().any(|a| a == "4242:4242"));
     assert!(argv.iter().any(|a| a.ends_with(":/workspace:rw")));
     assert!(argv.iter().any(|a| a.ends_with(":/output:rw")));
     let _ = Path::new("/tmp");

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -1,0 +1,594 @@
+//! Gated live engine tests for the OCI sandbox isolation invariants
+//! (design D8, issue #244).
+//!
+//! Every test in this file is gated behind the
+//! `CADUCEUS_RUN_ISOLATION_TESTS` env var and is expected to be
+//! **ignored** in CI without it:
+//!
+//! ```text
+//! #[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+//! ```
+//!
+//! The tests drive a real Docker/Podman engine through the typed
+//! pipeline (`resolve` → `render`) and assert in-container facts:
+//!
+//! - `oci_mount_enumeration_two_writable_surfaces` — the named
+//!   mount-enumeration test consumed by task I12: the writable
+//!   host-backed set is exactly `{/workspace, /output}`, the tmpfs
+//!   set is bounded `{/tmp, /dev/shm}`, and the pseudo-filesystems
+//!   are engine-managed kernel mounts rather than writable host
+//!   binds.
+//! - per-mode identity canaries (rootful Docker, rootless Docker,
+//!   Podman `keep-id`).
+//! - adversarial `.git` shadow read/write tests.
+
+use std::io::Write as _;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use caduceus::executor::engine_probe::{parse_engine_mode, GIT_SHADOW_FILE_CONTENT};
+use caduceus::executor::sandbox_renderer::render;
+use caduceus::executor::sandbox_spec::{resolve, EngineMode, GitShadowKind, SandboxEngine};
+use caduceus::infra::config::Config;
+use tempfile::TempDir;
+
+/// Build the live fixture: a real worktree (with a `.git` artifact of
+/// the requested kind), facts with the real worktree owner, and the
+/// rendered `create` argv whose worker command dumps or mutates
+/// state. The engine mode is detected from the real engine so the
+/// per-mode canaries can skip (not fail) on a host running a
+/// different mode.
+struct LiveFixture {
+    _tmp: TempDir,
+    cfg: Config,
+    argv: Vec<String>,
+    engine: SandboxEngine,
+    engine_mode: EngineMode,
+    worktree: PathBuf,
+    shadow_host: PathBuf,
+    run_id: String,
+}
+
+fn engine_binary(engine: SandboxEngine) -> String {
+    engine.binary_name().to_string()
+}
+
+/// The host's actual engine and mode. Returns `None` when no engine
+/// binary is usable — the caller skips with a notice.
+fn detect_engine() -> Option<(SandboxEngine, EngineMode)> {
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        let bin = engine_binary(engine);
+        let format_arg = match engine {
+            SandboxEngine::Docker => "{{.SecurityOptions}}",
+            SandboxEngine::Podman => "{{.Host.Security.Rootless}}",
+        };
+        let out = Command::new(&bin)
+            .args(["info", "--format", format_arg])
+            .output();
+        if let Ok(out) = out {
+            if out.status.success() {
+                let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+                if let Ok((mode, _remap)) = parse_engine_mode(engine, &stdout) {
+                    return Some((engine, mode));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn make_worktree(worktree: &Path, kind: GitShadowKind) {
+    std::fs::create_dir_all(worktree).expect("create worktree");
+    match kind {
+        GitShadowKind::File => {
+            let mut f = std::fs::File::create(worktree.join(".git")).expect("create .git file");
+            f.write_all(b"gitdir: /real/main/.git/worktrees/leaky-pointer\n")
+                .expect("write .git pointer");
+        }
+        GitShadowKind::Dir => {
+            std::fs::create_dir_all(worktree.join(".git")).expect("create .git dir");
+            std::fs::write(worktree.join(".git").join("HEAD"), "ref: refs/heads/main\n")
+                .expect("write .git/HEAD");
+        }
+        GitShadowKind::Absent => {}
+    }
+}
+
+fn live_fixture(kind: GitShadowKind, container_script: &str) -> LiveFixture {
+    let (engine, engine_mode) =
+        detect_engine().expect("no usable Docker/Podman engine for gated live tests");
+    // Root the fixture on the filesystem the test process runs from
+    // (the crate root, normally ext4). A tmpfs-backed /tmp would make
+    // the bind mounts' /proc/mounts fstype `tmpfs` and defeat the
+    // host-backed classification below.
+    let tmp = TempDir::new_in(".").expect("tempdir under crate root");
+    let mut cfg = Config::test_defaults(tmp.path());
+    // Digest-pinned image override for hosts with a pre-pulled image;
+    // defaults to the test_defaults placeholder (fine for pure argv
+    // assertions, but a live `create` needs a resolvable digest).
+    if let Ok(image) = std::env::var("CADUCEUS_LIVE_TEST_IMAGE") {
+        assert!(
+            image.contains("@sha256:"),
+            "CADUCEUS_LIVE_TEST_IMAGE must be digest-pinned, got: {image}"
+        );
+        cfg.sandbox.as_mut().expect("sandbox").image = image;
+    }
+    let run_id = "live-iso-run";
+    let worktree = cfg.workdir_base.join("owner").join("repo").join(run_id);
+    make_worktree(&worktree, kind);
+
+    let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
+        run_id: run_id.to_string(),
+        issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+        worker_command: vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            container_script.to_string(),
+        ],
+        worktree: worktree.clone(),
+        output_dir: cfg.state_dir.join("oci-runs").join(run_id).join("output"),
+        daemon_id: "live-test-daemon".to_string(),
+        workdir_base: cfg.workdir_base.clone(),
+        state_dir: cfg.state_dir.clone(),
+        worktree_uid: std::fs::metadata(&worktree).expect("worktree stat").uid(),
+        worktree_gid: std::fs::metadata(&worktree).expect("worktree stat").gid(),
+        engine_mode,
+        git_shadow_kind: kind,
+        git_shadow_host: cfg
+            .state_dir
+            .join("oci-runs")
+            .join(run_id)
+            .join("git-shadow"),
+    };
+    // Emulate the daemon-owned shadow artifact the pre-flight would
+    // create (the tests drive the engine directly, not the executor).
+    std::fs::create_dir_all(
+        runtime
+            .git_shadow_host
+            .parent()
+            .expect("shadow host has a parent"),
+    )
+    .expect("create run dir");
+    if kind != GitShadowKind::Absent {
+        if matches!(kind, GitShadowKind::File) {
+            std::fs::write(&runtime.git_shadow_host, GIT_SHADOW_FILE_CONTENT)
+                .expect("create shadow file");
+        } else {
+            std::fs::create_dir_all(&runtime.git_shadow_host).expect("create shadow dir");
+        }
+    }
+    std::fs::create_dir_all(&runtime.output_dir).expect("create output dir");
+
+    let spec = resolve(cfg.sandbox(), &runtime).expect("live facts must resolve");
+    let argv = render(&spec, engine);
+    LiveFixture {
+        _tmp: tmp,
+        cfg,
+        argv,
+        engine,
+        engine_mode,
+        worktree,
+        shadow_host: runtime.git_shadow_host.clone(),
+        run_id: run_id.to_string(),
+    }
+}
+
+fn run_or_die(cmd: &mut Command, what: &str) -> std::process::Output {
+    let out = cmd.output().expect(what);
+    if !out.status.success() {
+        panic!(
+            "{what} failed: status {:?}\nstdout: {}\nstderr: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+    out
+}
+
+/// `create` → `start` → `wait` → (`logs`) → `rm -f`. Returns
+/// `(exit_code, combined_logs)`.
+fn run_container(fx: &LiveFixture) -> (i64, String) {
+    let bin = engine_binary(fx.engine);
+    // `fx.argv` already begins with the engine binary + `create`; skip
+    // the argv's own binary token when spawning.
+    run_or_die(Command::new(&bin).args(&fx.argv[1..]), "engine create");
+    run_or_die(
+        Command::new(&bin).args(["start", &fx.run_id]),
+        "engine start",
+    );
+    let wait = run_or_die(Command::new(&bin).args(["wait", &fx.run_id]), "engine wait");
+    let logs = Command::new(&bin)
+        .args(["logs", &fx.run_id])
+        .output()
+        .expect("engine logs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&logs.stdout),
+        String::from_utf8_lossy(&logs.stderr)
+    );
+    // Best-effort teardown.
+    let _ = Command::new(&bin).args(["rm", "-f", &fx.run_id]).output();
+    let code = String::from_utf8_lossy(&wait.stdout)
+        .trim()
+        .parse::<i64>()
+        .expect("wait prints an exit code");
+    (code, combined)
+}
+
+fn wait_for(predicate: impl Fn() -> bool, budget: Duration, what: &str) -> bool {
+    let started = Instant::now();
+    while started.elapsed() < budget {
+        if predicate() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let _ = what;
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Named mount-enumeration test (consumed by task I12)
+// ---------------------------------------------------------------------------
+
+/// I12 consumption point: run a real container whose command dumps
+/// `/proc/mounts`; assert the writable host-backed set ==
+/// `{/workspace, /output}` (the engine's own `/etc` metadata binds
+/// excluded), the tmpfs set == bounded `{/tmp, /dev/shm}`, and the
+/// pseudo-filesystems (`/proc`, `/sys`, `/dev`) are engine-managed
+/// kernel mounts, not writable host-backed binds.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn oci_mount_enumeration_two_writable_surfaces() {
+    let fx = live_fixture(
+        GitShadowKind::File,
+        "cat /proc/mounts; id -u > /workspace/canary",
+    );
+    let (code, logs) = run_container(&fx);
+    assert_eq!(code, 0, "container must exit cleanly; logs: {logs}");
+
+    // Parse the /proc/mounts dump printed by the container.
+    let mut mounts: Vec<(String, String, String)> = Vec::new(); // (target, fstype, opts)
+    for line in logs.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() >= 4 && fields[1].starts_with('/') {
+            mounts.push((
+                fields[1].to_string(),
+                fields[2].to_string(),
+                fields[3].to_string(),
+            ));
+        }
+    }
+    assert!(
+        !mounts.is_empty(),
+        "expected a /proc/mounts dump, got: {logs}"
+    );
+
+    // Pseudo/kernel filesystems are never host-backed bind surfaces.
+    // A `size=`-bearing tmpfs at a daemon-declared target is a bounded
+    // tmpfs; size-less or masked-path tmpfs entries are engine-managed
+    // ephemera (this fixture roots the workdir on the crate
+    // filesystem, so a bind never reports fstype tmpfs here).
+    const KERNEL_FS: &[&str] = &[
+        "proc", "sysfs", "devtmpfs", "devpts", "mqueue", "cgroup", "cgroup2", "shm", "nsfs",
+    ];
+    let is_kernel_fs = |fs: &str| KERNEL_FS.contains(&fs);
+
+    // Daemon-declared bounded tmpfs: /tmp and /dev/shm are tmpfs, rw,
+    // and sized to the configured `tmpfs_mb`/`shm_mb` bounds (engines
+    // print the size in k or b units).
+    let size_bytes = |opts: &str| -> Option<u64> {
+        for opt in opts.split(',') {
+            if let Some(raw) = opt.strip_prefix("size=") {
+                if let Some(kb) = raw.strip_suffix('k') {
+                    return kb.parse::<u64>().ok().map(|v| v * 1024);
+                }
+                if let Some(mb) = raw.strip_suffix('m') {
+                    return mb.parse::<u64>().ok().map(|v| v * 1024 * 1024);
+                }
+                if let Some(b) = raw.strip_suffix('b') {
+                    return b.parse::<u64>().ok();
+                }
+            }
+        }
+        None
+    };
+    let tmpfs_mb = fx.cfg.sandbox().resources.tmpfs_mb;
+    let shm_mb = fx.cfg.sandbox().resources.shm_mb;
+    for (target, want_mb) in [("/tmp", tmpfs_mb), ("/dev/shm", shm_mb)] {
+        let entry = mounts
+            .iter()
+            .find(|(t, _, _)| t == target)
+            .unwrap_or_else(|| panic!("{target} must be mounted; dump: {logs}"));
+        assert_eq!(entry.1, "tmpfs", "{target} must be tmpfs; dump: {logs}");
+        assert!(
+            entry.2.split(',').any(|o| o == "rw"),
+            "{target} must be writable; dump: {logs}"
+        );
+        assert_eq!(
+            size_bytes(&entry.2),
+            Some(want_mb * 1024 * 1024),
+            "{target} tmpfs bound must equal the configured {want_mb}m; dump: {logs}"
+        );
+    }
+    // No other top-level tmpfs target exists beyond the daemon-declared
+    // pair and the engine's own /dev.
+    let other_top_level_tmpfs: Vec<&str> = mounts
+        .iter()
+        .filter(|(t, fs, _)| fs == "tmpfs" && t.matches('/').count() == 1)
+        .map(|(t, _, _)| t.as_str())
+        .filter(|t| *t != "/tmp" && *t != "/dev/shm" && *t != "/dev")
+        .collect();
+    assert!(
+        other_top_level_tmpfs.is_empty(),
+        "unexpected top-level tmpfs targets: {other_top_level_tmpfs:?}; dump: {logs}"
+    );
+
+    // Writable host-backed set: a real host filesystem (not kernel
+    // fs, not tmpfs) mounted rw. The engine's own
+    // `/etc/{hosts,hostname,resolv.conf}` metadata binds are excluded
+    // — they are engine-managed, not daemon-declared surfaces.
+    let is_host_fs =
+        |fs: &str| fs == "ext4" || fs == "xfs" || fs == "btrfs" || fs == "zfs" || fs == "overlay";
+    let mut writable: Vec<String> = mounts
+        .iter()
+        .filter(|(target, fs, opts)| {
+            is_host_fs(fs) && opts.split(',').any(|o| o == "rw") && !target.starts_with("/etc/")
+        })
+        .map(|(target, _, _)| target.clone())
+        .collect();
+    writable.sort();
+    writable.dedup();
+    assert_eq!(
+        writable,
+        vec!["/output".to_string(), "/workspace".to_string()],
+        "writable host-backed set must be exactly {{/workspace, /output}}; \
+         full dump: {logs}"
+    );
+
+    // The `.git` shadow must be a read-only host-backed mount.
+    let shadow_entry = mounts
+        .iter()
+        .find(|(target, _, _)| target == "/workspace/.git")
+        .unwrap_or_else(|| panic!("/workspace/.git must be mounted; dump: {logs}"));
+    assert!(
+        !shadow_entry.2.split(',').any(|o| o == "rw"),
+        "/workspace/.git must never be writable; entry: {shadow_entry:?}"
+    );
+
+    // Pseudo-filesystems present and kernel-managed (never writable
+    // host binds).
+    for (pseudo, expected_fs) in [("/proc", "proc"), ("/sys", "sysfs")] {
+        let entry = mounts
+            .iter()
+            .find(|(target, _, _)| target == pseudo)
+            .unwrap_or_else(|| panic!("{pseudo} must be mounted; dump: {logs}"));
+        assert_eq!(
+            entry.1, expected_fs,
+            "{pseudo} must be the kernel pseudo-filesystem; dump: {logs}"
+        );
+    }
+    let dev = mounts
+        .iter()
+        .find(|(target, _, _)| target == "/dev")
+        .unwrap_or_else(|| panic!("/dev must be mounted; dump: {logs}"));
+    assert!(
+        is_kernel_fs(&dev.1) || dev.1 == "tmpfs",
+        "/dev must be a kernel-managed mount (devtmpfs or the engine's \
+         mode-755 tmpfs), got fstype {}; dump: {logs}",
+        dev.1
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Per-mode identity canaries
+// ---------------------------------------------------------------------------
+
+/// Rootful Docker: the worker runs as `--user <owner-uid>:<gid>`, so
+/// a file the container writes into `/workspace` appears host-side
+/// owned by the worktree owner, and host finalize (commit/push from
+/// the same worktree) would succeed. Skips with a notice when the
+/// host engine is not rootful Docker.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn rootful_docker_identity_canary() {
+    let fx = live_fixture(
+        GitShadowKind::File,
+        "id -u > /workspace/canary && id -g >> /workspace/canary",
+    );
+    if fx.engine != SandboxEngine::Docker || fx.engine_mode != EngineMode::Rootful {
+        eprintln!("skipping: host engine is not rootful Docker");
+        return;
+    }
+    let (code, logs) = run_container(&fx);
+    assert_eq!(code, 0, "container must exit cleanly; logs: {logs}");
+
+    let canary = fx.worktree.join("canary");
+    assert!(
+        wait_for(|| canary.is_file(), Duration::from_secs(5), "canary"),
+        "container must have written the canary into /workspace"
+    );
+    let meta = std::fs::metadata(&canary).expect("canary stat");
+    assert_eq!(
+        meta.uid(),
+        std::fs::metadata(&fx.worktree)
+            .expect("worktree stat")
+            .uid(),
+        "host-side canary owner must equal the worktree owner"
+    );
+    // Host finalize would run from this worktree: prove git is usable
+    // on files the worker wrote (the worktree's `.git` is untouched).
+    let git_status = Command::new("git")
+        .args(["-C", fx.worktree.to_str().expect("utf8 worktree"), "status"])
+        .output()
+        .expect("git status");
+    eprintln!(
+        "host git status (expected to fail on the fake worktree; the \
+         point is the worktree itself is intact): {:?}",
+        git_status.status
+    );
+}
+
+/// Rootless Docker: no `--user` in the rendered argv (assertable
+/// pre-run) and the same ownership canary proving container root is
+/// NOT host root — the file lands owned by the unprivileged engine
+/// user (== worktree owner), never by host root (uid 0). Skips when
+/// the host engine is not rootless Docker.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn rootless_docker_identity_canary() {
+    let fx = live_fixture(
+        GitShadowKind::File,
+        "id -u > /workspace/canary && id -u >> /output/engine-user",
+    );
+    if fx.engine != SandboxEngine::Docker || fx.engine_mode != EngineMode::Rootless {
+        eprintln!("skipping: host engine is not rootless Docker");
+        return;
+    }
+    // Pre-run argv assertion: rootless Docker emits no --user.
+    assert!(
+        !fx.argv.contains(&"--user".to_string()),
+        "rootless docker must not emit --user, got: {:?}",
+        fx.argv
+    );
+
+    let (code, logs) = run_container(&fx);
+    assert_eq!(code, 0, "container must exit cleanly; logs: {logs}");
+
+    let canary = fx.worktree.join("canary");
+    assert!(
+        wait_for(|| canary.is_file(), Duration::from_secs(5), "canary"),
+        "container must have written the canary"
+    );
+    let meta = std::fs::metadata(&canary).expect("canary stat");
+    assert_ne!(
+        meta.uid(),
+        0,
+        "container root must not map to host root under rootless docker"
+    );
+    assert_eq!(
+        meta.uid(),
+        std::fs::metadata(&fx.worktree)
+            .expect("worktree stat")
+            .uid(),
+        "canary owner must equal the engine user (== worktree owner)"
+    );
+}
+
+/// Podman rootless: `--userns keep-id` present and in-container
+/// `id -u` == the daemon/worktree owner uid. Skips when the host
+/// engine is not Podman.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn podman_keep_id_identity_canary() {
+    let fx = live_fixture(GitShadowKind::File, "id -u");
+    if fx.engine != SandboxEngine::Podman {
+        eprintln!("skipping: host engine is not Podman");
+        return;
+    }
+    let pos = fx
+        .argv
+        .iter()
+        .position(|a| a == "--userns")
+        .expect("--userns must be present for podman");
+    assert_eq!(fx.argv[pos + 1], "keep-id", "plain keep-id, no uid=/gid=");
+
+    let (code, logs) = run_container(&fx);
+    assert_eq!(code, 0, "container must exit cleanly; logs: {logs}");
+    let in_container_uid: u32 = logs
+        .trim()
+        .parse()
+        .expect("container `id -u` output must be a uid");
+    assert_eq!(
+        in_container_uid,
+        std::fs::metadata(&fx.worktree)
+            .expect("worktree stat")
+            .uid(),
+        "keep-id must make the in-container uid equal the daemon/worktree owner"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial `.git` shadow tests
+// ---------------------------------------------------------------------------
+
+/// A worker reading `/workspace/.git` sees only the sentinel shadow —
+/// the real `gitdir:` pointer content is unreachable.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn git_shadow_read_sees_only_shadow() {
+    let fx = live_fixture(GitShadowKind::File, "cat /workspace/.git");
+    let (code, logs) = run_container(&fx);
+    assert_eq!(code, 0, "read must succeed; logs: {logs}");
+    assert_eq!(
+        logs, GIT_SHADOW_FILE_CONTENT,
+        "worker must see only the sentinel shadow content"
+    );
+    assert!(
+        !logs.contains("/real/main"),
+        "the real gitdir path must never be reachable through the shadow"
+    );
+}
+
+/// A worker writing `/workspace/.git` is rejected (read-only mount)
+/// and the host worktree `.git` is byte-identical after the run.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn git_shadow_write_rejected() {
+    let fx = live_fixture(GitShadowKind::File, "echo pwned > /workspace/.git");
+    let host_dot_git = fx.worktree.join(".git");
+    let before = std::fs::read(&host_dot_git).expect("read host .git");
+
+    let (_, _logs) = run_container(&fx);
+
+    let after = std::fs::read(&host_dot_git).expect("read host .git after run");
+    assert_eq!(
+        before, after,
+        "host worktree .git must be byte-identical after a write attempt"
+    );
+    // And the shadow on the daemon side still holds the sentinel.
+    let shadow = std::fs::read_to_string(&fx.shadow_host).expect("read shadow");
+    assert_eq!(shadow, GIT_SHADOW_FILE_CONTENT);
+    // The write must have failed inside the container (read-only
+    // mount ⇒ non-zero shell exit).
+    let fx2 = live_fixture(
+        GitShadowKind::File,
+        "if (echo pwned > /workspace/.git) 2>/dev/null; then exit 7; fi; exit 0",
+    );
+    let (code2, logs2) = run_container(&fx2);
+    assert_ne!(code2, 7, "writing /workspace/.git must fail; logs: {logs2}");
+}
+
+// ---------------------------------------------------------------------------
+// Directory-shadow variant
+// ---------------------------------------------------------------------------
+
+/// A directory `.git` yields an empty read-only directory shadow: the
+/// worker cannot reach the real HEAD content.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn git_shadow_dir_variant_is_empty_and_read_only() {
+    let fx = live_fixture(
+        GitShadowKind::Dir,
+        "ls -A /workspace/.git; if (echo x > /workspace/.git/HEAD) 2>/dev/null; then exit 7; fi; exit 0",
+    );
+    let (code, logs) = run_container(&fx);
+    assert_ne!(
+        code, 7,
+        "writing into the dir shadow must fail; logs: {logs}"
+    );
+    assert_eq!(
+        logs.trim(),
+        "",
+        "the dir shadow must be empty; logs: {logs}"
+    );
+    let host_head = fx.worktree.join(".git").join("HEAD");
+    assert_eq!(
+        std::fs::read_to_string(&host_head).expect("host HEAD"),
+        "ref: refs/heads/main\n",
+        "host .git/HEAD must be untouched"
+    );
+}

--- a/tests/executor/oci_label_test.rs
+++ b/tests/executor/oci_label_test.rs
@@ -8,10 +8,12 @@
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::executor::ExecutorSpec;
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
+
+mod support;
 
 fn test_cfg() -> Config {
     Config::test_defaults(Path::new("/tmp"))
@@ -19,16 +21,7 @@ fn test_cfg() -> Config {
 
 fn resolve_from(cfg: &Config, run_id: &str) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join(run_id);
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: run_id.to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "state".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, run_id, &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 

--- a/tests/executor/policy_test.rs
+++ b/tests/executor/policy_test.rs
@@ -8,23 +8,15 @@
 //! a structural property of the closed `SandboxSpec` + renderer.
 
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::{Config, SandboxNetwork};
+
+mod support;
 
 /// Resolve a spec from a config (paths under its workdir_base).
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: "run-001".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, "run-001", &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 
@@ -47,8 +39,8 @@ fn baseline_enforced() {
         "argv must contain --user"
     );
     assert!(
-        argv.iter().any(|a| a == "1000:1000"),
-        "argv must contain the fixed 1000:1000 identity"
+        argv.iter().any(|a| a == "4242:4242"),
+        "argv must contain the resolved worktree-owner identity"
     );
     assert!(
         argv.iter().any(|a| a == "--cap-drop"),
@@ -101,7 +93,7 @@ fn isolation_flags_precede_image() {
         .expect("image token must be present");
     let engine_flags = [
         "--user",
-        "1000:1000",
+        "4242:4242",
         "--cap-drop",
         "ALL",
         "--security-opt",
@@ -113,7 +105,6 @@ fn isolation_flags_precede_image() {
         "--cpus",
         "--memory",
         "--pids-limit",
-        "--shm-size",
         "--name",
         "-v",
         "-e",
@@ -167,7 +158,7 @@ fn no_network_mode_gives_none() {
     assert_eq!(argv[network_pos + 1], "none");
 }
 
-// git-less worker — .git is not mounted
+// git-shadow worker — `.git` is shadowed read-only, never writable
 
 #[test]
 fn git_less_worker() {
@@ -175,13 +166,23 @@ fn git_less_worker() {
     let spec = resolve_from(&cfg);
     let argv = render(&spec, SandboxEngine::Docker);
     let git_refs: Vec<&String> = argv.iter().filter(|a| a.contains(".git")).collect();
+    // The only `.git` reference is the daemon-owned read-only shadow
+    // at the fixed canonical path — the real gitdir is unreachable
+    // and `/workspace/.git` is never writable.
+    assert_eq!(
+        git_refs.len(),
+        1,
+        "exactly the shadow mount may reference .git, got: {git_refs:?}"
+    );
     assert!(
-        git_refs.is_empty(),
-        "unexpected .git reference in argv: {git_refs:?}"
+        git_refs[0].ends_with(":/workspace/.git:ro"),
+        "the .git reference must be the read-only shadow, got: {:?}",
+        git_refs[0]
     );
 }
 
-// resources always rendered — cpus/memory/pids/shm are total fields
+// resources always rendered — cpus/memory/pids are total fields; the
+// tmpfs pair covers the ephemeral surfaces
 
 #[test]
 fn resources_always_rendered() {
@@ -191,5 +192,6 @@ fn resources_always_rendered() {
     assert!(argv.iter().any(|a| a == "--cpus"));
     assert!(argv.iter().any(|a| a == "--memory"));
     assert!(argv.iter().any(|a| a == "--pids-limit"));
-    assert!(argv.iter().any(|a| a == "--shm-size"));
+    assert!(argv.iter().any(|a| a == "--tmpfs"));
+    assert!(argv.iter().any(|a| a == "/dev/shm:size=64m"));
 }

--- a/tests/executor/resource_limit_test.rs
+++ b/tests/executor/resource_limit_test.rs
@@ -1,29 +1,22 @@
 //! Adversarial resource-limit tests for the OCI executor.
 //!
 //! These tests verify that the typed `ResourceLimits` fields reach the
-//! rendered argv as engine flags (`--cpus`, `--memory`, `--pids-limit`,
-//! `--shm-size`). All tests require a live Docker/Podman engine for
+//! rendered argv as engine flags (`--cpus`, `--memory`, `--pids-limit`
+//! and the dual `--tmpfs` list). All tests require a live
+//! Docker/Podman engine for
 //! the cgroup-enforcement half and are gated behind
 //! `CADUCEUS_RUN_ISOLATION_TESTS`; the argv assertions themselves run
 //! whenever the suite is executed.
 
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::Config;
+
+mod support;
 
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: "run-001".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, "run-001", &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 
@@ -33,7 +26,8 @@ fn default_cfg() -> Config {
 }
 
 /// The resource flags are always present with the configured values
-/// (test_defaults: cpus 2.0, memory 2048m, pids 256, shm 64m).
+/// (test_defaults: cpus 2.0, memory 2048m, pids 256, tmpfs 256m,
+/// shm 64m — `/dev/shm` is declared via the dual tmpfs list).
 #[test]
 fn resource_flags_reach_argv() {
     let cfg = default_cfg();
@@ -45,8 +39,9 @@ fn resource_flags_reach_argv() {
     assert!(argv.iter().any(|a| a == "256"));
     assert!(argv.iter().any(|a| a == "--cpus"));
     assert!(argv.iter().any(|a| a == "2"));
-    assert!(argv.iter().any(|a| a == "--shm-size"));
-    assert!(argv.iter().any(|a| a == "64m"));
+    assert!(argv.iter().any(|a| a == "--tmpfs"));
+    assert!(argv.iter().any(|a| a == "/tmp:size=256m"));
+    assert!(argv.iter().any(|a| a == "/dev/shm:size=64m"));
 }
 
 // exhaust_memory — malloc beyond --memory=2048m triggers OOM-killer

--- a/tests/executor/sandbox_renderer_test.rs
+++ b/tests/executor/sandbox_renderer_test.rs
@@ -5,24 +5,29 @@
 //! fixtures resolve a fixed `Config` + `RuntimeFacts` first; `resolve`
 //! does no I/O, so the fixed host paths never need to exist and the
 //! goldens are byte-for-byte deterministic.
+//!
+//! Identity is now dynamic (worktree-owner facts from the shared
+//! fixture: `4242:4242`, rootful by default) and the `.git` shadow
+//! mount and dual tmpfs list are part of every golden.
 
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::sandbox_renderer::{render, render_with_env_files};
-use caduceus::executor::sandbox_spec::{RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{EngineMode, GitShadowKind, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::{Config, SandboxConfig, SandboxNetwork};
 
 /// Fixed root for the golden fixtures. Never touched on disk.
 const ROOT: &str = "/tmp/caduceus-renderer-goldens";
 
 /// Resolve a fixture spec from `Config::test_defaults` with an
-/// optional sandbox mutation. Returns the spec plus the host paths
-/// the goldens interpolate into mount args.
-fn fixture(
+/// optional sandbox mutation and runtime-fact overrides. Returns the
+/// spec plus the host paths the goldens interpolate into mount args.
+fn fixture_with(
     run_id: &str,
+    engine_mode: EngineMode,
+    shadow_kind: GitShadowKind,
     mutate: impl FnOnce(&mut SandboxConfig),
-) -> (SandboxSpec, PathBuf, PathBuf, String) {
+) -> (SandboxSpec, PathBuf, PathBuf, PathBuf, String) {
     let root = Path::new(ROOT);
     let mut cfg = Config::test_defaults(root);
     mutate(cfg.sandbox.as_mut().expect("test_defaults has a sandbox"));
@@ -31,42 +36,54 @@ fn fixture(
         .join("owner")
         .join("repo")
         .join(run_id);
-    let output = root
-        .join("workdirs")
-        .join("owner")
-        .join("repo")
-        .join("result");
-    let runtime = RuntimeFacts {
+    let output = cfg.state_dir.join("oci-runs").join(run_id).join("output");
+    let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
         run_id: run_id.to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         worktree: worktree.clone(),
         output_dir: output.clone(),
-        daemon_id: "state".to_string(),
+        daemon_id: "test-daemon".to_string(),
         workdir_base: root.join("workdirs"),
+        state_dir: cfg.state_dir.clone(),
+        worktree_uid: 4242,
+        worktree_gid: 4242,
+        engine_mode,
+        git_shadow_kind: shadow_kind,
+        git_shadow_host: cfg
+            .state_dir
+            .join("oci-runs")
+            .join(run_id)
+            .join("git-shadow"),
     };
     let spec = caduceus::executor::sandbox_spec::resolve(cfg.sandbox(), &runtime)
         .expect("fixture must resolve");
-    (spec, worktree, output, cfg.sandbox().image.clone())
+    (
+        spec,
+        worktree,
+        output,
+        runtime.git_shadow_host,
+        cfg.sandbox().image.clone(),
+    )
 }
 
-/// The default fixture with no sandbox mutation.
-fn default_fixture() -> (SandboxSpec, PathBuf, PathBuf, String) {
-    fixture("run-001", |_| {})
+/// The default fixture: rootful, pointer-file `.git` shadow.
+fn default_fixture() -> (SandboxSpec, PathBuf, PathBuf, PathBuf, String) {
+    fixture_with("run-001", EngineMode::Rootful, GitShadowKind::File, |_| {})
 }
 
 // ---------------------------------------------------------------------------
-// Golden snapshots — one per engine, byte-for-byte.
+// Golden snapshots — one per engine×mode, byte-for-byte.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn docker_golden_argv() {
-    let (spec, worktree, output, image) = default_fixture();
+fn docker_rootful_golden_argv() {
+    let (spec, worktree, output, shadow, image) = default_fixture();
     let expected = vec![
         "docker".to_string(),
         "create".to_string(),
         "--user".to_string(),
-        "1000:1000".to_string(),
+        "4242:4242".to_string(),
         "--cap-drop".to_string(),
         "ALL".to_string(),
         "--security-opt".to_string(),
@@ -80,22 +97,24 @@ fn docker_golden_argv() {
         "2048m".to_string(),
         "--pids-limit".to_string(),
         "256".to_string(),
-        "--shm-size".to_string(),
-        "64m".to_string(),
         "--name".to_string(),
         "run-001".to_string(),
         "-v".to_string(),
         format!("{}:/workspace:rw", worktree.display()),
         "-v".to_string(),
         format!("{}:/output:rw", output.display()),
+        "-v".to_string(),
+        format!("{}:/workspace/.git:ro", shadow.display()),
         "--tmpfs".to_string(),
         "/tmp:size=256m".to_string(),
+        "--tmpfs".to_string(),
+        "/dev/shm:size=64m".to_string(),
         "-e".to_string(),
         "CADUCEUS_RUN_ID=run-001".to_string(),
         "-e".to_string(),
         "CADUCEUS_ISSUE_ID=owner/repo#1".to_string(),
         "-l".to_string(),
-        "caduceus.daemon_id=state".to_string(),
+        "caduceus.daemon_id=test-daemon".to_string(),
         "-l".to_string(),
         "caduceus.run_id=run-001".to_string(),
         "-l".to_string(),
@@ -109,20 +128,22 @@ fn docker_golden_argv() {
 }
 
 #[test]
-fn podman_golden_argv() {
-    let (spec, worktree, output, image) = default_fixture();
+fn podman_rootless_golden_argv() {
+    let (spec, worktree, output, shadow, image) =
+        fixture_with("run-001", EngineMode::Rootless, GitShadowKind::File, |sb| {
+            sb.engine = SandboxEngine::Podman
+        });
     let expected = vec![
         "podman".to_string(),
         "create".to_string(),
-        "--user".to_string(),
-        "1000:1000".to_string(),
+        // Rootless: no --user; plain keep-id user namespace.
         "--cap-drop".to_string(),
         "ALL".to_string(),
         "--security-opt".to_string(),
         "no-new-privileges".to_string(),
         "--read-only".to_string(),
         "--userns".to_string(),
-        "keep-id:uid=1000,gid=1000".to_string(),
+        "keep-id".to_string(),
         "--network".to_string(),
         "none".to_string(),
         "--cpus".to_string(),
@@ -131,22 +152,24 @@ fn podman_golden_argv() {
         "2048m".to_string(),
         "--pids-limit".to_string(),
         "256".to_string(),
-        "--shm-size".to_string(),
-        "64m".to_string(),
         "--name".to_string(),
         "run-001".to_string(),
         "-v".to_string(),
         format!("{}:/workspace:rw", worktree.display()),
         "-v".to_string(),
         format!("{}:/output:rw", output.display()),
+        "-v".to_string(),
+        format!("{}:/workspace/.git:ro", shadow.display()),
         "--tmpfs".to_string(),
         "/tmp:size=256m".to_string(),
+        "--tmpfs".to_string(),
+        "/dev/shm:size=64m".to_string(),
         "-e".to_string(),
         "CADUCEUS_RUN_ID=run-001".to_string(),
         "-e".to_string(),
         "CADUCEUS_ISSUE_ID=owner/repo#1".to_string(),
         "-l".to_string(),
-        "caduceus.daemon_id=state".to_string(),
+        "caduceus.daemon_id=test-daemon".to_string(),
         "-l".to_string(),
         "caduceus.run_id=run-001".to_string(),
         "-l".to_string(),
@@ -159,38 +182,65 @@ fn podman_golden_argv() {
     assert_eq!(render(&spec, SandboxEngine::Podman), expected);
 }
 
-/// The Podman output differs from Docker ONLY by the binary name and
-/// the inserted `--userns keep-id:uid=1000,gid=1000` pair.
+/// The per-engine deltas are fully encoded in the spec's identity:
+/// - Podman rootful vs Docker rootful differ only by the binary name;
+/// - Docker rootless vs Docker rootful differ only by the missing
+///   `--user`/`4242:4242` pair;
+/// - Podman rootless vs Podman rootful swap the `--user` pair for the
+///   `--userns keep-id` pair.
 #[test]
-fn podman_delta_is_only_userns_and_binary() {
-    let (spec, _, _, _) = default_fixture();
-    let docker = render(&spec, SandboxEngine::Docker);
-    let podman = render(&spec, SandboxEngine::Podman);
+fn per_engine_mode_deltas() {
+    let (spec_docker_rootful, _, _, _, _) = default_fixture();
+    let (spec_docker_rootless, _, _, _, _) =
+        fixture_with("run-001", EngineMode::Rootless, GitShadowKind::File, |_| {});
+    let (spec_podman_rootful, _, _, _, _) =
+        fixture_with("run-001", EngineMode::Rootful, GitShadowKind::File, |sb| {
+            sb.engine = SandboxEngine::Podman
+        });
+    let (spec_podman_rootless, _, _, _, _) =
+        fixture_with("run-001", EngineMode::Rootless, GitShadowKind::File, |sb| {
+            sb.engine = SandboxEngine::Podman
+        });
 
-    assert_eq!(
-        docker.len() + 2,
-        podman.len(),
-        "podman adds exactly 2 tokens"
+    let docker_rootful = render(&spec_docker_rootful, SandboxEngine::Docker);
+    let docker_rootless = render(&spec_docker_rootless, SandboxEngine::Docker);
+    let podman_rootful = render(&spec_podman_rootful, SandboxEngine::Podman);
+    let podman_rootless = render(&spec_podman_rootless, SandboxEngine::Podman);
+
+    // Rootful across engines: binary name only.
+    let mut podman_rootful_expected = docker_rootful.clone();
+    podman_rootful_expected[0] = "podman".to_string();
+    assert_eq!(podman_rootful, podman_rootful_expected);
+
+    // Docker rootless = Docker rootful minus the --user pair.
+    let user_pos = docker_rootful
+        .iter()
+        .position(|a| a == "--user")
+        .expect("--user");
+    let mut docker_rootless_expected = docker_rootful.clone();
+    docker_rootless_expected.drain(user_pos..user_pos + 2);
+    assert_eq!(docker_rootless, docker_rootless_expected);
+
+    // Podman rootless = Podman rootful minus --user pair, plus the
+    // --userns keep-id pair.
+    let mut podman_rootless_expected = podman_rootful.clone();
+    let user_pos = podman_rootless_expected
+        .iter()
+        .position(|a| a == "--user")
+        .expect("--user");
+    podman_rootless_expected.drain(user_pos..user_pos + 2);
+    podman_rootless_expected.splice(
+        user_pos..user_pos,
+        ["--userns".to_string(), "keep-id".to_string()],
     );
-    let mut podman_expected = docker.clone();
-    podman_expected[0] = "podman".to_string();
-    // Insert the userns pair immediately after --read-only and before
-    // --network (the documented delta position).
-    podman_expected.splice(
-        9..9,
-        [
-            "--userns".to_string(),
-            "keep-id:uid=1000,gid=1000".to_string(),
-        ],
-    );
-    assert_eq!(podman, podman_expected);
+    assert_eq!(podman_rootless, podman_rootless_expected);
 }
 
 /// Determinism contract: two invocations on the same inputs are
 /// byte-identical.
 #[test]
 fn render_is_deterministic() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     assert_eq!(
         render(&spec, SandboxEngine::Docker),
         render(&spec, SandboxEngine::Docker)
@@ -215,49 +265,84 @@ fn render_is_deterministic() {
 
 #[test]
 fn renders_identity() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     assert!(argv.iter().any(|a| a == "--user"));
-    assert!(argv.iter().any(|a| a == "1000:1000"));
+    assert!(argv.iter().any(|a| a == "4242:4242"));
 }
 
 #[test]
 fn renders_workspace_mount() {
-    let (spec, worktree, _, _) = default_fixture();
+    let (spec, worktree, _, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     assert!(argv.iter().any(|a| a == "-v"));
     assert!(argv
         .iter()
         .any(|a| a == &format!("{}:/workspace:rw", worktree.display())));
-    // Exactly one workspace mount and one output mount — the
-    // double-RW bug is gone.
-    let mounts: Vec<&String> = argv
-        .iter()
-        .filter(|a| a.contains("/workspace:") || a.contains("/output:"))
-        .collect();
-    assert_eq!(mounts.len(), 2, "exactly two mounts, got: {mounts:?}");
 }
 
 #[test]
 fn renders_output_mount() {
-    let (spec, _, output, _) = default_fixture();
+    let (spec, _, output, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     assert!(argv
         .iter()
         .any(|a| a == &format!("{}:/output:rw", output.display())));
 }
 
+/// The `.git` shadow is rendered read-only AFTER the `/workspace`
+/// bind (mount precedence: the nested bind wins by target depth; the
+/// deterministic argv order matches the depth rule).
+#[test]
+fn renders_git_shadow_after_workspace() {
+    let (spec, _, _, shadow, _) = default_fixture();
+    let argv = render(&spec, SandboxEngine::Docker);
+    let ws_pos = argv
+        .iter()
+        .position(|a| a.ends_with(":/workspace:rw"))
+        .expect("workspace mount");
+    let shadow_pos = argv
+        .iter()
+        .position(|a| a == &format!("{}:/workspace/.git:ro", shadow.display()))
+        .expect("shadow mount");
+    assert!(
+        shadow_pos > ws_pos,
+        "shadow must be emitted after the workspace bind"
+    );
+}
+
 #[test]
 fn renders_tmpfs() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     assert!(argv.iter().any(|a| a == "--tmpfs"));
     assert!(argv.iter().any(|a| a == "/tmp:size=256m"));
+    assert!(argv.iter().any(|a| a == "/dev/shm:size=64m"));
+}
+
+/// `--shm-size` is gone; `/dev/shm` is declared via the dual tmpfs
+/// list (design D7).
+#[test]
+fn shm_size_is_not_emitted() {
+    let (spec, _, _, _, _) = default_fixture();
+    let argv = render(&spec, SandboxEngine::Docker);
+    assert!(
+        !argv.iter().any(|a| a == "--shm-size"),
+        "--shm-size must not be emitted, got: {argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|a| a == "64m"),
+        "the standalone shm-size value must be gone, got: {argv:?}"
+    );
+    assert!(
+        argv.iter().any(|a| a == "/dev/shm:size=64m"),
+        "/dev/shm must be declared as --tmpfs with the configured bound"
+    );
 }
 
 #[test]
 fn renders_environment() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     assert!(argv.iter().any(|a| a == "-e"));
     assert!(argv.iter().any(|a| a == "CADUCEUS_RUN_ID=run-001"));
@@ -266,7 +351,7 @@ fn renders_environment() {
 
 #[test]
 fn renders_env_files_in_slice_order() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     let env_files = vec![
         PathBuf::from("/tmp/secret-1.env"),
         PathBuf::from("/tmp/secret-2.env"),
@@ -289,13 +374,13 @@ fn renders_env_files_in_slice_order() {
 
 #[test]
 fn renders_labels_in_fixed_order() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     let labels: Vec<&String> = argv.iter().filter(|a| a.starts_with("caduceus.")).collect();
     assert_eq!(
         labels,
         vec![
-            &"caduceus.daemon_id=state".to_string(),
+            &"caduceus.daemon_id=test-daemon".to_string(),
             &"caduceus.run_id=run-001".to_string(),
             &"caduceus.issue_id=owner/repo#1".to_string(),
         ]
@@ -304,7 +389,7 @@ fn renders_labels_in_fixed_order() {
 
 #[test]
 fn renders_resources() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     assert!(argv.iter().any(|a| a == "--cpus"));
     assert!(argv.iter().any(|a| a == "2"));
@@ -312,13 +397,13 @@ fn renders_resources() {
     assert!(argv.iter().any(|a| a == "2048m"));
     assert!(argv.iter().any(|a| a == "--pids-limit"));
     assert!(argv.iter().any(|a| a == "256"));
-    assert!(argv.iter().any(|a| a == "--shm-size"));
-    assert!(argv.iter().any(|a| a == "64m"));
+    assert!(argv.iter().any(|a| a == "--tmpfs"));
+    assert!(argv.iter().any(|a| a == "/dev/shm:size=64m"));
 }
 
 #[test]
 fn renders_network_none_by_default() {
-    let (spec, _, _, _) = default_fixture();
+    let (spec, _, _, _, _) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     let pos = argv
         .iter()
@@ -329,9 +414,10 @@ fn renders_network_none_by_default() {
 
 #[test]
 fn renders_network_host_for_unrestricted() {
-    let (spec, _, _, _) = fixture("run-001", |sb| {
-        sb.network = SandboxNetwork::Unrestricted;
-    });
+    let (spec, _, _, _, _) =
+        fixture_with("run-001", EngineMode::Rootful, GitShadowKind::File, |sb| {
+            sb.network = SandboxNetwork::Unrestricted;
+        });
     let argv = render(&spec, SandboxEngine::Docker);
     let pos = argv
         .iter()
@@ -342,7 +428,7 @@ fn renders_network_host_for_unrestricted() {
 
 #[test]
 fn renders_entrypoint_image_and_worker_args() {
-    let (spec, _, _, image) = default_fixture();
+    let (spec, _, _, _, image) = default_fixture();
     let argv = render(&spec, SandboxEngine::Docker);
     let entrypoint_pos = argv
         .iter()
@@ -363,6 +449,33 @@ fn renders_entrypoint_image_and_worker_args() {
         !argv[..image_pos].iter().any(|a| a == "bridge.py"),
         "worker args must trail the image"
     );
+}
+
+/// An absent host `.git` renders no shadow mount — the rest of the
+/// argv is unchanged.
+#[test]
+fn absent_git_renders_no_shadow() {
+    let (spec_with, _, _, _, _) = default_fixture();
+    let (spec_absent, _, _, _, _) = fixture_with(
+        "run-001",
+        EngineMode::Rootful,
+        GitShadowKind::Absent,
+        |_| {},
+    );
+    let with = render(&spec_with, SandboxEngine::Docker);
+    let absent = render(&spec_absent, SandboxEngine::Docker);
+    let shadow_tokens: Vec<&String> = with
+        .iter()
+        .filter(|a| a.ends_with(":/workspace/.git:ro"))
+        .collect();
+    assert_eq!(shadow_tokens.len(), 1);
+    let expected_without_shadow: Vec<String> = with
+        .iter()
+        .filter(|a| !a.ends_with(":/workspace/.git:ro"))
+        .cloned()
+        .collect();
+    assert_eq!(absent, expected_without_shadow);
+    assert!(spec_absent.git_shadow().is_none());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/executor/sandbox_renderer_test.rs
+++ b/tests/executor/sandbox_renderer_test.rs
@@ -221,16 +221,22 @@ fn per_engine_mode_deltas() {
     docker_rootless_expected.drain(user_pos..user_pos + 2);
     assert_eq!(docker_rootless, docker_rootless_expected);
 
-    // Podman rootless = Podman rootful minus --user pair, plus the
-    // --userns keep-id pair.
+    // Podman rootless = Podman rootful minus the --user pair, plus
+    // the --userns keep-id pair at the renderer's structural
+    // position — after `--read-only`, before `--network`.
     let mut podman_rootless_expected = podman_rootful.clone();
     let user_pos = podman_rootless_expected
         .iter()
         .position(|a| a == "--user")
         .expect("--user");
     podman_rootless_expected.drain(user_pos..user_pos + 2);
+    let userns_pos = podman_rootless_expected
+        .iter()
+        .position(|a| a == "--read-only")
+        .expect("--read-only")
+        + 1;
     podman_rootless_expected.splice(
-        user_pos..user_pos,
+        userns_pos..userns_pos,
         ["--userns".to_string(), "keep-id".to_string()],
     );
     assert_eq!(podman_rootless, podman_rootless_expected);
@@ -469,10 +475,21 @@ fn absent_git_renders_no_shadow() {
         .filter(|a| a.ends_with(":/workspace/.git:ro"))
         .collect();
     assert_eq!(shadow_tokens.len(), 1);
+    // Drop the shadow mount's trailing `-v` flag token as well as the
+    // path token, so the expected argv has no dangling `-v`.
+    let mut drop_flags = vec![false; with.len()];
+    for (i, a) in with.iter().enumerate() {
+        if a.ends_with(":/workspace/.git:ro") {
+            assert_eq!(with[i - 1], "-v", "shadow mount is `-v <spec>`");
+            drop_flags[i - 1] = true;
+            drop_flags[i] = true;
+        }
+    }
     let expected_without_shadow: Vec<String> = with
         .iter()
-        .filter(|a| !a.ends_with(":/workspace/.git:ro"))
-        .cloned()
+        .zip(&drop_flags)
+        .filter(|(_, drop)| !**drop)
+        .map(|(a, _)| a.clone())
         .collect();
     assert_eq!(absent, expected_without_shadow);
     assert!(spec_absent.git_shadow().is_none());

--- a/tests/executor/sandbox_resolve_test.rs
+++ b/tests/executor/sandbox_resolve_test.rs
@@ -1,41 +1,38 @@
 //! Resolution contract tests for `SandboxConfig + RuntimeFacts ->
 //! SandboxSpec`.
 //!
-//! These tests pin the host-path allow-list, the overlap rejection,
-//! the fixed identity, the canonical container paths, `pass_env`
-//! filtering, and label order.
+//! These tests pin the per-root host-path allow-list, the
+//! cross-root containment rejections, the dynamic identity matrix,
+//! the type-aware `.git` shadow, the canonical container paths,
+//! the writable-surface invariant, `pass_env` filtering, and label
+//! order.
 
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::sandbox_spec::{
-    resolve, NetworkMode, ResolvedIdentity, RuntimeFacts, SandboxSpec, SANDBOX_GID, SANDBOX_UID,
+    resolve, select_git_shadow, EngineMode, GitShadowKind, MountSpec, NetworkMode,
+    ResolvedIdentity, RuntimeFacts, SandboxSpec,
 };
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::{Config, OciPullPolicy};
 use caduceus::infra::error::CaduceusError;
 
-/// Build a config and worktree/output paths under its `workdir_base`.
+mod support;
+
+/// Build a config and worktree path under its `workdir_base`.
 /// `resolve` does no I/O, so the paths never need to exist and the
 /// tempdir can be dropped immediately.
-fn base() -> (Config, PathBuf, PathBuf) {
+fn base() -> (Config, PathBuf) {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cfg = Config::test_defaults(tmp.path());
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    (cfg, worktree, output)
+    (cfg, worktree)
 }
 
-/// Build runtime facts from a config's workdir_base.
-fn runtime_for(cfg: &Config, worktree: &Path, output: &Path) -> RuntimeFacts {
-    RuntimeFacts {
-        run_id: "run-001".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree: worktree.to_path_buf(),
-        output_dir: output.to_path_buf(),
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    }
+/// Build runtime facts from a config's workdir_base via the shared
+/// fixture (owner 4242:4242, rootful, pointer-file shadow kind).
+fn runtime_for(cfg: &Config, worktree: &Path) -> RuntimeFacts {
+    support::runtime_facts(cfg, "run-001", worktree)
 }
 
 // ---------------------------------------------------------------------------
@@ -45,9 +42,9 @@ fn runtime_for(cfg: &Config, worktree: &Path, output: &Path) -> RuntimeFacts {
 /// (a) non-digest image → OciImageNotDigestPinned.
 #[test]
 fn rejects_non_digest_image() {
-    let (mut cfg, worktree, output) = base();
+    let (mut cfg, worktree) = base();
     cfg.sandbox.as_mut().expect("sandbox").image = "caduceus-worker:latest".to_string();
-    let runtime = runtime_for(&cfg, &worktree, &output);
+    let runtime = runtime_for(&cfg, &worktree);
     let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
     match err {
         CaduceusError::OciImageNotDigestPinned { reference } => {
@@ -60,9 +57,9 @@ fn rejects_non_digest_image() {
 /// (b) pull_policy Always + digest image → OciPullPolicyIncompatible.
 #[test]
 fn rejects_pull_policy_always_with_digest() {
-    let (mut cfg, worktree, output) = base();
+    let (mut cfg, worktree) = base();
     cfg.sandbox.as_mut().expect("sandbox").pull_policy = OciPullPolicy::Always;
-    let runtime = runtime_for(&cfg, &worktree, &output);
+    let runtime = runtime_for(&cfg, &worktree);
     let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
     match err {
         CaduceusError::OciPullPolicyIncompatible { .. } => {}
@@ -73,12 +70,8 @@ fn rejects_pull_policy_always_with_digest() {
 /// (c) worktree outside workdir_base → OciUndeclaredMount.
 #[test]
 fn rejects_worktree_outside_workdir_base() {
-    let (cfg, _, _) = base();
-    let runtime = runtime_for(
-        &cfg,
-        Path::new("/tmp/elsewhere/worktree"),
-        Path::new("/tmp/elsewhere/result"),
-    );
+    let (cfg, _) = base();
+    let runtime = runtime_for(&cfg, Path::new("/tmp/elsewhere/worktree"));
     let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
     match err {
         CaduceusError::OciUndeclaredMount { path } => {
@@ -91,11 +84,14 @@ fn rejects_worktree_outside_workdir_base() {
     }
 }
 
-/// (c) output_dir outside workdir_base → OciUndeclaredMount.
+/// (c) output_dir outside the daemon state dir → OciUndeclaredMount
+/// (the legacy worktree-sibling `result` path is no longer
+/// allow-listed; `/output` is daemon-owned now).
 #[test]
-fn rejects_output_outside_workdir_base() {
-    let (cfg, worktree, _) = base();
-    let runtime = runtime_for(&cfg, &worktree, Path::new("/tmp/elsewhere/result"));
+fn rejects_output_outside_state_dir() {
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.output_dir = PathBuf::from("/tmp/elsewhere/result");
     let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciUndeclaredMount { .. }),
@@ -107,8 +103,8 @@ fn rejects_output_outside_workdir_base() {
 /// workdir_base).
 #[test]
 fn rejects_relative_worktree() {
-    let (cfg, _, output) = base();
-    let runtime = runtime_for(&cfg, Path::new("relative/worktree"), &output);
+    let (cfg, _) = base();
+    let runtime = runtime_for(&cfg, Path::new("relative/worktree"));
     let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciUndeclaredMount { .. }),
@@ -119,13 +115,14 @@ fn rejects_relative_worktree() {
 /// (d) output_dir equal to worktree → OciMountConflict.
 #[test]
 fn rejects_output_equal_to_worktree() {
-    let (cfg, worktree, _) = base();
-    let runtime = runtime_for(&cfg, &worktree, &worktree);
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.output_dir = worktree.clone();
     let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
     match err {
         CaduceusError::OciMountConflict { detail } => {
             assert!(
-                detail.contains("double-RW"),
+                detail.contains("disjoint"),
                 "conflict detail should reference the double-RW bug, got: {detail}"
             );
         }
@@ -137,9 +134,9 @@ fn rejects_output_equal_to_worktree() {
 /// OciMountConflict.
 #[test]
 fn rejects_output_containing_worktree() {
-    let (cfg, worktree, _) = base();
-    let output = worktree.parent().expect("parent").to_path_buf();
-    let runtime = runtime_for(&cfg, &worktree, &output);
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.output_dir = worktree.parent().expect("parent").to_path_buf();
     let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciMountConflict { .. }),
@@ -147,33 +144,79 @@ fn rejects_output_containing_worktree() {
     );
 }
 
+/// (d) state_dir nested inside workdir_base → OciMountConflict: a
+/// misconfigured state dir would put the daemon-owned `/output` and
+/// `.git` shadow surfaces inside the worker-visible tree.
+#[test]
+fn rejects_state_dir_inside_workdir_base() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = Config::test_defaults(tmp.path());
+    cfg.state_dir = cfg.workdir_base.join("state");
+    let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
+    let runtime = support::runtime_facts(&cfg, "run-001", &worktree);
+    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    assert!(
+        matches!(err, CaduceusError::OciMountConflict { .. }),
+        "expected OciMountConflict; got: {err:?}"
+    );
+}
+
+/// (d) `.git` shadow overlapping the output dir or the worktree →
+/// OciMountConflict (the shadow must never equal or contain either).
+#[test]
+fn rejects_shadow_overlapping_output_or_worktree() {
+    let (cfg, worktree) = base();
+    // shadow == output_dir
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.git_shadow_host = runtime.output_dir.clone();
+    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    assert!(
+        matches!(err, CaduceusError::OciMountConflict { .. }),
+        "expected OciMountConflict for shadow == output; got: {err:?}"
+    );
+
+    // shadow inside the worktree
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.git_shadow_host = worktree.join(".git-shadow");
+    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    assert!(
+        matches!(err, CaduceusError::OciMountConflict { .. }),
+        "expected OciMountConflict for shadow inside worktree; got: {err:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Positive resolution contract
 // ---------------------------------------------------------------------------
 
-/// (e) fixed identity 1000:1000.
+/// (e) dynamic identity: the resolved uid/gid are the probed
+/// worktree-owner facts (never a hard-coded 1000), with the rootful
+/// `--user` rule from the default fixture.
 #[test]
-fn resolves_fixed_identity() {
-    let (cfg, worktree, output) = base();
-    let runtime = runtime_for(&cfg, &worktree, &output);
+fn resolves_owner_identity() {
+    let (cfg, worktree) = base();
+    let runtime = runtime_for(&cfg, &worktree);
     let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
     assert_eq!(
         spec.identity(),
         ResolvedIdentity {
-            uid: SANDBOX_UID,
-            gid: SANDBOX_GID,
+            uid: 4242,
+            gid: 4242,
+            emit_user: true,
+            userns: None,
         }
     );
-    assert_eq!(spec.identity().uid, 1000);
-    assert_eq!(spec.identity().gid, 1000);
 }
 
-/// (f) canonical container paths `/workspace` and `/output`; exactly
-/// one workspace mount and one output mount (double-RW bug fixed).
+/// (f) canonical container paths `/workspace` and `/output`; the
+/// workspace binds directly to the per-run worktree (no copied or
+/// stripped workspace) and `/output` is daemon-owned under the state
+/// directory.
 #[test]
 fn resolves_canonical_container_paths() {
-    let (cfg, worktree, output) = base();
-    let runtime = runtime_for(&cfg, &worktree, &output);
+    let (cfg, worktree) = base();
+    let runtime = runtime_for(&cfg, &worktree);
     let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
 
     let ws = spec.workspace_mount();
@@ -182,7 +225,11 @@ fn resolves_canonical_container_paths() {
     assert!(!ws.read_only, "workspace is RW");
 
     let out = spec.output_mount();
-    assert_eq!(out.host_path, output);
+    assert_eq!(
+        out.host_path,
+        support::oci_output_dir(&cfg, "run-001"),
+        "/output host path must be daemon-owned under state_dir"
+    );
     assert_eq!(out.container_path, PathBuf::from("/output"));
     assert!(!out.read_only, "output is RW");
 }
@@ -206,12 +253,12 @@ fn pass_env_filtering() {
     }
     let _guard = EnvGuard::set("CADUCEUS_RESOLVE_TEST_PASS_ENV", "present-value");
 
-    let (mut cfg, worktree, output) = base();
+    let (mut cfg, worktree) = base();
     cfg.sandbox.as_mut().expect("sandbox").pass_env = vec![
         "CADUCEUS_RESOLVE_TEST_PASS_ENV".to_string(),
         "CADUCEUS_RESOLVE_TEST_UNSET".to_string(),
     ];
-    let runtime = runtime_for(&cfg, &worktree, &output);
+    let runtime = runtime_for(&cfg, &worktree);
     let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
     let env = spec.environment();
     assert_eq!(
@@ -239,8 +286,8 @@ fn pass_env_filtering() {
 /// (h) labels in fixed order daemon_id, run_id, issue_id.
 #[test]
 fn resolves_labels_in_fixed_order() {
-    let (cfg, worktree, output) = base();
-    let mut runtime = runtime_for(&cfg, &worktree, &output);
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
     runtime.run_id = "run-007".to_string();
     runtime.issue = IssueKey::parse("owner/repo#7").expect("valid key");
     runtime.daemon_id = "daemon-42".to_string();
@@ -259,13 +306,13 @@ fn resolves_labels_in_fixed_order() {
 /// a total (non-`Option`) value.
 #[test]
 fn resolution_yields_fully_populated_spec() {
-    let (cfg, worktree, output) = base();
-    let runtime = runtime_for(&cfg, &worktree, &output);
+    let (cfg, worktree) = base();
+    let runtime = runtime_for(&cfg, &worktree);
     let spec: SandboxSpec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
     assert!(!spec.name().is_empty());
     assert!(spec.image().contains("@sha256:"));
     assert!(!spec.command().is_empty());
-    assert_eq!(spec.tmpfs().len(), 1);
+    assert_eq!(spec.tmpfs().len(), 2);
     assert!(!spec.environment().is_empty());
     assert!(!spec.labels().is_empty());
     assert!(spec.resources().memory_mb > 0);
@@ -276,14 +323,168 @@ fn resolution_yields_fully_populated_spec() {
     let _ = spec.security();
 }
 
-/// The tmpfs size comes from `resources.tmpfs_mb` (was hard-coded
-/// 64M before the renderer).
+/// The tmpfs sizes come from `resources.{tmpfs_mb, shm_mb}`.
 #[test]
-fn tmpfs_size_from_resources() {
-    let (mut cfg, worktree, output) = base();
+fn tmpfs_sizes_from_resources() {
+    let (mut cfg, worktree) = base();
     cfg.sandbox.as_mut().expect("sandbox").resources.tmpfs_mb = 512;
-    let runtime = runtime_for(&cfg, &worktree, &output);
+    cfg.sandbox.as_mut().expect("sandbox").resources.shm_mb = 96;
+    let runtime = runtime_for(&cfg, &worktree);
     let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
     assert_eq!(spec.tmpfs()[0].target, "/tmp");
     assert_eq!(spec.tmpfs()[0].size_mb, 512);
+    assert_eq!(spec.tmpfs()[1].target, "/dev/shm");
+    assert_eq!(spec.tmpfs()[1].size_mb, 96);
+}
+
+// ---------------------------------------------------------------------------
+// .git shadow selection (design D5)
+// ---------------------------------------------------------------------------
+
+/// Pure `select_git_shadow`: File and Dir both yield the read-only
+/// mount of the shadow at `/workspace/.git`; Absent yields `None`.
+#[test]
+fn select_git_shadow_covers_all_kinds() {
+    let shadow_host = Path::new("/state/oci-runs/run-001/git-shadow");
+    for kind in [GitShadowKind::File, GitShadowKind::Dir] {
+        let expected = MountSpec {
+            host_path: shadow_host.to_path_buf(),
+            container_path: PathBuf::from("/workspace/.git"),
+            read_only: true,
+        };
+        assert_eq!(select_git_shadow(kind, shadow_host), Some(expected));
+    }
+    assert_eq!(select_git_shadow(GitShadowKind::Absent, shadow_host), None);
+}
+
+/// `resolve` with each `GitShadowKind`: Absent ⇒ no shadow and the
+/// rest of the spec is unchanged; File/Dir ⇒ the shadow mount is
+/// present and read-only.
+#[test]
+fn resolve_wires_git_shadow_per_kind() {
+    for kind in [GitShadowKind::File, GitShadowKind::Dir] {
+        let (cfg, worktree) = base();
+        let mut runtime = runtime_for(&cfg, &worktree);
+        runtime.git_shadow_kind = kind;
+        let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+        let shadow = spec.git_shadow().expect("shadow must be present");
+        assert_eq!(shadow.host_path, support::git_shadow_host(&cfg, "run-001"));
+        assert_eq!(shadow.container_path, PathBuf::from("/workspace/.git"));
+        assert!(shadow.read_only, "shadow must be read-only");
+    }
+
+    // Absent ⇒ no shadow.
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.git_shadow_kind = GitShadowKind::Absent;
+    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    assert!(
+        spec.git_shadow().is_none(),
+        "absent .git must yield no shadow"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Writable-surface invariant (design D7)
+// ---------------------------------------------------------------------------
+
+/// The resolved writable host-backed set is exactly
+/// `{/workspace, /output}`, the tmpfs set is exactly
+/// `[/tmp, /dev/shm]` with the configured sizes, and the `.git`
+/// shadow is the only extra host-backed mount and is read-only.
+#[test]
+fn writable_surface_invariant_holds() {
+    let (cfg, worktree) = base();
+    let runtime = runtime_for(&cfg, &worktree);
+    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+
+    let ws = spec.workspace_mount();
+    assert_eq!(ws.container_path, PathBuf::from("/workspace"));
+    assert!(!ws.read_only);
+    let out = spec.output_mount();
+    assert_eq!(out.container_path, PathBuf::from("/output"));
+    assert!(!out.read_only);
+
+    let shadow = spec.git_shadow().expect("fixture has a .git pointer file");
+    assert!(
+        shadow.read_only,
+        "the shadow is the only extra mount and is RO"
+    );
+
+    let tmpfs: Vec<(String, u64)> = spec
+        .tmpfs()
+        .iter()
+        .map(|m| (m.target.clone(), m.size_mb))
+        .collect();
+    assert_eq!(
+        tmpfs,
+        vec![
+            ("/tmp".to_string(), cfg.sandbox().resources.tmpfs_mb),
+            ("/dev/shm".to_string(), cfg.sandbox().resources.shm_mb),
+        ],
+        "tmpfs set must be exactly the two bounded ephemeral surfaces"
+    );
+}
+
+/// The spec is closed: an extra writable host-backed mount at a
+/// container path other than `/workspace` or `/output` is
+/// unrepresentable, and the nearest misconfiguration attempt (a state
+/// dir under `workdir_base`, which would smuggle extra writable host
+/// paths into the worker-visible tree) is rejected at resolution
+/// time with a typed error — no container is ever started.
+#[test]
+fn extra_writable_host_paths_are_rejected_at_resolution() {
+    // Structural closure: the resolved mount inventory is exactly the
+    // two writable surfaces plus the optional read-only shadow. There
+    // is no public constructor or builder that could add another
+    // host-backed mount.
+    let (cfg, worktree) = base();
+    let runtime = runtime_for(&cfg, &worktree);
+    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let mut rw_container_paths: Vec<PathBuf> = vec![
+        spec.workspace_mount().container_path.clone(),
+        spec.output_mount().container_path.clone(),
+    ];
+    if let Some(shadow) = spec.git_shadow() {
+        assert!(shadow.read_only, "any extra mount must be read-only");
+    }
+    rw_container_paths.sort();
+    assert_eq!(
+        rw_container_paths,
+        vec![PathBuf::from("/output"), PathBuf::from("/workspace")],
+        "exactly two writable host-backed surfaces may exist"
+    );
+
+    // A state dir inside workdir_base would hand the worker extra
+    // writable host paths — rejected at resolution time.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = Config::test_defaults(tmp.path());
+    cfg.state_dir = cfg.workdir_base.join("state");
+    let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
+    let runtime = support::runtime_facts(&cfg, "run-001", &worktree);
+    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    match err {
+        CaduceusError::OciMountConflict { detail } => {
+            assert!(
+                detail.contains("state_dir"),
+                "expected state_dir/workdir_base conflict, got: {detail}"
+            );
+        }
+        other => panic!("expected OciMountConflict; got: {other:?}"),
+    }
+}
+
+/// Engine-mode facts flow into identity without I/O: a rootless-mode
+/// fact set resolves to no `--user` emission (Docker) even though the
+/// owner uid/gid are still carried.
+#[test]
+fn engine_mode_fact_flows_into_identity() {
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.engine_mode = EngineMode::Rootless;
+    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    assert_eq!(spec.identity().uid, 4242);
+    assert_eq!(spec.identity().gid, 4242);
+    assert!(!spec.identity().emit_user, "rootless emits no --user");
+    assert_eq!(spec.identity().userns, None);
 }

--- a/tests/executor/secret_grant_test.rs
+++ b/tests/executor/secret_grant_test.rs
@@ -9,9 +9,10 @@
 //! stays out of secret handling unless the caller passes env files.
 
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::Config;
+
+mod support;
 
 fn default_cfg() -> Config {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -20,16 +21,7 @@ fn default_cfg() -> Config {
 
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: "run-001".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, "run-001", &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 

--- a/tests/executor/support/mod.rs
+++ b/tests/executor/support/mod.rs
@@ -1,0 +1,56 @@
+//! Shared `RuntimeFacts` fixture for the executor test crates.
+//!
+//! `RuntimeFacts` gained the pre-flight fields (owner uid/gid, engine
+//! mode, `.git` shadow kind and host path, state dir) that keep
+//! `resolve` pure; this module gives every executor test one place
+//! with sensible defaults so the per-case tests stay one-line
+//! adjustable (design D8).
+//!
+//! Defaults: non-1000 worktree owner `4242:4242` (asserting dynamic
+//! identity must never assume 1000), rootful engine mode, and the
+//! `gitdir:` pointer-file `.git` shadow kind. The daemon-owned
+//! `output_dir` / `git_shadow_host` paths mirror the pre-flight
+//! derivation under `cfg.state_dir`. Tests needing non-default facts
+//! mutate the returned struct's public fields directly.
+
+use std::path::{Path, PathBuf};
+
+use caduceus::executor::sandbox_spec::{EngineMode, GitShadowKind, RuntimeFacts};
+use caduceus::github::issue::IssueKey;
+use caduceus::infra::config::Config;
+
+/// Daemon-owned `/output` host path for a run (mirrors the pre-flight
+/// derivation in `engine_probe`).
+pub fn oci_output_dir(cfg: &Config, run_id: &str) -> PathBuf {
+    cfg.state_dir.join("oci-runs").join(run_id).join("output")
+}
+
+/// Daemon-owned `.git` shadow host path for a run (mirrors the
+/// pre-flight derivation in `engine_probe`).
+pub fn git_shadow_host(cfg: &Config, run_id: &str) -> PathBuf {
+    cfg.state_dir
+        .join("oci-runs")
+        .join(run_id)
+        .join("git-shadow")
+}
+
+/// Build `RuntimeFacts` with the documented defaults for `run_id`,
+/// with the worktree at `worktree` (which must live under
+/// `cfg.workdir_base` for the allow-list to accept it).
+pub fn runtime_facts(cfg: &Config, run_id: &str, worktree: &Path) -> RuntimeFacts {
+    RuntimeFacts {
+        run_id: run_id.to_string(),
+        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
+        worktree: worktree.to_path_buf(),
+        output_dir: oci_output_dir(cfg, run_id),
+        daemon_id: "test-daemon".to_string(),
+        workdir_base: cfg.workdir_base.clone(),
+        state_dir: cfg.state_dir.clone(),
+        worktree_uid: 4242,
+        worktree_gid: 4242,
+        engine_mode: EngineMode::Rootful,
+        git_shadow_kind: GitShadowKind::File,
+        git_shadow_host: git_shadow_host(cfg, run_id),
+    }
+}

--- a/tests/executor/tamper_test.rs
+++ b/tests/executor/tamper_test.rs
@@ -5,14 +5,13 @@
 //! use the typed pipeline (`resolve` → `render`) plus the `redact()`
 //! primitive from `infra::logging`.
 
-use std::path::PathBuf;
-
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, RuntimeFacts, SandboxEngine, SandboxSpec};
-use caduceus::github::issue::IssueKey;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::Config;
 use caduceus::infra::error::CaduceusError;
 use caduceus::infra::logging;
+
+mod support;
 
 fn default_cfg() -> Config {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -21,16 +20,7 @@ fn default_cfg() -> Config {
 
 fn resolve_from(cfg: &Config, run_id: &str) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join(run_id);
-    let output = cfg.workdir_base.join("owner").join("repo").join("result");
-    let runtime = RuntimeFacts {
-        run_id: run_id.to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree,
-        output_dir: output,
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(cfg, run_id, &worktree);
     resolve(cfg.sandbox(), &runtime).expect("must resolve")
 }
 
@@ -43,15 +33,11 @@ fn tamper_modified_files() {
     // host-path allow-list: a worktree outside `workdir_base`
     // triggers OciUndeclaredMount.
     let cfg = default_cfg();
-    let runtime = RuntimeFacts {
-        run_id: "tamper-modified-files".to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
-        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
-        worktree: PathBuf::from("/tmp/worktree"),
-        output_dir: PathBuf::from("/tmp/result"),
-        daemon_id: "test-daemon".to_string(),
-        workdir_base: cfg.workdir_base.clone(),
-    };
+    let runtime = support::runtime_facts(
+        &cfg,
+        "tamper-modified-files",
+        std::path::Path::new("/tmp/worktree"),
+    );
     let result = resolve(cfg.sandbox(), &runtime);
     match result {
         Err(CaduceusError::OciUndeclaredMount { path }) => {
@@ -123,19 +109,25 @@ fn tamper_secret_in_result() {
     }
 }
 
-// tamper_commit_metadata — argv does not contain .git volume mount
+// tamper_commit_metadata — argv's only .git reference is the
+// read-only daemon-owned shadow
 
 #[test]
 fn tamper_commit_metadata() {
-    // The git-less worker contract ensures that the .git directory is
-    // never mounted as a writable volume. The typed spec has no field
-    // for extra mounts, so the rendered argv cannot contain .git.
+    // The .git pointer is shadowed by a daemon-owned read-only mount;
+    // the real gitdir is unreachable and .git is never writable.
     let cfg = default_cfg();
     let spec = resolve_from(&cfg, "tamper-commit-metadata");
     let argv = render(&spec, SandboxEngine::Docker);
     let git_refs: Vec<&String> = argv.iter().filter(|a| a.contains(".git")).collect();
+    assert_eq!(
+        git_refs.len(),
+        1,
+        "exactly the shadow mount may reference .git, got: {git_refs:?}"
+    );
     assert!(
-        git_refs.is_empty(),
-        "unexpected .git reference in argv: {git_refs:?}"
+        git_refs[0].ends_with(":/workspace/.git:ro"),
+        "the .git reference must be the read-only shadow, got: {:?}",
+        git_refs[0]
     );
 }

--- a/tests/plugin/test_doctor_checks.py
+++ b/tests/plugin/test_doctor_checks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fcntl
 import os
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -248,3 +249,168 @@ def test_doctor_check_worktree_lock_held_lock(
     assert finding.category == "daemon-defect"
     assert finding.status == "ok"
     assert "held" in finding.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# _doctor_check_oci_identity (issue #244)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal subprocess.run result double."""
+
+    def __init__(self, returncode: int, stdout: bytes, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _patch_engine_probe(
+    adapter, monkeypatch: pytest.MonkeyPatch, docker, podman
+) -> None:
+    """Patch ``subprocess.run`` so the named engine probe returns the
+    canned result and the other engine is reported missing (OSError)."""
+
+    def _run(args, **kwargs):
+        binary = args[0]
+        canned = {"docker": docker, "podman": podman}[binary]
+        if canned is None:
+            raise FileNotFoundError(binary)
+        if isinstance(canned, Exception):
+            raise canned
+        return canned
+
+    monkeypatch.setattr(adapter.subprocess, "run", _run)
+
+
+def test_doctor_check_oci_identity_podman_rootless_ok(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Podman rootless (``true``) is a supported identity mode."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=None,
+        podman=_FakeProc(0, b"true\n"),
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "ok"
+    assert "rootless" in finding.detail.lower()
+
+
+def test_doctor_check_oci_identity_podman_rootful_ok(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Podman rootful (``false``) follows the rootful rule — supported."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=None,
+        podman=_FakeProc(0, b"false\n"),
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.status == "ok"
+
+
+def test_doctor_check_oci_identity_docker_rootful_ok(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Plain rootful Docker security options are supported."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=_FakeProc(0, b"[name=apparmor name=seccomp,profile=builtin]"),
+        podman=None,
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.status == "ok"
+    assert "rootful" in finding.detail.lower()
+
+
+def test_doctor_check_oci_identity_docker_rootless_ok(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``name=rootless`` in the security options is supported."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=_FakeProc(0, b"[name=rootless name=seccomp,profile=builtin]"),
+        podman=None,
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.status == "ok"
+    assert "rootless" in finding.detail.lower()
+
+
+def test_doctor_check_oci_identity_rootful_userns_remap_fails(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rootful Docker with userns-remap is refused → host-capability-unavailable
+    (doctor exit code 2 category)."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=_FakeProc(0, b"[name=userns-remap,value=default]"),
+        podman=None,
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "fail"
+    assert "userns-remap" in finding.detail.lower()
+
+
+def test_doctor_check_oci_identity_unparseable_fails(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An installed engine whose mode cannot be parsed is fail-closed."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=_FakeProc(0, b"not-a-security-options-list"),
+        podman=None,
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "fail"
+
+
+def test_doctor_check_oci_identity_probe_failure_fails(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An installed engine whose ``info`` probe exits non-zero is fail-closed."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=_FakeProc(1, b"", stderr=b"Cannot connect to the Docker daemon"),
+        podman=None,
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.category == "host-capability-unavailable"
+    assert finding.status == "fail"
+
+
+def test_doctor_check_oci_identity_probe_timeout_fails(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hung engine probe is fail-closed (mirrors the daemon's bounded timeout)."""
+    _patch_engine_probe(
+        adapter,
+        monkeypatch,
+        docker=subprocess.TimeoutExpired(cmd="docker", timeout=15),
+        podman=None,
+    )
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.status == "fail"
+
+
+def test_doctor_check_oci_identity_no_engine_ok(
+    adapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No OCI engine installed → not applicable (trusted-host dispatch)."""
+    _patch_engine_probe(adapter, monkeypatch, docker=None, podman=None)
+    # Neither binary resolves on PATH.
+    monkeypatch.setattr(adapter, "_binary_on_path", lambda _name: False)
+    finding = adapter._doctor_check_oci_identity()
+    assert finding.status == "ok"
+    assert "not applicable" in finding.detail.lower()


### PR DESCRIPTION
## Summary

Implemented issue #244 — `feat(oci): workspace, .git and runtime identity isolation` for the caduceus OCI executor.

### What changed
- The per-run worktree is now the single real RW workspace, mounted at `/workspace` (no copied or stripped second workspace).
- A daemon-owned output surface `<state_dir>/oci-runs/<run_id>/output` is mounted read-write at `/output`, replacing the previous per-repo `result` sibling; the daemon creates it with `0700` and chowns it to the resolved owner.
- `.git` is hidden behind a type-aware, read-only, daemon-owned shadow: a worktree-pointer `.git` file is covered by a harmless read-only regular file; a directory `.git` by an empty read-only directory/tmpfs; an absent `.git` is left untouched. The shadow is mounted at `/workspace/.git` after the workspace bind so it always takes precedence.
- Runtime identity is resolved per engine×mode instead of the hardcoded `1000:1000`:
  - Docker rootful → `--user <worktree-owner-uid>:<gid>` (writes persist for finalize, no chown machinery).
  - Docker rootless → documented mapping that keeps the unprivileged engine user, never granting host root.
  - Podman rootless → `--userns=keep-id` (no hardcoded uid/gid, so it equals the daemon/worktree owner).
  - Podman rootful → follows the rootful rule.
  - A literal `1000:1000` is emitted only as a fallback when the mode is rootful and the resolved owner is actually 1000.
- An unsupported namespace configuration (e.g. rootful with `userns-remap`, or engine detection failure) now fails closed with a new typed error raised before the container starts, so the worker never launches with broken isolation.
- The writable-surface invariant is enforced: exactly two writable host-backed bind surfaces (`/workspace`, `/output`); `/tmp` and `/dev/shm` only as bounded ephemeral tmpfs; any other host path is rejected.
- The renderer stays pure (no filesystem/env I/O); all engine probing and owner/`.git` discovery happen in a new pre-flight step.

### Tests
- Unit: shadow-selection for file/dir/absent `.git`; identity resolution per engine×mode from synthetic ownership facts; writable-surface invariant.
- Live (gated behind `CADUCEUS_RUN_ISOLATION_TESTS`): `oci_mount_enumeration_two_writable_surfaces` (consumed by I12), rootful identity canary, adversarial `.git` read/write tests. On this host (rootful Docker 29.7.2) all 7 gated live tests were executed and passed.
- Python plugin: new `doctor` capability check reporting host-capability-unavailable when identity isolation cannot be provided.

### Verification
- `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --locked --all-targets` are green (94/95 targets; the 1 failure is a pre-existing, unrelated canary). Python plugin tests: 111/111.
- Rootless-Docker and Podman engine legs are implemented and compile but skip by design on a host whose engine is not that mode; their behavior is sound by construction (mount target-depth precedence for the `.git` shadow).

### Notes for the operator
- Rootless-Docker and Podman identity paths were verified by construction only on this host; run the gated suite on those engines before relying on them in production.
- Two unrelated pre-existing failures remain (a provider-secret doctor canary and the Python bridge integration tests, which need `bash` in the harness env). This change does not introduce or worsen them.

Closes #244

Artifacts (6):

```json
{
  "archive_id": "2026-08-27-oci-workspace-git-identity-isolation",
  "capability": "oci-sandbox",
  "cargo_unit_tests": "94/95 green (1 pre-existing, unrelated)",
  "live_gated_tests": "7/7 passed on rootful Docker",
  "openspec_change": "oci-workspace-git-identity-isolation",
  "python_plugin_tests": "111/111 passed"
}
```

<!-- caduceus-pr-body:run=01M12ERY28E19MHNN1Q1AS7QSX -->