### PR TITLE
feat(oci): agent-neutral worker execution contract + OCI result boundary

### DIFF
--- a/plugin-assets/worker-bridge.py
+++ b/plugin-assets/worker-bridge.py
@@ -85,7 +85,14 @@ REQUIRED_ENV_VARS: tuple[str, ...] = (
     "CADUCEUS_RUN_ID",
     "CADUCEUS_ISSUE_LABELS_JSON",
     "CADUCEUS_BRANCH_NAME",
+    "CADUCEUS_RESULT_PATH",
 )
+
+#: Names in :data:`REQUIRED_ENV_VARS` that are soft-required. A missing
+#: entry must not abort the worker: the bridge falls back to the legacy
+#: location (with a stderr warning) instead. Every other required name
+#: is hard-required and aborts with ``EXIT_MISSING_ENV``.
+SOFT_REQUIRED_ENV_VARS: frozenset[str] = frozenset({"CADUCEUS_RESULT_PATH"})
 
 #: File names inside the worktree the daemon prepares. The bridge never
 #: reads ``worker-result.json`` (the daemon reads it after the worker
@@ -301,7 +308,20 @@ def truncate_pull_request_title(title: str) -> str:
 
 
 def _result_path(worktree: Path) -> Path:
-    """Return the daemon-consumed result path for a worktree."""
+    """Return the daemon-consumed result path for a worktree.
+
+    The daemon may export ``CADUCEUS_RESULT_PATH`` (the agent-neutral
+    result location). When set and non-empty it wins; otherwise the
+    legacy ``<worktree>/worker-result.json`` location is used and a
+    visible but non-fatal warning is written to stderr.
+    """
+    override = os.environ.get("CADUCEUS_RESULT_PATH")
+    if override:
+        return Path(override)
+    sys.stderr.write(
+        "caduceus bridge: CADUCEUS_RESULT_PATH is not set; "
+        f"falling back to legacy result path {worktree / 'worker-result.json'}\n"
+    )
     return worktree / "worker-result.json"
 
 
@@ -317,6 +337,10 @@ def _synthesize_worker_result(
     result_path = _result_path(worktree)
     if result_path.exists():
         return
+
+    # The resolved parent may be a freshly mounted directory (for
+    # example an OCI ``/output`` bind) that does not exist yet.
+    result_path.parent.mkdir(parents=True, exist_ok=True)
 
     combined = _clean_terminal_text((stdout or "") + (stderr or ""))
     lines = [line.strip() for line in combined.split("\n") if line.strip()]
@@ -406,7 +430,11 @@ def read_required_env(env: Mapping[str, str]) -> dict:
     diagnostic naming each missing key. The error message never embeds
     the values (no echo of titles, bodies, or tokens).
     """
-    missing = [name for name in REQUIRED_ENV_VARS if not env.get(name)]
+    missing = [
+        name
+        for name in REQUIRED_ENV_VARS
+        if name not in SOFT_REQUIRED_ENV_VARS and not env.get(name)
+    ]
     if missing:
         print(
             "caduceus bridge: missing required environment: "
@@ -414,7 +442,11 @@ def read_required_env(env: Mapping[str, str]) -> dict:
             file=sys.stderr,
         )
         sys.exit(EXIT_MISSING_ENV)
-    return {name: env[name] for name in REQUIRED_ENV_VARS}
+    return {
+        name: env[name]
+        for name in REQUIRED_ENV_VARS
+        if name in env and env[name]
+    }
 
 
 def parse_labels(raw: str) -> list[str]:

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -254,19 +254,21 @@ pub(crate) async fn run_claim(
         labels: issue.labels.clone(),
         branch_name: worktree.branch_name.clone(),
     };
-    let supervisor_outcome = match services.executor.run(&spec).await {
+    let exec_outcome = match services.executor.run(&spec).await {
         Ok(o) => o,
         Err(err) => {
             let class = classify_error(&err);
             return handle_infra_or_retry(cfg, guard, &err, class).await;
         }
     };
+    let supervisor_outcome = exec_outcome.outcome.clone();
     guard.attach_supervisor(supervisor_outcome.clone()).await;
     if supervisor_outcome.timed_out || supervisor_outcome.cancelled {
         let _ = guard.finish_cancelled().await;
         return Ok(TickOutcome::Cancelled);
     }
     let _ = services.clock.now();
+    let host_result_path = exec_outcome.result_path.clone();
 
     // 14. Read the worker result from the worktree; a missing or
     //     unparseable result is a worker-attributable failure through
@@ -274,9 +276,8 @@ pub(crate) async fn run_claim(
     //     success signal even if the bridge exited nonzero (issue
     //     #118); a result whose own `status` is `failure` is still a
     //     worker-attributable failure.
-    let worktree_result_path = worktree.path.join("worker-result.json");
     let worker_result =
-        match crate::worker::parse_result_file(&worktree_result_path, &claimed.entry.key) {
+        match crate::worker::parse_result_file(&host_result_path, &claimed.entry.key) {
             Ok(r) => r,
             Err(err) => {
                 let stderr = if !supervisor_outcome.signaled && supervisor_outcome.status != 0 {
@@ -314,7 +315,7 @@ pub(crate) async fn run_claim(
 
     // 15. Archive the parsed result before finalization so the
     //     daemon can resume from it later.
-    let archive_path = match archive_worker_result(&worktree_result_path, &cfg.state_dir, &run_id) {
+    let archive_path = match archive_worker_result(&host_result_path, &cfg.state_dir, &run_id) {
         Ok(p) => p,
         Err(err) => {
             let class = classify_error(&err);
@@ -348,7 +349,7 @@ pub(crate) async fn run_claim(
         match run_investigation_finalize(
             &final_ctx,
             &worker_result,
-            &archive_path,
+            &host_result_path,
             client.as_ref(),
             store,
             &cfg.ticket_label_investigation,
@@ -371,7 +372,7 @@ pub(crate) async fn run_claim(
         &final_ctx,
         &worker_result,
         &runner,
-        &archive_path,
+        &host_result_path,
         client.as_ref(),
         store,
     )

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -71,6 +71,18 @@ pub struct ExecutorSpec {
     pub branch_name: String,
 }
 
+/// Result of [`Executor::run`] plus the host-side path the worker
+/// result JSON was written to. `result_path` is mode-dependent
+/// (`<worktree>/worker-result.json` for TrustedHost,
+/// `<state_dir>/oci-runs/<run_id>/output/worker-result.json` for
+/// OCI). The daemon reads the result exclusively from this path so
+/// the tick loop stays engine-agnostic.
+#[derive(Clone, Debug)]
+pub struct ExecutorOutcome {
+    pub outcome: SupervisorOutcome,
+    pub result_path: PathBuf,
+}
+
 /// Which execution mode the daemon uses to dispatch workers.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -90,12 +102,13 @@ pub enum ExecutorKind {
 pub trait Executor: Send + Sync {
     /// Run the worker according to the configured execution mode.
     ///
-    /// Returns a [`SupervisorOutcome`] on success or a typed
-    /// [`CaduceusError`] on failure.
+    /// Returns an [`ExecutorOutcome`] — the [`SupervisorOutcome`]
+    /// plus the host-side path the worker result JSON was written
+    /// to — on success, or a typed [`CaduceusError`] on failure.
     fn run<'a>(
         &'a self,
         spec: &'a ExecutorSpec,
-    ) -> Pin<Box<dyn Future<Output = CaduceusResult<SupervisorOutcome>> + Send + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = CaduceusResult<ExecutorOutcome>> + Send + 'a>>;
 }
 
 /// Construct the executor matching the configured mode.

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -18,13 +18,14 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::executor::{
-    engine_probe, oci_lifecycle, sandbox_renderer, sandbox_spec, Executor, ExecutorSpec,
+    engine_probe, oci_lifecycle, sandbox_renderer, sandbox_spec, Executor, ExecutorOutcome,
+    ExecutorSpec,
 };
 use crate::infra::config::Config;
 use crate::infra::error::CaduceusResult;
 use crate::state::oci_run::OciRunDao;
 use crate::state::store;
-use crate::worker::supervisor::SupervisorOutcome;
+use crate::worker::worker_contract::WORKER_RESULT_FILE;
 
 /// Executor that dispatches workers via Docker or Podman CLI.
 #[derive(Clone, Debug)]
@@ -43,7 +44,7 @@ impl Executor for OciExecutor {
     fn run<'a>(
         &'a self,
         spec: &'a ExecutorSpec,
-    ) -> Pin<Box<dyn Future<Output = CaduceusResult<SupervisorOutcome>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = CaduceusResult<ExecutorOutcome>> + Send + 'a>> {
         Box::pin(async move {
             // 1. Pre-flight probe: collect the runtime facts (worktree
             //    owner uid/gid, host `.git` type, engine mode) and
@@ -57,7 +58,7 @@ impl Executor for OciExecutor {
             // 2. Resolve the closed typed spec. All host-path,
             //    identity, and mount decisions happen here; the
             //    renderer invents nothing.
-            let resolved = sandbox_spec::resolve(self.cfg.sandbox(), &runtime)?;
+            let resolved = sandbox_spec::resolve(self.cfg.sandbox(), &runtime, spec)?;
 
             // 3. Open the state database.
             let db_path = self.cfg.state_dir.join(store::DB_FILENAME);
@@ -73,7 +74,7 @@ impl Executor for OciExecutor {
             let argv = sandbox_renderer::render_with_env_files(&resolved, engine, &[]);
 
             // 5. Run the lifecycle with the rendered argv.
-            oci_lifecycle::run_with_argv(
+            let outcome = oci_lifecycle::run_with_argv(
                 &self.cfg,
                 spec,
                 &dao,
@@ -81,7 +82,11 @@ impl Executor for OciExecutor {
                 argv,
                 spec.cancellation.child_token(),
             )
-            .await
+            .await?;
+            Ok(ExecutorOutcome {
+                outcome,
+                result_path: runtime.output_dir.join(WORKER_RESULT_FILE),
+            })
         })
     }
 }

--- a/src/executor/sandbox_renderer.rs
+++ b/src/executor/sandbox_renderer.rs
@@ -17,6 +17,9 @@
 use std::path::PathBuf;
 
 use crate::executor::sandbox_spec::{NetworkMode, SandboxEngine, SandboxSpec};
+use crate::worker::worker_contract::{
+    CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
+};
 
 /// Render the full `create` argv for the given engine with no secret
 /// env files. Delegates to [`render_with_env_files`] with an empty
@@ -152,6 +155,27 @@ pub fn render_with_env_files(
             label_value(spec, "caduceus.issue_id").unwrap_or_default(),
         )
     ));
+    // Remaining canonical `CADUCEUS_*` entries, in canonical order.
+    // `resolve` guarantees all of them; the fallbacks are a
+    // non-panicking safety net for a spec-construction bug.
+    let result_path_fallback = format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}");
+    for (key, fallback) in [
+        ("CADUCEUS_ISSUE_NUMBER", ""),
+        ("CADUCEUS_ISSUE_REPO", ""),
+        ("CADUCEUS_ISSUE_TITLE", ""),
+        ("CADUCEUS_ISSUE_BODY", ""),
+        ("CADUCEUS_ISSUE_LABELS_JSON", "[]"),
+        ("CADUCEUS_CONTEXT_JSON", "{}"),
+        ("CADUCEUS_BRANCH_NAME", ""),
+        ("CADUCEUS_WORKTREE_PATH", CONTAINER_WORKSPACE_PATH),
+        ("CADUCEUS_RESULT_PATH", result_path_fallback.as_str()),
+    ] {
+        argv.push("-e".to_string());
+        argv.push(format!(
+            "{key}={}",
+            env_value(spec, key, fallback.to_string())
+        ));
+    }
 
     // --- Labels (spec order — fixed: daemon_id, run_id, issue_id).
     for (key, value) in spec.labels() {

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -18,9 +18,13 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::executor::ExecutorSpec;
 use crate::github::issue::IssueKey;
 use crate::infra::config::{Config, OciPullPolicy, SandboxConfig, SandboxNetwork};
 use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::worker::worker_contract::{
+    CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
+};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -238,8 +242,10 @@ impl SandboxSpec {
     pub fn tmpfs(&self) -> &[TmpfsMount] {
         &self.tmpfs
     }
-    /// Environment entries (ordered). `resolve` guarantees
-    /// `CADUCEUS_RUN_ID` and `CADUCEUS_ISSUE_ID` entries.
+    /// Environment entries (ordered). `resolve` guarantees the full
+    /// canonical `CADUCEUS_*` set (run, issue, context, branch, and
+    /// the container-side worktree/result paths), not just the run
+    /// and issue identifiers.
     pub fn environment(&self) -> &[(String, String)] {
         &self.environment
     }
@@ -377,7 +383,11 @@ pub fn select_git_shadow(kind: GitShadowKind, shadow_host: &Path) -> Option<Moun
 /// filtering (task 1.13 contract). All facts the resolver needs
 /// (owner uid/gid, `.git` type, engine mode) must already be carried
 /// in [`RuntimeFacts`] by the pre-flight probe.
-pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResult<SandboxSpec> {
+pub fn resolve(
+    sandbox: &SandboxConfig,
+    runtime: &RuntimeFacts,
+    spec: &ExecutorSpec,
+) -> CaduceusResult<SandboxSpec> {
     // 1. Lexically normalize every declared path so containment can
     //    be checked without filesystem access (resolve is pure).
     let undeclared = |p: &Path| CaduceusError::OciUndeclaredMount {
@@ -443,12 +453,12 @@ pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResul
     //    read-only `.git` shadow at `/workspace/.git`.
     let workspace_mount = MountSpec {
         host_path: worktree_norm,
-        container_path: PathBuf::from("/workspace"),
+        container_path: PathBuf::from(CONTAINER_WORKSPACE_PATH),
         read_only: false,
     };
     let output_mount = MountSpec {
         host_path: output_norm,
-        container_path: PathBuf::from("/output"),
+        container_path: PathBuf::from(CONTAINER_OUTPUT_PATH),
         read_only: false,
     };
     let git_shadow = select_git_shadow(runtime.git_shadow_kind, &shadow_norm);
@@ -517,10 +527,47 @@ pub fn resolve(sandbox: &SandboxConfig, runtime: &RuntimeFacts) -> CaduceusResul
         SandboxNetwork::Unrestricted => NetworkMode::Unrestricted,
     };
 
-    // 10. Environment — ordered.
+    // 10. Environment — the full canonical `CADUCEUS_*` set, with
+    //     CONTAINER-side path values so host paths never leak into
+    //     the container environment (issue #243). Value formatting
+    //     mirrors the canonical layer of
+    //     `worker_contract::sanitized_env`; only
+    //     `CADUCEUS_WORKTREE_PATH` and `CADUCEUS_RESULT_PATH` are
+    //     substituted for their container paths — every other
+    //     canonical variable carries the same value as TrustedHost.
+    //     No credential variable is ever emitted here.
+    let labels_json = serde_json::to_string(&spec.labels)
+        .map_err(|err| CaduceusError::Config(format!("labels JSON serialise: {err}")))?;
     let mut environment: Vec<(String, String)> = vec![
         ("CADUCEUS_RUN_ID".to_string(), runtime.run_id.clone()),
         ("CADUCEUS_ISSUE_ID".to_string(), runtime.issue.display_key()),
+        (
+            "CADUCEUS_ISSUE_NUMBER".to_string(),
+            spec.issue.number.to_string(),
+        ),
+        (
+            "CADUCEUS_ISSUE_REPO".to_string(),
+            format!("{}/{}", spec.issue.owner, spec.issue.repo),
+        ),
+        ("CADUCEUS_ISSUE_TITLE".to_string(), spec.issue_title.clone()),
+        ("CADUCEUS_ISSUE_BODY".to_string(), spec.issue_body.clone()),
+        (
+            "CADUCEUS_ISSUE_LABELS_JSON".to_string(),
+            labels_json.clone(),
+        ),
+        (
+            "CADUCEUS_CONTEXT_JSON".to_string(),
+            spec.context_json.clone(),
+        ),
+        ("CADUCEUS_BRANCH_NAME".to_string(), spec.branch_name.clone()),
+        (
+            "CADUCEUS_WORKTREE_PATH".to_string(),
+            CONTAINER_WORKSPACE_PATH.to_string(),
+        ),
+        (
+            "CADUCEUS_RESULT_PATH".to_string(),
+            format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}"),
+        ),
     ];
     for name in &sandbox.pass_env {
         if let Ok(value) = std::env::var(name) {

--- a/src/executor/trusted_host.rs
+++ b/src/executor/trusted_host.rs
@@ -9,11 +9,12 @@ use std::pin::Pin;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::executor::{Executor, ExecutorSpec};
+use crate::executor::{Executor, ExecutorOutcome, ExecutorSpec};
 use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
 use crate::infra::error::CaduceusResult;
-use crate::worker::supervisor::{supervise, SupervisorOutcome};
+use crate::worker::supervisor::supervise;
+use crate::worker::worker_contract::WORKER_RESULT_FILE;
 
 /// Executor that dispatches workers on the trusted host via
 /// [`crate::worker::supervisor::supervise`].
@@ -33,7 +34,7 @@ impl Executor for TrustedHostExecutor {
     fn run<'a>(
         &'a self,
         spec: &'a ExecutorSpec,
-    ) -> Pin<Box<dyn Future<Output = CaduceusResult<SupervisorOutcome>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = CaduceusResult<ExecutorOutcome>> + Send + 'a>> {
         let self_exe: &'a Path = &spec.self_exe;
         let cfg: &'a Config = &self.cfg;
         let issue: &'a IssueKey = &spec.issue;
@@ -48,7 +49,7 @@ impl Executor for TrustedHostExecutor {
         let branch_name: &'a str = &spec.branch_name;
 
         Box::pin(async move {
-            supervise(
+            let outcome = supervise(
                 self_exe,
                 cfg,
                 issue,
@@ -62,7 +63,11 @@ impl Executor for TrustedHostExecutor {
                 labels,
                 branch_name,
             )
-            .await
+            .await?;
+            Ok(ExecutorOutcome {
+                outcome,
+                result_path: spec.worktree.join(WORKER_RESULT_FILE),
+            })
         })
     }
 }

--- a/src/infra/fixtures.rs
+++ b/src/infra/fixtures.rs
@@ -69,6 +69,7 @@ pub const CANONICAL_WORKER_ENV_VARS: &[&str] = &[
     "CADUCEUS_ISSUE_TITLE",
     "CADUCEUS_RUN_ID",
     "CADUCEUS_WORKTREE_PATH",
+    "CADUCEUS_RESULT_PATH",
 ];
 
 /// Default allowlist for the worker environment (the worker-result

--- a/src/worker/worker_contract.rs
+++ b/src/worker/worker_contract.rs
@@ -1,7 +1,43 @@
 //! Worker invocation and result schema.
 //!
-//! The bridge writes `<worktree>/worker-result.json` on exit 0. The
-//! daemon then [`parse_result_file`]s that file — opening it with
+//! # Normative worker filesystem contract
+//!
+//! The worker runs against a container filesystem with exactly
+//! three writable locations:
+//!
+//! * `/workspace` — read-write; bind-mounts the host worktree
+//!   (`CADUCEUS_WORKTREE_PATH`).
+//! * `/output` — read-write; bind-mounts the host run output
+//!   directory at `<state_dir>/oci-runs/<run_id>/output`.
+//! * `/tmp` — a bounded writable tmpfs; no size guarantee beyond
+//!   the container runtime's configured limit.
+//!
+//! Every other path is read-only or inaccessible; the worker must
+//! not depend on writing anywhere else.
+//!
+//! # Canonical `CADUCEUS_*` environment
+//!
+//! [`sanitized_env`] exports exactly these daemon-owned variables
+//! on every invocation (see also
+//! `crate::infra::fixtures::CANONICAL_WORKER_ENV_VARS`, mirrored by
+//! the bridge's `REQUIRED_ENV_VARS`):
+//!
+//! | Variable | Value |
+//! |---|---|
+//! | `CADUCEUS_BRANCH_NAME` | target branch name |
+//! | `CADUCEUS_CONTEXT_JSON` | serialised run context |
+//! | `CADUCEUS_ISSUE_BODY` | issue body |
+//! | `CADUCEUS_ISSUE_LABELS_JSON` | JSON array of issue labels |
+//! | `CADUCEUS_ISSUE_NUMBER` | issue number |
+//! | `CADUCEUS_ISSUE_REPO` | `owner/repo` |
+//! | `CADUCEUS_ISSUE_TITLE` | issue title |
+//! | `CADUCEUS_RUN_ID` | run identifier |
+//! | `CADUCEUS_WORKTREE_PATH` | host path of the mounted worktree |
+//! | `CADUCEUS_RESULT_PATH` | host result-file path (`<worktree>/worker-result.json`) |
+//!
+//! The bridge writes its result to `CADUCEUS_RESULT_PATH` (legacy
+//! fallback: `<worktree>/worker-result.json`). The daemon then
+//! [`parse_result_file`]s that file — opening it with
 //! `O_NOFOLLOW`, verifying the descriptor is a regular file, and
 //! reading with a 1 MiB cap before allocating the full document.
 //!
@@ -47,6 +83,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Container-side workspace mount target: read-write scratch and
+/// working directory bound to the host worktree. Normative for every
+/// containerized engine; see the module-level filesystem contract.
+pub const CONTAINER_WORKSPACE_PATH: &str = "/workspace";
+
+/// Container-side result-delivery mount target: read-write directory
+/// bound to the host run output directory. Normative for every
+/// containerized engine; see the module-level filesystem contract.
+pub const CONTAINER_OUTPUT_PATH: &str = "/output";
+
+/// File name of the worker result document, relative to
+/// `CADUCEUS_RESULT_PATH`'s parent on the host and to
+/// `CONTAINER_OUTPUT_PATH` inside the container.
+pub const WORKER_RESULT_FILE: &str = "worker-result.json";
 
 /// Hard cap on the worker-result file size.
 pub const MAX_RESULT_FILE_BYTES: u64 = 1 << 20; // 1 MiB
@@ -201,6 +252,7 @@ pub fn sanitized_env(
     // surface. A bad path or empty run id is a configuration
     // error, not a runtime error.
     let worktree_str = require_absolute_utf8_path(&inputs.worktree_path, "worktree_path")?;
+    let result_path_str = format!("{worktree_str}/worker-result.json");
     if inputs.run_id.trim().is_empty() {
         return Err(CaduceusError::Config(
             "run_id must not be empty".to_string(),
@@ -257,6 +309,7 @@ pub fn sanitized_env(
         ("CADUCEUS_ISSUE_REPO", &repo),
         ("CADUCEUS_ISSUE_LABELS_JSON", &labels_json),
         ("CADUCEUS_WORKTREE_PATH", &worktree_str),
+        ("CADUCEUS_RESULT_PATH", &result_path_str),
         ("CADUCEUS_RUN_ID", &inputs.run_id),
         ("CADUCEUS_BRANCH_NAME", &inputs.branch_name),
         ("CADUCEUS_CONTEXT_JSON", &inputs.context_json),

--- a/tests/architecture/docs_contract_test.rs
+++ b/tests/architecture/docs_contract_test.rs
@@ -628,3 +628,58 @@ fn camel_to_snake(s: &str) -> String {
 fn file_extension(path: &Path) -> Option<&OsStr> {
     path.extension()
 }
+
+// ---------------------------------------------------------------------------
+// Repository-search guard — the worker-result filename has a single
+// authority: `worker_contract::WORKER_RESULT_FILE`. Executors return
+// `ExecutorOutcome.result_path` and the daemon tick paths consume it,
+// so no daemon source may re-derive the path with a filesystem join.
+// ---------------------------------------------------------------------------
+
+fn collect_rs_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).unwrap_or_else(|err| panic!("read {}: {err}", dir.display())) {
+        let path = entry
+            .unwrap_or_else(|err| panic!("dir entry: {err}"))
+            .path();
+        if path.is_dir() {
+            collect_rs_sources(&path, out);
+        } else if path.extension() == Some(OsStr::new("rs")) {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn daemon_sources_never_join_worker_result_filename() {
+    let worker_contract = repo_root().join("src/worker/worker_contract.rs");
+    let mut sources = Vec::new();
+    collect_rs_sources(&repo_root().join("src"), &mut sources);
+    assert!(!sources.is_empty(), "expected Rust sources under src/");
+
+    let path_markers = ["join(", "PathBuf::from", "Path::new"];
+    let mut offenders: Vec<String> = Vec::new();
+    for path in &sources {
+        if path == &worker_contract {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(repo_root())
+            .unwrap_or(path)
+            .display()
+            .to_string();
+        let body = fs::read_to_string(path).unwrap_or_else(|err| panic!("read {rel}: {err}"));
+        for (idx, line) in body.lines().enumerate() {
+            if line.contains("worker-result.json")
+                && path_markers.iter().any(|marker| line.contains(marker))
+            {
+                offenders.push(format!("{rel}:{}", idx + 1));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "worker-result.json path construction must live only in \
+         worker_contract (use WORKER_RESULT_FILE / ExecutorOutcome.result_path); \
+         offenders: {offenders:?}"
+    );
+}

--- a/tests/daemon/per_claim_test.rs
+++ b/tests/daemon/per_claim_test.rs
@@ -359,6 +359,21 @@ async fn loop01_exit1_with_success_result_advances_to_awaiting_review() {
         "LOOP-01: attempts must not increment; got {}",
         entry.attempts
     );
+    // The daemon must persist the host-side result path it actually
+    // read (TrustedHost: `<worktree>/worker-result.json`) into the
+    // finalization checkpoint so resume never re-derives it.
+    let fin = entry
+        .finalization
+        .as_ref()
+        .expect("LOOP-01: finalization checkpoint must exist at AwaitingReview");
+    assert!(
+        fin.result_path
+            .file_name()
+            .map(|n| n == "worker-result.json")
+            .unwrap_or(false),
+        "LOOP-01: checkpoint result_path must be the host worker-result.json; got {:?}",
+        fin.result_path
+    );
     let fin = entry.finalization.expect("finalization present");
     assert_eq!(fin.stage, FinalizationStage::PrCreated);
     assert_eq!(fin.pr_number, Some(EXPECTED_PR_NUMBER));

--- a/tests/daemon/runtime_path_test.rs
+++ b/tests/daemon/runtime_path_test.rs
@@ -41,6 +41,7 @@ const DAEMON_ENV_VARS: &[&str] = &[
     "CADUCEUS_RUN_ID",
     "CADUCEUS_CONTEXT_JSON",
     "CADUCEUS_BRANCH_NAME",
+    "CADUCEUS_RESULT_PATH",
 ];
 
 #[test]

--- a/tests/executor/executor_trusted_host_test.rs
+++ b/tests/executor/executor_trusted_host_test.rs
@@ -3,6 +3,7 @@
 //! Verifies trait object-safety, dyn dispatch, input parity with
 //! `supervise`, and the subprocess-construction grep contract.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use caduceus::executor::trusted_host::TrustedHostExecutor;
@@ -122,5 +123,51 @@ fn worker_subprocess_construction_only_in_executor() {
     assert!(
         !oci_src.contains("tokio::process::Command"),
         "src/executor/oci.rs must not contain tokio::process::Command"
+    );
+}
+
+// SCN-01.5: trusted_host_run_reports_host_result_path
+
+/// `Executor::run` returns an `ExecutorOutcome` whose `result_path`
+/// is `<worktree>/worker-result.json` for the TrustedHost mode, so
+/// the tick loop reads the result without any Docker knowledge.
+/// This exercises the real supervisor subprocess (the built
+/// `caduceus` binary) with a trivially-succeeding worker.
+#[tokio::test]
+async fn trusted_host_run_reports_host_result_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = Config::test_defaults(tmp.path());
+    let worktree = tmp.path().join("worktree");
+    std::fs::create_dir_all(&worktree).expect("create worktree dir");
+
+    let spec = ExecutorSpec {
+        self_exe: PathBuf::from(env!("CARGO_BIN_EXE_caduceus")),
+        issue: issue_key(),
+        worktree: worktree.clone(),
+        run_id: "test-run-outcome".to_string(),
+        context_json: r#"{"x":1}"#.to_string(),
+        worker_command: vec!["/bin/true".to_string()],
+        cancellation: tokio_util::sync::CancellationToken::new(),
+        issue_title: "title".to_string(),
+        issue_body: "body".to_string(),
+        labels: Vec::new(),
+        branch_name: "automation/issue-1".to_string(),
+    };
+
+    let executor: Arc<dyn Executor> = Arc::new(TrustedHostExecutor::new(cfg));
+    let outcome = executor
+        .run(&spec)
+        .await
+        .expect("supervise must succeed for a trivially-succeeding worker");
+
+    assert!(
+        !outcome.outcome.timed_out && !outcome.outcome.cancelled,
+        "worker must not time out or be cancelled; got {:?}",
+        outcome.outcome
+    );
+    assert_eq!(
+        outcome.result_path,
+        worktree.join("worker-result.json"),
+        "TrustedHost result_path must be <worktree>/worker-result.json"
     );
 }

--- a/tests/executor/identity_resolution_test.rs
+++ b/tests/executor/identity_resolution_test.rs
@@ -26,7 +26,8 @@ fn rendered_for(engine: SandboxEngine, mode: EngineMode) -> (Config, Vec<String>
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let mut runtime = support::runtime_facts(&cfg, "run-001", &worktree);
     runtime.engine_mode = mode;
-    let spec = resolve(cfg.sandbox(), &runtime).expect("facts must resolve");
+    let spec = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect("facts must resolve");
     (cfg, render(&spec, engine))
 }
 
@@ -103,7 +104,8 @@ fn identity_never_assumes_1000() {
         cfg.sandbox.as_mut().expect("sandbox").engine = engine;
         let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
         let runtime = support::runtime_facts(&cfg, "run-001", &worktree);
-        let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+        let spec = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+            .expect("must resolve");
         assert_eq!(spec.identity().uid, 4242, "{engine:?}/{mode:?}");
         assert_eq!(spec.identity().gid, 4242, "{engine:?}/{mode:?}");
 

--- a/tests/executor/isolation_escape_test.rs
+++ b/tests/executor/isolation_escape_test.rs
@@ -21,7 +21,7 @@ mod support;
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let runtime = support::runtime_facts(cfg, "run-001", &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 fn default_cfg() -> Config {

--- a/tests/executor/network_isolation_test.rs
+++ b/tests/executor/network_isolation_test.rs
@@ -15,7 +15,7 @@ mod support;
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let runtime = support::runtime_facts(cfg, "run-001", &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 fn default_cfg() -> Config {

--- a/tests/executor/oci_args_test.rs
+++ b/tests/executor/oci_args_test.rs
@@ -18,7 +18,7 @@ mod support;
 fn resolve_from(cfg: &Config, run_id: &str) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join(run_id);
     let runtime = support::runtime_facts(cfg, run_id, &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 fn default_cfg() -> Config {
@@ -77,7 +77,8 @@ fn one_contract_both_clis() {
 fn undeclared_mount_rejected() {
     let cfg = default_cfg();
     let runtime = support::runtime_facts(&cfg, "run-002", Path::new("/tmp/worktree"));
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("undeclared worktree must be rejected");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("undeclared worktree must be rejected");
     assert!(
         matches!(
             err,

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -55,6 +55,25 @@ fn engine_binary(engine: SandboxEngine) -> String {
     engine.binary_name().to_string()
 }
 
+/// Build an `ExecutorSpec` fixture mirroring the live runtime facts.
+fn executor_spec_for(
+    runtime: &caduceus::executor::sandbox_spec::RuntimeFacts,
+) -> caduceus::executor::ExecutorSpec {
+    caduceus::executor::ExecutorSpec {
+        self_exe: PathBuf::from("/proc/self/exe"),
+        issue: runtime.issue.clone(),
+        worktree: runtime.worktree.clone(),
+        run_id: runtime.run_id.clone(),
+        context_json: "{}".to_string(),
+        worker_command: runtime.worker_command.clone(),
+        cancellation: tokio_util::sync::CancellationToken::new(),
+        issue_title: "Fix login bug".to_string(),
+        issue_body: "Steps to reproduce".to_string(),
+        labels: vec!["bug".to_string()],
+        branch_name: "caduceus/owner/repo#1".to_string(),
+    }
+}
+
 /// The host's actual engine and mode. Returns `None` when no engine
 /// binary is usable — the caller skips with a notice.
 fn detect_engine() -> Option<(SandboxEngine, EngineMode)> {
@@ -161,7 +180,8 @@ fn live_fixture(kind: GitShadowKind, container_script: &str) -> LiveFixture {
     }
     std::fs::create_dir_all(&runtime.output_dir).expect("create output dir");
 
-    let spec = resolve(cfg.sandbox(), &runtime).expect("live facts must resolve");
+    let spec = resolve(cfg.sandbox(), &runtime, &executor_spec_for(&runtime))
+        .expect("live facts must resolve");
     let argv = render(&spec, engine);
     LiveFixture {
         _tmp: tmp,

--- a/tests/executor/oci_label_test.rs
+++ b/tests/executor/oci_label_test.rs
@@ -22,7 +22,7 @@ fn test_cfg() -> Config {
 fn resolve_from(cfg: &Config, run_id: &str) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join(run_id);
     let runtime = support::runtime_facts(cfg, run_id, &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 // stable_labels_across_calls (AC-05)

--- a/tests/executor/policy_test.rs
+++ b/tests/executor/policy_test.rs
@@ -17,7 +17,7 @@ mod support;
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let runtime = support::runtime_facts(cfg, "run-001", &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 fn default_cfg() -> Config {

--- a/tests/executor/resource_limit_test.rs
+++ b/tests/executor/resource_limit_test.rs
@@ -17,7 +17,7 @@ mod support;
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let runtime = support::runtime_facts(cfg, "run-001", &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 fn default_cfg() -> Config {

--- a/tests/executor/sandbox_renderer_test.rs
+++ b/tests/executor/sandbox_renderer_test.rs
@@ -19,6 +19,27 @@ use caduceus::infra::config::{Config, SandboxConfig, SandboxNetwork};
 /// Fixed root for the golden fixtures. Never touched on disk.
 const ROOT: &str = "/tmp/caduceus-renderer-goldens";
 
+/// Build an `ExecutorSpec` fixture mirroring the runtime facts, with
+/// fixed representative canonical values (title/body/labels/branch/
+/// context) that the environment goldens interpolate.
+fn executor_spec_for(
+    runtime: &caduceus::executor::sandbox_spec::RuntimeFacts,
+) -> caduceus::executor::ExecutorSpec {
+    caduceus::executor::ExecutorSpec {
+        self_exe: PathBuf::from("/proc/self/exe"),
+        issue: runtime.issue.clone(),
+        worktree: runtime.worktree.clone(),
+        run_id: runtime.run_id.clone(),
+        context_json: "{}".to_string(),
+        worker_command: runtime.worker_command.clone(),
+        cancellation: tokio_util::sync::CancellationToken::new(),
+        issue_title: "Fix login bug".to_string(),
+        issue_body: "Steps to reproduce".to_string(),
+        labels: vec!["bug".to_string()],
+        branch_name: "caduceus/owner/repo#1".to_string(),
+    }
+}
+
 /// Resolve a fixture spec from `Config::test_defaults` with an
 /// optional sandbox mutation and runtime-fact overrides. Returns the
 /// spec plus the host paths the goldens interpolate into mount args.
@@ -56,8 +77,12 @@ fn fixture_with(
             .join(run_id)
             .join("git-shadow"),
     };
-    let spec = caduceus::executor::sandbox_spec::resolve(cfg.sandbox(), &runtime)
-        .expect("fixture must resolve");
+    let spec = caduceus::executor::sandbox_spec::resolve(
+        cfg.sandbox(),
+        &runtime,
+        &executor_spec_for(&runtime),
+    )
+    .expect("fixture must resolve");
     (
         spec,
         worktree,
@@ -113,6 +138,24 @@ fn docker_rootful_golden_argv() {
         "CADUCEUS_RUN_ID=run-001".to_string(),
         "-e".to_string(),
         "CADUCEUS_ISSUE_ID=owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_NUMBER=1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_REPO=owner/repo".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_TITLE=Fix login bug".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_BODY=Steps to reproduce".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_LABELS_JSON=[\"bug\"]".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_CONTEXT_JSON={}".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_BRANCH_NAME=caduceus/owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_WORKTREE_PATH=/workspace".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_RESULT_PATH=/output/worker-result.json".to_string(),
         "-l".to_string(),
         "caduceus.daemon_id=test-daemon".to_string(),
         "-l".to_string(),
@@ -168,6 +211,24 @@ fn podman_rootless_golden_argv() {
         "CADUCEUS_RUN_ID=run-001".to_string(),
         "-e".to_string(),
         "CADUCEUS_ISSUE_ID=owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_NUMBER=1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_REPO=owner/repo".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_TITLE=Fix login bug".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_BODY=Steps to reproduce".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_LABELS_JSON=[\"bug\"]".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_CONTEXT_JSON={}".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_BRANCH_NAME=caduceus/owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_WORKTREE_PATH=/workspace".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_RESULT_PATH=/output/worker-result.json".to_string(),
         "-l".to_string(),
         "caduceus.daemon_id=test-daemon".to_string(),
         "-l".to_string(),
@@ -353,6 +414,48 @@ fn renders_environment() {
     assert!(argv.iter().any(|a| a == "-e"));
     assert!(argv.iter().any(|a| a == "CADUCEUS_RUN_ID=run-001"));
     assert!(argv.iter().any(|a| a == "CADUCEUS_ISSUE_ID=owner/repo#1"));
+}
+
+/// The full canonical `CADUCEUS_*` set is emitted as `-e` entries in
+/// canonical order, with the container-side worktree/result paths
+/// (issue #243). No credential variable is ever emitted.
+#[test]
+fn renders_canonical_environment_entries() {
+    let (spec, _, _, _, _) = default_fixture();
+    let argv = render(&spec, SandboxEngine::Docker);
+    let expected: &[&str] = &[
+        "CADUCEUS_RUN_ID=run-001",
+        "CADUCEUS_ISSUE_ID=owner/repo#1",
+        "CADUCEUS_ISSUE_NUMBER=1",
+        "CADUCEUS_ISSUE_REPO=owner/repo",
+        "CADUCEUS_ISSUE_TITLE=Fix login bug",
+        "CADUCEUS_ISSUE_BODY=Steps to reproduce",
+        "CADUCEUS_ISSUE_LABELS_JSON=[\"bug\"]",
+        "CADUCEUS_CONTEXT_JSON={}",
+        "CADUCEUS_BRANCH_NAME=caduceus/owner/repo#1",
+        "CADUCEUS_WORKTREE_PATH=/workspace",
+        "CADUCEUS_RESULT_PATH=/output/worker-result.json",
+    ];
+    let env_entries: Vec<&String> = argv.iter().filter(|a| a.starts_with("CADUCEUS_")).collect();
+    assert_eq!(
+        env_entries
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>(),
+        expected,
+        "canonical -e entries must be present in canonical order"
+    );
+    assert!(
+        !env_entries
+            .iter()
+            .any(|a| a.contains("TOKEN") || a.contains("SECRET")),
+        "no credential -e entry may be emitted: {env_entries:?}"
+    );
+    // Host paths must never leak into the rendered environment.
+    assert!(
+        !env_entries.iter().any(|a| a.contains(ROOT)),
+        "host paths must not appear in container env entries: {env_entries:?}"
+    );
 }
 
 #[test]

--- a/tests/executor/sandbox_resolve_test.rs
+++ b/tests/executor/sandbox_resolve_test.rs
@@ -45,7 +45,8 @@ fn rejects_non_digest_image() {
     let (mut cfg, worktree) = base();
     cfg.sandbox.as_mut().expect("sandbox").image = "caduceus-worker:latest".to_string();
     let runtime = runtime_for(&cfg, &worktree);
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     match err {
         CaduceusError::OciImageNotDigestPinned { reference } => {
             assert_eq!(reference, "caduceus-worker:latest");
@@ -60,7 +61,8 @@ fn rejects_pull_policy_always_with_digest() {
     let (mut cfg, worktree) = base();
     cfg.sandbox.as_mut().expect("sandbox").pull_policy = OciPullPolicy::Always;
     let runtime = runtime_for(&cfg, &worktree);
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     match err {
         CaduceusError::OciPullPolicyIncompatible { .. } => {}
         other => panic!("expected OciPullPolicyIncompatible; got: {other:?}"),
@@ -72,7 +74,8 @@ fn rejects_pull_policy_always_with_digest() {
 fn rejects_worktree_outside_workdir_base() {
     let (cfg, _) = base();
     let runtime = runtime_for(&cfg, Path::new("/tmp/elsewhere/worktree"));
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     match err {
         CaduceusError::OciUndeclaredMount { path } => {
             assert!(
@@ -92,7 +95,8 @@ fn rejects_output_outside_state_dir() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.output_dir = PathBuf::from("/tmp/elsewhere/result");
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciUndeclaredMount { .. }),
         "expected OciUndeclaredMount; got: {err:?}"
@@ -105,7 +109,8 @@ fn rejects_output_outside_state_dir() {
 fn rejects_relative_worktree() {
     let (cfg, _) = base();
     let runtime = runtime_for(&cfg, Path::new("relative/worktree"));
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciUndeclaredMount { .. }),
         "expected OciUndeclaredMount; got: {err:?}"
@@ -118,7 +123,8 @@ fn rejects_output_equal_to_worktree() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.output_dir = worktree.clone();
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     match err {
         CaduceusError::OciMountConflict { detail } => {
             assert!(
@@ -137,7 +143,8 @@ fn rejects_output_containing_worktree() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.output_dir = worktree.parent().expect("parent").to_path_buf();
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciMountConflict { .. }),
         "expected OciMountConflict; got: {err:?}"
@@ -154,7 +161,8 @@ fn rejects_state_dir_inside_workdir_base() {
     cfg.state_dir = cfg.workdir_base.join("state");
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let runtime = support::runtime_facts(&cfg, "run-001", &worktree);
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciMountConflict { .. }),
         "expected OciMountConflict; got: {err:?}"
@@ -169,7 +177,8 @@ fn rejects_shadow_overlapping_output_or_worktree() {
     // shadow == output_dir
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.git_shadow_host = runtime.output_dir.clone();
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciMountConflict { .. }),
         "expected OciMountConflict for shadow == output; got: {err:?}"
@@ -179,7 +188,8 @@ fn rejects_shadow_overlapping_output_or_worktree() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.git_shadow_host = worktree.join(".git-shadow");
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     assert!(
         matches!(err, CaduceusError::OciMountConflict { .. }),
         "expected OciMountConflict for shadow inside worktree; got: {err:?}"
@@ -197,7 +207,8 @@ fn rejects_shadow_overlapping_output_or_worktree() {
 fn resolves_owner_identity() {
     let (cfg, worktree) = base();
     let runtime = runtime_for(&cfg, &worktree);
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     assert_eq!(
         spec.identity(),
         ResolvedIdentity {
@@ -217,7 +228,8 @@ fn resolves_owner_identity() {
 fn resolves_canonical_container_paths() {
     let (cfg, worktree) = base();
     let runtime = runtime_for(&cfg, &worktree);
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
 
     let ws = spec.workspace_mount();
     assert_eq!(ws.host_path, worktree);
@@ -235,8 +247,8 @@ fn resolves_canonical_container_paths() {
 }
 
 /// (g) pass_env filtering — names present in the process environment
-/// are appended after the two CADUCEUS_* entries, in config order;
-/// unset names are skipped.
+/// are appended after the full canonical CADUCEUS_* set, in config
+/// order; unset names are skipped.
 #[test]
 fn pass_env_filtering() {
     struct EnvGuard(&'static str);
@@ -259,7 +271,8 @@ fn pass_env_filtering() {
         "CADUCEUS_RESOLVE_TEST_UNSET".to_string(),
     ];
     let runtime = runtime_for(&cfg, &worktree);
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     let env = spec.environment();
     assert_eq!(
         env[0],
@@ -269,17 +282,85 @@ fn pass_env_filtering() {
         env[1],
         ("CADUCEUS_ISSUE_ID".to_string(), "owner/repo#1".to_string())
     );
+    // The 11 canonical entries precede the pass_env entries.
+    let canonical_tail = &env[11..];
     assert_eq!(
-        env[2],
-        (
+        canonical_tail,
+        &[(
             "CADUCEUS_RESOLVE_TEST_PASS_ENV".to_string(),
             "present-value".to_string()
-        )
+        ),]
     );
     assert_eq!(
         env.len(),
-        3,
+        12,
         "unset pass_env names must be skipped, got: {env:?}"
+    );
+}
+
+/// (g') The resolved environment carries the FULL canonical
+/// `CADUCEUS_*` set with CONTAINER-side path values: worktree and
+/// result paths are the fixed container paths, never the host
+/// worktree/output paths, and the remaining canonical variables
+/// mirror the spec inputs exactly (issue #243).
+#[test]
+fn resolves_full_canonical_environment_with_container_paths() {
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.run_id = "run-100".to_string();
+    runtime.issue = IssueKey::parse("octocat/hello#42").expect("valid key");
+    let spec_input = caduceus::executor::ExecutorSpec {
+        self_exe: PathBuf::from("/proc/self/exe"),
+        issue: runtime.issue.clone(),
+        worktree: worktree.clone(),
+        run_id: "run-100".to_string(),
+        context_json: "{\"context\":true}".to_string(),
+        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
+        cancellation: tokio_util::sync::CancellationToken::new(),
+        issue_title: "A title".to_string(),
+        issue_body: "A body\nwith newline".to_string(),
+        labels: vec!["p1".to_string(), "p2".to_string()],
+        branch_name: "caduceus/octocat/hello#42".to_string(),
+    };
+    let resolved = resolve(cfg.sandbox(), &runtime, &spec_input).expect("must resolve");
+    let env = resolved.environment();
+
+    let expected: &[(&str, String)] = &[
+        ("CADUCEUS_RUN_ID", "run-100".to_string()),
+        ("CADUCEUS_ISSUE_ID", "octocat/hello#42".to_string()),
+        ("CADUCEUS_ISSUE_NUMBER", "42".to_string()),
+        ("CADUCEUS_ISSUE_REPO", "octocat/hello".to_string()),
+        ("CADUCEUS_ISSUE_TITLE", "A title".to_string()),
+        ("CADUCEUS_ISSUE_BODY", "A body\nwith newline".to_string()),
+        ("CADUCEUS_ISSUE_LABELS_JSON", "[\"p1\",\"p2\"]".to_string()),
+        ("CADUCEUS_CONTEXT_JSON", "{\"context\":true}".to_string()),
+        (
+            "CADUCEUS_BRANCH_NAME",
+            "caduceus/octocat/hello#42".to_string(),
+        ),
+        // Container-side paths, never host paths.
+        ("CADUCEUS_WORKTREE_PATH", "/workspace".to_string()),
+        (
+            "CADUCEUS_RESULT_PATH",
+            "/output/worker-result.json".to_string(),
+        ),
+    ];
+    assert_eq!(env.len(), expected.len(), "exactly the canonical set");
+    for (entry, (key, value)) in env.iter().zip(expected.iter()) {
+        assert_eq!(entry.0, *key);
+        assert_eq!(&entry.1, value);
+    }
+    assert!(
+        !env.iter().any(|entry| entry.0.contains("TOKEN")
+            || entry.0.contains("SECRET")
+            || entry.0.contains("GITHUB_TOKEN")),
+        "no credential variable may be emitted: {env:?}"
+    );
+    // Host paths must not leak into the container environment.
+    let host_worktree = worktree.display().to_string();
+    assert!(
+        !env.iter().any(|(_, v)| v.contains(&host_worktree)),
+        "host worktree path must not appear in container env, got: {env:?}"
     );
 }
 
@@ -291,7 +372,8 @@ fn resolves_labels_in_fixed_order() {
     runtime.run_id = "run-007".to_string();
     runtime.issue = IssueKey::parse("owner/repo#7").expect("valid key");
     runtime.daemon_id = "daemon-42".to_string();
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     assert_eq!(
         spec.labels(),
         &[
@@ -308,7 +390,8 @@ fn resolves_labels_in_fixed_order() {
 fn resolution_yields_fully_populated_spec() {
     let (cfg, worktree) = base();
     let runtime = runtime_for(&cfg, &worktree);
-    let spec: SandboxSpec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec: SandboxSpec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     assert!(!spec.name().is_empty());
     assert!(spec.image().contains("@sha256:"));
     assert!(!spec.command().is_empty());
@@ -330,7 +413,8 @@ fn tmpfs_sizes_from_resources() {
     cfg.sandbox.as_mut().expect("sandbox").resources.tmpfs_mb = 512;
     cfg.sandbox.as_mut().expect("sandbox").resources.shm_mb = 96;
     let runtime = runtime_for(&cfg, &worktree);
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     assert_eq!(spec.tmpfs()[0].target, "/tmp");
     assert_eq!(spec.tmpfs()[0].size_mb, 512);
     assert_eq!(spec.tmpfs()[1].target, "/dev/shm");
@@ -366,7 +450,8 @@ fn resolve_wires_git_shadow_per_kind() {
         let (cfg, worktree) = base();
         let mut runtime = runtime_for(&cfg, &worktree);
         runtime.git_shadow_kind = kind;
-        let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+        let spec = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+            .expect("must resolve");
         let shadow = spec.git_shadow().expect("shadow must be present");
         assert_eq!(shadow.host_path, support::git_shadow_host(&cfg, "run-001"));
         assert_eq!(shadow.container_path, PathBuf::from("/workspace/.git"));
@@ -377,7 +462,8 @@ fn resolve_wires_git_shadow_per_kind() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.git_shadow_kind = GitShadowKind::Absent;
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     assert!(
         spec.git_shadow().is_none(),
         "absent .git must yield no shadow"
@@ -396,7 +482,8 @@ fn resolve_wires_git_shadow_per_kind() {
 fn writable_surface_invariant_holds() {
     let (cfg, worktree) = base();
     let runtime = runtime_for(&cfg, &worktree);
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
 
     let ws = spec.workspace_mount();
     assert_eq!(ws.container_path, PathBuf::from("/workspace"));
@@ -440,7 +527,8 @@ fn extra_writable_host_paths_are_rejected_at_resolution() {
     // host-backed mount.
     let (cfg, worktree) = base();
     let runtime = runtime_for(&cfg, &worktree);
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     let mut rw_container_paths: Vec<PathBuf> = vec![
         spec.workspace_mount().container_path.clone(),
         spec.output_mount().container_path.clone(),
@@ -462,7 +550,8 @@ fn extra_writable_host_paths_are_rejected_at_resolution() {
     cfg.state_dir = cfg.workdir_base.join("state");
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let runtime = support::runtime_facts(&cfg, "run-001", &worktree);
-    let err = resolve(cfg.sandbox(), &runtime).expect_err("must reject");
+    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect_err("must reject");
     match err {
         CaduceusError::OciMountConflict { detail } => {
             assert!(
@@ -482,7 +571,8 @@ fn engine_mode_fact_flows_into_identity() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.engine_mode = EngineMode::Rootless;
-    let spec = resolve(cfg.sandbox(), &runtime).expect("must resolve");
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
     assert_eq!(spec.identity().uid, 4242);
     assert_eq!(spec.identity().gid, 4242);
     assert!(!spec.identity().emit_user, "rootless emits no --user");

--- a/tests/executor/secret_grant_test.rs
+++ b/tests/executor/secret_grant_test.rs
@@ -22,7 +22,7 @@ fn default_cfg() -> Config {
 fn resolve_from(cfg: &Config) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
     let runtime = support::runtime_facts(cfg, "run-001", &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 // render_does_not_emit_secret_env_file — the plain renderer emits no

--- a/tests/executor/support/mod.rs
+++ b/tests/executor/support/mod.rs
@@ -54,3 +54,23 @@ pub fn runtime_facts(cfg: &Config, run_id: &str, worktree: &Path) -> RuntimeFact
         git_shadow_host: git_shadow_host(cfg, run_id),
     }
 }
+
+/// Build an `ExecutorSpec` fixture whose identity fields mirror the
+/// `RuntimeFacts` defaults: same run id and issue key, with fixed
+/// representative title/body/labels/branch/context values. Tests
+/// needing non-default spec inputs mutate the returned struct.
+pub fn executor_spec(runtime: &RuntimeFacts) -> caduceus::executor::ExecutorSpec {
+    caduceus::executor::ExecutorSpec {
+        self_exe: PathBuf::from("/proc/self/exe"),
+        issue: runtime.issue.clone(),
+        worktree: runtime.worktree.clone(),
+        run_id: runtime.run_id.clone(),
+        context_json: "{\"key\":\"value\"}".to_string(),
+        worker_command: runtime.worker_command.clone(),
+        cancellation: tokio_util::sync::CancellationToken::new(),
+        issue_title: "Fix the thing".to_string(),
+        issue_body: "Body text".to_string(),
+        labels: vec!["bug".to_string()],
+        branch_name: "caduceus/owner/repo#1".to_string(),
+    }
+}

--- a/tests/executor/tamper_test.rs
+++ b/tests/executor/tamper_test.rs
@@ -21,7 +21,7 @@ fn default_cfg() -> Config {
 fn resolve_from(cfg: &Config, run_id: &str) -> SandboxSpec {
     let worktree = cfg.workdir_base.join("owner").join("repo").join(run_id);
     let runtime = support::runtime_facts(cfg, run_id, &worktree);
-    resolve(cfg.sandbox(), &runtime).expect("must resolve")
+    resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve")
 }
 
 // tamper_modified_files — an undeclared host path is rejected
@@ -38,7 +38,7 @@ fn tamper_modified_files() {
         "tamper-modified-files",
         std::path::Path::new("/tmp/worktree"),
     );
-    let result = resolve(cfg.sandbox(), &runtime);
+    let result = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime));
     match result {
         Err(CaduceusError::OciUndeclaredMount { path }) => {
             assert!(

--- a/tests/integration/bridge_test.py
+++ b/tests/integration/bridge_test.py
@@ -32,6 +32,7 @@ REQUIRED_ENV_KEYS = (
     "CADUCEUS_RUN_ID",
     "CADUCEUS_ISSUE_LABELS_JSON",
     "CADUCEUS_BRANCH_NAME",
+    "CADUCEUS_RESULT_PATH",
 )
 
 
@@ -72,6 +73,7 @@ def fake_env(tmp_path: Path) -> dict:
         "CADUCEUS_RUN_ID": "01J0X0X0X0X0X0X0X0X0X0X0X",
         "CADUCEUS_ISSUE_LABELS_JSON": json.dumps(["🤖 auto-fix", "good first issue"]),
         "CADUCEUS_BRANCH_NAME": "automation/issue-42-01j0x0x0x0x0x0x0x0x0x0x",
+        "CADUCEUS_RESULT_PATH": str(worktree / "worker-result.json"),
     }
 
 
@@ -355,7 +357,7 @@ class TestMain:
     def test_bridge_passes_env_validation_with_full_set(
         self, bridge_module, monkeypatch, fake_env
     ):
-        """When all 9 CADUCEUS_* vars are present, validation passes and the
+        """When all 10 CADUCEUS_* vars are present, validation passes and the
         bridge reaches invoke_harness.
         """
         captured = {}
@@ -483,6 +485,7 @@ def _build_env(tmp_path: Path, **overrides: str) -> dict:
         "CADUCEUS_RUN_ID": "01J0X0X0X0X0X0X0X0X0X0X0X",
         "CADUCEUS_ISSUE_LABELS_JSON": json.dumps(["🤖 auto-fix", "good first issue"]),
         "CADUCEUS_BRANCH_NAME": "automation/issue-42-01j0x0x0x0x0x0x0x0x0x0x",
+        "CADUCEUS_RESULT_PATH": str(tmp_path / "worker-result.json"),
     }
     env.update({k: v for k, v in overrides.items() if v is not None})
     return env
@@ -1061,3 +1064,125 @@ class TestNewContract:
             env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
         ) == 0
         assert result_path.read_text(encoding="utf-8") == payload_text
+
+
+# ---------------------------------------------------------------------------
+# 9. CADUCEUS_RESULT_PATH resolution — soft-required override + fallback
+# ---------------------------------------------------------------------------
+
+
+class TestResultPathResolution:
+    """``CADUCEUS_RESULT_PATH`` is soft-required: when set it wins,
+    when unset the bridge falls back to the legacy worktree-relative
+    path with a stderr warning instead of aborting."""
+
+    def test_soft_required_result_path_missing_does_not_abort(
+        self, bridge_module, fake_env
+    ):
+        env = dict(fake_env)
+        env.pop("CADUCEUS_RESULT_PATH")
+        result = bridge_module.read_required_env(env)
+        # The hard check passes; only the soft name is absent.
+        assert "CADUCEUS_RESULT_PATH" not in result
+        assert "CADUCEUS_ISSUE_NUMBER" in result
+
+    def test_hard_required_vars_still_abort_when_result_path_missing(
+        self, bridge_module, fake_env, capsys
+    ):
+        env = dict(fake_env)
+        env.pop("CADUCEUS_RESULT_PATH")
+        env.pop("CADUCEUS_RUN_ID")
+        with pytest.raises(SystemExit) as excinfo:
+            bridge_module.read_required_env(env)
+        assert excinfo.value.code == bridge_module.EXIT_MISSING_ENV
+        err = capsys.readouterr().err
+        assert "CADUCEUS_RUN_ID" in err
+        # The soft-required name is never listed as a hard failure.
+        assert "CADUCEUS_RESULT_PATH" not in err
+
+    def test_synthesis_writes_at_caduceus_result_path(
+        self, bridge_module, tmp_path, monkeypatch
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        # A distinct path whose parent directories do not exist yet —
+        # mirrors a freshly mounted `/output` directory.
+        result_path = tmp_path / "out" / "results" / "worker-result.json"
+        monkeypatch.setenv("CADUCEUS_RESULT_PATH", str(result_path))
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "print('routed to override path')"]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 0
+        assert result_path.exists()
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        assert result["status"] == "success"
+        assert "routed to override path" in result["summary"]
+        # The legacy worktree location stays untouched.
+        assert not (worktree / "worker-result.json").exists()
+
+    def test_post_hook_exist_check_honors_result_path_override(
+        self, bridge_module, tmp_path, monkeypatch
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        result_path = tmp_path / "out" / "worker-result.json"
+        result_path.parent.mkdir(parents=True)
+        payload = {
+            "status": "success",
+            "summary": "pre-written",
+            "commit_message": "feat: pre-written",
+            "pull_request_title": "feat: pre-written",
+            "artifacts": {},
+            "investigation": False,
+        }
+        payload_text = json.dumps(payload, ensure_ascii=False)
+        result_path.write_text(payload_text, encoding="utf-8")
+        monkeypatch.setenv("CADUCEUS_RESULT_PATH", str(result_path))
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "print('harness ran')"]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 0
+        # The exist-check resolved the override path, saw the direct
+        # write, and did NOT overwrite it with a synthesized result.
+        assert result_path.read_text(encoding="utf-8") == payload_text
+
+    def test_unset_result_path_falls_back_to_legacy_with_warning(
+        self, bridge_module, tmp_path, monkeypatch, capsys
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.delenv("CADUCEUS_RESULT_PATH", raising=False)
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "print('legacy fallback')"]
+            """,
+        )
+
+        assert bridge_module.main(
+            env=_new_contract_env(worktree, hermes_home), argv=["bridge"]
+        ) == 0
+        # The legacy worktree-relative path received the result.
+        result = json.loads(
+            (worktree / "worker-result.json").read_text(encoding="utf-8")
+        )
+        assert result["status"] == "success"
+        # A visible but non-fatal fallback warning reached stderr.
+        err = capsys.readouterr().err
+        assert "CADUCEUS_RESULT_PATH is not set" in err
+        assert "falling back" in err


### PR DESCRIPTION
Implemented the agent-neutral worker execution contract and OCI result boundary (issue #243).

- Added `CADUCEUS_RESULT_PATH` as the 10th canonical `CADUCEUS_*` worker env var in `src/infra/fixtures.rs` and bumped the bridge's `REQUIRED_ENV_VARS` to match; both are cross-pinned by `tests/architecture/docs_contract_test.rs`.
- Documented the agent-neutral worker filesystem contract (`/workspace` RW, `/output` RW, bounded `/tmp`) in `src/worker/worker_contract.rs` with named constants; host paths are never exposed to containerized workers.
- `sanitized_env()` now emits `CADUCEUS_RESULT_PATH=<worktree>/worker-result.json` for TrustedHost with byte-for-byte unchanged behaviour.
- Introduced `ExecutorOutcome { outcome, result_path }` so the executor exposes the host-side result path; `per_claim` and the resume checkpoint read the worker result exclusively from that path, keeping the tick loop engine-agnostic (TrustedHost path unchanged end-to-end).
- OCI `sandbox_spec::resolve` now injects the full canonical env with container-side values (`CADUCEUS_WORKTREE_PATH=/workspace`, `CADUCEUS_RESULT_PATH=/output/worker-result.json`); `sandbox_renderer` emits all `-e` entries; no host path or credential var leaks into the container.
- The bundled bridge honours `CADUCEUS_RESULT_PATH` with a legacy fallback; synthesis and the post-hook use the same resolution; legacy full-script copies are untouched.
- Tests added: Rust (OCI env mapping with container paths, result-path resolution for both modes, a guard proving the daemon never joins `worker-result.json` outside the contract module) and Python (bridge `CADUCEUS_RESULT_PATH` resolution + fallback). `cargo test` reports 819 passed with 1 known pre-existing environmental failure (`release_binary_canary`, the hermes `doctor` subcommand absent in this sandbox); `pytest` reports 157 passed with 9 known pre-existing environmental failures (machine harness contamination without `HERMES_HOME`), both confirmed unchanged by reverting this change.

Closes #243

Artifacts (5):

```json
{
  "archive": "openspec/changes/archive/2026-08-28-oci-worker-contract",
  "capabilities": [
    "worker-filesystem-contract",
    "worker-env-contract",
    "worker-result-channel"
  ],
  "change": "oci-worker-contract",
  "python_tests": "157 passed, 9 known pre-existing environmental failures",
  "rust_tests": "819 passed, 1 known pre-existing environmental failure"
}
```

<!-- caduceus-pr-body:run=01M13NW9PXQ6Z3K2ECHC1MWYQV -->