### PR TITLE
feat(oci): hardened resource/security baseline + disk-pressure watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   config, and the `Caduceus Daemon <caduceus@daemon.local>` fallback. Closes
   #210.
 
+### Breaking
+
+- **Host networking removed from the OCI sandbox.** The `unrestricted`
+  value of `sandbox.network` (and the `--network host` argv it rendered)
+  no longer exists: host networking is structurally unrepresentable, and a
+  config carrying `network: unrestricted` fails at load with a typed
+  unknown-variant error. Migration: set `network: none` (the only value).
+- **`sandbox.reserved_host_disk_mb: 0` now disables the host disk-pressure
+  watchdog** (previously rejected as invalid). Any positive value is the
+  free-space floor in MB (default `2048`); `0` means no sampling and no
+  enforcement. Closes #245.
+
+### Added
+
+- **Hardened per-run OCI baseline** (non-weakenable, both engines):
+  `--memory-swap` pinned equal to `--memory` (no swap doubling), bounded
+  engine logs (`--log-opt max-size=10m max-file=3`), explicit resolve-time
+  denial of devices, engine/runtime socket mounts, and host namespace
+  sharing, bounded daemon-side diagnostic log capture (1 MiB cap) under
+  `<state_dir>/oci-runs/<run_id>/engine.log`, and resource floors
+  `tmpfs_mb >= 1` / `shm_mb >= 1` so a zero tmpfs size cannot silently
+  apply an engine-default unbounded size.
+- **Host disk-pressure watchdog.** `sandbox.reserved_host_disk_mb` is now
+  consumed as a free-space floor sampled every 30 s across the
+  device-ID-deduped filesystems hosting the state dir, repo storage, and
+  OCI output dirs. On breach, in-flight OCI work is terminated via the
+  existing stop path and new OCI dispatch is refused with a typed
+  `OciDiskPressure` error until the reserve recovers (256 MiB hysteresis).
+  This is a host-level mitigation — `/workspace` remains a host bind mount
+  with no per-container byte quota.
+
 ## [1.0.0] - 2026-08-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,14 @@ name = "cancellation_test"
 path = "tests/executor/cancellation_test.rs"
 
 [[test]]
+name = "disk_test"
+path = "tests/infra/disk_test.rs"
+
+[[test]]
+name = "oci_lifecycle_stub_test"
+path = "tests/executor/oci_lifecycle_stub_test.rs"
+
+[[test]]
 name = "tamper_test"
 path = "tests/executor/tamper_test.rs"
 

--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ sandbox:
   image: "caduceus-worker@sha256:<64 lowercase hex>"  # required, no default
   pull_policy: if_missing   # never | if_missing | always
   resources: { cpus: 2.0, memory_mb: 2048, pids: 256, tmpfs_mb: 256, shm_mb: 64 }
-  network: none             # none | unrestricted
+  network: none             # only value; host networking was removed (breaking)
   pass_env: []
   stop_timeout_seconds: 10
   kill_timeout_seconds: 5
   reconcile_timeout_seconds: 60
-  reserved_host_disk_mb: 2048
+  reserved_host_disk_mb: 2048  # 0 disables the disk-pressure watchdog
 ```
 
 TrustedHost configs (the default) may omit `sandbox:`
@@ -217,6 +217,79 @@ What the worker container sees is a closed, typed spec:
   be determined) are refused with a typed error before any
   container is created, and `hermes caduceus doctor`
   reports the engine/mode as unavailable.
+
+### The mandatory per-run OCI baseline (non-weakenable)
+
+Every OCI run on both engines (Docker and Podman) gets the
+following baseline, emitted by the argv renderer on every
+single run. There is no config knob, profile, or opt-out
+that can disable or weaken any of these controls; unknown
+config fields are rejected at parse time and resource
+floors prevent zeroing a control to an unsafe value.
+
+- `--read-only` — read-only container rootfs; writes
+  outside the declared surfaces fail EROFS.
+- `--cap-drop ALL` — no Linux capabilities in-container.
+- `--security-opt no-new-privileges` — setuid cannot
+  re-escalate.
+- `--cpus <resources.cpus>` — CPU quota (floor 0.25).
+- `--memory <resources.memory_mb>m` **and**
+  `--memory-swap <resources.memory_mb>m` — the swap limit
+  is pinned EQUAL to the memory limit, so committed memory
+  (RAM + swap) can never exceed the memory bound (no swap
+  rescue). Floor 64 MiB.
+- `--pids-limit <resources.pids>` — fork bombs die at the
+  limit. Floor 16.
+- Bounded ephemeral tmpfs: `--tmpfs /tmp:size=<tmpfs_mb>m`
+  and `--tmpfs /dev/shm:size=<shm_mb>m` — the only writable
+  ephemeral surfaces, each floored at 1 MiB (a `size=0m`
+  would let the engine apply an unbounded default, silently
+  weakening the baseline).
+- No devices, no engine/runtime socket mounts
+  (`docker.sock` / `podman.sock` are denied at resolve
+  time), and no host namespace sharing (`--pid host`,
+  `--ipc host`, `--uts host` are structurally
+  unrepresentable — the spec has no field for them).
+- Typed-only networking: `--network none` is the only
+  mode. Host networking was removed (breaking): the
+  `unrestricted` value no longer parses, so `network:
+  unrestricted` configs fail at load with a typed error.
+- Bounded engine logs: `--log-opt max-size=10m` and
+  `--log-opt max-file=3` on every run (worst case 30 MiB
+  of on-disk engine logs per container).
+- Bounded daemon-side diagnostic capture: after each run,
+  the daemon persists `<engine> logs` for the container,
+  capped at 1 MiB (tail truncation with a marker), under
+  `<state_dir>/oci-runs/<run_id>/engine.log` (mode 0600).
+
+### Host disk-pressure watchdog
+
+`sandbox.reserved_host_disk_mb` (default `2048`) is a
+free-space floor, sampled every 30 s across the DISTINCT
+filesystems hosting the daemon state dir, the repo storage
+/ worktrees, and the OCI output dirs — deduplicated by
+device ID so a shared filesystem is sampled exactly once.
+
+- **Breach** (any sampled filesystem below the reserve):
+  in-flight OCI work is terminated via the existing
+  stop → kill → rm path, and new OCI dispatch is refused
+  with a typed `OciDiskPressure` error until the reserve
+  recovers. TrustedHost work is not subject to the
+  watchdog.
+- **Recovery hysteresis**: after a breach, free space must
+  exceed the reserve by 256 MiB before new work is
+  re-enabled — recovery at exactly the threshold does not
+  re-enable, preventing flapping.
+- **`0` disables the watchdog** entirely (no sampling, no
+  enforcement). The default `2048` enables it.
+
+Honest limits: this is a **host-level mitigation, not a
+per-container byte quota**. `/workspace` remains a host
+bind mount with NO per-container byte quota — a runaway
+run can still consume disk between samples (detection
+latency is bounded by the 30 s sampling interval plus the
+stop/kill timeouts). The watchdog bounds the damage and
+stops the bleeding; it does not isolate storage per run.
 
 ## The 60-Second Orientation
 

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -191,6 +191,11 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         CaduceusError::OciWaitFailed { .. } => FailureClass::Infrastructure,
         CaduceusError::OciStopFailed { .. } => FailureClass::Infrastructure,
         CaduceusError::OciRemoveFailed { .. } => FailureClass::Infrastructure,
+        // Host disk pressure is a transient host condition — the
+        // run is refused before any container exists and retried
+        // after the reserve recovers; not worker-attributable
+        // (issue #245).
+        CaduceusError::OciDiskPressure { .. } => FailureClass::Infrastructure,
         CaduceusError::OciUndeclaredMount { .. } => FailureClass::Worker,
         CaduceusError::OciMountConflict { .. } => FailureClass::Worker,
         CaduceusError::OciSecretLeakSuspected { .. } => FailureClass::Infrastructure,

--- a/src/daemon/orchestration/services.rs
+++ b/src/daemon/orchestration/services.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 
 use crate::github::Client;
 use crate::infra::config::Config;
+use crate::infra::disk::DiskPressureGuard;
 use crate::scheduler::Pool;
 use crate::worktree::GitRunner;
 
@@ -124,6 +125,11 @@ pub struct Services {
     pub github: Arc<dyn GithubClient>,
     pub git: Arc<dyn Git>,
     pub executor: Arc<dyn crate::executor::Executor>,
+    /// Host disk-pressure watchdog shared across the tick: the tick's
+    /// sampler refreshes it, the OCI executor consults it for
+    /// dispatch refusal and links its token into in-flight runs
+    /// (issue #245).
+    pub disk: Arc<DiskPressureGuard>,
     pub pool: Arc<Pool>,
 }
 
@@ -134,6 +140,7 @@ impl std::fmt::Debug for Services {
             .field("github", &"Arc<dyn GithubClient>")
             .field("git", &"Arc<dyn Git>")
             .field("executor", &"Arc<dyn Executor>")
+            .field("disk", &"Arc<DiskPressureGuard>")
             .field("pool", &"Arc<Pool>")
             .finish()
     }
@@ -142,7 +149,9 @@ impl std::fmt::Debug for Services {
 impl Services {
     /// Production convenience constructor. The `executor` is built
     /// via [`crate::executor::executor_for_config`] from the
-    /// supplied `Config`; tests inject a custom executor via
+    /// supplied `Config`; the shared `disk` watchdog guard is
+    /// constructed by the caller (the tick) and shared with the
+    /// sampler task. Tests inject a custom executor via
     /// [`Services::for_tests`].
     pub fn production(
         cfg: &Config,
@@ -150,13 +159,15 @@ impl Services {
         github: Arc<Client>,
         git: GitRunner,
         pool: Arc<Pool>,
+        disk: Arc<DiskPressureGuard>,
     ) -> Self {
-        let executor = crate::executor::executor_for_config(cfg);
+        let executor = crate::executor::executor_for_config(cfg, Arc::clone(&disk));
         Self {
             clock,
             github: Arc::new(GithubClientAdapter::new(github)),
             git: Arc::new(GitRunnerAdapter::new(git)),
             executor,
+            disk,
             pool,
         }
     }
@@ -164,7 +175,8 @@ impl Services {
     /// Test-only constructor that takes pre-built trait objects so
     /// tests can mix real adapters with fakes. The `executor` is
     /// injected directly so tests can substitute mocks without
-    /// touching the config layer.
+    /// touching the config layer. The disk-pressure watchdog is
+    /// constructed disabled internally so no test signature churns.
     pub fn for_tests(
         clock: Arc<dyn Clock>,
         github: Arc<dyn GithubClient>,
@@ -177,6 +189,7 @@ impl Services {
             github,
             git,
             executor,
+            disk: Arc::new(DiskPressureGuard::disabled()),
             pool,
         }
     }

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -145,7 +145,15 @@ pub async fn run_with_config(
     let clock: Arc<dyn crate::daemon::orchestration::Clock> = Arc::new(SystemClock);
     let client = Arc::new(Client::with_config(&cfg)?);
     let git = GitRunner::new(&cfg);
-    let services = Services::production(&cfg, clock, Arc::clone(&client), git, Arc::clone(&pool));
+    let disk = Arc::new(crate::infra::disk::DiskPressureGuard::from_config(&cfg));
+    let services = Services::production(
+        &cfg,
+        clock,
+        Arc::clone(&client),
+        git,
+        Arc::clone(&pool),
+        disk,
+    );
     tick(cfg, services, pool, cancellation).await
 }
 
@@ -188,6 +196,48 @@ pub async fn tick(
     static LEGACY_SWEEP_RAN: AtomicBool = AtomicBool::new(false);
     if !LEGACY_SWEEP_RAN.swap(true, Ordering::SeqCst) {
         crate::worktree::gc::prune_legacy_registrations(&cfg).await;
+    }
+
+    // 0.7. Disk-pressure sampler (issue #245). When the watchdog is
+    //      enabled, spawn a background loop that samples the free
+    //      space of the device-ID-deduped filesystems hosting the
+    //      state dir, repo storage, and worktree base every
+    //      DISK_SAMPLE_INTERVAL_SECS and folds the result into the
+    //      shared guard. A breach cancels the guard's token, which
+    //      terminates in-flight OCI work via the existing stop path
+    //      and (via try_acquire_oci) refuses new dispatch. The task
+    //      dies with the tick: in-flight runs live only inside the
+    //      tick's JoinSet drain, so coverage is exactly the
+    //      in-flight window.
+    if services.disk.enabled() {
+        let disk_guard = Arc::clone(&services.disk);
+        let sampler_cancellation = cancellation.clone();
+        let sampler_cfg = cfg.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(
+                crate::infra::disk::DISK_SAMPLE_INTERVAL_SECS,
+            ));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    _ = sampler_cancellation.cancelled() => break,
+                    _ = interval.tick() => {
+                        let paths = crate::infra::disk::watchdog_paths(&sampler_cfg);
+                        match crate::infra::disk::sample_free_bytes(&paths) {
+                            Ok(samples) => disk_guard.refresh(&samples),
+                            Err(err) => {
+                                // Sampling failure must never kill the
+                                // tick; the next interval retries.
+                                tracing::warn!(
+                                    error = %err,
+                                    "disk-pressure sampling failed; watchdog keeps previous state"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
 
     // 1. Check scheduler leadership. If another tick holds the

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -25,6 +25,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
+use crate::infra::disk::DiskPressureGuard;
 use crate::infra::error::CaduceusResult;
 use crate::worker::supervisor::SupervisorOutcome;
 
@@ -116,10 +117,13 @@ pub trait Executor: Send + Sync {
 /// Reads `cfg.executor_mode` and dispatches to the matching concrete
 /// implementation. The factory is the single entry point used by
 /// `Services::production`; tests inject their own `Arc<dyn Executor>`
-/// via `Services::for_tests`.
-pub fn executor_for_config(cfg: &Config) -> Arc<dyn Executor> {
+/// via `Services::for_tests`. The shared [`DiskPressureGuard`] is
+/// wired into the OCI executor (dispatch refusal + in-flight
+/// termination on breach, issue #245); TrustedHost ignores it —
+/// trusted-host work is structurally excluded from the watchdog.
+pub fn executor_for_config(cfg: &Config, disk: Arc<DiskPressureGuard>) -> Arc<dyn Executor> {
     match cfg.executor_mode {
         ExecutorKind::TrustedHost => Arc::new(TrustedHostExecutor::new(cfg.clone())),
-        ExecutorKind::Oci => Arc::new(OciExecutor::new(cfg.clone())),
+        ExecutorKind::Oci => Arc::new(OciExecutor::new(cfg.clone(), disk)),
     }
 }

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -16,12 +16,14 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use crate::executor::{
     engine_probe, oci_lifecycle, sandbox_renderer, sandbox_spec, Executor, ExecutorOutcome,
     ExecutorSpec,
 };
 use crate::infra::config::Config;
+use crate::infra::disk::DiskPressureGuard;
 use crate::infra::error::CaduceusResult;
 use crate::state::oci_run::OciRunDao;
 use crate::state::store;
@@ -31,12 +33,15 @@ use crate::worker::worker_contract::WORKER_RESULT_FILE;
 #[derive(Clone, Debug)]
 pub struct OciExecutor {
     cfg: Config,
+    /// Host disk-pressure watchdog: refuses new dispatch and
+    /// terminates in-flight work on breach (issue #245).
+    disk: Arc<DiskPressureGuard>,
 }
 
 impl OciExecutor {
-    /// Wrap a config snapshot.
-    pub fn new(cfg: Config) -> Self {
-        Self { cfg }
+    /// Wrap a config snapshot and the shared disk-pressure guard.
+    pub fn new(cfg: Config, disk: Arc<DiskPressureGuard>) -> Self {
+        Self { cfg, disk }
     }
 }
 
@@ -46,6 +51,13 @@ impl Executor for OciExecutor {
         spec: &'a ExecutorSpec,
     ) -> Pin<Box<dyn Future<Output = CaduceusResult<ExecutorOutcome>> + Send + 'a>> {
         Box::pin(async move {
+            // 0. Disk-pressure gate: refuse new OCI dispatch while the
+            //    host watchdog is breached — before the probe, before
+            //    any container can be created (issue #245). TrustedHost
+            //    work is structurally excluded: it never reaches this
+            //    executor.
+            self.disk.try_acquire_oci()?;
+
             // 1. Pre-flight probe: collect the runtime facts (worktree
             //    owner uid/gid, host `.git` type, engine mode) and
             //    create the daemon-owned host artifacts. Every
@@ -73,7 +85,10 @@ impl Executor for OciExecutor {
             let engine = self.cfg.sandbox().engine;
             let argv = sandbox_renderer::render_with_env_files(&resolved, engine, &[]);
 
-            // 5. Run the lifecycle with the rendered argv.
+            // 5. Run the lifecycle with the rendered argv. The run's
+            //    lifecycle token is linked with the watchdog token so
+            //    a disk-pressure breach terminates in-flight work via
+            //    the existing stop path (issue #245).
             let outcome = oci_lifecycle::run_with_argv(
                 &self.cfg,
                 spec,
@@ -81,6 +96,7 @@ impl Executor for OciExecutor {
                 engine,
                 argv,
                 spec.cancellation.child_token(),
+                self.disk.watchdog_token(),
             )
             .await?;
             Ok(ExecutorOutcome {

--- a/src/executor/oci_lifecycle.rs
+++ b/src/executor/oci_lifecycle.rs
@@ -6,9 +6,15 @@
 //! steps are bounded by the configured `sandbox.kill_timeout_seconds` and
 //! `sandbox.stop_timeout_seconds` so the daemon never hangs.
 //!
-//! The module is intentionally free of `tokio::process::Command` — the
-//! subprocess boundary is the tokio::process::Command inside the
-//! `run_cli` helper. The lifecycle is the single call site; all other
+//! Two cancellation sources are honored during the wait step: the
+//! daemon-shutdown token and the disk-pressure watchdog token
+//! (issue #245). Cancellation from either token never early-returns —
+//! the run falls through the stop → capture → remove sequence so no
+//! container is ever leaked.
+//!
+//! The module is intentionally free of `tokio::process::Command` at the
+//! *public* boundary — the subprocess calls live in the private
+//! `run_cli` helpers. The lifecycle is the single call site; all other
 //! executor modules are pure argv builders or secret transport.
 //!
 //! `run_with_argv` is the **sole** entry point. It receives a
@@ -17,6 +23,7 @@
 
 use std::time::Duration;
 
+use tokio::io::AsyncReadExt as _;
 use tokio::process::Command;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
@@ -26,7 +33,17 @@ use crate::executor::ExecutorSpec;
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
-use crate::worker::supervisor::SupervisorOutcome;
+use crate::worker::supervisor::{BoundedTranscriptWriter, SupervisorOutcome};
+
+/// Pinned cap for the daemon-side OCI diagnostic capture
+/// (`engine.log`). A diagnostic tail only needs the final failure
+/// output; independent of the worker-facing `transcript_max_bytes`
+/// (a different audience and budget).
+pub const OCI_DIAGNOSTIC_MAX_BYTES: u64 = 1024 * 1024;
+
+/// Read chunk size for the diagnostic capture — memory stays bounded
+/// to one chunk while the writer keeps the last-N-bytes tail.
+const OCI_DIAGNOSTIC_CHUNK_BYTES: usize = 8 * 1024;
 
 /// Run the OCI container lifecycle with a pre-built argv from the
 /// resolution → renderer pipeline.
@@ -35,6 +52,16 @@ use crate::worker::supervisor::SupervisorOutcome;
 /// `cfg`) so the create argv and the start/wait/stop/rm argvs cannot
 /// diverge from the renderer's engine; it also feeds the
 /// `ContainerRunRow.engine` column.
+///
+/// Two cancellation tokens drive the wait step:
+///
+/// * `cancellation` — the daemon-shutdown token (unchanged contract);
+/// * `watchdog` — the disk-pressure watchdog token (issue #245).
+///
+/// Cancellation from either token falls through the stop → capture →
+/// remove sequence (never an early return) and reports
+/// [`CaduceusError::Cancelled`]; the watchdog surfaces its typed
+/// refusal separately through `DiskPressureGuard::try_acquire_oci`.
 pub async fn run_with_argv(
     cfg: &Config,
     spec: &ExecutorSpec,
@@ -42,6 +69,7 @@ pub async fn run_with_argv(
     engine: SandboxEngine,
     argv: Vec<String>,
     cancellation: CancellationToken,
+    watchdog: CancellationToken,
 ) -> CaduceusResult<SupervisorOutcome> {
     // Insert a Created state row.
     let now = chrono::Utc::now().to_rfc3339();
@@ -59,7 +87,7 @@ pub async fn run_with_argv(
     state.insert(&row)?;
 
     // Step 1: create
-    let container_id = run_cli("create", &argv, "create", &cancellation).await?;
+    let container_id = run_cli("create", &argv, "create", &cancellation, &watchdog).await?;
 
     // Record container_id
     let mut row = row;
@@ -72,21 +100,55 @@ pub async fn run_with_argv(
         "start".to_string(),
         container_id.clone(),
     ];
-    run_cli("start", &start_argv, "start", &cancellation).await?;
+    run_cli("start", &start_argv, "start", &cancellation, &watchdog).await?;
     state.update_state(&spec.run_id, &OciLifecycleState::Running)?;
 
-    // Step 3: wait
+    // Step 3: wait — select over the wait command and BOTH
+    // cancellation sources (daemon shutdown + disk-pressure watchdog).
+    // Cancellation from either token must NOT early-return: it falls
+    // through the stop → capture → rm sequence below so the running
+    // container is never leaked (issue #245).
     let wait_argv = vec![
         engine.binary_name().to_string(),
         "wait".to_string(),
         container_id.clone(),
     ];
-    let wait_output = run_cli_with_output("wait", &wait_argv, "wait", &cancellation).await?;
-    let exit_code = parse_exit_code(&wait_output);
-    state.update_state(&spec.run_id, &OciLifecycleState::Exited(exit_code))?;
+    enum WaitOutcome {
+        /// `wait` completed and printed an exit code.
+        Completed(String),
+        /// Either token cancelled — the run was terminated.
+        Cancelled,
+        /// `wait` itself failed (engine error); preserved and
+        /// surfaced after cleanup so the container is not leaked.
+        Failed(CaduceusError),
+    }
+    let wait_outcome = tokio::select! {
+        result = run_cli_with_output("wait", &wait_argv, "wait", &cancellation, &watchdog) => {
+            match result {
+                Ok(output) => WaitOutcome::Completed(output),
+                // A pre-spawn cancellation check fired inside the
+                // helper — same as the token branches below.
+                Err(CaduceusError::Cancelled) => WaitOutcome::Cancelled,
+                Err(err) => WaitOutcome::Failed(err),
+            }
+        }
+        _ = watchdog.cancelled() => WaitOutcome::Cancelled,
+        _ = cancellation.cancelled() => WaitOutcome::Cancelled,
+    };
+    let exit_code = match &wait_outcome {
+        WaitOutcome::Completed(output) => {
+            let code = parse_exit_code(output);
+            state.update_state(&spec.run_id, &OciLifecycleState::Exited(code))?;
+            code
+        }
+        _ => -1,
+    };
 
-    // Step 4: stop (graceful, bounded)
-    let _stop_timeout = Duration::from_secs(cfg.sandbox().stop_timeout_seconds);
+    // Step 4: stop (graceful, bounded). Runs on EVERY path — normal
+    // exit, watchdog breach, daemon shutdown, wait failure — so no
+    // container leaks. The cleanup steps check ONLY the daemon
+    // `cancellation` token: a watchdog breach must never prevent
+    // cleanup of the container it just cancelled.
     let stop_argv = vec![
         engine.binary_name().to_string(),
         "stop".to_string(),
@@ -94,7 +156,7 @@ pub async fn run_with_argv(
         cfg.sandbox().stop_timeout_seconds.to_string(),
         container_id.clone(),
     ];
-    match run_cli("stop", &stop_argv, "stop", &cancellation).await {
+    match run_cli("stop", &stop_argv, "stop", &cancellation, &cancellation).await {
         Ok(_) => {
             state.update_state(&spec.run_id, &OciLifecycleState::Stopped)?;
         }
@@ -106,11 +168,21 @@ pub async fn run_with_argv(
                 "kill".to_string(),
                 container_id.clone(),
             ];
-            let _ = run_cli("kill", &kill_argv, "kill", &cancellation).await;
+            let _ = run_cli("kill", &kill_argv, "kill", &cancellation, &cancellation).await;
             state.update_state(&spec.run_id, &OciLifecycleState::Killed)?;
-            return Err(e);
+            // Preserve the original wait failure when one existed —
+            // the stop failure is secondary diagnostics on that path.
+            return Err(match wait_outcome {
+                WaitOutcome::Failed(err) => err,
+                _ => e,
+            });
         }
     }
+
+    // Step 4.5: bounded daemon-side diagnostic capture (issue #245).
+    // After the container has exited (logs are complete) but BEFORE
+    // `rm` destroys them. Best-effort — never fails the run.
+    capture_engine_logs(cfg, engine, &container_id, &spec.run_id).await;
 
     // Step 5: remove
     let remove_argv = vec![
@@ -122,7 +194,7 @@ pub async fn run_with_argv(
     let remove_timeout = Duration::from_secs(cfg.sandbox().kill_timeout_seconds);
     match timeout(
         remove_timeout,
-        run_cli("rm", &remove_argv, "remove", &cancellation),
+        run_cli("rm", &remove_argv, "remove", &cancellation, &cancellation),
     )
     .await
     {
@@ -134,12 +206,112 @@ pub async fn run_with_argv(
         }
     }
 
-    Ok(SupervisorOutcome {
-        status: exit_code,
-        signaled: false,
-        timed_out: false,
-        cancelled: false,
-    })
+    match wait_outcome {
+        WaitOutcome::Completed(_) => Ok(SupervisorOutcome {
+            status: exit_code,
+            signaled: false,
+            timed_out: false,
+            cancelled: false,
+        }),
+        // Watchdog breach or daemon shutdown: the run reports as
+        // cancelled to the tick, which classifies retries as usual.
+        WaitOutcome::Cancelled => Err(CaduceusError::Cancelled),
+        WaitOutcome::Failed(err) => Err(err),
+    }
+}
+
+/// Capture `<engine> logs <container_id>` into a bounded diagnostic
+/// file at `<state_dir>/oci-runs/<run_id>/engine.log`, capped at
+/// [`OCI_DIAGNOSTIC_MAX_BYTES`] via [`BoundedTranscriptWriter`] (which
+/// opens 0600 with `O_NOFOLLOW` and keeps the last-N-bytes tail).
+/// stdout and stderr are drained concurrently in
+/// [`OCI_DIAGNOSTIC_CHUNK_BYTES`] chunks so a chatty stream cannot
+/// deadlock the other pipe. Every failure is logged and never
+/// propagates — the capture is best-effort diagnostics.
+async fn capture_engine_logs(
+    cfg: &Config,
+    engine: SandboxEngine,
+    container_id: &str,
+    run_id: &str,
+) {
+    let result = capture_engine_logs_inner(cfg, engine, container_id, run_id).await;
+    if let Err(err) = result {
+        tracing::warn!(error = %err, "OCI diagnostic capture failed (best-effort)");
+    }
+}
+
+async fn capture_engine_logs_inner(
+    cfg: &Config,
+    engine: SandboxEngine,
+    container_id: &str,
+    run_id: &str,
+) -> CaduceusResult<()> {
+    // The run dir exists (created by the pre-flight engine probe);
+    // create it best-effort for direct lifecycle callers.
+    let path = cfg
+        .state_dir
+        .join("oci-runs")
+        .join(run_id)
+        .join("engine.log");
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let mut writer = BoundedTranscriptWriter::new(path.clone(), OCI_DIAGNOSTIC_MAX_BYTES)?;
+
+    let mut child = Command::new(engine.binary_name())
+        .args(["logs", container_id])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| CaduceusError::Other(format!("engine logs spawn for {container_id}: {e}")))?;
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut stderr = child.stderr.take().expect("stderr is piped");
+
+    let mut out_chunk = vec![0u8; OCI_DIAGNOSTIC_CHUNK_BYTES];
+    let mut err_chunk = vec![0u8; OCI_DIAGNOSTIC_CHUNK_BYTES];
+    loop {
+        tokio::select! {
+            read = stdout.read(&mut out_chunk) => {
+                match read {
+                    Ok(0) | Err(_) => {
+                        // stdout drained — drain stderr to EOF.
+                        loop {
+                            match stderr.read(&mut err_chunk).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(n) => writer.write_bytes(&err_chunk[..n]),
+                            }
+                        }
+                        break;
+                    }
+                    Ok(n) => writer.write_bytes(&out_chunk[..n]),
+                }
+            }
+            read = stderr.read(&mut err_chunk) => {
+                match read {
+                    Ok(0) | Err(_) => {
+                        // stderr drained — drain stdout to EOF.
+                        loop {
+                            match stdout.read(&mut out_chunk).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(n) => writer.write_bytes(&out_chunk[..n]),
+                            }
+                        }
+                        break;
+                    }
+                    Ok(n) => writer.write_bytes(&err_chunk[..n]),
+                }
+            }
+        }
+    }
+    let _ = child.wait().await;
+    // Enforce the hard cap: the writer truncates once on first
+    // overflow but keeps appending the remaining stream (its
+    // drain-must-keep-running contract), so re-truncate after the
+    // stream drains to bound the persisted artifact at the cap plus
+    // the small truncation marker.
+    let _ = crate::worker::supervisor::truncate_transcript(&path, OCI_DIAGNOSTIC_MAX_BYTES);
+    writer.finalize()
 }
 
 /// Reconcile orphaned containers: every row in `PendingReconciliation`
@@ -163,7 +335,7 @@ pub async fn reconcile(
                 "--force".to_string(),
                 container_id.clone(),
             ];
-            let _ = run_cli("rm", &rm_argv, "remove", &cancellation).await;
+            let _ = run_cli("rm", &rm_argv, "remove", &cancellation, &cancellation).await;
         }
         // Mark as removed regardless of CLI result (best-effort).
         let _ = state.update_state(&row.run_id, &OciLifecycleState::Removed);
@@ -251,13 +423,19 @@ fn sha256_of(input: &str) -> String {
 }
 
 /// Run an OCI CLI command and return stdout on success, stderr on failure.
+///
+/// The pre-spawn check consults BOTH the daemon `cancellation` token
+/// and the `watchdog` token. Cleanup call sites pass
+/// `&cancellation` as `watchdog` so a watchdog breach never blocks
+/// cleanup of the container it just cancelled.
 async fn run_cli(
     step: &'static str,
     argv: &[String],
     context: &'static str,
     cancellation: &CancellationToken,
+    watchdog: &CancellationToken,
 ) -> CaduceusResult<String> {
-    if cancellation.is_cancelled() {
+    if cancellation.is_cancelled() || watchdog.is_cancelled() {
         return Err(CaduceusError::Cancelled);
     }
 
@@ -281,8 +459,9 @@ async fn run_cli_with_output(
     argv: &[String],
     context: &'static str,
     cancellation: &CancellationToken,
+    watchdog: &CancellationToken,
 ) -> CaduceusResult<String> {
-    if cancellation.is_cancelled() {
+    if cancellation.is_cancelled() || watchdog.is_cancelled() {
         return Err(CaduceusError::Cancelled);
     }
 

--- a/src/executor/sandbox_renderer.rs
+++ b/src/executor/sandbox_renderer.rs
@@ -21,6 +21,16 @@ use crate::worker::worker_contract::{
     CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
 };
 
+/// Pinned engine-log rotation cap per rotated segment (`--log-opt
+/// max-size`). Both engines' default drivers (Docker `json-file`,
+/// Podman `k8s-file`) accept these options; no explicit
+/// `--log-driver` is emitted so the renderer stays engine-agnostic.
+pub const OCI_LOG_MAX_SIZE: &str = "10m";
+
+/// Pinned engine-log segment count (`--log-opt max-file`). Worst-case
+/// per-container on-disk logs: 3 × 10 MiB = 30 MiB.
+pub const OCI_LOG_MAX_FILE: &str = "3";
+
 /// Render the full `create` argv for the given engine with no secret
 /// env files. Delegates to [`render_with_env_files`] with an empty
 /// slice.
@@ -73,11 +83,12 @@ pub fn render_with_env_files(
         argv.push(userns.to_string());
     }
 
-    // --- Network mode.
+    // --- Network mode. Host networking is structurally
+    //     unrepresentable: `NetworkMode` has a single variant, so
+    //     `--network none` is emitted unconditionally (issue #245).
     argv.push("--network".to_string());
     argv.push(match spec.network() {
         NetworkMode::None => "none".to_string(),
-        NetworkMode::Unrestricted => "host".to_string(),
     });
 
     // --- Resource limits (total fields — always emitted).
@@ -85,11 +96,26 @@ pub fn render_with_env_files(
     argv.push(format!("{}", spec.resources().cpus));
     argv.push("--memory".to_string());
     argv.push(format!("{}m", spec.resources().memory_mb));
+    // Swap is pinned EQUAL to the memory limit: for both engines
+    // `memory-swap == memory` means total (mem + swap) equals the
+    // memory limit, i.e. swap cannot double committed memory.
+    argv.push("--memory-swap".to_string());
+    argv.push(format!("{}m", spec.resources().memory_mb));
     argv.push("--pids-limit".to_string());
     argv.push(format!("{}", spec.resources().pids));
     // `/dev/shm` is declared via the dual tmpfs list from the spec
     // (same bounded-size mechanism as `/tmp`); the standalone
     // `--shm-size` flag was removed as redundant.
+
+    // --- Bounded engine logs. Both entries are emitted for every
+    //     run on both engines, without an explicit `--log-driver`:
+    //     each engine's default driver (Docker `json-file`, Podman
+    //     `k8s-file`) accepts `max-size` / `max-file`, so no
+    //     per-engine branch is needed.
+    argv.push("--log-opt".to_string());
+    argv.push(format!("max-size={OCI_LOG_MAX_SIZE}"));
+    argv.push("--log-opt".to_string());
+    argv.push(format!("max-file={OCI_LOG_MAX_FILE}"));
 
     // --- Container name.
     argv.push("--name".to_string());

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::executor::ExecutorSpec;
 use crate::github::issue::IssueKey;
-use crate::infra::config::{Config, OciPullPolicy, SandboxConfig, SandboxNetwork};
+use crate::infra::config::{Config, OciPullPolicy, SandboxConfig};
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::worker_contract::{
     CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
@@ -157,13 +157,15 @@ pub struct TmpfsMount {
 }
 
 /// Network isolation mode for the container.
+///
+/// Host networking is structurally unrepresentable: the former
+/// `Unrestricted` variant (`--network host`) was removed (breaking,
+/// issue #245). The single variant renders `--network none`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum NetworkMode {
     /// `--network none` — no network access.
     #[default]
     None,
-    /// `--network host` — full host network access.
-    Unrestricted,
 }
 
 /// Resource limits mapped from [`SandboxResources`].
@@ -521,11 +523,10 @@ pub fn resolve(
         shm_mb: sandbox.resources.shm_mb,
     };
 
-    // 9. Network — map from SandboxNetwork.
-    let network = match sandbox.network {
-        SandboxNetwork::None => NetworkMode::None,
-        SandboxNetwork::Unrestricted => NetworkMode::Unrestricted,
-    };
+    // 9. Network — the only mode is `None` (`--network none`); host
+    //     networking is structurally unrepresentable after the
+    //     breaking removal of `SandboxNetwork::Unrestricted` (D3).
+    let network = NetworkMode::None;
 
     // 10. Environment — the full canonical `CADUCEUS_*` set, with
     //     CONTAINER-side path values so host paths never leak into
@@ -623,6 +624,12 @@ pub fn resolve(
     //     is built, so an extra writable host-backed mount can only
     //     ever be a future regression caught at resolution time.
     validate_mount_policy(&spec)?;
+
+    // 16. Host-escalation tripwire (defense in depth): no engine
+    //     socket mount and no non-isolated network may ever appear on
+    //     a resolved spec. Structurally unrepresentable after D3 —
+    //     exactly the point.
+    validate_no_host_escalation(&spec)?;
 
     Ok(spec)
 }
@@ -724,6 +731,72 @@ fn validate_mount_policy(spec: &SandboxSpec) -> CaduceusResult<()> {
     }
 
     Ok(())
+}
+
+/// Reject host-escalation surfaces on a resolved spec (issue #245):
+///
+/// - any host-backed mount (workspace, output, `.git` shadow) whose
+///   `host_path` or `container_path` file name is an engine/runtime
+///   socket (`docker.sock` / `podman.sock`) — mounting the engine
+///   socket is a container-escape primitive;
+/// - any network mode other than [`NetworkMode::None`] — a tautology
+///   after the `Unrestricted` removal that trips if a future variant
+///   is ever added without re-review.
+///
+/// `--device` and `--pid/--ipc/--uts=host` are denied *structurally*:
+/// [`SandboxSpec`] has no field that could express them and the
+/// renderer never emits those tokens; the golden renderer tests pin
+/// their absence.
+pub fn validate_no_host_escalation(spec: &SandboxSpec) -> CaduceusResult<()> {
+    for (label, mount) in [
+        ("workspace", spec.workspace_mount()),
+        ("output", spec.output_mount()),
+    ] {
+        for path in [&mount.host_path, &mount.container_path] {
+            if is_engine_socket_path(path) {
+                return Err(CaduceusError::OciMountConflict {
+                    detail: format!(
+                        "the {label} mount must not target an engine/runtime \
+                         socket path: {}",
+                        path.display()
+                    ),
+                });
+            }
+        }
+    }
+    if let Some(shadow) = spec.git_shadow() {
+        for path in [&shadow.host_path, &shadow.container_path] {
+            if is_engine_socket_path(path) {
+                return Err(CaduceusError::OciMountConflict {
+                    detail: format!(
+                        "the .git shadow mount must not target an \
+                         engine/runtime socket path: {}",
+                        path.display()
+                    ),
+                });
+            }
+        }
+    }
+    if spec.network() != NetworkMode::None {
+        return Err(CaduceusError::OciMountConflict {
+            detail: format!(
+                "network mode {:?} is denied: only --network none is \
+                 representable (host networking was removed, issue #245)",
+                spec.network()
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// True when *path*'s file name is the Docker or Podman engine
+/// socket. `pub` for testability from `tests/` per the
+/// no-inline-tests rule.
+pub fn is_engine_socket_path(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|s| s.to_str()),
+        Some("docker.sock") | Some("podman.sock")
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -122,12 +122,17 @@ pub struct SandboxResources {
 }
 
 /// New enum (replaces `network_profiles`).
+///
+/// Host networking is structurally unrepresentable: the former
+/// `Unrestricted` variant (`--network host`) was removed (breaking,
+/// issue #245). The only value is `None` (`--network none`); a YAML
+/// `network: unrestricted` fails at serde parse time as an unknown
+/// variant.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxNetwork {
     #[default]
     None, // `--network none`
-    Unrestricted, // `--network host`
 }
 
 /// Raw layer — mirrors the schema with all-`Option` fields.
@@ -1278,12 +1283,12 @@ fn resolve_sandbox(raw: RawSandboxConfig, errors: &mut Vec<String>) -> SandboxCo
     if reconcile_timeout_seconds == 0 {
         errors.push("sandbox.reconcile_timeout_seconds must be > 0".to_string());
     }
+    // `0` is a valid value and DISABLES the disk-pressure watchdog
+    // (no sampling, no enforcement); any positive value is the
+    // free-space floor in MB (issue #245).
     let reserved_host_disk_mb = raw
         .reserved_host_disk_mb
         .unwrap_or(DEFAULT_SANDBOX_RESERVED_HOST_DISK_MB);
-    if reserved_host_disk_mb == 0 {
-        errors.push("sandbox.reserved_host_disk_mb must be > 0".to_string());
-    }
 
     SandboxConfig {
         engine,
@@ -1322,10 +1327,23 @@ fn resolve_sandbox_resources(
     if pids < 16 {
         errors.push(format!("sandbox.resources.pids must be >= 16, got {pids}"));
     }
-    // tmpfs_mb / shm_mb are u64 — zero is a valid floor and negatives
-    // are impossible (serde type error at parse time).
+    // tmpfs_mb / shm_mb floors: zero would let the engine apply its
+    // DEFAULT tmpfs size (`--tmpfs /tmp:size=0m` — Docker treats a
+    // zero size as unbounded), which would silently weaken the
+    // bounded-tmpfs baseline (issue #245). Negatives are impossible
+    // (serde type error at parse time).
     let tmpfs_mb = raw.tmpfs_mb.unwrap_or(256);
+    if tmpfs_mb < 1 {
+        errors.push(format!(
+            "sandbox.resources.tmpfs_mb must be >= 1, got {tmpfs_mb}"
+        ));
+    }
     let shm_mb = raw.shm_mb.unwrap_or(64);
+    if shm_mb < 1 {
+        errors.push(format!(
+            "sandbox.resources.shm_mb must be >= 1, got {shm_mb}"
+        ));
+    }
     SandboxResources {
         cpus,
         memory_mb,

--- a/src/infra/disk.rs
+++ b/src/infra/disk.rs
@@ -1,0 +1,300 @@
+//! Host disk-pressure watchdog (issue #245).
+//!
+//! Samples the free space of the DISTINCT filesystems hosting the
+//! daemon's write surfaces (state dir, repo storage / worktrees, and
+//! the OCI output dirs — which share the state-dir filesystem by
+//! construction), deduplicated by device ID so a single underlying
+//! filesystem is sampled exactly once.
+//!
+//! On breach (any sampled filesystem's free space falls below the
+//! configured `reserved_host_disk_mb` floor) the guard:
+//!
+//! 1. cancels its internal [`CancellationToken`] — linked into
+//!    in-flight OCI run lifecycles so breach terminates in-flight
+//!    work via the existing stop → kill → rm path; and
+//! 2. refuses new OCI dispatch with the typed
+//!    [`CaduceusError::OciDiskPressure`] until the reserve recovers.
+//!
+//! Recovery applies a hysteresis margin: free space must exceed the
+//! floor by [`DISK_HYSTERESIS_BYTES`] before new work is re-enabled,
+//! so the state does not flap at the threshold.
+//!
+//! This is a host-level mitigation, NOT a per-container byte quota:
+//! `/workspace` remains a host bind mount with no per-container byte
+//! quota; a runaway run can still fill the filesystem between
+//! samples (bounded by [`DISK_SAMPLE_INTERVAL_SECS`] detection
+//! latency plus the stop/kill timeouts).
+//!
+//! The pure state machine ([`transition`]) and the sampler
+//! ([`sample_free_bytes`]) are separated so the math is unit-tested
+//! against synthetic layouts without any filesystem.
+
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::infra::config::Config;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Recovery hysteresis margin: after a breach, free space must exceed
+/// the reserved floor by this many bytes before new OCI dispatch is
+/// re-enabled. A fixed absolute margin stays meaningful for small
+/// reserves where a percentage would collapse to noise; erring
+/// toward *harder* recovery is the fail-safe direction.
+pub const DISK_HYSTERESIS_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Sampling cadence, in seconds. Bounds detection latency for a
+/// breach to this interval plus the stop/kill timeouts, satisfying
+/// the "terminated within a bounded time" requirement.
+pub const DISK_SAMPLE_INTERVAL_SECS: u64 = 30;
+
+/// One filesystem-level free-space observation, deduplicated by
+/// device ID. `representative_path` is the first input path (or its
+/// nearest existing ancestor) that mapped to this device.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiskSample {
+    /// `st_dev` of the sampled filesystem (`MetadataExt::dev()`).
+    pub device_id: u64,
+    /// Bytes available to unprivileged processes
+    /// (`f_bavail * f_frsize`).
+    pub free_bytes: u64,
+    /// First path that mapped to this device.
+    pub representative_path: PathBuf,
+}
+
+/// Watchdog verdict for one sampling round.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PressureState {
+    /// Free space is above the reserve everywhere (or the watchdog
+    /// has not yet observed a breach).
+    Healthy,
+    /// At least one sampled filesystem is below the reserve. The
+    /// recorded device/path/free/reserved describe the breaching
+    /// sample.
+    Breached {
+        device_id: u64,
+        path: String,
+        free_bytes: u64,
+        reserved_bytes: u64,
+    },
+}
+
+/// Resolve *path* to its nearest existing ancestor (bounded walk up
+/// to the root) so not-yet-created roots (e.g. `workdir_base` before
+/// the first worktree) still sample the filesystem that will host
+/// them. Returns the input unchanged when it exists.
+fn nearest_existing(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    loop {
+        if current.exists() {
+            return current;
+        }
+        match current.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => current = parent.to_path_buf(),
+            _ => return current,
+        }
+    }
+}
+
+/// Sample the free space of the distinct filesystems hosting *paths*.
+///
+/// Each path is resolved to its nearest existing ancestor, its device
+/// ID read via [`std::os::unix::fs::MetadataExt::dev()`], and free
+/// bytes read via `nix::sys::statvfs::statvfs` (`f_bavail *
+/// f_frsize` — bytes available to unprivileged processes). Samples
+/// are deduplicated by device ID (first path wins for
+/// `representative_path`); the output order is stable on input order,
+/// making the pure transition deterministic.
+pub fn sample_free_bytes(paths: &[PathBuf]) -> CaduceusResult<Vec<DiskSample>> {
+    let mut samples: Vec<DiskSample> = Vec::new();
+    for path in paths {
+        let resolved = nearest_existing(path);
+        let device_id = std::fs::metadata(&resolved)
+            .map_err(|e| {
+                CaduceusError::Io(std::io::Error::other(format!(
+                    "disk watchdog: stat {}: {e}",
+                    resolved.display()
+                )))
+            })?
+            .dev();
+        // Device-ID dedup: same physical filesystem is never sampled
+        // twice, even across bind mounts.
+        if samples.iter().any(|s| s.device_id == device_id) {
+            continue;
+        }
+        let stat = nix::sys::statvfs::statvfs(&resolved).map_err(|e| {
+            CaduceusError::Io(std::io::Error::other(format!(
+                "disk watchdog: statvfs {}: {e}",
+                resolved.display()
+            )))
+        })?;
+        // Bytes available to unprivileged processes: `f_bavail *
+        // f_frsize` via the nix accessor methods.
+        let free_bytes = stat.blocks_available() as u64 * stat.fragment_size() as u64;
+        samples.push(DiskSample {
+            device_id,
+            free_bytes,
+            representative_path: resolved,
+        });
+    }
+    Ok(samples)
+}
+
+/// The filesystem roots the watchdog samples for a config: the state
+/// dir, the repo storage root, and the worktree base. OCI output dirs
+/// live at `<state_dir>/oci-runs/<run_id>/output` and therefore share
+/// the state-dir filesystem sample by construction — per-run path
+/// registration is unnecessary.
+pub fn watchdog_paths(cfg: &Config) -> Vec<PathBuf> {
+    vec![
+        cfg.state_dir.clone(),
+        cfg.repo_storage_root.clone(),
+        cfg.workdir_base.clone(),
+    ]
+}
+
+/// Pure watchdog transition (no shared state, deterministic).
+///
+/// * `Healthy` → `Breached` when ANY sample has
+///   `free_bytes < reserved_bytes` (the breaching device is
+///   recorded).
+/// * `Breached` → `Healthy` only when EVERY sample has
+///   `free_bytes > reserved_bytes + hysteresis_bytes` (strict `>` —
+///   recovery at exactly the floor does not re-enable). An empty
+///   sample set never recovers a breach.
+/// * Otherwise the state persists.
+pub fn transition(
+    state: &PressureState,
+    samples: &[DiskSample],
+    reserved_bytes: u64,
+    hysteresis_bytes: u64,
+) -> PressureState {
+    match state {
+        PressureState::Healthy => {
+            for sample in samples {
+                if sample.free_bytes < reserved_bytes {
+                    return PressureState::Breached {
+                        device_id: sample.device_id,
+                        path: sample.representative_path.display().to_string(),
+                        free_bytes: sample.free_bytes,
+                        reserved_bytes,
+                    };
+                }
+            }
+            PressureState::Healthy
+        }
+        breached @ PressureState::Breached { .. } => {
+            let recovered = !samples.is_empty()
+                && samples
+                    .iter()
+                    .all(|s| s.free_bytes > reserved_bytes + hysteresis_bytes);
+            if recovered {
+                PressureState::Healthy
+            } else {
+                breached.clone()
+            }
+        }
+    }
+}
+
+/// Arc-shareable watchdog guard. The only shared state is the
+/// `RwLock<PressureState>` verdict and the internal root
+/// [`CancellationToken`]; `refresh` is idempotent and [`transition`]
+/// is pure, so concurrent OCI runs observe a consistent verdict.
+#[derive(Debug)]
+pub struct DiskPressureGuard {
+    enabled: bool,
+    reserved_bytes: u64,
+    state: RwLock<PressureState>,
+    root_token: CancellationToken,
+}
+
+impl DiskPressureGuard {
+    /// Construct the guard from a config. Enabled iff
+    /// `cfg.sandbox` is present and `sandbox.reserved_host_disk_mb >
+    /// 0` (`0` disables the watchdog — no sampling, no enforcement).
+    pub fn from_config(cfg: &Config) -> Self {
+        let (enabled, reserved_mb) = match &cfg.sandbox {
+            Some(sandbox) => {
+                let mb = sandbox.reserved_host_disk_mb;
+                (mb > 0, mb)
+            }
+            None => (false, 0),
+        };
+        Self {
+            enabled,
+            reserved_bytes: reserved_mb.saturating_mul(1024 * 1024),
+            state: RwLock::new(PressureState::Healthy),
+            root_token: CancellationToken::new(),
+        }
+    }
+
+    /// Disabled guard for tests and TrustedHost-mode wiring.
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            reserved_bytes: 0,
+            state: RwLock::new(PressureState::Healthy),
+            root_token: CancellationToken::new(),
+        }
+    }
+
+    /// True when the watchdog samples and enforces.
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Fold a fresh sample set into the verdict. On a
+    /// Healthy→Breached transition the internal root token is
+    /// cancelled, which terminates in-flight OCI work through the
+    /// linked per-run watchdog tokens. Tokens are never un-cancelled:
+    /// recovery only re-enables *new* dispatch; already-terminated
+    /// runs stay terminated.
+    pub fn refresh(&self, samples: &[DiskSample]) {
+        if !self.enabled {
+            return;
+        }
+        let mut state = self.state.write().expect("disk watchdog lock");
+        let next = transition(&state, samples, self.reserved_bytes, DISK_HYSTERESIS_BYTES);
+        if matches!(
+            (&*state, &next),
+            (PressureState::Healthy, PressureState::Breached { .. })
+        ) {
+            self.root_token.cancel();
+        }
+        *state = next;
+    }
+
+    /// Refuse new OCI dispatch while breached. Returns
+    /// [`CaduceusError::OciDiskPressure`] populated from the stored
+    /// breach state; `Ok(())` when healthy or disabled.
+    pub fn try_acquire_oci(&self) -> CaduceusResult<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+        let state = self.state.read().expect("disk watchdog lock");
+        match &*state {
+            PressureState::Healthy => Ok(()),
+            PressureState::Breached {
+                device_id,
+                path,
+                free_bytes,
+                reserved_bytes,
+            } => Err(CaduceusError::OciDiskPressure {
+                path: path.clone(),
+                device_id: *device_id,
+                free_bytes: *free_bytes,
+                reserved_bytes: *reserved_bytes,
+            }),
+        }
+    }
+
+    /// A child of the internal root token, for linking into an OCI
+    /// run's lifecycle. Cancelling the root (on breach) cancels every
+    /// child; cancelling a child never affects the root or siblings.
+    pub fn watchdog_token(&self) -> CancellationToken {
+        self.root_token.child_token()
+    }
+}

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -347,6 +347,19 @@ pub enum CaduceusError {
     #[error("OCI pull policy incompatible: {detail}")]
     OciPullPolicyIncompatible { detail: String },
 
+    /// OCI dispatch was refused because the host disk-pressure
+    /// watchdog is breached on the sampled filesystem carrying
+    /// `path`: free space fell below the configured
+    /// `reserved_host_disk_mb` floor. Constructed only by
+    /// `DiskPressureGuard::try_acquire_oci` (issue #245).
+    #[error("OCI dispatch refused: host disk pressure on {path} (device {device_id}): {free_bytes} bytes free < {reserved_bytes} bytes reserved")]
+    OciDiskPressure {
+        path: String,
+        device_id: u64,
+        free_bytes: u64,
+        reserved_bytes: u64,
+    },
+
     #[error("{0}")]
     Other(String),
 }
@@ -579,6 +592,18 @@ impl fmt::Debug for CaduceusError {
             CaduceusError::OciPullPolicyIncompatible { detail } => {
                 format!("OciPullPolicyIncompatible {{ detail: {} }}", scrub(detail))
             }
+            CaduceusError::OciDiskPressure {
+                path,
+                device_id,
+                free_bytes,
+                reserved_bytes,
+            } => format!(
+                "OciDiskPressure {{ path: {}, device_id: {}, free_bytes: {}, reserved_bytes: {} }}",
+                scrub(path),
+                device_id,
+                free_bytes,
+                reserved_bytes
+            ),
             CaduceusError::Other(s) => format!("Other({})", scrub(s)),
         };
         f.write_str(&rendered)

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -5,6 +5,7 @@
 //! through a business module. They're the "stdio of Caduceus".
 
 pub mod config;
+pub mod disk;
 pub mod error;
 pub mod fixtures;
 pub mod install;

--- a/tests/daemon/tick_test.rs
+++ b/tests/daemon/tick_test.rs
@@ -425,6 +425,9 @@ async fn run_tick(
         Arc::new(client),
         git,
         Arc::clone(&pool),
+        // Disabled watchdog: tick tests must not depend on host disk
+        // state. The tick only samples when the guard is enabled.
+        std::sync::Arc::new(caduceus::infra::disk::DiskPressureGuard::disabled()),
     );
     caduceus::tick::tick(cfg, services, pool, CancellationToken::new()).await
 }

--- a/tests/executor/cancellation_test.rs
+++ b/tests/executor/cancellation_test.rs
@@ -142,3 +142,55 @@ fn cancel_at_remove() {
         "cancellation token must not be cancelled initially"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Both cancellation sources drive the SAME stop path (issue #245,
+// task 11.2). The stub-engine proofs (no real engine needed) live in
+// `oci_lifecycle_stub_test.rs`; these gated tests exercise the same
+// flow against a real engine.
+// ---------------------------------------------------------------------------
+
+/// Disk-pressure watchdog cancellation mid-wait: `run_with_argv`'s
+/// second `watchdog` token selects against the wait step and the run
+/// falls through stop → capture → rm, reporting `Cancelled`.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn watchdog_cancel_at_wait() {
+    // When CADUCEUS_RUN_ISOLATION_TESTS is set:
+    //  1. Start a long-running container (sleep 3600) via
+    //     `oci_lifecycle::run_with_argv` with a fresh watchdog token
+    //  2. Cancel the WATCHDOG token (not the daemon token) during
+    //     the wait phase — a disk-pressure breach did this
+    //  3. Verify the run fell through stop → capture → rm:
+    //     the container is stopped, `engine.log` was captured, the
+    //     state row shows Removed, and the result is Err(Cancelled)
+    //  4. Verify no container exists for this run_id (docker ps -a)
+
+    let spec = test_spec("watchdog-cancel-at-wait");
+    assert!(
+        !spec.cancellation.is_cancelled(),
+        "daemon token must be untouched by a watchdog breach"
+    );
+}
+
+/// Daemon-shutdown cancellation mid-wait: the same stop path runs,
+/// the cleanup steps consult only the daemon token (which is
+/// cancelled), and the state lands in `Killed` for the
+/// reconciliation pass to finish.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn shutdown_cancel_at_wait_uses_same_stop_path() {
+    // When CADUCEUS_RUN_ISOLATION_TESTS is set:
+    //  1. Start a long-running container (sleep 3600)
+    //  2. Cancel the DAEMON SHUTDOWN token during the wait phase
+    //  3. Verify the result is Err(Cancelled) and the run did not
+    //     early-return (the stop step was reached)
+    //  4. Verify the state row shows Killed and the next daemon
+    //     startup's reconciliation removes the container
+
+    let spec = test_spec("shutdown-cancel-at-wait");
+    assert!(
+        !spec.cancellation.is_cancelled(),
+        "cancellation token must not be cancelled initially"
+    );
+}

--- a/tests/executor/executor_oci_test.rs
+++ b/tests/executor/executor_oci_test.rs
@@ -16,6 +16,7 @@ use caduceus::executor::oci::OciExecutor;
 use caduceus::executor::{Executor, ExecutorSpec};
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
+use caduceus::infra::disk::DiskPressureGuard;
 use caduceus::infra::error::CaduceusError;
 use tempfile::TempDir;
 
@@ -75,7 +76,10 @@ fn test_spec(cfg: &Config) -> ExecutorSpec {
 #[tokio::test]
 async fn oci_executor_returns_typed_error() {
     let (cfg, _tmp) = setup();
-    let executor: Arc<dyn Executor> = Arc::new(OciExecutor::new(cfg.clone()));
+    let executor: Arc<dyn Executor> = Arc::new(OciExecutor::new(
+        cfg.clone(),
+        Arc::new(DiskPressureGuard::from_config(&cfg)),
+    ));
     let spec = test_spec(&cfg);
     let err = executor
         .run(&spec)
@@ -103,7 +107,10 @@ async fn oci_executor_returns_typed_error() {
 #[tokio::test]
 async fn oci_executor_does_not_spawn_process() {
     let (cfg, _tmp) = setup();
-    let executor: Arc<dyn Executor> = Arc::new(OciExecutor::new(cfg.clone()));
+    let executor: Arc<dyn Executor> = Arc::new(OciExecutor::new(
+        cfg.clone(),
+        Arc::new(DiskPressureGuard::from_config(&cfg)),
+    ));
     let spec = test_spec(&cfg);
     let started = Instant::now();
     let _ = executor.run(&spec).await;

--- a/tests/executor/network_isolation_test.rs
+++ b/tests/executor/network_isolation_test.rs
@@ -8,7 +8,7 @@
 
 use caduceus::executor::sandbox_renderer::render;
 use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
-use caduceus::infra::config::{Config, SandboxNetwork};
+use caduceus::infra::config::Config;
 
 mod support;
 
@@ -49,18 +49,32 @@ fn probe_blocked_egress() {
     );
 }
 
-// probe_allowed_egress — unrestricted network mode allows egress
+// probe_allowed_egress — host networking is structurally
+// unrepresentable (breaking, issue #245): a config that requests
+// `network: unrestricted` fails at YAML parse time with a typed
+// unknown-variant error.
 
 #[test]
 #[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
 fn probe_allowed_egress() {
-    let mut cfg = default_cfg();
-    cfg.sandbox.as_mut().unwrap().network = SandboxNetwork::Unrestricted;
-    assert_eq!(
-        network_value(&cfg),
-        "host",
-        "expected --network=host for allowed egress"
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.yaml");
+    let image =
+        "caduceus-worker@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    let body = format!(
+        "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
+         state_dir: \"{}/state\"\n\
+         reduced_containment_acknowledged: true\n\
+         sandbox:\n\
+         \x20 image: \"{image}\"\n\
+         \x20 network: unrestricted\n",
+        dir.path().display()
     );
+    std::fs::write(&path, body).expect("write config");
+    let err = Config::load_from(&path).expect_err("network: unrestricted must fail to parse");
+    let msg = err.to_string();
+    assert!(msg.contains("unknown variant"), "got: {msg}");
+    assert!(msg.contains("unrestricted"), "got: {msg}");
 }
 
 // probe_dns_exfiltration — DNS queries are blocked with no network

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -612,3 +612,233 @@ fn git_shadow_dir_variant_is_empty_and_read_only() {
         "host .git/HEAD must be untouched"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Disk-fill watchdog (issue #245, task 13.2)
+// ---------------------------------------------------------------------------
+
+/// The host disk-pressure watchdog terminates an in-flight OCI run via
+/// the existing stop path and refuses new dispatch with
+/// `OciDiskPressure` — WITHOUT actually filling the host disk: the
+/// reserve is set ABOVE the sampled free space, so the state-dir
+/// filesystem is observed as already breached. Recovery-with-margin is
+/// asserted on the pure transition the guard runs.
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
+    use std::sync::Arc;
+
+    use tokio_util::sync::CancellationToken;
+
+    use caduceus::executor::oci_lifecycle;
+    use caduceus::infra::disk::{
+        sample_free_bytes, transition, watchdog_paths, DiskPressureGuard, DiskSample,
+        PressureState, DISK_HYSTERESIS_BYTES,
+    };
+    use caduceus::infra::error::CaduceusError;
+    use caduceus::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
+
+    struct NullState;
+    impl OciRunState for NullState {
+        fn insert(&self, _row: &ContainerRunRow) -> Result<(), caduceus::error::CaduceusError> {
+            Ok(())
+        }
+        fn update_state(
+            &self,
+            _run_id: &str,
+            _state: &OciLifecycleState,
+        ) -> Result<(), caduceus::error::CaduceusError> {
+            Ok(())
+        }
+        fn list_pending_reconciliation(
+            &self,
+        ) -> Result<Vec<ContainerRunRow>, caduceus::error::CaduceusError> {
+            Ok(Vec::new())
+        }
+        fn get(
+            &self,
+            _run_id: &str,
+        ) -> Result<Option<ContainerRunRow>, caduceus::error::CaduceusError> {
+            Ok(None)
+        }
+        fn delete(&self, _run_id: &str) -> Result<(), caduceus::error::CaduceusError> {
+            Ok(())
+        }
+    }
+
+    let fx = live_fixture(GitShadowKind::File, "sleep 3600");
+
+    // 1. Sample the real filesystem hosting the state dir and set the
+    //    reserve ABOVE current free space — breach without filling.
+    let samples = sample_free_bytes(&watchdog_paths(&fx.cfg)).expect("sample");
+    assert!(!samples.is_empty(), "state dir must sample");
+    let free = samples[0].free_bytes;
+    let device_id = samples[0].device_id;
+    let state_dir = fx.cfg.state_dir.clone();
+    let reserved_mb = free / (1024 * 1024) + 64; // 64 MiB above free space
+    let reserved_bytes = reserved_mb * 1024 * 1024;
+    let mut cfg = fx.cfg.clone();
+    cfg.sandbox.as_mut().expect("sandbox").reserved_host_disk_mb = reserved_mb;
+    let guard = Arc::new(DiskPressureGuard::from_config(&cfg));
+    assert!(guard.enabled());
+
+    // 2. In-flight run: drive the REAL engine through `run_with_argv`
+    //    with the fixture's rendered create argv. The wait step blocks
+    //    on `sleep 3600` until the breach cancels the watchdog token.
+    let guard_for_run = Arc::clone(&guard);
+    let guard_for_refresh = Arc::clone(&guard);
+    let run_id = fx.run_id.clone();
+    let engine = fx.engine;
+    let argv = fx.argv.clone();
+    let fx_cfg = cfg.clone();
+    let run = tokio::runtime::Runtime::new().expect("runtime");
+    let result = run.block_on(async move {
+        let spec = caduceus::executor::ExecutorSpec {
+            self_exe: std::path::PathBuf::from("/proc/self/exe"),
+            issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+            worktree: std::path::PathBuf::from("/tmp/worktree"),
+            run_id: run_id.clone(),
+            context_json: "{}".to_string(),
+            worker_command: vec!["sleep".to_string(), "3600".to_string()],
+            cancellation: CancellationToken::new(),
+            issue_title: "t".to_string(),
+            issue_body: "b".to_string(),
+            labels: Vec::new(),
+            branch_name: "b".to_string(),
+        };
+        let lifecycle = tokio::spawn(async move {
+            oci_lifecycle::run_with_argv(
+                &fx_cfg,
+                &spec,
+                &NullState,
+                engine,
+                argv,
+                CancellationToken::new(),
+                guard_for_run.watchdog_token(),
+            )
+            .await
+        });
+        // Deterministic breach point: wait until the container is
+        // actually RUNNING (the wait step blocks on `sleep 3600`), so
+        // the breach exercises the in-flight stop → capture → rm path
+        // and not merely the pre-spawn create check.
+        let bin = engine_binary(engine);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        loop {
+            let ps = Command::new(&bin)
+                .args([
+                    "ps",
+                    "--filter",
+                    &format!("name={}", run_id),
+                    "--format",
+                    "{{.ID}}",
+                ])
+                .output()
+                .expect("engine ps");
+            if !String::from_utf8_lossy(&ps.stdout).trim().is_empty() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "container never reached the running state"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        // The watchdog breaches on this refresh.
+        guard_for_refresh.refresh(&samples);
+        assert!(guard_for_refresh.watchdog_token().is_cancelled());
+        lifecycle.await.expect("lifecycle task joins")
+    });
+
+    // (a) The in-flight run was terminated via the stop path within
+    //     the bounded stop/kill timeouts and reported as cancelled.
+    match result {
+        Err(CaduceusError::Cancelled) => {}
+        other => panic!("expected Cancelled from the watchdog termination; got {other:?}"),
+    }
+    // (a') The container is really gone from the engine.
+    let bin = engine_binary(engine);
+    let ps = Command::new(&bin)
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name={}", fx.run_id),
+            "--format",
+            "{{.ID}}",
+        ])
+        .output()
+        .expect("engine ps");
+    assert!(
+        String::from_utf8_lossy(&ps.stdout).trim().is_empty(),
+        "container must be removed after the breach; got: {}",
+        String::from_utf8_lossy(&ps.stdout)
+    );
+    // (a'') The bounded diagnostic capture was persisted for the
+    // terminated run (stop → capture → rm ran in order).
+    let engine_log = state_dir
+        .join("oci-runs")
+        .join(&fx.run_id)
+        .join("engine.log");
+    assert!(
+        engine_log.exists(),
+        "engine.log must be captured on the watchdog termination path"
+    );
+
+    // (b) New dispatch is refused with the typed error carrying the
+    //     breaching path/device/free/reserved facts.
+    let err = guard.try_acquire_oci().expect_err("breached guard refuses");
+    match err {
+        CaduceusError::OciDiskPressure {
+            path,
+            device_id: err_device,
+            free_bytes: err_free,
+            reserved_bytes: err_reserved,
+        } => {
+            assert_eq!(path, state_dir.display().to_string());
+            assert_eq!(err_device, device_id);
+            assert_eq!(err_free, free);
+            assert_eq!(err_reserved, reserved_bytes);
+        }
+        other => panic!("expected OciDiskPressure; got {other:?}"),
+    }
+
+    // (c) TrustedHost work is structurally unaffected: the executor
+    //     factory never wires the guard into TrustedHostExecutor, and
+    //     a breached guard only cancels its own watchdog tokens.
+    let unrelated = CancellationToken::new();
+    assert!(!unrelated.is_cancelled());
+
+    // (d) Recovery requires the margin — exactly the pure transition
+    //     the guard computes each refresh. (The real filesystem was
+    //     never filled, so the live free space stays below the
+    //     inflated reserve; the recovery math is asserted here.)
+    let breached = PressureState::Breached {
+        device_id,
+        path: state_dir.display().to_string(),
+        free_bytes: free,
+        reserved_bytes,
+    };
+    let still = transition(
+        &breached,
+        &[DiskSample {
+            device_id,
+            free_bytes: reserved_bytes + DISK_HYSTERESIS_BYTES,
+            representative_path: state_dir.clone(),
+        }],
+        reserved_bytes,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(still, breached, "exact floor does not re-enable");
+    let recovered = transition(
+        &breached,
+        &[DiskSample {
+            device_id,
+            free_bytes: reserved_bytes + DISK_HYSTERESIS_BYTES + 1,
+            representative_path: state_dir.clone(),
+        }],
+        reserved_bytes,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(recovered, PressureState::Healthy);
+}

--- a/tests/executor/oci_lifecycle_stub_test.rs
+++ b/tests/executor/oci_lifecycle_stub_test.rs
@@ -1,0 +1,405 @@
+//! Lifecycle wait-cancellation and bounded diagnostic-capture tests
+//! driven by a stub OCI engine (issue #245, tasks 11.1 / 11.3).
+//!
+//! The lifecycle invokes the engine binary by name (`docker`), so
+//! these tests prepend a stub-script directory to `PATH` and drive
+//! `run_with_argv` end-to-end without a real container engine:
+//!
+//! - wait cancellation from the **watchdog token** falls through
+//!   stop → capture → rm and reports `Cancelled` with no leaked
+//!   container (state reaches `Removed`);
+//! - wait cancellation from the **daemon shutdown token** reports
+//!   `Cancelled`; the cleanup steps check only the daemon token
+//!   (which is itself cancelled), so the state reaches `Killed` and
+//!   the reconciliation pass finishes the `rm` — the pre-existing
+//!   daemon-shutdown stop-path contract;
+//! - over-cap engine logs are persisted bounded (≤ 1 MiB + marker)
+//!   under `<state_dir>/oci-runs/<run_id>/engine.log` with a
+//!   truncation marker.
+//!
+//! Every test mutates the process `PATH`, so all tests in this binary
+//! are `#[serial]` (exclusive among themselves; other test binaries
+//! run in separate processes with their own environment).
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use serial_test::serial;
+use tokio_util::sync::CancellationToken;
+
+use caduceus::executor::oci_lifecycle;
+use caduceus::executor::sandbox_spec::SandboxEngine;
+use caduceus::executor::ExecutorSpec;
+use caduceus::github::issue::IssueKey;
+use caduceus::infra::config::Config;
+use caduceus::infra::error::{CaduceusError, CaduceusResult};
+use caduceus::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+struct FakeOciRunState {
+    rows: Mutex<Vec<ContainerRunRow>>,
+}
+
+impl FakeOciRunState {
+    fn new() -> Self {
+        Self {
+            rows: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl OciRunState for FakeOciRunState {
+    fn insert(&self, row: &ContainerRunRow) -> CaduceusResult<()> {
+        self.rows.lock().unwrap().push(row.clone());
+        Ok(())
+    }
+
+    fn update_state(&self, run_id: &str, state: &OciLifecycleState) -> CaduceusResult<()> {
+        if let Some(row) = self
+            .rows
+            .lock()
+            .unwrap()
+            .iter_mut()
+            .find(|r| r.run_id == run_id)
+        {
+            row.state = state.clone();
+        }
+        Ok(())
+    }
+
+    fn list_pending_reconciliation(&self) -> CaduceusResult<Vec<ContainerRunRow>> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.state == OciLifecycleState::PendingReconciliation)
+            .cloned()
+            .collect())
+    }
+
+    fn get(&self, run_id: &str) -> CaduceusResult<Option<ContainerRunRow>> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|r| r.run_id == run_id)
+            .cloned())
+    }
+
+    fn delete(&self, run_id: &str) -> CaduceusResult<()> {
+        self.rows.lock().unwrap().retain(|r| r.run_id != run_id);
+        Ok(())
+    }
+}
+
+fn test_spec(run_id: &str) -> ExecutorSpec {
+    ExecutorSpec {
+        self_exe: Path::new("/usr/bin/caduceus").to_path_buf(),
+        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        worktree: Path::new("/tmp/worktree").to_path_buf(),
+        run_id: run_id.to_string(),
+        context_json: r#"{"x":1}"#.to_string(),
+        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
+        cancellation: CancellationToken::new(),
+        issue_title: "title".to_string(),
+        issue_body: "body".to_string(),
+        labels: Vec::new(),
+        branch_name: "automation/issue-1".to_string(),
+    }
+}
+
+fn create_argv() -> Vec<String> {
+    vec![
+        "docker".to_string(),
+        "create".to_string(),
+        "caduceus-worker@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            .to_string(),
+        "bridge.py".to_string(),
+    ]
+}
+
+/// Stub engine script. Behavior is env-tunable:
+/// - `STUB_WAIT_SLEEP`: seconds `wait` sleeps before printing `0`
+///   (lets the test cancel mid-wait);
+/// - `STUB_LOG_BYTES`: byte count `logs` emits (over-feeds the
+///   diagnostic capture when large).
+const STUB_SCRIPT: &str = r#"#!/bin/sh
+DIR="$(dirname "$0")"
+case "$1" in
+  create) echo "stub-container-000" ;;
+  start) touch "$DIR/started" ;;
+  wait)
+    if [ -n "$STUB_WAIT_SLEEP" ]; then sleep "$STUB_WAIT_SLEEP"; fi
+    echo 0 ;;
+  stop) touch "$DIR/stopped" ;;
+  kill) touch "$DIR/killed" ;;
+  rm) touch "$DIR/removed" ;;
+  logs)
+    if [ -n "$STUB_LOG_BYTES" ]; then
+      head -c "$STUB_LOG_BYTES" /dev/zero | tr '\0' 'x'
+    else
+      echo "stub engine log line"
+    fi ;;
+  *) exit 0 ;;
+esac
+"#;
+
+/// Prepends a stub-engine directory to `PATH` and restores the
+/// original on drop. Also clears the stub's tuning env vars on drop.
+struct StubEngine {
+    _dir: tempfile::TempDir,
+    started: PathBuf,
+    stopped: PathBuf,
+    removed: PathBuf,
+}
+
+impl StubEngine {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("stub tempdir");
+        let script = dir.path().join("docker");
+        std::fs::write(&script, STUB_SCRIPT).expect("write stub script");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod stub script");
+        let path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{path}", dir.path().display()));
+        Self {
+            started: dir.path().join("started"),
+            stopped: dir.path().join("stopped"),
+            removed: dir.path().join("removed"),
+            _dir: dir,
+        }
+    }
+}
+
+impl Drop for StubEngine {
+    fn drop(&mut self) {
+        // Rebuild PATH without the stub dir (best-effort restore).
+        // The tempdir removal alone already breaks the stub, but a
+        // clean PATH keeps later serial tests honest.
+        if let Ok(path) = std::env::var("PATH") {
+            let stub_dir = self._dir.path().to_string_lossy().to_string();
+            let filtered: Vec<&str> = path.split(':').filter(|p| *p != stub_dir).collect();
+            std::env::set_var("PATH", filtered.join(":"));
+        }
+        std::env::remove_var("STUB_WAIT_SLEEP");
+        std::env::remove_var("STUB_LOG_BYTES");
+    }
+}
+
+/// Poll for a marker file with a bounded budget (the stub creates
+/// markers synchronously, so a couple of seconds is generous). If the
+/// lifecycle finishes before the marker appears, panic with its result
+/// — that is a real failure, not a timing miss.
+async fn wait_for_marker(
+    marker: &Path,
+    budget: Duration,
+    lifecycle_result: &mut tokio::sync::mpsc::Receiver<String>,
+) {
+    let started = std::time::Instant::now();
+    loop {
+        if marker.exists() {
+            return;
+        }
+        if let Ok(result) = lifecycle_result.try_recv() {
+            panic!("lifecycle finished before the start marker appeared: {result}");
+        }
+        assert!(
+            started.elapsed() < budget,
+            "stub engine never reached the start step"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn engine_log_path(cfg: &Config, run_id: &str) -> PathBuf {
+    cfg.state_dir
+        .join("oci-runs")
+        .join(run_id)
+        .join("engine.log")
+}
+
+// ---------------------------------------------------------------------------
+// Wait cancellation — both token sources through the same stop path
+// ---------------------------------------------------------------------------
+
+/// Watchdog-token cancellation mid-wait: the run falls through the
+/// stop → capture → rm sequence (never an early return), reports
+/// `Cancelled`, and reaches `Removed` — no container leak.
+#[tokio::test]
+#[serial]
+async fn watchdog_cancellation_proceeds_through_stop_capture_rm() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let stub = StubEngine::new();
+    std::env::set_var("STUB_WAIT_SLEEP", "10");
+    let state = std::sync::Arc::new(FakeOciRunState::new());
+    let spec = test_spec("stub-watchdog-cancel");
+    let shutdown = CancellationToken::new();
+    let watchdog = CancellationToken::new();
+
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+    let lifecycle = tokio::spawn({
+        let cfg = cfg.clone();
+        let state = std::sync::Arc::clone(&state);
+        let shutdown = shutdown.clone();
+        let watchdog = watchdog.clone();
+        async move {
+            let outcome = oci_lifecycle::run_with_argv(
+                &cfg,
+                &spec,
+                &*state,
+                SandboxEngine::Docker,
+                create_argv(),
+                shutdown,
+                watchdog,
+            )
+            .await;
+            let _ = result_tx.send(format!("{outcome:?}")).await;
+            outcome
+        }
+    });
+
+    // Deterministic cancel point: the stub's start step creates the
+    // marker right before the wait step begins.
+    wait_for_marker(&stub.started, Duration::from_secs(10), &mut result_rx).await;
+    watchdog.cancel();
+
+    let result = lifecycle
+        .await
+        .expect("lifecycle task joins")
+        .expect_err("watchdog cancellation must report Cancelled");
+    assert!(
+        matches!(result, CaduceusError::Cancelled),
+        "expected Cancelled; got: {result:?}"
+    );
+
+    // Cleanup ran: stop and rm markers exist, state is Removed, and
+    // the bounded diagnostic capture was persisted.
+    assert!(stub.stopped.exists(), "stop step must run");
+    assert!(stub.removed.exists(), "rm step must run after cancellation");
+    let row = state
+        .get("stub-watchdog-cancel")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.state, OciLifecycleState::Removed);
+    assert!(engine_log_path(&cfg, "stub-watchdog-cancel").exists());
+}
+
+/// Daemon-shutdown-token cancellation mid-wait: the run also falls
+/// through to the cleanup sequence and reports `Cancelled`. The
+/// cleanup steps check ONLY the daemon token — which is itself
+/// cancelled — so the state lands in `Killed` and the reconciliation
+/// pass finishes the `rm` (the pre-existing daemon-shutdown stop-path
+/// contract; no early return, no hang).
+#[tokio::test]
+#[serial]
+async fn shutdown_cancellation_falls_through_cleanup_and_reports_cancelled() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let stub = StubEngine::new();
+    std::env::set_var("STUB_WAIT_SLEEP", "10");
+    let state = std::sync::Arc::new(FakeOciRunState::new());
+    let spec = test_spec("stub-shutdown-cancel");
+    let shutdown = CancellationToken::new();
+    let watchdog = CancellationToken::new();
+
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+    let lifecycle = tokio::spawn({
+        let cfg = cfg.clone();
+        let state = std::sync::Arc::clone(&state);
+        let shutdown = shutdown.clone();
+        async move {
+            let outcome = oci_lifecycle::run_with_argv(
+                &cfg,
+                &spec,
+                &*state,
+                SandboxEngine::Docker,
+                create_argv(),
+                shutdown,
+                watchdog,
+            )
+            .await;
+            let _ = result_tx.send(format!("{outcome:?}")).await;
+            outcome
+        }
+    });
+
+    wait_for_marker(&stub.started, Duration::from_secs(10), &mut result_rx).await;
+    shutdown.cancel();
+
+    let result = lifecycle
+        .await
+        .expect("lifecycle task joins")
+        .expect_err("shutdown cancellation must report Cancelled");
+    assert!(
+        matches!(result, CaduceusError::Cancelled),
+        "expected Cancelled; got: {result:?}"
+    );
+
+    // The wait cancellation did not early-return: the stop step was
+    // reached (its pre-spawn check refused to spawn because the daemon
+    // token is cancelled) and the kill fallback recorded Killed.
+    let row = state
+        .get("stub-shutdown-cancel")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.state, OciLifecycleState::Killed);
+    assert!(
+        !stub.removed.exists(),
+        "rm is left to reconciliation when the daemon token is cancelled"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bounded diagnostic capture (task 11.3)
+// ---------------------------------------------------------------------------
+
+/// A container emitting > 1 MiB of engine logs yields a persisted
+/// diagnostic that (a) exists under
+/// `<state_dir>/oci-runs/<run_id>/engine.log`, (b) is bounded at the
+/// 1 MiB cap (plus the small truncation marker), and (c) carries the
+/// truncation marker when over-fed.
+#[tokio::test]
+#[serial]
+async fn diagnostic_capture_is_bounded_with_truncation_marker() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let _stub = StubEngine::new();
+    std::env::set_var("STUB_LOG_BYTES", "2097152"); // 2 MiB > 1 MiB cap
+    let state = FakeOciRunState::new();
+    let spec = test_spec("stub-capture-bounded");
+
+    let outcome = oci_lifecycle::run_with_argv(
+        &cfg,
+        &spec,
+        &state,
+        SandboxEngine::Docker,
+        create_argv(),
+        CancellationToken::new(),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("stub lifecycle completes");
+
+    assert_eq!(outcome.status, 0, "stub wait prints 0");
+
+    let path = engine_log_path(&cfg, "stub-capture-bounded");
+    assert!(path.exists(), "engine.log must be persisted");
+    let meta = std::fs::metadata(&path).expect("stat engine.log");
+    // Hard cap: the writer's first-N semantics plus the marker stay
+    // within the cap plus a small marker allowance.
+    assert!(
+        meta.len() <= oci_lifecycle::OCI_DIAGNOSTIC_MAX_BYTES + 128,
+        "engine.log must be bounded at the 1 MiB cap, got {} bytes",
+        meta.len()
+    );
+    let body = std::fs::read_to_string(&path).expect("read engine.log");
+    assert!(
+        body.contains("...<truncated"),
+        "over-fed capture must carry the truncation marker"
+    );
+}

--- a/tests/executor/oci_lifecycle_test.rs
+++ b/tests/executor/oci_lifecycle_test.rs
@@ -120,7 +120,8 @@ async fn cleanup_on_cancel_and_timeout() {
         &state,
         SandboxEngine::Docker,
         create_argv(),
-        cancel,
+        cancel.clone(),
+        CancellationToken::new(),
     )
     .await;
     assert!(result.is_err(), "expected error without Docker");
@@ -155,7 +156,8 @@ async fn engine_unavailable_surfaces_structured() {
         &state,
         SandboxEngine::Docker,
         create_argv(),
-        cancel,
+        cancel.clone(),
+        CancellationToken::new(),
     )
     .await
     .expect_err("expected error without Docker");
@@ -193,6 +195,7 @@ async fn stop_kill_remove_bounded() {
             SandboxEngine::Docker,
             create_argv(),
             cancel,
+            CancellationToken::new(),
         ),
     )
     .await;
@@ -240,6 +243,7 @@ async fn run_with_argv_wires_engine_into_state_row() {
         SandboxEngine::Podman,
         create_argv(),
         cancel,
+        CancellationToken::new(),
     )
     .await;
 

--- a/tests/executor/policy_test.rs
+++ b/tests/executor/policy_test.rs
@@ -9,7 +9,7 @@
 
 use caduceus::executor::sandbox_renderer::render;
 use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
-use caduceus::infra::config::{Config, SandboxNetwork};
+use caduceus::infra::config::Config;
 
 mod support;
 
@@ -129,19 +129,19 @@ fn isolation_flags_precede_image() {
     );
 }
 
-// network_mode_applied — unrestricted network → --network host
+// network_mode_applied — the only network mode is `none` (host
+// networking was removed, breaking: issue #245)
 
 #[test]
 fn network_mode_applied() {
-    let mut cfg = default_cfg();
-    cfg.sandbox.as_mut().unwrap().network = SandboxNetwork::Unrestricted;
+    let cfg = default_cfg();
     let spec = resolve_from(&cfg);
     let argv = render(&spec, SandboxEngine::Docker);
     let network_pos = argv
         .iter()
         .position(|a| a == "--network")
         .expect("--network");
-    assert_eq!(argv[network_pos + 1], "host");
+    assert_eq!(argv[network_pos + 1], "none");
 }
 
 // no_network_mode_gives_none — default network mode → --network=none

--- a/tests/executor/resource_limit_test.rs
+++ b/tests/executor/resource_limit_test.rs
@@ -99,3 +99,116 @@ fn exhaust_cpu() {
         "argv must carry --cpus for the CPU boundary"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Hardened baseline additions (issue #245, task 13.1)
+// ---------------------------------------------------------------------------
+
+// memory_swap_pinned — --memory-swap equals --memory, so a worker
+// cannot escape the memory bound via swap (no swap rescue)
+
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn memory_swap_pinned_no_swap_rescue() {
+    // When CADUCEUS_RUN_ISOLATION_TESTS is set:
+    //  docker run --memory 2048m --memory-swap 2048m caduceus-worker \
+    //  python3 -c 'x = bytearray(4096 * 1024 * 1024)'
+    // Expected: OOM kill (exit 137) with NO swap rescue — committed
+    // memory (mem + swap) cannot exceed the --memory value.
+    let cfg = default_cfg();
+    let spec = resolve_from(&cfg);
+    let argv = render(&spec, SandboxEngine::Docker);
+    let mem_pos = argv.iter().position(|a| a == "--memory").expect("--memory");
+    let swap_pos = argv
+        .iter()
+        .position(|a| a == "--memory-swap")
+        .expect("--memory-swap must be rendered");
+    assert_eq!(
+        argv[swap_pos + 1],
+        argv[mem_pos + 1],
+        "--memory-swap must be pinned equal to --memory"
+    );
+}
+
+// tmpfs_bounds — writes beyond the configured tmpfs `size=` fail
+
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn tmpfs_write_beyond_size_fails() {
+    // When CADUCEUS_RUN_ISOLATION_TESTS is set:
+    //  dd if=/dev/zero of=/tmp/over bs=1M count=$((tmpfs_mb + 16))
+    //  dd if=/dev/zero of=/dev/shm/over bs=1M count=$((shm_mb + 16))
+    // Expected: both writes fail with ENOSPC once the bounded tmpfs
+    // is full — the sizes come from --tmpfs size= in the argv below.
+    let cfg = default_cfg();
+    let spec = resolve_from(&cfg);
+    let argv = render(&spec, SandboxEngine::Docker);
+    assert!(
+        argv.iter()
+            .any(|a| a == &format!("/tmp:size={}m", cfg.sandbox().resources.tmpfs_mb)),
+        "/tmp tmpfs must be bounded by resources.tmpfs_mb"
+    );
+    assert!(
+        argv.iter()
+            .any(|a| a == &format!("/dev/shm:size={}m", cfg.sandbox().resources.shm_mb)),
+        "/dev/shm tmpfs must be bounded by resources.shm_mb"
+    );
+}
+
+// rootfs_read_only — writes to the container rootfs fail EROFS
+
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn rootfs_write_fails_erofs() {
+    // When CADUCEUS_RUN_ISOLATION_TESTS is set:
+    //  touch /etc/escape-attempt
+    // Expected: touch fails with EROFS (Read-only file system) — the
+    // rootfs is --read-only and the only writable surfaces are the
+    // two binds and the two bounded tmpfs.
+    let cfg = default_cfg();
+    let spec = resolve_from(&cfg);
+    let argv = render(&spec, SandboxEngine::Docker);
+    assert!(
+        argv.iter().any(|a| a == "--read-only"),
+        "argv must carry --read-only for the rootfs boundary"
+    );
+}
+
+// caps_absent — --cap-drop ALL leaves no capabilities in-container
+
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn capabilities_absent() {
+    // When CADUCEUS_RUN_ISOLATION_TESTS is set:
+    //  capsh --print   (or: grep CapEff /proc/self/status)
+    // Expected: CapEff == 0000000000000000 — every capability was
+    // dropped; no-new-privileges blocks re-acquisition via setuid.
+    let cfg = default_cfg();
+    let spec = resolve_from(&cfg);
+    let argv = render(&spec, SandboxEngine::Docker);
+    let cap_pos = argv
+        .iter()
+        .position(|a| a == "--cap-drop")
+        .expect("--cap-drop");
+    assert_eq!(argv[cap_pos + 1], "ALL", "every capability must be dropped");
+    assert!(
+        argv.iter().any(|a| a == "no-new-privileges"),
+        "no-new-privileges must accompany --cap-drop ALL"
+    );
+}
+
+// network_none_default — default render asserts --network none; no
+// egress, no DNS, no host networking (structurally unrepresentable)
+
+#[test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+fn default_render_is_network_none() {
+    let cfg = default_cfg();
+    let spec = resolve_from(&cfg);
+    let argv = render(&spec, SandboxEngine::Docker);
+    let pos = argv
+        .iter()
+        .position(|a| a == "--network")
+        .expect("--network");
+    assert_eq!(argv[pos + 1], "none");
+}

--- a/tests/executor/sandbox_renderer_test.rs
+++ b/tests/executor/sandbox_renderer_test.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use caduceus::executor::sandbox_renderer::{render, render_with_env_files};
 use caduceus::executor::sandbox_spec::{EngineMode, GitShadowKind, SandboxEngine, SandboxSpec};
-use caduceus::infra::config::{Config, SandboxConfig, SandboxNetwork};
+use caduceus::infra::config::{Config, SandboxConfig};
 
 /// Fixed root for the golden fixtures. Never touched on disk.
 const ROOT: &str = "/tmp/caduceus-renderer-goldens";
@@ -120,8 +120,14 @@ fn docker_rootful_golden_argv() {
         "2".to_string(),
         "--memory".to_string(),
         "2048m".to_string(),
+        "--memory-swap".to_string(),
+        "2048m".to_string(),
         "--pids-limit".to_string(),
         "256".to_string(),
+        "--log-opt".to_string(),
+        "max-size=10m".to_string(),
+        "--log-opt".to_string(),
+        "max-file=3".to_string(),
         "--name".to_string(),
         "run-001".to_string(),
         "-v".to_string(),
@@ -193,8 +199,14 @@ fn podman_rootless_golden_argv() {
         "2".to_string(),
         "--memory".to_string(),
         "2048m".to_string(),
+        "--memory-swap".to_string(),
+        "2048m".to_string(),
         "--pids-limit".to_string(),
         "256".to_string(),
+        "--log-opt".to_string(),
+        "max-size=10m".to_string(),
+        "--log-opt".to_string(),
+        "max-file=3".to_string(),
         "--name".to_string(),
         "run-001".to_string(),
         "-v".to_string(),
@@ -521,18 +533,94 @@ fn renders_network_none_by_default() {
     assert_eq!(argv[pos + 1], "none");
 }
 
+/// Host networking was removed (breaking, issue #245): the rendered
+/// argv must never carry `--network host` — the only value after
+/// `--network` is `none`, for both engines.
 #[test]
-fn renders_network_host_for_unrestricted() {
-    let (spec, _, _, _, _) =
-        fixture_with("run-001", EngineMode::Rootful, GitShadowKind::File, |sb| {
-            sb.network = SandboxNetwork::Unrestricted;
-        });
-    let argv = render(&spec, SandboxEngine::Docker);
-    let pos = argv
-        .iter()
-        .position(|a| a == "--network")
-        .expect("--network");
-    assert_eq!(argv[pos + 1], "host");
+fn renders_network_none_never_host() {
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        let (spec, _, _, _, _) = default_fixture();
+        let argv = render(&spec, engine);
+        let pos = argv
+            .iter()
+            .position(|a| a == "--network")
+            .expect("--network");
+        assert_ne!(
+            argv.get(pos + 1).map(String::as_str),
+            Some("host"),
+            "--network host must never be rendered ({engine:?}); got: {argv:?}"
+        );
+        assert_eq!(argv[pos + 1], "none");
+    }
+}
+
+/// `--memory-swap` is pinned EQUAL to `--memory` (no swap doubling)
+/// and both `--log-opt max-size=10m` / `--log-opt max-file=3` entries
+/// are present, for BOTH engines (issue #245).
+#[test]
+fn renders_memory_swap_pinned_and_bounded_log_opts() {
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        let (spec, _, _, _, _) = default_fixture();
+        let argv = render(&spec, engine);
+        let mem_pos = argv.iter().position(|a| a == "--memory").expect("--memory");
+        assert_eq!(argv[mem_pos + 1], "2048m");
+        let swap_pos = argv
+            .iter()
+            .position(|a| a == "--memory-swap")
+            .expect("--memory-swap");
+        assert_eq!(
+            argv[swap_pos + 1],
+            argv[mem_pos + 1],
+            "--memory-swap must equal --memory ({engine:?}); got: {argv:?}"
+        );
+        assert!(
+            swap_pos == mem_pos + 2,
+            "--memory-swap must immediately follow --memory's value"
+        );
+        let log_opt_positions: Vec<usize> = argv
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.as_str() == "--log-opt")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            log_opt_positions.len(),
+            2,
+            "exactly two --log-opt entries for {engine:?}: {argv:?}"
+        );
+        assert_eq!(argv[log_opt_positions[0] + 1], "max-size=10m");
+        assert_eq!(argv[log_opt_positions[1] + 1], "max-file=3");
+    }
+}
+
+/// Deny tripwire (issue #245): the rendered argv for BOTH engines
+/// contains NO `--device`, NO `--pid host` / `--ipc host` /
+/// `--uts host`, NO `--network host`, and no engine/runtime socket
+/// substring. The renderer structurally cannot emit these; this test
+/// pins that against regressions.
+#[test]
+fn renders_no_host_escalation_tokens() {
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        let (spec, _, _, _, _) = default_fixture();
+        let argv = render(&spec, engine);
+        for denied in ["--device", "--pid", "--ipc", "--uts"] {
+            assert!(
+                !argv.iter().any(|a| a == denied),
+                "{denied} must never be rendered ({engine:?}); got: {argv:?}"
+            );
+        }
+        let net_pos = argv
+            .iter()
+            .position(|a| a == "--network")
+            .expect("--network");
+        assert_eq!(argv[net_pos + 1], "none", "--network host is denied");
+        for socket in ["docker.sock", "podman.sock"] {
+            assert!(
+                !argv.iter().any(|a| a.contains(socket)),
+                "engine socket {socket} must never be mounted ({engine:?}); got: {argv:?}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/tests/executor/sandbox_resolve_test.rs
+++ b/tests/executor/sandbox_resolve_test.rs
@@ -10,8 +10,8 @@
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::sandbox_spec::{
-    resolve, select_git_shadow, EngineMode, GitShadowKind, MountSpec, NetworkMode,
-    ResolvedIdentity, RuntimeFacts, SandboxSpec,
+    is_engine_socket_path, resolve, select_git_shadow, validate_no_host_escalation, EngineMode,
+    GitShadowKind, MountSpec, NetworkMode, ResolvedIdentity, RuntimeFacts, SandboxSpec,
 };
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::{Config, OciPullPolicy};
@@ -399,10 +399,9 @@ fn resolution_yields_fully_populated_spec() {
     assert!(!spec.environment().is_empty());
     assert!(!spec.labels().is_empty());
     assert!(spec.resources().memory_mb > 0);
-    assert!(matches!(
-        spec.network(),
-        NetworkMode::None | NetworkMode::Unrestricted
-    ));
+    // Host networking was removed (breaking, issue #245): `None` is
+    // the only variant, so every resolved spec is network-isolated.
+    assert!(matches!(spec.network(), NetworkMode::None));
     let _ = spec.security();
 }
 
@@ -577,4 +576,87 @@ fn engine_mode_fact_flows_into_identity() {
     assert_eq!(spec.identity().gid, 4242);
     assert!(!spec.identity().emit_user, "rootless emits no --user");
     assert_eq!(spec.identity().userns, None);
+}
+
+// ---------------------------------------------------------------------------
+// Host-escalation deny (design D2, issue #245)
+// ---------------------------------------------------------------------------
+
+/// (a) A host-backed mount whose host path is named `docker.sock` /
+/// `podman.sock` is rejected at resolution time, before any container
+/// exists. Reached through `resolve`'s validate_mount_policy →
+/// validate_no_host_escalation call ordering via the `.git` shadow
+/// host path (the only caller-supplied host path that stays inside
+/// the state-dir allow-list).
+#[test]
+fn resolve_rejects_socket_named_host_path() {
+    for socket in ["docker.sock", "podman.sock"] {
+        let (cfg, worktree) = base();
+        let mut runtime = runtime_for(&cfg, &worktree);
+        runtime.git_shadow_host = cfg.state_dir.join("oci-runs").join("run-001").join(socket);
+        let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+            .expect_err("socket-named host path must be rejected");
+        match &err {
+            CaduceusError::OciMountConflict { detail } => {
+                assert!(
+                    detail.contains(socket),
+                    "conflict must name the socket path, got: {detail}"
+                );
+            }
+            other => panic!("expected OciMountConflict; got: {other:?}"),
+        }
+    }
+}
+
+/// (b) Container paths are fixed canonical constants, so the
+/// socket-named *container* path branch of the validator is
+/// structurally unreachable through `resolve`; the socket-name check
+/// itself is pinned via `is_engine_socket_path` on container-path
+/// shapes, and the validator rejects anything it is ever fed.
+#[test]
+fn engine_socket_detection_covers_container_path_shapes() {
+    assert!(is_engine_socket_path(Path::new("/var/run/docker.sock")));
+    assert!(is_engine_socket_path(Path::new("/run/podman/podman.sock")));
+    assert!(is_engine_socket_path(Path::new("docker.sock")));
+    assert!(!is_engine_socket_path(Path::new("/workspace")));
+    assert!(!is_engine_socket_path(Path::new("/output")));
+    assert!(!is_engine_socket_path(Path::new("/workspace/.git")));
+    assert!(!is_engine_socket_path(Path::new(
+        "/var/run/docker.sock.bak"
+    )));
+    assert!(!is_engine_socket_path(Path::new("")));
+}
+
+/// (c) The default spec passes the escalation validator — a plain
+/// resolved spec carries no socket paths and `NetworkMode::None`.
+#[test]
+fn default_spec_passes_escalation_validator() {
+    let (cfg, worktree) = base();
+    let runtime = runtime_for(&cfg, &worktree);
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
+    validate_no_host_escalation(&spec).expect("default spec must pass");
+}
+
+/// (d) The validator runs inside `resolve` (ordering: after the mount
+/// policy, before the spec is returned) — a socket-named shadow host
+/// path is refused by `resolve` itself with a typed error, proving
+/// the call site is reachable end-to-end.
+#[test]
+fn escalation_validator_is_reachable_through_resolve() {
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.git_shadow_host = cfg
+        .state_dir
+        .join("oci-runs")
+        .join("run-001")
+        .join("docker.sock");
+    let result = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime));
+    assert!(
+        matches!(
+            result,
+            Err(CaduceusError::OciMountConflict { ref detail }) if detail.contains("socket")
+        ),
+        "resolve must run the escalation validator; got: {result:?}"
+    );
 }

--- a/tests/infra/config/sandbox_config_test.rs
+++ b/tests/infra/config/sandbox_config_test.rs
@@ -88,7 +88,7 @@ fn explicit_full_sandbox_parses_to_given_values() {
          \x20 image: \"caduceus-worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n\
          \x20 pull_policy: always\n\
          \x20 resources: { cpus: 4.0, memory_mb: 4096, pids: 512, tmpfs_mb: 512, shm_mb: 128 }\n\
-         \x20 network: unrestricted\n\
+         \x20 network: none\n\
          \x20 pass_env: [\"HTTP_PROXY\", \"NO_PROXY\"]\n\
          \x20 stop_timeout_seconds: 30\n\
          \x20 kill_timeout_seconds: 15\n\
@@ -108,7 +108,9 @@ fn explicit_full_sandbox_parses_to_given_values() {
     assert_eq!(sb.resources.pids, 512);
     assert_eq!(sb.resources.tmpfs_mb, 512);
     assert_eq!(sb.resources.shm_mb, 128);
-    assert_eq!(sb.network, SandboxNetwork::Unrestricted);
+    // Host networking was removed (breaking, issue #245): `none` is
+    // the only value.
+    assert_eq!(sb.network, SandboxNetwork::None);
     assert_eq!(
         sb.pass_env,
         vec!["HTTP_PROXY".to_string(), "NO_PROXY".to_string()]
@@ -204,9 +206,30 @@ fn unknown_network_value_rejected() {
     let msg = err.to_string();
     assert!(msg.contains("unknown variant"), "got: {msg}");
     assert!(msg.contains("filtered"), "got: {msg}");
+    // Host networking was removed (issue #245): `none` is the only
+    // allowed value.
     assert!(
-        msg.contains("none") && msg.contains("unrestricted"),
-        "allowed values must be listed; got: {msg}"
+        msg.contains("none") && !msg.contains("unrestricted"),
+        "allowed values must list only `none`; got: {msg}"
+    );
+}
+
+/// `network: unrestricted` (the removed host-networking value,
+/// issue #245) fails at serde parse time as an unknown variant — a
+/// typed error, exactly the spec's "parsing fails with a typed
+/// error" scenario.
+#[test]
+fn unrestricted_network_rejected() {
+    let err = load_sandbox_line(&format!(
+        "image: \"{VALID_IMAGE}\"\n  network: unrestricted"
+    ))
+    .expect_err("network: unrestricted must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("unknown variant"), "got: {msg}");
+    assert!(msg.contains("unrestricted"), "got: {msg}");
+    assert!(
+        msg.contains("none"),
+        "the only valid value must be listed; got: {msg}"
     );
 }
 
@@ -321,22 +344,57 @@ fn pids_below_floor_rejected() {
     );
 }
 
+/// `tmpfs_mb: 0` is rejected: `--tmpfs /tmp:size=0m` lets the engine
+/// apply its DEFAULT size (Docker: effectively unbounded), which
+/// would silently weaken the bounded-tmpfs baseline (issue #245).
 #[test]
-fn tmpfs_mb_valid_at_zero() {
-    let cfg = load(&with_sandbox(&format!(
+fn tmpfs_mb_below_floor_rejected() {
+    let err = load(&with_sandbox(&format!(
         "sandbox:\n  image: \"{VALID_IMAGE}\"\n  resources: {{ tmpfs_mb: 0 }}\n"
     )))
-    .expect("tmpfs_mb 0 is a valid floor");
-    assert_eq!(cfg.sandbox().resources.tmpfs_mb, 0);
+    .expect_err("tmpfs_mb 0 must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("sandbox.resources.tmpfs_mb") && msg.contains(">= 1"),
+        "got: {msg}"
+    );
 }
 
+/// `shm_mb: 0` is rejected for the same reason (issue #245).
 #[test]
-fn shm_mb_valid_at_zero() {
-    let cfg = load(&with_sandbox(&format!(
+fn shm_mb_below_floor_rejected() {
+    let err = load(&with_sandbox(&format!(
         "sandbox:\n  image: \"{VALID_IMAGE}\"\n  resources: {{ shm_mb: 0 }}\n"
     )))
-    .expect("shm_mb 0 is a valid floor");
-    assert_eq!(cfg.sandbox().resources.shm_mb, 0);
+    .expect_err("shm_mb 0 must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("sandbox.resources.shm_mb") && msg.contains(">= 1"),
+        "got: {msg}"
+    );
+}
+
+/// `reserved_host_disk_mb: 0` parses and DISABLES the disk-pressure
+/// watchdog (no sampling, no enforcement) — issue #245.
+#[test]
+fn reserved_host_disk_mb_zero_parses_watchdog_disabled() {
+    let cfg = load(&with_sandbox(&format!(
+        "sandbox:\n  image: \"{VALID_IMAGE}\"\n  reserved_host_disk_mb: 0\n"
+    )))
+    .expect("reserved_host_disk_mb 0 must parse (watchdog disabled)");
+    assert_eq!(cfg.sandbox().reserved_host_disk_mb, 0);
+    // The guard built from this config is disabled: it never refuses.
+    use caduceus::infra::disk::DiskPressureGuard;
+    let guard = DiskPressureGuard::from_config(&cfg);
+    assert!(!guard.enabled());
+    guard.refresh(&[caduceus::infra::disk::DiskSample {
+        device_id: 1,
+        free_bytes: 0,
+        representative_path: cfg.state_dir.clone(),
+    }]);
+    guard
+        .try_acquire_oci()
+        .expect("disabled guard never refuses");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/infra/disk_test.rs
+++ b/tests/infra/disk_test.rs
@@ -1,0 +1,409 @@
+//! Unit tests for the host disk-pressure watchdog (issue #245):
+//! pure transition math across same/multi-device layouts, statvfs
+//! sampling with device-ID dedup, and guard behavior (breach refusal,
+//! hysteresis recovery, disabled no-op).
+
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use caduceus::executor::sandbox_spec::is_engine_socket_path;
+use caduceus::infra::config::Config;
+use caduceus::infra::disk::{
+    transition, DiskPressureGuard, DiskSample, PressureState, DISK_HYSTERESIS_BYTES,
+};
+use caduceus::infra::error::CaduceusError;
+
+/// Synthetic sample helper.
+fn sample(device_id: u64, free_bytes: u64, path: &str) -> DiskSample {
+    DiskSample {
+        device_id,
+        free_bytes,
+        representative_path: PathBuf::from(path),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// transition — pure state machine (tasks 12.2)
+// ---------------------------------------------------------------------------
+
+/// (a) Healthy → Breached when ANY device is under the reserve;
+/// the breaching device is recorded.
+#[test]
+fn transition_breaches_on_any_device() {
+    let reserved = 2048 * 1024 * 1024;
+
+    // Single device.
+    let next = transition(
+        &PressureState::Healthy,
+        &[sample(1, reserved - 1, "/state")],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(
+        next,
+        PressureState::Breached {
+            device_id: 1,
+            path: "/state".to_string(),
+            free_bytes: reserved - 1,
+            reserved_bytes: reserved,
+        }
+    );
+
+    // Three devices; only the second breaches.
+    let next = transition(
+        &PressureState::Healthy,
+        &[
+            sample(1, reserved + 10 * 1024 * 1024, "/state"),
+            sample(2, reserved - 1, "/repos"),
+            sample(3, reserved + 10 * 1024 * 1024, "/workdirs"),
+        ],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    match next {
+        PressureState::Breached {
+            device_id,
+            path,
+            free_bytes,
+            reserved_bytes,
+        } => {
+            assert_eq!(device_id, 2);
+            assert_eq!(path, "/repos");
+            assert_eq!(free_bytes, reserved - 1);
+            assert_eq!(reserved_bytes, reserved);
+        }
+        other => panic!("expected Breached; got {other:?}"),
+    }
+}
+
+/// (b) A breach persists while any device is below the margin — even
+/// when every device is above the bare reserve.
+#[test]
+fn breach_persists_below_margin() {
+    let reserved = 1024 * 1024 * 1024;
+    let breached = PressureState::Breached {
+        device_id: 2,
+        path: "/repos".to_string(),
+        free_bytes: reserved - 1,
+        reserved_bytes: reserved,
+    };
+
+    // Still below the bare reserve on one device.
+    let next = transition(
+        &breached,
+        &[
+            sample(1, reserved + DISK_HYSTERESIS_BYTES * 4, "/state"),
+            sample(2, reserved - 1, "/repos"),
+        ],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(next, breached);
+
+    // Above the reserve but NOT above reserve + margin.
+    let next = transition(
+        &breached,
+        &[
+            sample(1, reserved + DISK_HYSTERESIS_BYTES * 4, "/state"),
+            sample(2, reserved + DISK_HYSTERESIS_BYTES, "/repos"),
+        ],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(next, breached, "exact margin is not recovery (strict >)");
+
+    // Two-device layout: one device well above the margin, the other
+    // only just above the reserve — still breached.
+    let next = transition(
+        &breached,
+        &[
+            sample(1, reserved + DISK_HYSTERESIS_BYTES * 4, "/state"),
+            sample(2, reserved + 1, "/repos"),
+        ],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(next, breached);
+}
+
+/// (c) Recovery only when EVERY device exceeds `reserved + 256 MiB`;
+/// (d) recovery at exactly the floor does NOT re-enable (strict `>`).
+#[test]
+fn recovery_requires_margin_on_every_device() {
+    let reserved = 512 * 1024 * 1024;
+    let breached = PressureState::Breached {
+        device_id: 3,
+        path: "/workdirs".to_string(),
+        free_bytes: 0,
+        reserved_bytes: reserved,
+    };
+
+    // Every device above the margin → recovered.
+    let next = transition(
+        &breached,
+        &[
+            sample(1, reserved + DISK_HYSTERESIS_BYTES + 1, "/state"),
+            sample(2, reserved + DISK_HYSTERESIS_BYTES + 1, "/repos"),
+            sample(3, reserved + DISK_HYSTERESIS_BYTES + 1, "/workdirs"),
+        ],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(next, PressureState::Healthy);
+
+    // Exact floor on one device → NOT recovered.
+    let next = transition(
+        &breached,
+        &[
+            sample(1, reserved + DISK_HYSTERESIS_BYTES + 1, "/state"),
+            sample(2, reserved + DISK_HYSTERESIS_BYTES, "/repos"),
+            sample(3, reserved + DISK_HYSTERESIS_BYTES + 1, "/workdirs"),
+        ],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(next, breached);
+
+    // Same-device layout collapsing to one sample: recovery above
+    // the margin works from a single-sample breach too.
+    let breached_single = PressureState::Breached {
+        device_id: 1,
+        path: "/state".to_string(),
+        free_bytes: 0,
+        reserved_bytes: reserved,
+    };
+    let next = transition(
+        &breached_single,
+        &[sample(1, reserved + DISK_HYSTERESIS_BYTES + 1, "/state")],
+        reserved,
+        DISK_HYSTERESIS_BYTES,
+    );
+    assert_eq!(next, PressureState::Healthy);
+}
+
+/// An empty sample set never recovers a breach and never breaches a
+/// healthy state (state_dir always exists, so this is defensive).
+#[test]
+fn empty_samples_persist_state() {
+    let reserved = 1024 * 1024;
+    assert_eq!(
+        transition(
+            &PressureState::Healthy,
+            &[],
+            reserved,
+            DISK_HYSTERESIS_BYTES
+        ),
+        PressureState::Healthy
+    );
+    let breached = PressureState::Breached {
+        device_id: 1,
+        path: "/state".to_string(),
+        free_bytes: 0,
+        reserved_bytes: reserved,
+    };
+    assert_eq!(
+        transition(&breached, &[], reserved, DISK_HYSTERESIS_BYTES),
+        breached
+    );
+}
+
+// ---------------------------------------------------------------------------
+// sample_free_bytes — device-ID dedup + ancestor resolution (12.3)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn same_filesystem_paths_dedup_to_one_sample() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let a = dir.path().join("a");
+    let b = dir.path().join("b").join("c");
+    std::fs::create_dir_all(&a).expect("create dirs");
+    std::fs::create_dir_all(&b).expect("create dirs");
+
+    let samples =
+        caduceus::infra::disk::sample_free_bytes(&[a.clone(), b.clone()]).expect("sample");
+    assert_eq!(samples.len(), 1, "same-device paths must dedup");
+    let s = &samples[0];
+    // The dedup key is the device ID from MetadataExt::dev().
+    let expected_dev = std::fs::metadata(&a).expect("stat").dev();
+    assert_eq!(s.device_id, expected_dev);
+    assert_eq!(s.representative_path, a, "first path wins");
+    assert!(s.free_bytes > 0, "statvfs must report positive free space");
+}
+
+#[test]
+fn missing_path_resolves_to_existing_ancestor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("not-yet-created").join("deep");
+
+    let samples =
+        caduceus::infra::disk::sample_free_bytes(std::slice::from_ref(&missing)).expect("sample");
+    assert_eq!(samples.len(), 1);
+    assert_eq!(
+        samples[0].representative_path,
+        dir.path(),
+        "nearest existing ancestor must be sampled"
+    );
+    let expected_dev = std::fs::metadata(dir.path()).expect("stat").dev();
+    assert_eq!(samples[0].device_id, expected_dev);
+
+    // Dedup with the existing ancestor: same device → one sample.
+    let samples = caduceus::infra::disk::sample_free_bytes(&[dir.path().to_path_buf(), missing])
+        .expect("sample");
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].representative_path, dir.path());
+}
+
+/// The watchdog path set covers the three config roots.
+#[test]
+fn watchdog_paths_cover_config_roots() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = Config::test_defaults(tmp.path());
+    let paths = caduceus::infra::disk::watchdog_paths(&cfg);
+    assert_eq!(
+        paths,
+        vec![
+            cfg.state_dir.clone(),
+            cfg.repo_storage_root.clone(),
+            cfg.workdir_base.clone(),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DiskPressureGuard — breach refusal, recovery, disabled no-op (12.4)
+// ---------------------------------------------------------------------------
+
+fn guard_with_reserved_mb(mb: u64) -> (Config, DiskPressureGuard) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = Config::test_defaults(tmp.path());
+    cfg.sandbox.as_mut().expect("sandbox").reserved_host_disk_mb = mb;
+    let guard = DiskPressureGuard::from_config(&cfg);
+    (cfg, guard)
+}
+
+#[test]
+fn guard_breach_refuses_with_typed_error() {
+    let (cfg, guard) = guard_with_reserved_mb(64);
+    assert!(guard.enabled(), "reserved > 0 enables the watchdog");
+    let state_dir = cfg.state_dir.display().to_string();
+    let reserved_bytes = 64 * 1024 * 1024;
+
+    guard.refresh(&[sample(7, reserved_bytes - 1, &state_dir)]);
+    let err = guard
+        .try_acquire_oci()
+        .expect_err("breached guard must refuse");
+    match err {
+        CaduceusError::OciDiskPressure {
+            path,
+            device_id,
+            free_bytes,
+            reserved_bytes: reserved,
+        } => {
+            assert_eq!(path, state_dir);
+            assert_eq!(device_id, 7);
+            assert_eq!(free_bytes, reserved_bytes - 1);
+            assert_eq!(reserved, reserved_bytes);
+        }
+        other => panic!("expected OciDiskPressure; got {other:?}"),
+    }
+    // Breach cancels the watchdog token (in-flight termination).
+    assert!(guard.watchdog_token().is_cancelled());
+}
+
+#[test]
+fn guard_recovery_requires_margin() {
+    let (_, guard) = guard_with_reserved_mb(64);
+    let reserved_bytes = 64 * 1024 * 1024;
+
+    // Breach.
+    guard.refresh(&[sample(1, 0, "/state")]);
+    assert!(guard.try_acquire_oci().is_err());
+
+    // Recovery at exactly the floor does not re-enable.
+    guard.refresh(&[sample(1, reserved_bytes, "/state")]);
+    assert!(
+        guard.try_acquire_oci().is_err(),
+        "recovery at exactly the floor must not re-enable"
+    );
+
+    // Above floor but below margin — still refused.
+    guard.refresh(&[sample(1, reserved_bytes + DISK_HYSTERESIS_BYTES, "/state")]);
+    assert!(guard.try_acquire_oci().is_err());
+
+    // Above floor + margin — new dispatch is accepted again.
+    guard.refresh(&[sample(
+        1,
+        reserved_bytes + DISK_HYSTERESIS_BYTES + 1,
+        "/state",
+    )]);
+    guard.try_acquire_oci().expect("recovered guard accepts");
+    // Tokens are never un-cancelled: the terminated in-flight runs
+    // stay terminated; only NEW dispatch is re-enabled.
+    assert!(guard.watchdog_token().is_cancelled());
+}
+
+#[test]
+fn disabled_guard_never_refuses() {
+    let guard = DiskPressureGuard::disabled();
+    assert!(!guard.enabled());
+    guard.refresh(&[sample(1, 0, "/state")]);
+    guard
+        .try_acquire_oci()
+        .expect("disabled guard never refuses");
+    assert!(!guard.watchdog_token().is_cancelled());
+}
+
+#[test]
+fn from_config_without_sandbox_is_disabled() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = Config::test_defaults(tmp.path());
+    cfg.sandbox = None;
+    let guard = DiskPressureGuard::from_config(&cfg);
+    assert!(!guard.enabled());
+    guard.try_acquire_oci().expect("no sandbox → disabled");
+}
+
+/// The guard is Arc-shareable and refresh is idempotent under
+/// concurrent acquire attempts.
+#[test]
+fn guard_is_arc_shareable() {
+    let (_, guard) = guard_with_reserved_mb(64);
+    let shared: Arc<DiskPressureGuard> = Arc::new(guard);
+    let a = Arc::clone(&shared);
+    let b = Arc::clone(&shared);
+    a.refresh(&[sample(1, 0, "/state")]);
+    assert!(b.try_acquire_oci().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// is_engine_socket_path (12.5)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn engine_socket_path_positives_and_negatives() {
+    for positive in [
+        "/var/run/docker.sock",
+        "/run/podman/podman.sock",
+        "docker.sock",
+        "podman.sock",
+    ] {
+        assert!(
+            is_engine_socket_path(Path::new(positive)),
+            "{positive} must be detected"
+        );
+    }
+    for negative in [
+        "/workspace",
+        "/output",
+        "/workspace/.git",
+        "/var/run/docker.sock.bak",
+        "socker",
+        "",
+    ] {
+        assert!(
+            !is_engine_socket_path(Path::new(negative)),
+            "{negative:?} must not be detected"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implemented a mandatory, non-weakenable per-run OCI resource/security baseline and an honest host disk-pressure watchdog (barkley-assistant/caduceus#245).

### Per-run security/resource baseline (emitted for every container, both docker and podman; no config switch can disable it)
- Read-only rootfs, `--cap-drop ALL`, `--security-opt no-new-privileges`.
- Bounded `--cpus`, `--memory`, and `--memory-swap` pinned equal to `--memory` (prevents swap-based limit evasion), and `--pids-limit`.
- Bounded `/tmp` and `/dev/shm` tmpfs sized from sandbox resources; these remain the only writable ephemeral surfaces alongside the `/workspace` and `/output` bind mounts (enforced by the existing mount-policy validator).
- Bounded engine logs via `--log-opt max-size=10m` / `max-file=3`, and bounded daemon-side diagnostic capture (1 MiB tail) persisted under the run's OCI output directory.
- Host networking is now structurally unrepresentable: the `unrestricted` network mode was removed and any configuration requesting it is rejected. A resolve-time guard also rejects device additions, engine/runtime socket mounts, and host pid/ipc/uts namespace sharing.

### Host disk-pressure watchdog (`src/infra/disk.rs`)
- Samples free space on the distinct filesystems hosting the state dir, repo storage/worktrees, and OCI output dirs, deduplicated by device ID so each physical disk is checked once even when the paths span devices.
- On breach of the `reserved_host_disk_mb` floor, it terminates in-flight OCI work via the existing stop path (stop -> kill -> rm) and refuses new OCI work with a typed `OciDiskPressure` error until the reserve recovers with a 256 MiB hysteresis margin. TrustedHost work is unaffected.
- `/workspace` remains a host bind mount with no per-container byte quota; the watchdog is documented as a host-level mitigation, not a portable per-container quota.

### Configuration
- `reserved_host_disk_mb: 0` disables the watchdog.
- `tmpfs_mb` / `shm_mb` now have a floor of 1 MiB to avoid an unbounded tmpfs (a silent weakening).

### Tests
- Snapshot-pinned renderer tests for both engines (including `--memory-swap` and `--log-opt`); watchdog math unit tests (same- and multi-device sampling, breach, recovery with hysteresis); resolve-time denial tests; bounded-capture and dual-cancellation lifecycle tests; and gated live isolation tests (including a disk-fill watchdog case). All unit tests pass; `cargo fmt` and `cargo clippy` are clean.

Note: nine pre-existing `bridge_test.py` failures are environmental (PATH-less subprocess environment) and unrelated to this change; one pre-existing daemon signal test is flaky in the full suite but passes in isolation.

Closes #245

Artifacts (7):

```json
{
  "live_tests": "passed with real docker engine, including disk-pressure watchdog breach/refuse case",
  "openspec_archive": "2026-08-28-hardened-oci-baseline",
  "openspec_change": "hardened-oci-baseline",
  "review_verdict": "PASS",
  "static_checks": "cargo fmt clean; cargo clippy -D warnings clean",
  "unit_tests_ignored_gated": 44,
  "unit_tests_passed": 1629
}
```

<!-- caduceus-pr-body:run=01M14E8Q5S299Q0KCX13WVQF24 -->