### PR TITLE
feat(oci): immutable worker-image pull + verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,30 @@ name = "oci_label_test"
 path = "tests/executor/oci_label_test.rs"
 
 [[test]]
+name = "oci_image_policy_test"
+path = "tests/executor/oci_image_policy_test.rs"
+
+[[test]]
+name = "oci_image_inspect_test"
+path = "tests/executor/oci_image_inspect_test.rs"
+
+[[test]]
+name = "oci_image_verify_test"
+path = "tests/executor/oci_image_verify_test.rs"
+
+[[test]]
+name = "oci_engine_seam_test"
+path = "tests/executor/oci_engine_seam_test.rs"
+
+[[test]]
+name = "oci_ensure_image_test"
+path = "tests/executor/oci_ensure_image_test.rs"
+
+[[test]]
+name = "oci_provenance_test"
+path = "tests/executor/oci_provenance_test.rs"
+
+[[test]]
 name = "policy_test"
 path = "tests/executor/policy_test.rs"
 

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -12,6 +12,9 @@ use crate::infra::error::CaduceusError;
 ///   that counts against its retry budget (`Worker { .. }`
 ///   variants, content/schema/result validation errors, voice
 ///   rejections, code-result with no changes).
+/// * [`FailureClass::ImageVerification`] — a digest or architecture
+///   contract violation was found in an image. These deterministic
+///   failures do not count against the worker retry budget.
 /// * [`FailureClass::Infrastructure`] — the daemon encountered a
 ///   transport, filesystem, or operator configuration problem
 ///   that does not count against the budget. The orchestrator
@@ -27,6 +30,7 @@ use crate::infra::error::CaduceusError;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FailureClass {
     Worker,
+    ImageVerification,
     Infrastructure,
     RateLimit {
         reset_at: u64,
@@ -55,7 +59,10 @@ impl FailureClass {
         match self {
             FailureClass::RateLimit { .. } => Some(crate::state::meta::TickOutcome::RateLimited),
             FailureClass::Cancellation => Some(crate::state::meta::TickOutcome::Cancelled),
-            FailureClass::Worker | FailureClass::Infrastructure | FailureClass::Terminal => None,
+            FailureClass::Worker
+            | FailureClass::ImageVerification
+            | FailureClass::Infrastructure
+            | FailureClass::Terminal => None,
         }
     }
 
@@ -185,7 +192,15 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         // worker-attributable.
         CaduceusError::OciIdentityUnsupported { .. } => FailureClass::Infrastructure,
         CaduceusError::OciMismatchedCliVersion { .. } => FailureClass::Infrastructure,
-        CaduceusError::OciPullFailed { .. } => FailureClass::Infrastructure,
+        // Pull, inspect, and missing-image failures are transient engine or
+        // environment conditions and receive the existing worker treatment.
+        CaduceusError::OciPullFailed { .. }
+        | CaduceusError::OciImageInspectFailed { .. }
+        | CaduceusError::OciImageMissing { .. } => FailureClass::Worker,
+        // Digest and architecture failures are deterministic image-contract
+        // violations, so callers can distinguish them from transient pulls.
+        CaduceusError::OciImageDigestMismatch { .. }
+        | CaduceusError::OciImageArchitectureMismatch { .. } => FailureClass::ImageVerification,
         CaduceusError::OciCreateFailed { .. } => FailureClass::Infrastructure,
         CaduceusError::OciStartFailed { .. } => FailureClass::Infrastructure,
         CaduceusError::OciWaitFailed { .. } => FailureClass::Infrastructure,
@@ -202,7 +217,6 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         CaduceusError::OciSecretLeakDetected { .. } => FailureClass::Infrastructure,
         CaduceusError::ReducedContainmentNotAcknowledged => FailureClass::Infrastructure,
         CaduceusError::OciImageNotDigestPinned { .. } => FailureClass::Worker,
-        CaduceusError::OciPullPolicyIncompatible { .. } => FailureClass::Worker,
 
         // Generic Other — content / schema / public-voice / worker
         // result validation land here. Voice rejections and

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -34,7 +34,10 @@ use self::trusted_host::TrustedHostExecutor;
 
 pub mod engine_probe;
 pub mod oci;
+pub mod oci_engine;
+pub mod oci_image;
 pub mod oci_lifecycle;
+pub mod oci_platform;
 pub mod sandbox_renderer;
 pub mod sandbox_spec;
 pub mod secret_transport;

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -4,23 +4,23 @@
 //! the runtime facts (worktree owner, `.git` type, engine mode) and
 //! create the daemon-owned host artifacts, resolves a typed
 //! [`SandboxSpec`] from the sandbox config and those facts, renders
-//! the `create` argv with the pure renderer, then delegates to
-//! [`oci_lifecycle::run_with_argv`] for the five-step container
-//! lifecycle (create → start → wait → stop → remove). The state DAO
-//! is injected through the config's state directory.
+//! the `create` argv with the pure renderer, acquires and verifies the
+//! configured image, then delegates to [`oci_lifecycle::run_with_argv`]
+//! for the five-step container lifecycle (create → start → wait → stop →
+//! remove). The state DAO is injected through the config's state directory.
 //!
 //! The renderer is the sole argv producer in the crate: `resolve` owns
-//! every host-path and identity decision, `engine_probe` is the sole
-//! pre-flight I/O surface, and `oci_lifecycle` only consumes
-//! already-rendered argv.
+//! every host-path and identity decision, `engine_probe` owns runtime facts
+//! and daemon-owned artifact creation, `oci_image` owns image acquisition,
+//! and `oci_lifecycle` only consumes already-rendered argv.
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::executor::{
-    engine_probe, oci_lifecycle, sandbox_renderer, sandbox_spec, Executor, ExecutorOutcome,
-    ExecutorSpec,
+    engine_probe, oci_image, oci_lifecycle, oci_platform, sandbox_renderer, sandbox_spec, Executor,
+    ExecutorOutcome, ExecutorSpec,
 };
 use crate::infra::config::Config;
 use crate::infra::disk::DiskPressureGuard;
@@ -85,7 +85,23 @@ impl Executor for OciExecutor {
             let engine = self.cfg.sandbox().engine;
             let argv = sandbox_renderer::render_with_env_files(&resolved, engine, &[]);
 
-            // 5. Run the lifecycle with the rendered argv. The run's
+            // 5. Acquire and verify the immutable worker image before the
+            //    lifecycle can insert its Created state or invoke create.
+            //    The run directory is already created by the probe, but is
+            //    passed explicitly so provenance remains scoped to this run.
+            let host = oci_platform::host_platform();
+            let run_dir = runtime.state_dir.join("oci-runs").join(&runtime.run_id);
+            let _image = oci_image::ensure_image(
+                engine,
+                resolved.image_ref(),
+                self.cfg.sandbox().pull_policy,
+                &host,
+                &run_dir,
+                &runtime.run_id,
+            )
+            .await?;
+
+            // 6. Run the lifecycle with the rendered argv. The run's
             //    lifecycle token is linked with the watchdog token so
             //    a disk-pressure breach terminates in-flight work via
             //    the existing stop path (issue #245).

--- a/src/executor/oci_engine.rs
+++ b/src/executor/oci_engine.rs
@@ -1,0 +1,291 @@
+//! Engine adapter for OCI image acquisition and inspection.
+//!
+//! Docker and Podman command differences intentionally stop at this module.
+//! Callers consume [`NormalizedImage`] and do not need to know which CLI
+//! produced it.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::executor::sandbox_spec::SandboxEngine;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Engine-independent image identity and platform information.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NormalizedImage {
+    pub id: String,
+    pub repo_digests: Vec<String>,
+    pub architecture: String,
+    pub variant: Option<String>,
+}
+
+/// Lenient common subset of Docker and Podman inspect output.
+///
+/// The explicit aliases cover the casing emitted by current engines. The
+/// value-based fallback in [`parse_inspect`] additionally accepts nested and
+/// otherwise case-insensitive fields without making the normalizer depend on
+/// one engine's exact JSON shape.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct RawInspect {
+    #[serde(default, alias = "ID", alias = "id")]
+    id: Option<String>,
+    #[serde(
+        default,
+        alias = "REPO_DIGESTS",
+        alias = "repo_digests",
+        alias = "repoDigests",
+        alias = "repodigests"
+    )]
+    repo_digests: Vec<String>,
+    #[serde(default, alias = "ARCHITECTURE", alias = "architecture")]
+    architecture: Option<String>,
+    #[serde(default, alias = "VARIANT", alias = "variant")]
+    variant: Option<String>,
+}
+
+/// Adapter that owns the Docker/Podman CLI contract.
+#[derive(Clone, Debug)]
+pub struct OciImageAdapter {
+    engine: SandboxEngine,
+    binary: PathBuf,
+}
+
+impl OciImageAdapter {
+    /// Construct an adapter using the configured engine's normal binary name.
+    pub fn new(engine: SandboxEngine) -> Self {
+        Self {
+            engine,
+            binary: PathBuf::from(engine.binary_name()),
+        }
+    }
+
+    /// Construct an adapter against an executable seam, primarily for
+    /// offline integration tests.
+    pub fn with_binary(engine: SandboxEngine, binary: impl Into<PathBuf>) -> Self {
+        Self {
+            engine,
+            binary: binary.into(),
+        }
+    }
+
+    /// Pull a digest-pinned image reference.
+    pub async fn pull(&self, image_ref: &str) -> CaduceusResult<()> {
+        let output = self
+            .run_command(["pull", image_ref])
+            .await
+            .map_err(|detail| CaduceusError::OciPullFailed {
+                image: image_ref.to_string(),
+                stderr: detail,
+            })?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(CaduceusError::OciPullFailed {
+                image: image_ref.to_string(),
+                stderr: command_stderr(&output),
+            })
+        }
+    }
+
+    /// Probe local image presence without contacting a registry.
+    pub async fn image_exists(&self, image_ref: &str) -> CaduceusResult<bool> {
+        let args = match self.engine {
+            SandboxEngine::Docker => vec!["image", "inspect", image_ref],
+            SandboxEngine::Podman => vec!["image", "exists", image_ref],
+        };
+        let output = self.run_command(args).await.map_err(|detail| {
+            CaduceusError::OciImageInspectFailed {
+                reference: image_ref.to_string(),
+                detail,
+            }
+        })?;
+        if output.status.success() {
+            return Ok(true);
+        }
+
+        let stderr = command_stderr(&output);
+        match self.engine {
+            SandboxEngine::Docker if is_missing_image_message(&stderr) => Ok(false),
+            SandboxEngine::Podman
+                if output.status.code() == Some(1)
+                    && (stderr.is_empty() || is_missing_image_message(&stderr)) =>
+            {
+                Ok(false)
+            }
+            _ => Err(CaduceusError::OciImageInspectFailed {
+                reference: image_ref.to_string(),
+                detail: stderr,
+            }),
+        }
+    }
+
+    /// Inspect an image and normalize the engine's JSON response.
+    pub async fn inspect(&self, image_ref: &str) -> CaduceusResult<NormalizedImage> {
+        let output = self
+            .run_command(["image", "inspect", "--format", "{{json .}}", image_ref])
+            .await
+            .map_err(|detail| CaduceusError::OciImageInspectFailed {
+                reference: image_ref.to_string(),
+                detail,
+            })?;
+        if !output.status.success() {
+            return Err(CaduceusError::OciImageInspectFailed {
+                reference: image_ref.to_string(),
+                detail: command_stderr(&output),
+            });
+        }
+        parse_inspect_with_reference(&String::from_utf8_lossy(&output.stdout), image_ref)
+    }
+
+    async fn run_command<I, S>(&self, args: I) -> Result<std::process::Output, String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        let mut command = tokio::process::Command::new(&self.binary);
+        command
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        command
+            .output()
+            .await
+            .map_err(|err| format!("failed to execute {}: {err}", self.binary.display()))
+    }
+}
+
+/// Parse Docker- or Podman-shaped inspect JSON into a common image shape.
+pub fn parse_inspect(json: &str) -> CaduceusResult<NormalizedImage> {
+    parse_inspect_with_reference(json, "<inspect>")
+}
+
+fn parse_inspect_with_reference(json: &str, reference: &str) -> CaduceusResult<NormalizedImage> {
+    let value: Value = serde_json::from_str(json)
+        .map_err(|err| inspect_error(reference, format!("invalid inspect JSON: {err}")))?;
+    let object = value.as_object().ok_or_else(|| {
+        inspect_error(
+            reference,
+            "inspect output must be a JSON object".to_string(),
+        )
+    })?;
+    let raw: RawInspect = serde_json::from_value(value.clone())
+        .map_err(|err| inspect_error(reference, format!("invalid inspect fields: {err}")))?;
+
+    let id = raw
+        .id
+        .or_else(|| string_field(object, "id"))
+        .ok_or_else(|| inspect_error(reference, "inspect output is missing Id".to_string()))?;
+    let id = canonical_image_id(&id).ok_or_else(|| {
+        inspect_error(
+            reference,
+            "Id must be sha256:<64 lowercase hex>".to_string(),
+        )
+    })?;
+
+    let repo_digests = if raw.repo_digests.is_empty() {
+        string_array_field(object, "repo_digests").unwrap_or_default()
+    } else {
+        raw.repo_digests
+    };
+
+    let config = object_field(object, "config");
+    let architecture = raw
+        .architecture
+        .or_else(|| string_field(object, "architecture"))
+        .or_else(|| {
+            config
+                .and_then(|v| v.as_object())
+                .and_then(|v| string_field(v, "architecture"))
+        })
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            inspect_error(
+                reference,
+                "inspect output is missing Architecture".to_string(),
+            )
+        })?;
+
+    let variant = raw
+        .variant
+        .or_else(|| string_field(object, "variant"))
+        .or_else(|| {
+            config
+                .and_then(|v| v.as_object())
+                .and_then(|v| string_field(v, "variant"))
+        })
+        .and_then(|value| {
+            let value = value.trim().to_ascii_lowercase();
+            (!value.is_empty()).then_some(value)
+        });
+
+    Ok(NormalizedImage {
+        id,
+        repo_digests,
+        architecture,
+        variant,
+    })
+}
+
+fn canonical_image_id(id: &str) -> Option<String> {
+    let hex = id.strip_prefix("sha256:").unwrap_or(id);
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return None;
+    }
+    Some(format!("sha256:{hex}"))
+}
+
+fn object_field<'a>(object: &'a serde_json::Map<String, Value>, name: &str) -> Option<&'a Value> {
+    object
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value)
+}
+
+fn string_field(object: &serde_json::Map<String, Value>, name: &str) -> Option<String> {
+    object_field(object, name)?
+        .as_str()
+        .map(ToString::to_string)
+}
+
+fn string_array_field(object: &serde_json::Map<String, Value>, name: &str) -> Option<Vec<String>> {
+    object_field(object, name)?.as_array().map(|items| {
+        items
+            .iter()
+            .filter_map(|item| item.as_str().map(ToString::to_string))
+            .collect()
+    })
+}
+
+fn inspect_error(reference: &str, detail: String) -> CaduceusError {
+    CaduceusError::OciImageInspectFailed {
+        reference: reference.to_string(),
+        detail,
+    }
+}
+
+fn is_missing_image_message(stderr: &str) -> bool {
+    let message = stderr.to_ascii_lowercase();
+    message.contains("no such image")
+        || message.contains("no such object")
+        || message.contains("image not known")
+        || message.contains("does not exist")
+        || message.contains("not found")
+}
+
+fn command_stderr(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        format!("engine command exited with {}", output.status)
+    } else {
+        stderr
+    }
+}

--- a/src/executor/oci_image.rs
+++ b/src/executor/oci_image.rs
@@ -1,0 +1,359 @@
+//! Pull-policy orchestration, image verification, and provenance auditing.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+use std::time::Instant;
+
+use serde::Serialize;
+
+use crate::executor::oci_engine::{NormalizedImage, OciImageAdapter};
+use crate::executor::oci_platform::HostPlatform;
+use crate::executor::sandbox_spec::SandboxEngine;
+use crate::infra::config::OciPullPolicy;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Action selected after probing local image presence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PullAction {
+    Pull,
+    ProbeLocalOnly,
+    UseLocal,
+}
+
+/// Decide the image action without contacting a registry.
+pub fn decide_pull_action(policy: OciPullPolicy, local_present: bool) -> PullAction {
+    match policy {
+        OciPullPolicy::Never if local_present => PullAction::UseLocal,
+        OciPullPolicy::Never => PullAction::ProbeLocalOnly,
+        OciPullPolicy::IfMissing if local_present => PullAction::UseLocal,
+        OciPullPolicy::IfMissing => PullAction::Pull,
+        OciPullPolicy::Always => PullAction::Pull,
+    }
+}
+
+/// Verify that the configured digest is represented by a repository digest.
+pub fn verify_digest(image: &NormalizedImage, expected_ref: &str) -> CaduceusResult<()> {
+    let expected = expected_ref
+        .rsplit_once("@sha256:")
+        .map(|(_, digest)| format!("sha256:{digest}"))
+        .unwrap_or_else(|| "sha256:<invalid>".to_string())
+        .to_ascii_lowercase();
+    let expected_suffix = format!("@{expected}");
+    if image
+        .repo_digests
+        .iter()
+        .any(|entry| entry.to_ascii_lowercase().ends_with(&expected_suffix))
+    {
+        return Ok(());
+    }
+    Err(CaduceusError::OciImageDigestMismatch {
+        reference: expected_ref.to_string(),
+        expected,
+        found: image.repo_digests.clone(),
+    })
+}
+
+/// Verify a normalized image against a host platform.
+///
+/// The two-argument form is a public test seam. The production orchestrator
+/// uses the reference-aware helper below so operator errors identify the
+/// configured reference exactly.
+pub fn verify_arch(image: &NormalizedImage, host: &HostPlatform) -> CaduceusResult<()> {
+    verify_arch_for_reference(image, host, &image.id)
+}
+
+fn verify_arch_for_reference(
+    image: &NormalizedImage,
+    host: &HostPlatform,
+    reference: &str,
+) -> CaduceusResult<()> {
+    let host_arch = host.architecture.to_ascii_lowercase();
+    let image_arch = image.architecture.to_ascii_lowercase();
+    let known_host_arch = [
+        "amd64", "arm64", "arm", "ppc64le", "s390x", "riscv64", "386",
+    ]
+    .contains(&host_arch.as_str());
+    let variant_matches = match host.variant.as_deref() {
+        None => true,
+        Some(expected) => image
+            .variant
+            .as_deref()
+            .map(|found| found.eq_ignore_ascii_case(expected))
+            .unwrap_or(false),
+    };
+    if !known_host_arch || image_arch != host_arch || !variant_matches {
+        return Err(CaduceusError::OciImageArchitectureMismatch {
+            reference: reference.to_string(),
+            expected: platform_label(host),
+            found: platform_label(&HostPlatform {
+                architecture: image.architecture.clone(),
+                variant: image.variant.clone(),
+            }),
+        });
+    }
+    Ok(())
+}
+
+/// A single per-run provenance record.
+#[derive(Clone, Debug, Serialize)]
+pub struct ProvenanceRecord {
+    pub run_id: String,
+    pub engine: String,
+    pub reference: String,
+    pub resolved_id: Option<String>,
+    pub repo_digests: Option<Vec<String>>,
+    pub architecture: Option<String>,
+    pub variant: Option<String>,
+    pub host_arch: String,
+    pub host_variant: Option<String>,
+    pub policy: String,
+    pub pull_attempted: bool,
+    pub cache_hit: bool,
+    pub mode: String,
+    pub stage: String,
+    pub outcome: String,
+    pub error: Option<ProvenanceError>,
+    pub verification: Option<VerificationRecord>,
+    pub timings: ProvenanceTimings,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ProvenanceError {
+    pub variant: String,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct VerificationRecord {
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct ProvenanceTimings {
+    pub probe_ms: u64,
+    pub pull_ms: u64,
+    pub inspect_ms: u64,
+    pub verify_ms: u64,
+    pub total_ms: u64,
+}
+
+/// Ensure the image is pulled, inspected, verified, and audited.
+pub async fn ensure_image(
+    engine: SandboxEngine,
+    image_ref: &str,
+    policy: OciPullPolicy,
+    host: &HostPlatform,
+    run_dir: &Path,
+    run_id: &str,
+) -> CaduceusResult<NormalizedImage> {
+    ensure_image_with_adapter(
+        OciImageAdapter::new(engine),
+        engine,
+        image_ref,
+        policy,
+        host,
+        run_dir,
+        run_id,
+    )
+    .await
+}
+
+/// Test seam for driving the complete orchestrator with an offline fake CLI.
+#[doc(hidden)]
+pub async fn ensure_image_with_adapter(
+    adapter: OciImageAdapter,
+    engine: SandboxEngine,
+    image_ref: &str,
+    policy: OciPullPolicy,
+    host: &HostPlatform,
+    run_dir: &Path,
+    run_id: &str,
+) -> CaduceusResult<NormalizedImage> {
+    let started = Instant::now();
+    let mut stage = "presence_probe".to_string();
+    let mut local_present = false;
+    let mut pull_attempted = false;
+    let mut verification = None;
+    let mut timings = ProvenanceTimings::default();
+    let result = async {
+        let probe_started = Instant::now();
+        let presence = adapter.image_exists(image_ref).await;
+        timings.probe_ms = elapsed_ms(probe_started);
+        local_present = presence?;
+
+        match decide_pull_action(policy, local_present) {
+            PullAction::ProbeLocalOnly => {
+                return Err(CaduceusError::OciImageMissing {
+                    reference: image_ref.to_string(),
+                });
+            }
+            PullAction::UseLocal => {}
+            PullAction::Pull => {
+                stage = "pull".to_string();
+                pull_attempted = true;
+                let pull_started = Instant::now();
+                let pull = adapter.pull(image_ref).await;
+                timings.pull_ms = elapsed_ms(pull_started);
+                pull?;
+            }
+        }
+
+        stage = "inspect".to_string();
+        let inspect_started = Instant::now();
+        let inspected = adapter.inspect(image_ref).await;
+        timings.inspect_ms = elapsed_ms(inspect_started);
+        let image = inspected?;
+
+        stage = "digest_verify".to_string();
+        let verify_started = Instant::now();
+        if let Err(error) = verify_digest(&image, image_ref) {
+            verification = Some(VerificationRecord {
+                status: "failed".to_string(),
+                detail: "digest mismatch".to_string(),
+            });
+            timings.verify_ms = elapsed_ms(verify_started);
+            return Err(error);
+        }
+
+        stage = "arch_verify".to_string();
+        if let Err(error) = verify_arch_for_reference(&image, host, image_ref) {
+            verification = Some(VerificationRecord {
+                status: "failed".to_string(),
+                detail: "architecture mismatch".to_string(),
+            });
+            timings.verify_ms = elapsed_ms(verify_started);
+            return Err(error);
+        }
+        timings.verify_ms = elapsed_ms(verify_started);
+        verification = Some(VerificationRecord {
+            status: "passed".to_string(),
+            detail: "digest+arch ok".to_string(),
+        });
+        Ok(image)
+    }
+    .await;
+
+    timings.total_ms = elapsed_ms(started);
+    let success = result.is_ok();
+    let resolved = if success { result.as_ref().ok() } else { None };
+    let record = ProvenanceRecord {
+        run_id: run_id.to_string(),
+        engine: engine.binary_name().to_string(),
+        reference: image_ref.to_string(),
+        resolved_id: resolved.map(|image| image.id.clone()),
+        repo_digests: resolved.map(|image| image.repo_digests.clone()),
+        architecture: resolved.map(|image| image.architecture.clone()),
+        variant: resolved.and_then(|image| image.variant.clone()),
+        host_arch: host.architecture.clone(),
+        host_variant: host.variant.clone(),
+        policy: policy_name(policy).to_string(),
+        pull_attempted,
+        cache_hit: local_present && policy != OciPullPolicy::Always,
+        mode: if pull_attempted { "pulled" } else { "local" }.to_string(),
+        stage: if success {
+            "acquired".to_string()
+        } else {
+            stage
+        },
+        outcome: if success { "ok" } else { "aborted" }.to_string(),
+        error: result.as_ref().err().map(|error| ProvenanceError {
+            variant: error_variant(error).to_string(),
+            detail: error.to_string(),
+        }),
+        verification,
+        timings,
+    };
+    write_provenance(run_dir, &record);
+    result
+}
+
+fn write_provenance(run_dir: &Path, record: &ProvenanceRecord) {
+    if let Err(error) = fs::create_dir_all(run_dir) {
+        tracing::warn!(path = %run_dir.display(), error = %error, "cannot create OCI provenance directory");
+    } else {
+        let path = run_dir.join("provenance.log");
+        match serde_json::to_string(record) {
+            Ok(mut line) => {
+                line.push('\n');
+                match OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .mode(0o600)
+                    .custom_flags(libc::O_NOFOLLOW)
+                    .open(&path)
+                {
+                    Ok(mut file) => {
+                        if let Err(error) = file
+                            .set_permissions(std::fs::Permissions::from_mode(0o600))
+                            .and_then(|_| file.write_all(line.as_bytes()))
+                        {
+                            tracing::warn!(path = %path.display(), error = %error, "cannot write OCI provenance record");
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(path = %path.display(), error = %error, "cannot open OCI provenance log");
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "cannot serialize OCI provenance record");
+            }
+        }
+    }
+
+    tracing::info!(
+        target: "caduceus_oci_provenance",
+        run_id = %record.run_id,
+        engine = %record.engine,
+        reference = %record.reference,
+        resolved_id = ?record.resolved_id,
+        repo_digests = ?record.repo_digests,
+        architecture = ?record.architecture,
+        variant = ?record.variant,
+        host_arch = %record.host_arch,
+        host_variant = ?record.host_variant,
+        policy = %record.policy,
+        pull_attempted = record.pull_attempted,
+        cache_hit = record.cache_hit,
+        mode = %record.mode,
+        stage = %record.stage,
+        outcome = %record.outcome,
+        error = ?record.error,
+        verification = ?record.verification,
+        timings = ?record.timings,
+        "OCI image provenance"
+    );
+}
+
+fn platform_label(platform: &HostPlatform) -> String {
+    match &platform.variant {
+        Some(variant) => format!("{}/{}", platform.architecture, variant),
+        None => platform.architecture.clone(),
+    }
+}
+
+fn policy_name(policy: OciPullPolicy) -> &'static str {
+    match policy {
+        OciPullPolicy::Never => "never",
+        OciPullPolicy::IfMissing => "if_missing",
+        OciPullPolicy::Always => "always",
+    }
+}
+
+fn error_variant(error: &CaduceusError) -> &'static str {
+    match error {
+        CaduceusError::OciImageDigestMismatch { .. } => "OciImageDigestMismatch",
+        CaduceusError::OciImageArchitectureMismatch { .. } => "OciImageArchitectureMismatch",
+        CaduceusError::OciImageMissing { .. } => "OciImageMissing",
+        CaduceusError::OciImageInspectFailed { .. } => "OciImageInspectFailed",
+        CaduceusError::OciPullFailed { .. } => "OciPullFailed",
+        _ => "CaduceusError",
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}

--- a/src/executor/oci_platform.rs
+++ b/src/executor/oci_platform.rs
@@ -1,0 +1,30 @@
+//! Host platform normalization for OCI image verification.
+
+/// The OCI architecture and optional variant reported by the host build.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostPlatform {
+    pub architecture: String,
+    pub variant: Option<String>,
+}
+
+/// Normalize Rust's target architecture name to the OCI architecture name.
+///
+/// Unknown target names are retained verbatim. The verifier deliberately
+/// rejects those names rather than silently treating an unverifiable host as
+/// compatible with an image.
+pub fn host_platform() -> HostPlatform {
+    let (architecture, variant) = match std::env::consts::ARCH {
+        "x86_64" => ("amd64", None),
+        "aarch64" => ("arm64", None),
+        "armv7" => ("arm", Some("v7")),
+        "powerpc64le" => ("ppc64le", None),
+        "s390x" => ("s390x", None),
+        "riscv64" => ("riscv64", None),
+        "i686" => ("386", None),
+        raw => (raw, None),
+    };
+    HostPlatform {
+        architecture: architecture.to_string(),
+        variant: variant.map(str::to_string),
+    }
+}

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::executor::ExecutorSpec;
 use crate::github::issue::IssueKey;
-use crate::infra::config::{Config, OciPullPolicy, SandboxConfig};
+use crate::infra::config::{Config, SandboxConfig};
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::worker_contract::{
     CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
@@ -217,6 +217,10 @@ impl SandboxSpec {
     /// Digest-pinned image reference.
     pub fn image(&self) -> &ImageRef {
         &self.image
+    }
+    /// The configured digest-pinned image reference as a plain string.
+    pub fn image_ref(&self) -> &str {
+        self.image.as_ref()
     }
     /// Worker command argv.
     pub fn command(&self) -> &[String] {
@@ -505,16 +509,7 @@ pub fn resolve(
     // 6. Image — reject non-digest-pinned references.
     let image = ImageRef::new(&sandbox.image)?;
 
-    // 7. Pull policy — `Always` is incompatible with digest-pinned images.
-    if sandbox.pull_policy == OciPullPolicy::Always {
-        return Err(CaduceusError::OciPullPolicyIncompatible {
-            detail: "pull_policy 'Always' is incompatible with \
-                     digest-pinned images; use 'IfMissing' or 'Never'"
-                .to_string(),
-        });
-    }
-
-    // 8. Resources — mapped 1:1 from SandboxResources.
+    // 7. Resources — mapped 1:1 from SandboxResources.
     let resources = ResourceLimits {
         cpus: sandbox.resources.cpus,
         memory_mb: sandbox.resources.memory_mb,

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -985,7 +985,7 @@ impl Config {
                 // Format-valid placeholder; `test_defaults` bypasses
                 // from_raw, so the regex never sees it. YAML-loading
                 // tests supply real-shaped digests.
-                image: format!("caduceus-worker@sha256:{}", "0".repeat(64)),
+                image: format!("placeholder/worker@sha256:{}", "0".repeat(64)),
                 pull_policy: OciPullPolicy::IfMissing,
                 resources: SandboxResources {
                     cpus: 2.0,
@@ -1204,12 +1204,15 @@ impl Config {
 /// caller aggregates them into `CaduceusError::Config`.
 fn resolve_sandbox(raw: RawSandboxConfig, errors: &mut Vec<String>) -> SandboxConfig {
     // image — required, no default; validated by the full-reference
-    // regex `^[^@\s/]+@sha256:[a-f0-9]{64}$`. Failures are decomposed
+    // regex `^[A-Za-z0-9][A-Za-z0-9.-]*(?::[0-9]+)?(?:/[A-Za-z0-9._-]+)*@sha256:[a-f0-9]{64}$`.
+    // Failures are decomposed
     // so the operator can locate and fix the exact problem.
     let image = match raw.image {
         Some(s) if !s.is_empty() => {
-            let image_regex = Regex::new(r"^[^@\s/]+@sha256:[a-f0-9]{64}$")
-                .expect("sandbox image regex is valid");
+            let image_regex = Regex::new(
+                r"^[A-Za-z0-9][A-Za-z0-9.-]*(?::[0-9]+)?(?:/[A-Za-z0-9._-]+)*@sha256:[a-f0-9]{64}$",
+            )
+            .expect("sandbox image regex is valid");
             if !image_regex.is_match(&s) {
                 match s.split_once('@') {
                     None => {

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -343,9 +343,31 @@ pub enum CaduceusError {
     #[error("OCI image is not digest-pinned: {reference}")]
     OciImageNotDigestPinned { reference: String },
 
-    /// Pull policy `Always` is incompatible with digest-pinned images.
-    #[error("OCI pull policy incompatible: {detail}")]
-    OciPullPolicyIncompatible { detail: String },
+    /// The inspected image does not advertise the configured digest in its
+    /// repository digests.
+    #[error("OCI image digest mismatch for {reference}: expected {expected}, found {found:?}")]
+    OciImageDigestMismatch {
+        reference: String,
+        expected: String,
+        found: Vec<String>,
+    },
+
+    /// The inspected image does not match the host architecture and variant
+    /// required for this run.
+    #[error("OCI image architecture mismatch for {reference}: expected {expected}, found {found}")]
+    OciImageArchitectureMismatch {
+        reference: String,
+        expected: String,
+        found: String,
+    },
+
+    /// A local image was not found while pulling was disabled.
+    #[error("OCI image missing for {reference}: pull is disabled")]
+    OciImageMissing { reference: String },
+
+    /// The engine returned an unusable or otherwise failed image inspection.
+    #[error("OCI image inspect failed for {reference}: {detail}")]
+    OciImageInspectFailed { reference: String, detail: String },
 
     /// OCI dispatch was refused because the host disk-pressure
     /// watchdog is breached on the sampled filesystem carrying
@@ -589,9 +611,30 @@ impl fmt::Debug for CaduceusError {
             CaduceusError::OciImageNotDigestPinned { reference } => {
                 format!("OciImageNotDigestPinned {{ reference: {:?} }}", reference)
             }
-            CaduceusError::OciPullPolicyIncompatible { detail } => {
-                format!("OciPullPolicyIncompatible {{ detail: {} }}", scrub(detail))
+            CaduceusError::OciImageDigestMismatch {
+                reference,
+                expected,
+                found,
+            } => format!(
+                "OciImageDigestMismatch {{ reference: {:?}, expected: {:?}, found: {:?} }}",
+                reference, expected, found
+            ),
+            CaduceusError::OciImageArchitectureMismatch {
+                reference,
+                expected,
+                found,
+            } => format!(
+                "OciImageArchitectureMismatch {{ reference: {:?}, expected: {:?}, found: {:?} }}",
+                reference, expected, found
+            ),
+            CaduceusError::OciImageMissing { reference } => {
+                format!("OciImageMissing {{ reference: {:?} }}", reference)
             }
+            CaduceusError::OciImageInspectFailed { reference, detail } => format!(
+                "OciImageInspectFailed {{ reference: {:?}, detail: {} }}",
+                reference,
+                scrub(detail)
+            ),
             CaduceusError::OciDiskPressure {
                 path,
                 device_id,

--- a/tests/executor/oci_engine_seam_test.rs
+++ b/tests/executor/oci_engine_seam_test.rs
@@ -1,0 +1,50 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use caduceus::executor::oci_engine::OciImageAdapter;
+use caduceus::executor::oci_image::ensure_image_with_adapter;
+use caduceus::executor::oci_platform::HostPlatform;
+use caduceus::executor::SandboxEngine;
+use caduceus::infra::config::OciPullPolicy;
+
+const DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+const IMAGE_REF: &str = "registry.example/worker@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+fn fake_engine(root: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let binary = root.join("fake-oci");
+    let calls = root.join("calls.log");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"pull\" ]; then\n  printf 'pull must not be called on a warm cache\\n' >&2\n  exit 91\nfi\nif [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"--format\" ]; then\n  printf '%s' '{{\"Id\":\"sha256:{DIGEST}\",\"RepoDigests\":[\"{IMAGE_REF}\"],\"Architecture\":\"amd64\"}}'\nfi\nexit 0\n",
+        calls.display()
+    );
+    std::fs::write(&binary, script).expect("write fake OCI executable");
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
+        .expect("make fake OCI executable");
+    (binary, calls)
+}
+
+#[tokio::test]
+async fn if_missing_warm_cache_never_invokes_pull() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (binary, calls) = fake_engine(temp.path());
+    let run_dir = temp.path().join("run");
+    let image = ensure_image_with_adapter(
+        OciImageAdapter::with_binary(SandboxEngine::Docker, binary),
+        SandboxEngine::Docker,
+        IMAGE_REF,
+        OciPullPolicy::IfMissing,
+        &HostPlatform {
+            architecture: "amd64".to_string(),
+            variant: None,
+        },
+        &run_dir,
+        "warm-cache",
+    )
+    .await
+    .expect("warm cache should verify");
+
+    assert_eq!(image.id, format!("sha256:{DIGEST}"));
+    let calls = std::fs::read_to_string(calls).expect("fake engine call log");
+    assert!(calls.contains("image inspect"));
+    assert!(!calls.lines().any(|line| line == "pull"), "calls: {calls}");
+}

--- a/tests/executor/oci_ensure_image_test.rs
+++ b/tests/executor/oci_ensure_image_test.rs
@@ -1,0 +1,63 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use caduceus::executor::oci_engine::OciImageAdapter;
+use caduceus::executor::oci_image::ensure_image_with_adapter;
+use caduceus::executor::oci_platform::HostPlatform;
+use caduceus::executor::SandboxEngine;
+use caduceus::infra::config::OciPullPolicy;
+use caduceus::infra::error::CaduceusError;
+
+const DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const IMAGE_REF: &str = "registry.example/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn fake_engine(root: &Path, inspect_json: &str) -> (PathBuf, PathBuf) {
+    let binary = root.join("fake-oci");
+    let calls = root.join("calls.log");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" != \"--format\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"--format\" ]; then\n  printf '%s' '{}'\n  exit 0\nfi\nif [ \"$1\" = \"pull\" ]; then\n  exit 0\nfi\nexit 97\n",
+        calls.display(),
+        inspect_json
+    );
+    std::fs::write(&binary, script).expect("write fake OCI executable");
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
+        .expect("make fake OCI executable");
+    (binary, calls)
+}
+
+fn host() -> HostPlatform {
+    HostPlatform {
+        architecture: "amd64".to_string(),
+        variant: None,
+    }
+}
+
+#[tokio::test]
+async fn digest_mismatch_is_returned_before_any_create_call() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let inspect = format!(
+        r#"{{"Id":"sha256:{DIGEST}","RepoDigests":["registry.example/worker@sha256:{wrong}"],"Architecture":"amd64"}}"#,
+        wrong = "b".repeat(64)
+    );
+    let (binary, calls) = fake_engine(temp.path(), &inspect);
+    let run_dir = temp.path().join("run");
+    let error = ensure_image_with_adapter(
+        OciImageAdapter::with_binary(SandboxEngine::Docker, binary),
+        SandboxEngine::Docker,
+        IMAGE_REF,
+        OciPullPolicy::IfMissing,
+        &host(),
+        &run_dir,
+        "digest-mismatch",
+    )
+    .await
+    .expect_err("mismatched RepoDigests must abort");
+
+    assert!(matches!(
+        error,
+        CaduceusError::OciImageDigestMismatch { .. }
+    ));
+    let calls = std::fs::read_to_string(calls).expect("fake engine call log");
+    assert!(!calls.lines().any(|line| line.starts_with("create")));
+    assert!(!calls.lines().any(|line| line.starts_with("pull")));
+}

--- a/tests/executor/oci_image_inspect_test.rs
+++ b/tests/executor/oci_image_inspect_test.rs
@@ -1,0 +1,62 @@
+use caduceus::executor::oci_engine::{parse_inspect, NormalizedImage};
+use caduceus::infra::error::CaduceusError;
+
+const DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+#[test]
+fn docker_and_podman_inspect_shapes_normalize_equivalently() {
+    let docker = format!(
+        r#"{{
+            "Id": "sha256:{DIGEST}",
+            "RepoDigests": ["registry.example/worker@sha256:{DIGEST}"],
+            "Architecture": "AMD64",
+            "Variant": null
+        }}"#
+    );
+    let podman = format!(
+        r#"{{
+            "id": "{DIGEST}",
+            "repo_digests": ["registry.example/worker@sha256:{DIGEST}"],
+            "Config": {{"architecture": "amd64", "variant": ""}}
+        }}"#
+    );
+
+    let expected = NormalizedImage {
+        id: format!("sha256:{DIGEST}"),
+        repo_digests: vec![format!("registry.example/worker@sha256:{DIGEST}")],
+        architecture: "amd64".to_string(),
+        variant: None,
+    };
+    assert_eq!(parse_inspect(&docker).expect("Docker fixture"), expected);
+    assert_eq!(parse_inspect(&podman).expect("Podman fixture"), expected);
+}
+
+#[test]
+fn inspect_parser_accepts_case_insensitive_top_level_fields() {
+    let json = format!(
+        r#"{{"iD":"sha256:{DIGEST}","rEpO_DiGeStS":["worker@sha256:{DIGEST}"],"aRcHiTeCtUrE":"amd64","vArIaNt":"v8"}}"#
+    );
+    let image = parse_inspect(&json).expect("case-insensitive fixture");
+    assert_eq!(image.id, format!("sha256:{DIGEST}"));
+    assert_eq!(image.repo_digests, vec![format!("worker@sha256:{DIGEST}")]);
+    assert_eq!(image.architecture, "amd64");
+    assert_eq!(image.variant.as_deref(), Some("v8"));
+}
+
+#[test]
+fn malformed_inspect_and_invalid_ids_are_typed_inspect_failures() {
+    for json in [
+        "not json".to_string(),
+        r#"{"Architecture":"amd64"}"#.to_string(),
+        r#"{"Id":"sha256:bad","Architecture":"amd64"}"#.to_string(),
+        format!(r#"{{"Id":"{DIGEST}"}}"#),
+    ] {
+        assert!(
+            matches!(
+                parse_inspect(&json),
+                Err(CaduceusError::OciImageInspectFailed { .. })
+            ),
+            "expected typed inspect failure for {json}"
+        );
+    }
+}

--- a/tests/executor/oci_image_policy_test.rs
+++ b/tests/executor/oci_image_policy_test.rs
@@ -1,0 +1,22 @@
+use caduceus::executor::oci_image::{decide_pull_action, PullAction};
+use caduceus::infra::config::OciPullPolicy;
+
+#[test]
+fn pull_policy_decision_table() {
+    let cases = [
+        (OciPullPolicy::Never, true, PullAction::UseLocal),
+        (OciPullPolicy::Never, false, PullAction::ProbeLocalOnly),
+        (OciPullPolicy::IfMissing, true, PullAction::UseLocal),
+        (OciPullPolicy::IfMissing, false, PullAction::Pull),
+        (OciPullPolicy::Always, true, PullAction::Pull),
+        (OciPullPolicy::Always, false, PullAction::Pull),
+    ];
+
+    for (policy, local_present, expected) in cases {
+        assert_eq!(
+            decide_pull_action(policy, local_present),
+            expected,
+            "policy {policy:?}, local_present={local_present}"
+        );
+    }
+}

--- a/tests/executor/oci_image_verify_test.rs
+++ b/tests/executor/oci_image_verify_test.rs
@@ -1,0 +1,91 @@
+use caduceus::executor::oci_engine::NormalizedImage;
+use caduceus::executor::oci_image::{verify_arch, verify_digest};
+use caduceus::executor::oci_platform::HostPlatform;
+use caduceus::infra::error::CaduceusError;
+
+const DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const IMAGE_REF: &str = "registry.example/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn image(repo_digests: Vec<String>, architecture: &str, variant: Option<&str>) -> NormalizedImage {
+    NormalizedImage {
+        id: format!("sha256:{DIGEST}"),
+        repo_digests,
+        architecture: architecture.to_string(),
+        variant: variant.map(str::to_string),
+    }
+}
+
+fn host(architecture: &str, variant: Option<&str>) -> HostPlatform {
+    HostPlatform {
+        architecture: architecture.to_string(),
+        variant: variant.map(str::to_string),
+    }
+}
+
+#[test]
+fn digest_and_architecture_accept_matching_images() {
+    let image = image(vec![IMAGE_REF.to_string()], "amd64", None);
+    verify_digest(&image, IMAGE_REF).expect("digest should match");
+    verify_arch(&image, &host("amd64", None)).expect("architecture should match");
+}
+
+#[test]
+fn digest_mismatch_is_distinct_and_checked_before_architecture() {
+    let image = image(
+        vec!["registry.example/worker@sha256:bbbb".to_string()],
+        "arm64",
+        None,
+    );
+    let error = verify_digest(&image, IMAGE_REF).expect_err("digest must mismatch");
+    assert!(matches!(
+        error,
+        CaduceusError::OciImageDigestMismatch { .. }
+    ));
+
+    // A caller must run digest verification before architecture verification;
+    // this input would otherwise report the less authoritative arch failure.
+    assert!(matches!(
+        verify_digest(&image, IMAGE_REF),
+        Err(CaduceusError::OciImageDigestMismatch { .. })
+    ));
+}
+
+#[test]
+fn architecture_mismatch_is_distinct_from_digest_failure() {
+    let image = image(vec![IMAGE_REF.to_string()], "arm64", None);
+    let error = verify_arch(&image, &host("amd64", None)).expect_err("architecture must mismatch");
+    assert!(matches!(
+        error,
+        CaduceusError::OciImageArchitectureMismatch { .. }
+    ));
+    assert!(!matches!(error, CaduceusError::OciPullFailed { .. }));
+}
+
+#[test]
+fn host_without_variant_accepts_any_image_variant() {
+    let image = image(vec![IMAGE_REF.to_string()], "arm64", Some("v8"));
+    verify_arch(&image, &host("arm64", None)).expect("host without variant accepts v8");
+}
+
+#[test]
+fn host_variant_requires_a_matching_image_variant() {
+    let matching = image(vec![IMAGE_REF.to_string()], "arm", Some("V7"));
+    verify_arch(&matching, &host("arm", Some("v7"))).expect("variant should compare insensitive");
+
+    for variant in [None, Some("v6")] {
+        let image = image(vec![IMAGE_REF.to_string()], "arm", variant);
+        assert!(matches!(
+            verify_arch(&image, &host("arm", Some("v7"))),
+            Err(CaduceusError::OciImageArchitectureMismatch { .. })
+        ));
+    }
+}
+
+#[test]
+fn unknown_host_architecture_fails_closed() {
+    let image = image(vec![IMAGE_REF.to_string()], "mips", None);
+    assert!(matches!(
+        verify_arch(&image, &host("mips", None)),
+        Err(CaduceusError::OciImageArchitectureMismatch { .. })
+    ));
+}

--- a/tests/executor/oci_provenance_test.rs
+++ b/tests/executor/oci_provenance_test.rs
@@ -1,0 +1,235 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use caduceus::executor::oci_engine::OciImageAdapter;
+use caduceus::executor::oci_image::ensure_image_with_adapter;
+use caduceus::executor::oci_platform::HostPlatform;
+use caduceus::executor::SandboxEngine;
+use caduceus::infra::config::OciPullPolicy;
+use caduceus::infra::error::CaduceusError;
+use serde_json::Value;
+
+const DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const IMAGE_REF: &str = "registry.example/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn host() -> HostPlatform {
+    HostPlatform {
+        architecture: "amd64".to_string(),
+        variant: None,
+    }
+}
+
+fn fake_engine(root: &Path, local_present: bool, inspect_json: &str, pull_fails: bool) -> PathBuf {
+    let binary = root.join("fake-oci");
+    let present_exit = if local_present { "0" } else { "1" };
+    let pull_body = if pull_fails {
+        "printf 'registry offline\\n' >&2\n  exit 42"
+    } else {
+        "exit 0"
+    };
+    let inspect_json = inspect_json.replace('\\', "\\\\").replace('\'', "'\\''");
+    let script = format!(
+        "#!/bin/sh\nif [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" != \"--format\" ]; then\n  if [ \"{present_exit}\" = \"1\" ]; then\n    printf 'No such image\\n' >&2\n  fi\n  exit {present_exit}\nfi\nif [ \"$1\" = \"pull\" ]; then\n  {pull_body}\nfi\nif [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"--format\" ]; then\n  printf '%s' '{inspect_json}'\n  exit 0\nfi\nexit 97\n",
+        present_exit = present_exit,
+        pull_body = pull_body,
+        inspect_json = inspect_json,
+    );
+    std::fs::write(&binary, script).expect("write fake OCI executable");
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
+        .expect("make fake OCI executable");
+    binary
+}
+
+fn read_record(run_dir: &Path) -> Value {
+    let contents = std::fs::read_to_string(run_dir.join("provenance.log"))
+        .expect("provenance log should exist");
+    let mut lines = contents.lines();
+    let record: Value = serde_json::from_str(lines.next().expect("one provenance line"))
+        .expect("provenance line must be JSON");
+    assert!(lines.next().is_none(), "ensure_image must emit one record");
+    record
+}
+
+fn assert_common_fields(record: &Value) {
+    for field in [
+        "reference",
+        "engine",
+        "policy",
+        "mode",
+        "stage",
+        "outcome",
+        "timings",
+    ] {
+        assert!(!record[field].is_null(), "field {field} must be present");
+    }
+    assert_eq!(record["reference"], IMAGE_REF);
+    assert_eq!(record["engine"], "docker");
+    assert!(record["timings"].is_object());
+}
+
+#[tokio::test]
+async fn successful_acquisition_is_audited_with_resolved_fields() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let inspect = format!(
+        r#"{{"Id":"sha256:{DIGEST}","RepoDigests":["{IMAGE_REF}"],"Architecture":"amd64"}}"#
+    );
+    let binary = fake_engine(temp.path(), true, &inspect, false);
+    let run_dir = temp.path().join("success");
+    ensure_image_with_adapter(
+        OciImageAdapter::with_binary(SandboxEngine::Docker, binary),
+        SandboxEngine::Docker,
+        IMAGE_REF,
+        OciPullPolicy::IfMissing,
+        &host(),
+        &run_dir,
+        "success-run",
+    )
+    .await
+    .expect("matching image should verify");
+
+    let record = read_record(&run_dir);
+    assert_common_fields(&record);
+    assert_eq!(record["run_id"], "success-run");
+    assert_eq!(record["resolved_id"], format!("sha256:{DIGEST}"));
+    assert_eq!(record["repo_digests"].as_array().map(Vec::len), Some(1));
+    assert_eq!(record["architecture"], "amd64");
+    assert_eq!(record["policy"], "if_missing");
+    assert_eq!(record["mode"], "local");
+    assert_eq!(record["cache_hit"], true);
+    assert_eq!(record["pull_attempted"], false);
+    assert_eq!(record["stage"], "acquired");
+    assert_eq!(record["outcome"], "ok");
+    assert_eq!(record["verification"]["status"], "passed");
+}
+
+#[tokio::test]
+async fn verification_abort_is_audited_with_null_resolved_fields() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let inspect = format!(
+        r#"{{"Id":"sha256:{DIGEST}","RepoDigests":["registry.example/worker@sha256:{wrong}"],"Architecture":"amd64"}}"#,
+        wrong = "b".repeat(64)
+    );
+    let binary = fake_engine(temp.path(), true, &inspect, false);
+    let run_dir = temp.path().join("digest-abort");
+    let error = ensure_image_with_adapter(
+        OciImageAdapter::with_binary(SandboxEngine::Docker, binary),
+        SandboxEngine::Docker,
+        IMAGE_REF,
+        OciPullPolicy::IfMissing,
+        &host(),
+        &run_dir,
+        "digest-abort-run",
+    )
+    .await
+    .expect_err("digest mismatch should abort");
+    assert!(matches!(
+        error,
+        CaduceusError::OciImageDigestMismatch { .. }
+    ));
+
+    let record = read_record(&run_dir);
+    assert_common_fields(&record);
+    assert_eq!(record["resolved_id"], Value::Null);
+    assert_eq!(record["repo_digests"], Value::Null);
+    assert_eq!(record["architecture"], Value::Null);
+    assert_eq!(record["variant"], Value::Null);
+    assert_eq!(record["stage"], "digest_verify");
+    assert_eq!(record["outcome"], "aborted");
+    assert_eq!(record["error"]["variant"], "OciImageDigestMismatch");
+    assert_eq!(record["verification"]["status"], "failed");
+}
+
+#[tokio::test]
+async fn architecture_abort_is_audited_at_the_architecture_stage() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let inspect = format!(
+        r#"{{"Id":"sha256:{DIGEST}","RepoDigests":["{IMAGE_REF}"],"Architecture":"arm64"}}"#
+    );
+    let binary = fake_engine(temp.path(), true, &inspect, false);
+    let run_dir = temp.path().join("architecture-abort");
+    let error = ensure_image_with_adapter(
+        OciImageAdapter::with_binary(SandboxEngine::Docker, binary),
+        SandboxEngine::Docker,
+        IMAGE_REF,
+        OciPullPolicy::IfMissing,
+        &host(),
+        &run_dir,
+        "architecture-abort-run",
+    )
+    .await
+    .expect_err("architecture mismatch should abort");
+    assert!(matches!(
+        error,
+        CaduceusError::OciImageArchitectureMismatch { .. }
+    ));
+
+    let record = read_record(&run_dir);
+    assert_common_fields(&record);
+    assert_eq!(record["resolved_id"], Value::Null);
+    assert_eq!(record["repo_digests"], Value::Null);
+    assert_eq!(record["architecture"], Value::Null);
+    assert_eq!(record["variant"], Value::Null);
+    assert_eq!(record["stage"], "arch_verify");
+    assert_eq!(record["outcome"], "aborted");
+    assert_eq!(record["error"]["variant"], "OciImageArchitectureMismatch");
+    assert_eq!(record["verification"]["status"], "failed");
+}
+
+#[tokio::test]
+async fn provenance_write_failure_does_not_fail_image_acquisition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let inspect = format!(
+        r#"{{"Id":"sha256:{DIGEST}","RepoDigests":["{IMAGE_REF}"],"Architecture":"amd64"}}"#
+    );
+    let binary = fake_engine(temp.path(), true, &inspect, false);
+    let run_path = temp.path().join("run-file");
+    std::fs::write(&run_path, "not a directory").expect("run path fixture");
+
+    let image = ensure_image_with_adapter(
+        OciImageAdapter::with_binary(SandboxEngine::Docker, binary),
+        SandboxEngine::Docker,
+        IMAGE_REF,
+        OciPullPolicy::IfMissing,
+        &host(),
+        &run_path,
+        "provenance-write-failure",
+    )
+    .await
+    .expect("provenance failure must not fail acquisition");
+
+    assert_eq!(image.id, format!("sha256:{DIGEST}"));
+}
+
+#[tokio::test]
+async fn pull_abort_is_audited_at_the_pull_stage() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let binary = fake_engine(temp.path(), false, "{}", true);
+    let run_dir = temp.path().join("pull-abort");
+    let error = ensure_image_with_adapter(
+        OciImageAdapter::with_binary(SandboxEngine::Docker, binary),
+        SandboxEngine::Docker,
+        IMAGE_REF,
+        OciPullPolicy::IfMissing,
+        &host(),
+        &run_dir,
+        "pull-abort-run",
+    )
+    .await
+    .expect_err("pull failure should abort");
+    assert!(matches!(error, CaduceusError::OciPullFailed { .. }));
+
+    let record = read_record(&run_dir);
+    assert_common_fields(&record);
+    assert_eq!(record["resolved_id"], Value::Null);
+    assert_eq!(record["stage"], "pull");
+    assert_eq!(record["outcome"], "aborted");
+    assert_eq!(record["error"]["variant"], "OciPullFailed");
+    assert_eq!(
+        record["error"]["detail"]
+            .as_str()
+            .map(|s| s.contains("registry offline")),
+        Some(true)
+    );
+    assert_eq!(record["pull_attempted"], true);
+    assert_eq!(record["mode"], "pulled");
+}

--- a/tests/executor/sandbox_resolve_test.rs
+++ b/tests/executor/sandbox_resolve_test.rs
@@ -55,18 +55,16 @@ fn rejects_non_digest_image() {
     }
 }
 
-/// (b) pull_policy Always + digest image → OciPullPolicyIncompatible.
+/// (b) pull_policy Always + digest image is accepted and remains available
+/// to the acquisition layer.
 #[test]
-fn rejects_pull_policy_always_with_digest() {
+fn accepts_pull_policy_always_with_digest() {
     let (mut cfg, worktree) = base();
     cfg.sandbox.as_mut().expect("sandbox").pull_policy = OciPullPolicy::Always;
     let runtime = runtime_for(&cfg, &worktree);
-    let err = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
-        .expect_err("must reject");
-    match err {
-        CaduceusError::OciPullPolicyIncompatible { .. } => {}
-        other => panic!("expected OciPullPolicyIncompatible; got: {other:?}"),
-    }
+    let resolved = resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime))
+        .expect("always must resolve");
+    assert_eq!(resolved.image_ref(), cfg.sandbox().image);
 }
 
 /// (c) worktree outside workdir_base → OciUndeclaredMount.

--- a/tests/infra/config/sandbox_config_test.rs
+++ b/tests/infra/config/sandbox_config_test.rs
@@ -174,6 +174,26 @@ fn overlong_digest_rejected() {
     );
 }
 
+#[test]
+fn registry_paths_and_ports_are_valid_immutable_references() {
+    for image in [
+        "worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example:5000/ns/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ] {
+        load(&with_sandbox(&format!("sandbox:\n  image: \"{image}\"\n")))
+            .expect("digest-pinned registry reference should load");
+    }
+}
+
+#[test]
+fn tagged_image_reference_is_rejected_even_with_a_digest_suffix() {
+    assert_image_rejected(
+        "\"registry.example/worker:latest@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+        "name@sha256:<64 hex>",
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 10.3 — serde enum rejections (surface from serde, not from_raw)
 // ---------------------------------------------------------------------------
@@ -513,7 +533,7 @@ fn test_defaults_sandbox_is_some() {
     assert_eq!(sb.pull_policy, OciPullPolicy::IfMissing);
     assert_eq!(
         sb.image,
-        format!("caduceus-worker@sha256:{}", "0".repeat(64))
+        format!("placeholder/worker@sha256:{}", "0".repeat(64))
     );
     let res: &SandboxResources = &sb.resources;
     assert_eq!(res.cpus, 2.0);

--- a/tests/infra/error_classify_test.rs
+++ b/tests/infra/error_classify_test.rs
@@ -63,6 +63,45 @@ fn infrastructure_still_infrastructure() {
 }
 
 #[test]
+fn oci_image_failures_use_their_distinct_failure_classes() {
+    let digest_mismatch = CaduceusError::OciImageDigestMismatch {
+        reference: "worker@sha256:expected".to_string(),
+        expected: "sha256:expected".to_string(),
+        found: vec![],
+    };
+    assert_eq!(
+        classify_error(&digest_mismatch),
+        FailureClass::ImageVerification
+    );
+
+    let architecture_mismatch = CaduceusError::OciImageArchitectureMismatch {
+        reference: "worker@sha256:expected".to_string(),
+        expected: "amd64".to_string(),
+        found: "arm64".to_string(),
+    };
+    assert_eq!(
+        classify_error(&architecture_mismatch),
+        FailureClass::ImageVerification
+    );
+
+    for error in [
+        CaduceusError::OciPullFailed {
+            image: "worker@sha256:expected".to_string(),
+            stderr: "registry unavailable".to_string(),
+        },
+        CaduceusError::OciImageInspectFailed {
+            reference: "worker@sha256:expected".to_string(),
+            detail: "inspect failed".to_string(),
+        },
+        CaduceusError::OciImageMissing {
+            reference: "worker@sha256:expected".to_string(),
+        },
+    ] {
+        assert_eq!(classify_error(&error), FailureClass::Worker);
+    }
+}
+
+#[test]
 fn terminal_predicates_match_existing_classes() {
     // Worker still counts against budget; RateLimit/Cancellation still have
     // their dedicated predicates; Infrastructure and Terminal do not.
@@ -72,6 +111,10 @@ fn terminal_predicates_match_existing_classes() {
     );
     assert_eq!(
         failure_class_predicates_for_tests(FailureClass::Infrastructure),
+        (false, false, false)
+    );
+    assert_eq!(
+        failure_class_predicates_for_tests(FailureClass::ImageVerification),
         (false, false, false)
     );
     assert_eq!(

--- a/tests/oci_image_live_test.rs
+++ b/tests/oci_image_live_test.rs
@@ -1,0 +1,232 @@
+//! Opt-in live OCI image tests.
+//!
+//! These tests are intentionally inert unless `CADUCEUS_OCI_LIVE` selects an
+//! engine. A selected suite also requires `CADUCEUS_LIVE_TEST_IMAGE`, a
+//! digest-pinned reference suitable for the local registry credentials.
+//!
+//! Docker/Podman image command differences remain confined to
+//! `OciImageAdapter`; these live cases share the same acquisition path.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use caduceus::executor::oci_engine::{NormalizedImage, OciImageAdapter};
+use caduceus::executor::oci_image::{ensure_image_with_adapter, verify_digest};
+use caduceus::executor::oci_platform::{host_platform, HostPlatform};
+use caduceus::executor::SandboxEngine;
+use caduceus::infra::config::OciPullPolicy;
+use caduceus::infra::error::CaduceusError;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn selected(engine: SandboxEngine) -> bool {
+    match std::env::var("CADUCEUS_OCI_LIVE").ok().as_deref() {
+        None | Some("") => {
+            println!("skipped: set CADUCEUS_OCI_LIVE=docker|podman|1");
+            false
+        }
+        Some("1") => true,
+        Some(value) => value == engine.binary_name(),
+    }
+}
+
+fn configured_image() -> Option<String> {
+    match std::env::var("CADUCEUS_LIVE_TEST_IMAGE") {
+        Ok(reference) if reference.contains("@sha256:") => Some(reference),
+        Ok(_) => panic!("CADUCEUS_LIVE_TEST_IMAGE must be digest-pinned"),
+        Err(_) => {
+            println!("skipped: set CADUCEUS_LIVE_TEST_IMAGE to a digest-pinned image");
+            None
+        }
+    }
+}
+
+fn engine_available(engine: SandboxEngine) -> bool {
+    let format = match engine {
+        SandboxEngine::Docker => "{{.SecurityOptions}}",
+        SandboxEngine::Podman => "{{.Host.Security.Rootless}}",
+    };
+    match Command::new(engine.binary_name())
+        .args(["info", "--format", format])
+        .output()
+    {
+        Ok(output) if output.status.success() => true,
+        _ => {
+            println!("skipped: {} daemon is unavailable", engine.binary_name());
+            false
+        }
+    }
+}
+
+struct LiveRun {
+    _temp: TempDir,
+    run_dir: PathBuf,
+    image: NormalizedImage,
+    image_ref: String,
+    engine: SandboxEngine,
+}
+
+async fn acquire(engine: SandboxEngine, label: &str) -> Option<LiveRun> {
+    if !selected(engine) || !engine_available(engine) {
+        return None;
+    }
+    let image_ref = configured_image()?;
+    let temp = tempfile::tempdir().expect("live test tempdir");
+    let run_dir = temp.path().join(label);
+    let result = ensure_image_with_adapter(
+        OciImageAdapter::new(engine),
+        engine,
+        &image_ref,
+        OciPullPolicy::IfMissing,
+        &host_platform(),
+        &run_dir,
+        &format!("live-{label}"),
+    )
+    .await;
+    let image = match result {
+        Ok(image) => image,
+        Err(CaduceusError::OciPullFailed { stderr, .. }) => {
+            println!(
+                "skipped: {} image pull unavailable: {stderr}",
+                engine.binary_name()
+            );
+            return None;
+        }
+        Err(error) => panic!("live image acquisition failed: {error}"),
+    };
+    Some(LiveRun {
+        _temp: temp,
+        run_dir,
+        image,
+        image_ref,
+        engine,
+    })
+}
+
+fn assert_no_container(engine: SandboxEngine, run_id: &str) {
+    let filter = format!("name={run_id}");
+    let output = Command::new(engine.binary_name())
+        .args(["ps", "-a", "--filter", &filter, "--format", "{{.ID}}"])
+        .output()
+        .expect("query live containers");
+    assert!(output.status.success(), "container query failed");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "verification failure must not create a container"
+    );
+}
+
+async fn run_tier(engine: SandboxEngine, label: &str) {
+    let Some(run) = acquire(engine, label).await else {
+        return;
+    };
+    assert!(!run.image.id.is_empty());
+    assert_no_container(run.engine, &format!("live-{label}"));
+}
+
+#[tokio::test]
+async fn docker_tier_pulls_a_real_digest_pinned_image() {
+    run_tier(SandboxEngine::Docker, "docker-pull").await;
+}
+
+#[tokio::test]
+async fn podman_tier_pulls_a_real_digest_pinned_image() {
+    run_tier(SandboxEngine::Podman, "podman-pull").await;
+}
+
+async fn wrong_digest_tier(engine: SandboxEngine, label: &str) {
+    let Some(run) = acquire(engine, label).await else {
+        return;
+    };
+    let base = run
+        .image_ref
+        .split_once('@')
+        .map(|(base, _)| base)
+        .expect("digest-pinned reference");
+    let wrong_ref = format!("{base}@sha256:{}", "b".repeat(64));
+    assert!(matches!(
+        verify_digest(&run.image, &wrong_ref),
+        Err(CaduceusError::OciImageDigestMismatch { .. })
+    ));
+    assert_no_container(run.engine, &format!("live-{label}"));
+}
+
+#[tokio::test]
+async fn docker_tier_rejects_a_wrong_digest_before_create() {
+    wrong_digest_tier(SandboxEngine::Docker, "docker-digest").await;
+}
+
+#[tokio::test]
+async fn podman_tier_rejects_a_wrong_digest_before_create() {
+    wrong_digest_tier(SandboxEngine::Podman, "podman-digest").await;
+}
+
+async fn arch_mismatch_tier(engine: SandboxEngine, label: &str) {
+    let Some(run) = acquire(engine, label).await else {
+        return;
+    };
+    let bad_host = HostPlatform {
+        architecture: "unsupported-live-architecture".to_string(),
+        variant: None,
+    };
+    let error = ensure_image_with_adapter(
+        OciImageAdapter::new(engine),
+        engine,
+        &run.image_ref,
+        OciPullPolicy::IfMissing,
+        &bad_host,
+        &run.run_dir,
+        &format!("live-{label}-arch"),
+    )
+    .await
+    .expect_err("wrong host architecture must abort");
+    assert!(matches!(
+        error,
+        CaduceusError::OciImageArchitectureMismatch { .. }
+    ));
+    assert_no_container(run.engine, &format!("live-{label}"));
+}
+
+#[tokio::test]
+async fn docker_tier_rejects_an_architecture_mismatch_before_create() {
+    arch_mismatch_tier(SandboxEngine::Docker, "docker-arch").await;
+}
+
+#[tokio::test]
+async fn podman_tier_rejects_an_architecture_mismatch_before_create() {
+    arch_mismatch_tier(SandboxEngine::Podman, "podman-arch").await;
+}
+
+async fn provenance_tier(engine: SandboxEngine, label: &str) {
+    let Some(run) = acquire(engine, label).await else {
+        return;
+    };
+    let line =
+        std::fs::read_to_string(run.run_dir.join("provenance.log")).expect("live provenance log");
+    let record: Value = serde_json::from_str(line.lines().next().expect("provenance line"))
+        .expect("provenance JSON");
+    for field in [
+        "reference",
+        "resolved_id",
+        "repo_digests",
+        "policy",
+        "engine",
+        "mode",
+        "timings",
+    ] {
+        assert!(
+            !record[field].is_null(),
+            "required provenance field {field}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn docker_tier_records_provenance() {
+    provenance_tier(SandboxEngine::Docker, "docker-provenance").await;
+}
+
+#[tokio::test]
+async fn podman_tier_records_provenance() {
+    provenance_tier(SandboxEngine::Podman, "podman-provenance").await;
+}


### PR DESCRIPTION
Closes #246

## Summary
- Adds pull-before-create for the OCI worker image with policies `never | if_missing | always`, an engine-abstracted adapter (`pull`/`inspect` → `NormalizedImage`) that confines Docker/Podman differences, and post-pull/post-inspect digest + architecture verification with distinct typed errors before any container is created.
- Adds per-run provenance audit logging and deletes the hardcoded `caduceus-worker` placeholder and the `Always`-rejection (so `always` is now supported).

## Changes
| File | Change |
|------|--------|
| `src/executor/oci_platform.rs` | New: host-platform detection (ARCH → OCI arch mapping) |
| `src/executor/oci_engine.rs` | New: `OciImageAdapter` (pull/inspect/normalize) |
| `src/executor/oci_image.rs` | New: pull decision, digest/arch verification, provenance, `ensure_image` |
| `src/executor/oci.rs` | Wire `ensure_image` before `run_with_argv` |
| `src/executor/sandbox_spec.rs` | Remove `Always`-rejection |
| `src/infra/config/mod.rs` | Relax image regex; replace placeholder |
| `src/infra/error.rs` | New error variants; remove `OciPullPolicyIncompatible` |
| `src/daemon/orchestration/failure_class.rs` | `ImageVerification` failure class |
| `tests/executor/*` | New unit tests + gated live suites |

## Test Plan
- [x] `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked --all-targets` green (153 test binaries, 0 failures)
- [x] `openspec validate` valid; independent SpecOps review PASS
- [x] Live Tier-1/Tier-2 suites gated by `CADUCEUS_OCI_LIVE` (skip cleanly offline)
- [ ] Human review / merge

## Notes
- 9 pre-existing Python bridge-test failures on the parent commit are unrelated (no Python files changed in this change).
