### PR TITLE
feat(oci): add none|unrestricted network mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ sandbox:
   image: "caduceus-worker@sha256:<64 lowercase hex>"  # required, no default
   pull_policy: if_missing   # never | if_missing | always
   resources: { cpus: 2.0, memory_mb: 2048, pids: 256, tmpfs_mb: 256, shm_mb: 64 }
-  network: none             # only value; host networking was removed (breaking)
+  network: none             # none | unrestricted (see below; never host)
   pass_env: []
   stop_timeout_seconds: 10
   kill_timeout_seconds: 5
@@ -250,10 +250,16 @@ floors prevent zeroing a control to an unsafe value.
   time), and no host namespace sharing (`--pid host`,
   `--ipc host`, `--uts host` are structurally
   unrepresentable — the spec has no field for them).
-- Typed-only networking: `--network none` is the only
-  mode. Host networking was removed (breaking): the
-  `unrestricted` value no longer parses, so `network:
-  unrestricted` configs fail at load with a typed error.
+- Typed-only networking, two modes: `sandbox.network` is
+  `none` (the default) or `unrestricted`. `none` renders
+  `--network none`: loopback-only, no outbound connectivity
+  at all. `unrestricted` renders `--network bridge` on
+  both engines: the engine's default isolated bridge with
+  full outbound internet access via NAT. `unrestricted`
+  is NOT host networking — the container joins no host
+  namespace, and `--network host` is structurally
+  unrepresentable (the config rejects any `host` token at
+  load with a typed error).
 - Bounded engine logs: `--log-opt max-size=10m` and
   `--log-opt max-file=3` on every run (worst case 30 MiB
   of on-disk engine logs per container).

--- a/src/executor/sandbox_renderer.rs
+++ b/src/executor/sandbox_renderer.rs
@@ -83,13 +83,27 @@ pub fn render_with_env_files(
         argv.push(userns.to_string());
     }
 
-    // --- Network mode. Host networking is structurally
-    //     unrepresentable: `NetworkMode` has a single variant, so
-    //     `--network none` is emitted unconditionally (issue #245).
+    // --- Network mode. This exhaustive `(mode, engine)` match is
+    //     the only code path that can produce the `--network` token:
+    //     `None` renders `--network none` on both engines;
+    //     `Unrestricted` renders the engine's default isolated bridge
+    //     (`bridge` — NAT'd outbound egress, no host namespace
+    //     joining; the Podman token is pinned per `podman-create(1)`:
+    //     "bridge: Create a network stack on the default bridge").
+    //     Host networking is structurally unrepresentable: no arm can
+    //     emit `host`, and adding a third `NetworkMode` or
+    //     `SandboxEngine` variant fails to compile until this match
+    //     is deliberately extended.
+    let network_token = match (spec.network(), engine) {
+        (NetworkMode::None, _) => "none",
+        // Docker: the default isolated bridge (NAT'd egress).
+        (NetworkMode::Unrestricted, SandboxEngine::Docker) => "bridge",
+        // Podman: the default isolated bridge (NAT'd egress) — token
+        // verified against `podman-create(1)`. Never `host`.
+        (NetworkMode::Unrestricted, SandboxEngine::Podman) => "bridge",
+    };
     argv.push("--network".to_string());
-    argv.push(match spec.network() {
-        NetworkMode::None => "none".to_string(),
-    });
+    argv.push(network_token.to_string());
 
     // --- Resource limits (total fields — always emitted).
     argv.push("--cpus".to_string());

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::executor::ExecutorSpec;
 use crate::github::issue::IssueKey;
-use crate::infra::config::{Config, SandboxConfig};
+use crate::infra::config::{Config, SandboxConfig, SandboxNetwork};
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::worker_contract::{
     CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
@@ -156,16 +156,38 @@ pub struct TmpfsMount {
     pub size_mb: u64,
 }
 
-/// Network isolation mode for the container.
+/// Network isolation mode for the container — a closed two-variant
+/// enum.
 ///
-/// Host networking is structurally unrepresentable: the former
-/// `Unrestricted` variant (`--network host`) was removed (breaking,
-/// issue #245). The single variant renders `--network none`.
+/// `None` renders `--network none` (loopback-only). `Unrestricted`
+/// renders the engine's default isolated bridge (`--network bridge`
+/// on both Docker and Podman): NAT'd outbound egress with **no** host
+/// namespace joining — it is **not** host networking. Host networking
+/// is structurally unrepresentable: no variant can ever produce
+/// `--network host`, and the exhaustive matches in the renderer and
+/// in [`validate_no_host_escalation`] force a deliberate dual edit
+/// before any third mode can exist.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum NetworkMode {
-    /// `--network none` — no network access.
+    /// `--network none` — no network access (the default).
     #[default]
     None,
+    /// The engine's default isolated bridge (`--network bridge`) —
+    /// NAT'd outbound egress, never host networking.
+    Unrestricted,
+}
+
+/// The single conversion site between the config layer
+/// (`SandboxNetwork`) and the spec layer ([`NetworkMode`]).
+/// Exhaustive by construction: a new `SandboxNetwork` variant breaks
+/// this build until the spec-layer mapping is deliberately extended.
+impl From<SandboxNetwork> for NetworkMode {
+    fn from(value: SandboxNetwork) -> Self {
+        match value {
+            SandboxNetwork::None => Self::None,
+            SandboxNetwork::Unrestricted => Self::Unrestricted,
+        }
+    }
 }
 
 /// Resource limits mapped from [`SandboxResources`].
@@ -518,10 +540,12 @@ pub fn resolve(
         shm_mb: sandbox.resources.shm_mb,
     };
 
-    // 9. Network — the only mode is `None` (`--network none`); host
-    //     networking is structurally unrepresentable after the
-    //     breaking removal of `SandboxNetwork::Unrestricted` (D3).
-    let network = NetworkMode::None;
+    // 9. Network — sourced from `sandbox.network` through the single
+    //     `SandboxNetwork → NetworkMode` conversion. `None` renders
+    //     `--network none` (loopback-only); `Unrestricted` renders the
+    //     engine's default isolated bridge (NAT'd egress) — host
+    //     networking is structurally unrepresentable either way.
+    let network = NetworkMode::from(sandbox.network);
 
     // 10. Environment — the full canonical `CADUCEUS_*` set, with
     //     CONTAINER-side path values so host paths never leak into
@@ -621,9 +645,10 @@ pub fn resolve(
     validate_mount_policy(&spec)?;
 
     // 16. Host-escalation tripwire (defense in depth): no engine
-    //     socket mount and no non-isolated network may ever appear on
-    //     a resolved spec. Structurally unrepresentable after D3 —
-    //     exactly the point.
+    //     socket mount may ever appear on a resolved spec, and the
+    //     network mode is re-checked against the closed two-mode
+    //     allow-list — the host network namespace is never joined,
+    //     structurally, on every path.
     validate_no_host_escalation(&spec)?;
 
     Ok(spec)
@@ -734,9 +759,13 @@ fn validate_mount_policy(spec: &SandboxSpec) -> CaduceusResult<()> {
 ///   `host_path` or `container_path` file name is an engine/runtime
 ///   socket (`docker.sock` / `podman.sock`) — mounting the engine
 ///   socket is a container-escape primitive;
-/// - any network mode other than [`NetworkMode::None`] — a tautology
-///   after the `Unrestricted` removal that trips if a future variant
-///   is ever added without re-review.
+/// - any network mode outside the closed two-variant allow-list —
+///   both [`NetworkMode::None`] (loopback-only) and
+///   [`NetworkMode::Unrestricted`] (the engine's default isolated
+///   bridge, NAT'd egress) preserve the
+///   host-namespace-never-joined invariant; the exhaustive `match`
+///   trips at compile time if a host-representing variant is ever
+///   added without re-review.
 ///
 /// `--device` and `--pid/--ipc/--uts=host` are denied *structurally*:
 /// [`SandboxSpec`] has no field that could express them and the
@@ -772,14 +801,14 @@ pub fn validate_no_host_escalation(spec: &SandboxSpec) -> CaduceusResult<()> {
             }
         }
     }
-    if spec.network() != NetworkMode::None {
-        return Err(CaduceusError::OciMountConflict {
-            detail: format!(
-                "network mode {:?} is denied: only --network none is \
-                 representable (host networking was removed, issue #245)",
-                spec.network()
-            ),
-        });
+    // Both network modes keep the host network namespace out of
+    // reach: `None` is loopback-only; `Unrestricted` is the engine's
+    // default isolated bridge (NAT'd outbound egress, never host).
+    // The match is exhaustive over the closed enum, so a hypothetical
+    // future host-representing variant fails to compile here until
+    // this guard is deliberately re-reviewed (SAN-NET-4).
+    match spec.network() {
+        NetworkMode::None | NetworkMode::Unrestricted => {}
     }
     Ok(())
 }

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -121,18 +121,27 @@ pub struct SandboxResources {
     pub shm_mb: u64,
 }
 
-/// New enum (replaces `network_profiles`).
+/// Closed two-variant network mode for the OCI sandbox
+/// (`sandbox.network`).
 ///
-/// Host networking is structurally unrepresentable: the former
-/// `Unrestricted` variant (`--network host`) was removed (breaking,
-/// issue #245). The only value is `None` (`--network none`); a YAML
-/// `network: unrestricted` fails at serde parse time as an unknown
-/// variant.
+/// `None` (the default) renders `--network none` — loopback-only, no
+/// network access. `Unrestricted` renders the engine's default
+/// isolated bridge (`--network bridge` on both Docker and Podman):
+/// NAT'd outbound egress with **no** host namespace joining — it is
+/// **not** host networking. Host networking is structurally
+/// unrepresentable: no variant maps to `--network host`, and any
+/// other YAML token (`host`, `bridge`, unknown names) fails at serde
+/// parse time as an unknown variant.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxNetwork {
+    /// `--network none` — loopback-only, no network access (the
+    /// default).
     #[default]
-    None, // `--network none`
+    None,
+    /// The engine's default isolated bridge (`--network bridge`) —
+    /// NAT'd outbound egress, never host networking.
+    Unrestricted,
 }
 
 /// Raw layer — mirrors the schema with all-`Option` fields.

--- a/tests/executor/network_isolation_test.rs
+++ b/tests/executor/network_isolation_test.rs
@@ -1,13 +1,18 @@
-//! Adversarial network-isolation tests for the OCI executor.
+//! Network-isolation tests for the OCI executor, driven through the
+//! typed pipeline (`resolve` → `render`).
 //!
-//! These tests verify that network egress is correctly blocked or
-//! allowed based on the configured sandbox network mode, via the
-//! typed pipeline (`resolve` → `render`). All tests that require a
-//! live container engine are gated behind
-//! `CADUCEUS_RUN_ISOLATION_TESTS`.
+//! The network policy is a closed two-variant enum: `none`
+//! (loopback-only, the default — every outbound connection fails at
+//! the engine level) or `unrestricted` (the engine's default isolated
+//! bridge — NAT'd outbound egress with no host namespace joining).
+//! Neither mode can ever render `--network host`: host networking is
+//! structurally unrepresentable (no variant maps to it), pinned here
+//! and in the renderer goldens.
+//!
+//! These tests are pure — no live container engine is required.
 
 use caduceus::executor::sandbox_renderer::render;
-use caduceus::executor::sandbox_spec::{resolve, SandboxEngine, SandboxSpec};
+use caduceus::executor::sandbox_spec::{resolve, NetworkMode, SandboxEngine, SandboxSpec};
 use caduceus::infra::config::Config;
 
 mod support;
@@ -23,9 +28,24 @@ fn default_cfg() -> Config {
     Config::test_defaults(tmp.path())
 }
 
-fn network_value(cfg: &Config) -> String {
-    let spec = resolve_from(cfg);
-    let argv = render(&spec, SandboxEngine::Docker);
+/// `Config::test_defaults` with `sandbox.network` set to
+/// `unrestricted` (the engine's default isolated bridge — NAT'd
+/// egress, never host networking).
+fn unrestricted_cfg() -> Config {
+    use caduceus::infra::config::SandboxNetwork;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = Config::test_defaults(tmp.path());
+    cfg.sandbox
+        .as_mut()
+        .expect("test_defaults has a sandbox")
+        .network = SandboxNetwork::Unrestricted;
+    cfg
+}
+
+/// The token rendered after `--network` for the given engine.
+fn network_value(spec: &SandboxSpec, engine: SandboxEngine) -> String {
+    let argv = render(spec, engine);
     let pos = argv
         .iter()
         .position(|a| a == "--network")
@@ -33,62 +53,71 @@ fn network_value(cfg: &Config) -> String {
     argv[pos + 1].clone()
 }
 
-// probe_blocked_egress — no network profile → all egress blocked
+// probe_blocked_egress — the default network mode is `none` → all
+// egress blocked
 
 #[test]
-#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
 fn probe_blocked_egress() {
-    // With the default sandbox network, the rendered argv carries
-    // --network none. Any outbound connection from the container must
-    // fail at the engine level.
+    // With the default sandbox network, the spec resolves to
+    // NetworkMode::None and the rendered argv carries --network none
+    // on both engines. Any outbound connection from the container
+    // must fail at the engine level.
     let cfg = default_cfg();
-    assert_eq!(
-        network_value(&cfg),
-        "none",
-        "expected --network=none for blocked egress"
-    );
+    let spec = resolve_from(&cfg);
+    assert_eq!(spec.network(), NetworkMode::None);
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        assert_eq!(
+            network_value(&spec, engine),
+            "none",
+            "expected --network=none for blocked egress ({engine:?})"
+        );
+    }
 }
 
-// probe_allowed_egress — host networking is structurally
-// unrepresentable (breaking, issue #245): a config that requests
-// `network: unrestricted` fails at YAML parse time with a typed
-// unknown-variant error.
+// probe_allowed_egress — `sandbox.network = unrestricted` resolves to
+// `NetworkMode::Unrestricted` and renders the engine's default
+// isolated bridge (`bridge`) — NAT'd outbound egress, NOT host
+// networking, and NOT `none`.
 
 #[test]
-#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
 fn probe_allowed_egress() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("config.yaml");
-    let image =
-        "caduceus-worker@sha256:0000000000000000000000000000000000000000000000000000000000000000";
-    let body = format!(
-        "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
-         state_dir: \"{}/state\"\n\
-         reduced_containment_acknowledged: true\n\
-         sandbox:\n\
-         \x20 image: \"{image}\"\n\
-         \x20 network: unrestricted\n",
-        dir.path().display()
-    );
-    std::fs::write(&path, body).expect("write config");
-    let err = Config::load_from(&path).expect_err("network: unrestricted must fail to parse");
-    let msg = err.to_string();
-    assert!(msg.contains("unknown variant"), "got: {msg}");
-    assert!(msg.contains("unrestricted"), "got: {msg}");
+    let cfg = unrestricted_cfg();
+    let spec = resolve_from(&cfg);
+    assert_eq!(spec.network(), NetworkMode::Unrestricted);
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        assert_eq!(
+            network_value(&spec, engine),
+            "bridge",
+            "expected --network=bridge (engine default isolated bridge) for \
+             unrestricted ({engine:?})"
+        );
+        assert_ne!(
+            network_value(&spec, engine),
+            "none",
+            "unrestricted must not render --network=none ({engine:?})"
+        );
+        assert_ne!(
+            network_value(&spec, engine),
+            "host",
+            "unrestricted must never render --network=host ({engine:?})"
+        );
+    }
 }
 
-// probe_dns_exfiltration — DNS queries are blocked with no network
-// profile
+// probe_dns_exfiltration — DNS queries are blocked with the default
+// `none` mode
 
 #[test]
-#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
 fn probe_dns_exfiltration() {
     // --network none blocks DNS resolution entirely because the
     // container has no network stack.
     let cfg = default_cfg();
-    assert_eq!(
-        network_value(&cfg),
-        "none",
-        "expected --network=none for DNS exfiltration prevention"
-    );
+    let spec = resolve_from(&cfg);
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        assert_eq!(
+            network_value(&spec, engine),
+            "none",
+            "expected --network=none for DNS exfiltration prevention ({engine:?})"
+        );
+    }
 }

--- a/tests/executor/policy_test.rs
+++ b/tests/executor/policy_test.rs
@@ -25,6 +25,21 @@ fn default_cfg() -> Config {
     Config::test_defaults(tmp.path())
 }
 
+/// `Config::test_defaults` with `sandbox.network` set to
+/// `unrestricted` (the engine's default isolated bridge — NAT'd
+/// egress, never host networking).
+fn unrestricted_cfg() -> Config {
+    use caduceus::infra::config::SandboxNetwork;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = Config::test_defaults(tmp.path());
+    cfg.sandbox
+        .as_mut()
+        .expect("test_defaults has a sandbox")
+        .network = SandboxNetwork::Unrestricted;
+    cfg
+}
+
 // baseline_enforced — argv has --user, --cap-drop ALL, --security-opt
 // no-new-privileges, --read-only, --tmpfs; no docker.sock; no --device
 
@@ -129,8 +144,9 @@ fn isolation_flags_precede_image() {
     );
 }
 
-// network_mode_applied — the only network mode is `none` (host
-// networking was removed, breaking: issue #245)
+// network_mode_applied — the default network mode is `none`
+// (loopback-only); `unrestricted` opts into the engine's default
+// isolated bridge and renders `--network bridge`, never host
 
 #[test]
 fn network_mode_applied() {
@@ -142,6 +158,78 @@ fn network_mode_applied() {
         .position(|a| a == "--network")
         .expect("--network");
     assert_eq!(argv[network_pos + 1], "none");
+}
+
+// both_network_modes_pass_host_escalation_validation — SAN-NET-4:
+// `validate_no_host_escalation` permits the closed two-variant set
+// (`None`, `Unrestricted`); neither joins the host network namespace.
+
+#[test]
+fn both_network_modes_pass_host_escalation_validation() {
+    use caduceus::executor::sandbox_spec::{validate_no_host_escalation, NetworkMode};
+
+    // Default config → NetworkMode::None passes.
+    let cfg = default_cfg();
+    let spec = resolve_from(&cfg);
+    assert_eq!(spec.network(), NetworkMode::None);
+    validate_no_host_escalation(&spec).expect("NetworkMode::None must pass");
+
+    // `unrestricted` config → NetworkMode::Unrestricted passes too.
+    let cfg = unrestricted_cfg();
+    let spec = resolve_from(&cfg);
+    assert_eq!(spec.network(), NetworkMode::Unrestricted);
+    validate_no_host_escalation(&spec).expect("NetworkMode::Unrestricted must pass");
+
+    // And the rendered argv for both modes never carries host
+    // networking on either engine.
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        for cfg in [default_cfg(), unrestricted_cfg()] {
+            let spec = resolve_from(&cfg);
+            let argv = render(&spec, engine);
+            let pos = argv
+                .iter()
+                .position(|a| a == "--network")
+                .expect("--network");
+            assert_ne!(
+                argv.get(pos + 1).map(String::as_str),
+                Some("host"),
+                "--network host must never be rendered ({engine:?}); got: {argv:?}"
+            );
+        }
+    }
+}
+
+// unrestricted_config_renders_bridge — `sandbox.network =
+// unrestricted` resolves to `NetworkMode::Unrestricted` and renders
+// the engine's default isolated bridge (`bridge`) on both engines,
+// never `none`, never `host`.
+
+#[test]
+fn unrestricted_config_renders_bridge() {
+    use caduceus::infra::config::SandboxNetwork;
+
+    let cfg = unrestricted_cfg();
+    assert_eq!(
+        cfg.sandbox().network,
+        SandboxNetwork::Unrestricted,
+        "the mutated config must carry network: unrestricted"
+    );
+    let spec = resolve_from(&cfg);
+    for engine in [SandboxEngine::Docker, SandboxEngine::Podman] {
+        let argv = render(&spec, engine);
+        let pos = argv
+            .iter()
+            .position(|a| a == "--network")
+            .expect("--network");
+        assert_eq!(
+            argv[pos + 1],
+            "bridge",
+            "--network bridge (engine default isolated bridge) expected for \
+             unrestricted ({engine:?}); got: {argv:?}"
+        );
+        assert_ne!(argv[pos + 1], "none");
+        assert_ne!(argv[pos + 1], "host");
+    }
 }
 
 // no_network_mode_gives_none — default network mode → --network=none

--- a/tests/executor/sandbox_renderer_test.rs
+++ b/tests/executor/sandbox_renderer_test.rs
@@ -13,8 +13,10 @@
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::sandbox_renderer::{render, render_with_env_files};
-use caduceus::executor::sandbox_spec::{EngineMode, GitShadowKind, SandboxEngine, SandboxSpec};
-use caduceus::infra::config::{Config, SandboxConfig};
+use caduceus::executor::sandbox_spec::{
+    EngineMode, GitShadowKind, NetworkMode, SandboxEngine, SandboxSpec,
+};
+use caduceus::infra::config::{Config, SandboxConfig, SandboxNetwork};
 
 /// Fixed root for the golden fixtures. Never touched on disk.
 const ROOT: &str = "/tmp/caduceus-renderer-goldens";
@@ -253,6 +255,197 @@ fn podman_rootless_golden_argv() {
         "bridge.py".to_string(),
     ];
     assert_eq!(render(&spec, SandboxEngine::Podman), expected);
+}
+
+/// Golden: Docker + `NetworkMode::Unrestricted` renders the engine's
+/// default isolated bridge — exactly `--network bridge` (NAT'd
+/// outbound egress), never `--network host` and never `none`
+/// (SAN-NET-3). Every other token matches the Docker rootful `none`
+/// golden.
+#[test]
+fn docker_unrestricted_golden_argv() {
+    let (spec, worktree, output, shadow, image) =
+        fixture_with("run-001", EngineMode::Rootful, GitShadowKind::File, |sb| {
+            sb.network = SandboxNetwork::Unrestricted
+        });
+    assert_eq!(spec.network(), NetworkMode::Unrestricted);
+    let expected = vec![
+        "docker".to_string(),
+        "create".to_string(),
+        "--user".to_string(),
+        "4242:4242".to_string(),
+        "--cap-drop".to_string(),
+        "ALL".to_string(),
+        "--security-opt".to_string(),
+        "no-new-privileges".to_string(),
+        "--read-only".to_string(),
+        "--network".to_string(),
+        "bridge".to_string(),
+        "--cpus".to_string(),
+        "2".to_string(),
+        "--memory".to_string(),
+        "2048m".to_string(),
+        "--memory-swap".to_string(),
+        "2048m".to_string(),
+        "--pids-limit".to_string(),
+        "256".to_string(),
+        "--log-opt".to_string(),
+        "max-size=10m".to_string(),
+        "--log-opt".to_string(),
+        "max-file=3".to_string(),
+        "--name".to_string(),
+        "run-001".to_string(),
+        "-v".to_string(),
+        format!("{}:/workspace:rw", worktree.display()),
+        "-v".to_string(),
+        format!("{}:/output:rw", output.display()),
+        "-v".to_string(),
+        format!("{}:/workspace/.git:ro", shadow.display()),
+        "--tmpfs".to_string(),
+        "/tmp:size=256m".to_string(),
+        "--tmpfs".to_string(),
+        "/dev/shm:size=64m".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_RUN_ID=run-001".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_ID=owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_NUMBER=1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_REPO=owner/repo".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_TITLE=Fix login bug".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_BODY=Steps to reproduce".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_LABELS_JSON=[\"bug\"]".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_CONTEXT_JSON={}".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_BRANCH_NAME=caduceus/owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_WORKTREE_PATH=/workspace".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_RESULT_PATH=/output/worker-result.json".to_string(),
+        "-l".to_string(),
+        "caduceus.daemon_id=test-daemon".to_string(),
+        "-l".to_string(),
+        "caduceus.run_id=run-001".to_string(),
+        "-l".to_string(),
+        "caduceus.issue_id=owner/repo#1".to_string(),
+        "--entrypoint".to_string(),
+        "python3".to_string(),
+        image.clone(),
+        "bridge.py".to_string(),
+    ];
+    let argv = render(&spec, SandboxEngine::Docker);
+    // Exact token: the only value after --network is `bridge`.
+    let net_pos = argv
+        .iter()
+        .position(|a| a == "--network")
+        .expect("--network");
+    assert_eq!(argv[net_pos + 1], "bridge");
+    assert_ne!(argv.get(net_pos + 1).map(String::as_str), Some("host"));
+    assert_ne!(argv.get(net_pos + 1).map(String::as_str), Some("none"));
+    // Byte-for-byte golden.
+    assert_eq!(argv, expected);
+}
+
+/// Golden: Podman + `NetworkMode::Unrestricted` renders Podman's
+/// default isolated bridge — exactly `--network bridge` (NAT'd
+/// outbound egress; token pinned per `podman-create(1)`: "bridge:
+/// Create a network stack on the default bridge"), never
+/// `--network host` and never `none` (SAN-NET-3). Every other token
+/// matches the Podman rootless `none` golden.
+#[test]
+fn podman_unrestricted_golden_argv() {
+    let (spec, worktree, output, shadow, image) =
+        fixture_with("run-001", EngineMode::Rootless, GitShadowKind::File, |sb| {
+            sb.engine = SandboxEngine::Podman;
+            sb.network = SandboxNetwork::Unrestricted;
+        });
+    assert_eq!(spec.network(), NetworkMode::Unrestricted);
+    let expected = vec![
+        "podman".to_string(),
+        "create".to_string(),
+        // Rootless: no --user; plain keep-id user namespace.
+        "--cap-drop".to_string(),
+        "ALL".to_string(),
+        "--security-opt".to_string(),
+        "no-new-privileges".to_string(),
+        "--read-only".to_string(),
+        "--userns".to_string(),
+        "keep-id".to_string(),
+        "--network".to_string(),
+        "bridge".to_string(),
+        "--cpus".to_string(),
+        "2".to_string(),
+        "--memory".to_string(),
+        "2048m".to_string(),
+        "--memory-swap".to_string(),
+        "2048m".to_string(),
+        "--pids-limit".to_string(),
+        "256".to_string(),
+        "--log-opt".to_string(),
+        "max-size=10m".to_string(),
+        "--log-opt".to_string(),
+        "max-file=3".to_string(),
+        "--name".to_string(),
+        "run-001".to_string(),
+        "-v".to_string(),
+        format!("{}:/workspace:rw", worktree.display()),
+        "-v".to_string(),
+        format!("{}:/output:rw", output.display()),
+        "-v".to_string(),
+        format!("{}:/workspace/.git:ro", shadow.display()),
+        "--tmpfs".to_string(),
+        "/tmp:size=256m".to_string(),
+        "--tmpfs".to_string(),
+        "/dev/shm:size=64m".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_RUN_ID=run-001".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_ID=owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_NUMBER=1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_REPO=owner/repo".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_TITLE=Fix login bug".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_BODY=Steps to reproduce".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_ISSUE_LABELS_JSON=[\"bug\"]".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_CONTEXT_JSON={}".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_BRANCH_NAME=caduceus/owner/repo#1".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_WORKTREE_PATH=/workspace".to_string(),
+        "-e".to_string(),
+        "CADUCEUS_RESULT_PATH=/output/worker-result.json".to_string(),
+        "-l".to_string(),
+        "caduceus.daemon_id=test-daemon".to_string(),
+        "-l".to_string(),
+        "caduceus.run_id=run-001".to_string(),
+        "-l".to_string(),
+        "caduceus.issue_id=owner/repo#1".to_string(),
+        "--entrypoint".to_string(),
+        "python3".to_string(),
+        image.clone(),
+        "bridge.py".to_string(),
+    ];
+    let argv = render(&spec, SandboxEngine::Podman);
+    // Exact token: the only value after --network is `bridge`.
+    let net_pos = argv
+        .iter()
+        .position(|a| a == "--network")
+        .expect("--network");
+    assert_eq!(argv[net_pos + 1], "bridge");
+    assert_ne!(argv.get(net_pos + 1).map(String::as_str), Some("host"));
+    assert_ne!(argv.get(net_pos + 1).map(String::as_str), Some("none"));
+    // Byte-for-byte golden.
+    assert_eq!(argv, expected);
 }
 
 /// The per-engine deltas are fully encoded in the spec's identity:

--- a/tests/executor/sandbox_resolve_test.rs
+++ b/tests/executor/sandbox_resolve_test.rs
@@ -397,8 +397,9 @@ fn resolution_yields_fully_populated_spec() {
     assert!(!spec.environment().is_empty());
     assert!(!spec.labels().is_empty());
     assert!(spec.resources().memory_mb > 0);
-    // Host networking was removed (breaking, issue #245): `None` is
-    // the only variant, so every resolved spec is network-isolated.
+    // SAN-NET-2: the default network mode is `None` (`--network
+    // none`, loopback-only); `unrestricted` opts into the engine's
+    // default isolated bridge.
     assert!(matches!(spec.network(), NetworkMode::None));
     let _ = spec.security();
 }

--- a/tests/infra/config/sandbox_config_test.rs
+++ b/tests/infra/config/sandbox_config_test.rs
@@ -108,8 +108,8 @@ fn explicit_full_sandbox_parses_to_given_values() {
     assert_eq!(sb.resources.pids, 512);
     assert_eq!(sb.resources.tmpfs_mb, 512);
     assert_eq!(sb.resources.shm_mb, 128);
-    // Host networking was removed (breaking, issue #245): `none` is
-    // the only value.
+    // Closed two-variant network model: `none` (loopback-only
+    // default) or `unrestricted` (engine default isolated bridge).
     assert_eq!(sb.network, SandboxNetwork::None);
     assert_eq!(
         sb.pass_env,
@@ -226,31 +226,60 @@ fn unknown_network_value_rejected() {
     let msg = err.to_string();
     assert!(msg.contains("unknown variant"), "got: {msg}");
     assert!(msg.contains("filtered"), "got: {msg}");
-    // Host networking was removed (issue #245): `none` is the only
-    // allowed value.
+    // The closed two-variant set: only `none` and `unrestricted` are
+    // allowed values.
     assert!(
-        msg.contains("none") && !msg.contains("unrestricted"),
-        "allowed values must list only `none`; got: {msg}"
+        msg.contains("none") && msg.contains("unrestricted"),
+        "allowed values must list `none` and `unrestricted`; got: {msg}"
     );
 }
 
-/// `network: unrestricted` (the removed host-networking value,
-/// issue #245) fails at serde parse time as an unknown variant — a
-/// typed error, exactly the spec's "parsing fails with a typed
-/// error" scenario.
+/// `network: host` (and every other non-`none`/`unrestricted` token)
+/// fails at serde parse time as an unknown variant — host networking
+/// is structurally unrepresentable (SAN-NET-5).
 #[test]
-fn unrestricted_network_rejected() {
-    let err = load_sandbox_line(&format!(
-        "image: \"{VALID_IMAGE}\"\n  network: unrestricted"
-    ))
-    .expect_err("network: unrestricted must be rejected");
+fn host_network_rejected() {
+    let err = load_sandbox_line(&format!("image: \"{VALID_IMAGE}\"\n  network: host"))
+        .expect_err("network: host must be rejected");
     let msg = err.to_string();
     assert!(msg.contains("unknown variant"), "got: {msg}");
-    assert!(msg.contains("unrestricted"), "got: {msg}");
-    assert!(
-        msg.contains("none"),
-        "the only valid value must be listed; got: {msg}"
+    assert!(msg.contains("host"), "got: {msg}");
+}
+
+/// `network: unrestricted` parses to `SandboxNetwork::Unrestricted`
+/// and round-trips through `resolve()` into `NetworkMode::Unrestricted`
+/// (SAN-NET-5). It maps to the engine's default isolated bridge
+/// (NAT'd outbound egress) — never host networking.
+#[test]
+fn unrestricted_network_accepted() {
+    use caduceus::executor::sandbox_spec::{resolve, NetworkMode};
+
+    #[path = "../../executor/support/mod.rs"]
+    mod support;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let body = format!(
+        "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
+         state_dir: \"{}/state\"\n\
+         workdir_base: \"{}/projects\"\n\
+         reduced_containment_acknowledged: true\n\
+         sandbox:\n\
+         \x20 image: \"{VALID_IMAGE}\"\n\
+         \x20 network: unrestricted\n",
+        dir.path().display(),
+        dir.path().display()
     );
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, body).expect("write config");
+    let cfg = Config::load_from(&path).expect("network: unrestricted must parse");
+    assert_eq!(cfg.sandbox().network, SandboxNetwork::Unrestricted);
+
+    // Round-trip: the resolved spec carries NetworkMode::Unrestricted.
+    let worktree = cfg.workdir_base.join("owner").join("repo").join("run-001");
+    let runtime = support::runtime_facts(&cfg, "run-001", &worktree);
+    let spec =
+        resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
+    assert_eq!(spec.network(), NetworkMode::Unrestricted);
 }
 
 #[test]


### PR DESCRIPTION
## Sandbox network policy: exactly two modes — `none` and `unrestricted`

The OCI sandbox now has a closed, two-variant network policy sourced from the `sandbox.network` config key. `none` (the default) renders `--network none` on both Docker and Podman: loopback-only, no outbound connectivity, unchanged behavior for every existing config that omits the key. `unrestricted` renders `--network bridge` on both engines: the engine's default isolated bridge, with full outbound internet access via NAT.

**`unrestricted` is not host networking.** The container joins no host network namespace on any path. Host networking is structurally unrepresentable: neither `NetworkMode` (spec layer) nor `SandboxNetwork` (config layer) has a variant that could produce `--network host`, the Podman token was confirmed against the `podman-create(1)` manual (`bridge: Create a network stack on the default bridge` — a separate, explicitly security-warned `host` mode exists and is never emitted), and the renderer's `match (mode, engine)` is exhaustive over the closed enum. Adding a third mode — in particular any host-like variant — is a compile error in the renderer and in the host-escalation validation guard until both are deliberately extended.

**What changed:**

- `NetworkMode` and `SandboxNetwork` each gained an `Unrestricted` variant; `None` remains the default in both layers.
- `resolve()` now sources the mode from `sandbox.network` through a single exhaustive `From<SandboxNetwork> for NetworkMode` conversion, instead of hard-coding `none`.
- The argv renderer maps the mode per engine: `none` → `--network none` on both engines; `unrestricted` → `--network bridge` on Docker and `--network bridge` on Podman (token verified per above; never `host`). No string ever reaches the `--network` position except from this match.
- The host-escalation validator now permits both modes via an exhaustive allow-match and keeps every other denial intact: engine/runtime socket mounts (`docker.sock` / `podman.sock`) and `--device` / `--pid host` / `--ipc host` / `--uts host` remain structurally impossible.
- Config parsing strictly widens: `sandbox.network` previously rejected `unrestricted`; it now accepts exactly `none` and `unrestricted`. Everything else — `host`, `bridge`, arbitrary names, and the legacy network-profiles machinery — still fails at parse time with a typed serde error.
- The networking documentation now describes both modes and states plainly that `unrestricted` grants full outbound internet access through the engine's default isolated bridge and never host networking.

**Threat note:** a worker running with `sandbox.network: unrestricted` can reach any endpoint the host can reach, and can exfiltrate anything it can read. Operators who need loopback-only isolation should keep the default `none`.

**Tests:** the previously inverted expectations were rewritten to the two-variant model — config acceptance/rejection matrix (`unrestricted` accepted and round-tripped through resolution into the spec; `host` and unknown tokens rejected; legacy network-profile keys still rejected), per-engine renderer goldens for both modes asserting the exact tokens and that `host` never appears, and host-escalation validation covering both modes. The full Rust suite (153 test binaries) passes; lint and format gates are clean.

Closes #248

Artifacts (2):

```json
{
  "change": "issue-248-network-mode",
  "network_modes": [
    "none",
    "unrestricted"
  ]
}
```

<!-- caduceus-pr-body:run=01M16NW64S9HTNDTR2FVNT1WHS -->