### PR TITLE
Potential fix for code scanning alert no. 1: Cleartext logging of sensitive information

### DIFF
--- a/src/worker/context.rs
+++ b/src/worker/context.rs
@@ -517,9 +517,9 @@ fn approx_json_array_len<T: Serialize + Clone>(key: &str, items: &[T]) -> Caduce
     let owned: Vec<T> = items.to_vec();
     let mut map: BTreeMap<&str, &Vec<T>> = BTreeMap::new();
     map.insert(key, &owned);
-    let s = serde_json::to_string(&map).map_err(|err| CaduceusError::Worker {
+    let s = serde_json::to_string(&map).map_err(|_err| CaduceusError::Worker {
         context: "context:approx_size",
-        stderr: format!("serde_json: {err}"),
+        stderr: "serde_json encoding failed".to_string(),
     })?;
     Ok(s.len())
 }


### PR DESCRIPTION
Potential fix for [https://github.com/barkley-assistant/caduceus/security/code-scanning/1](https://github.com/barkley-assistant/caduceus/security/code-scanning/1)

To fix this without changing functional behavior, keep all current truncation/filtering logic, but sanitize the error text emitted in `approx_json_array_len` so no potentially sensitive serialized content can be propagated to logs.

Best single fix in the shown file:
- In `src/worker/context.rs`, inside `approx_json_array_len`, replace:
  - `stderr: format!("serde_json: {err}")`
- with a constant non-sensitive message such as:
  - `stderr: "serde_json encoding failed".to_string()`

This preserves control flow and error semantics (still returns `CaduceusError::Worker` with same context), while removing dynamic error interpolation that can carry tainted content into logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
