### PR TITLE
Potential fix for code scanning alert no. 2: Cleartext logging of sensitive information

### DIFF
--- a/tests/executor/credential_leak_test.rs
+++ b/tests/executor/credential_leak_test.rs
@@ -56,15 +56,15 @@ fn leak_via_argv() {
 
     assert!(
         !debug_output.contains("ghp_abc123_secret"),
-        "secret leaked into Debug: {debug_output}"
+        "secret leaked into Debug output"
     );
     assert!(
         !debug_output.contains("ghp_def456_secret"),
-        "second secret leaked into Debug: {debug_output}"
+        "second secret leaked into Debug output"
     );
     assert!(
         !display_output.contains("ghp_abc123_secret"),
-        "secret leaked into Display: {display_output}"
+        "secret leaked into Display output"
     );
 
     // Verify paths don't contain secret values
@@ -72,7 +72,7 @@ fn leak_via_argv() {
         let path_str = path.to_string_lossy();
         assert!(
             !path_str.contains("ghp_abc123_secret"),
-            "secret leaked into path: {path_str}"
+            "secret leaked into path"
         );
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/barkley-assistant/caduceus/security/code-scanning/2](https://github.com/barkley-assistant/caduceus/security/code-scanning/2)

The best fix is to remove dynamic assertion-message interpolation of potentially tainted strings and replace it with constant, non-sensitive failure messages. This preserves functionality (the assertions still check the same conditions) while preventing any accidental leakage to test logs on failure.

In `tests/executor/credential_leak_test.rs`, update the assertions in `leak_via_argv` so messages no longer include `{debug_output}`, `{display_output}`, or `{path_str}`. Keep the boolean checks unchanged. No import or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
