### PR TITLE
fix(oci): crash-safe lifecycle, reconciliation, and heartbeat continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,26 @@ What the worker container sees is a closed, typed spec:
   engine with userns-remap, or an engine whose mode cannot
   be determined) are refused with a typed error before any
   container is created, and `hermes caduceus doctor`
-  reports the engine/mode as unavailable.
+   reports the engine/mode as unavailable.
+
+### OCI crash recovery and state compatibility
+
+OCI runs use one crash-safe lifecycle. The container ID is durably recorded
+after `create` and before `start`; execution is raced against the worker
+deadline, daemon cancellation, and disk pressure. Cleanup uses bounded
+`stop` → `kill` → `rm --force` and confirms the container is absent before
+recording `Removed`. A fresh daemon token keeps cleanup running even when the
+parent run is cancelled, and active runs refresh the normal 5-second
+heartbeat.
+
+The OCI run store is schema **v7**. There is no legacy v6 migration: starting
+against a v6 state database stops with a stale-schema error, and operators
+must initialise fresh state. Each installation also gets a UUID persisted
+atomically by the metadata store. It replaces the state-directory basename
+as `caduceus.daemon_id`, so discovery never touches containers belonging to a
+different installation. Restarting the daemon is the recovery operation;
+startup reconciliation converges durable rows and labeled engine containers
+without manual container cleanup.
 
 ### The mandatory per-run OCI baseline (non-weakenable)
 

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -260,12 +260,22 @@ pub async fn tick(
     // 2. Open the metadata + state stores and enforce the
     //    rate-limit and cadence gates.
     let use_sqlite = cfg.state_backend == "sqlite";
-    let meta = LeaderToken::with_lock(&state_dir, || {
-        if use_sqlite {
-            MetaStore::open_sqlite(&state_dir)
+    let (meta, oci_daemon_id) = LeaderToken::with_lock(&state_dir, || {
+        let meta = if use_sqlite {
+            MetaStore::open_sqlite(&state_dir)?
         } else {
-            MetaStore::open(&state_dir)
-        }
+            MetaStore::open(&state_dir)?
+        };
+        // Establish the installation identity during daemon initialization,
+        // before any OCI executor can render labels or create a container.
+        // Keep generation under the scheduler lock so concurrent daemon
+        // starts cannot replace the persisted identity between read/write.
+        let daemon_id = if cfg.executor_mode == crate::executor::ExecutorKind::Oci {
+            Some(meta.get_or_create_installation_uuid()?)
+        } else {
+            None
+        };
+        Ok((meta, daemon_id))
     })?;
     let gate = if use_sqlite {
         CadenceGate::open_with_store(MetaStore::open_sqlite(&state_dir)?)
@@ -301,6 +311,27 @@ pub async fn tick(
             StateStore::open(&state_dir)
         }
     })?);
+
+    // 3.1. OCI startup recovery is deliberately before stale-claim
+    // handling and before the dispatcher can accept a new claim. The
+    // identity is loaded first, then the same adapter teardown path is
+    // used to converge labeled containers and durable run rows.
+    if cfg.executor_mode == crate::executor::ExecutorKind::Oci {
+        let daemon_id = oci_daemon_id
+            .as_deref()
+            .expect("OCI initialization must load installation UUID");
+        let oci_state = Arc::new(crate::state::oci_run::OciRunDao::new(
+            crate::state::store::open_in(&state_dir)?,
+        ));
+        crate::executor::oci_lifecycle::reconcile_installation(
+            &cfg,
+            oci_state,
+            daemon_id,
+            cancellation.clone(),
+        )
+        .await?;
+    }
+
     let _ = crate::state::queue::reap_stale_claims(
         &state_dir,
         services.clock.now(),

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -263,7 +263,10 @@ pub(crate) async fn run_claim(
     };
     let supervisor_outcome = exec_outcome.outcome.clone();
     guard.attach_supervisor(supervisor_outcome.clone()).await;
-    if supervisor_outcome.timed_out || supervisor_outcome.cancelled {
+    if supervisor_outcome.timed_out
+        || supervisor_outcome.cancelled
+        || supervisor_outcome.disk_pressure
+    {
         let _ = guard.finish_cancelled().await;
         return Ok(TickOutcome::Cancelled);
     }

--- a/src/executor/engine_probe.rs
+++ b/src/executor/engine_probe.rs
@@ -35,9 +35,7 @@ use std::time::Duration;
 
 use nix::unistd::{chown, Gid, Uid};
 
-use crate::executor::sandbox_spec::{
-    derive_daemon_id, EngineMode, GitShadowKind, RuntimeFacts, SandboxEngine,
-};
+use crate::executor::sandbox_spec::{EngineMode, GitShadowKind, RuntimeFacts, SandboxEngine};
 use crate::executor::ExecutorSpec;
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
@@ -64,6 +62,23 @@ const ENGINE_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 pub async fn probe_runtime_facts(
     cfg: &Config,
     spec: &ExecutorSpec,
+) -> CaduceusResult<RuntimeFacts> {
+    let meta = if cfg.state_backend == "sqlite" {
+        crate::state::meta::MetaStore::open_sqlite(&cfg.state_dir)?
+    } else {
+        crate::state::meta::MetaStore::open(&cfg.state_dir)?
+    };
+    let daemon_id = meta.get_or_create_installation_uuid()?;
+    probe_runtime_facts_with_daemon_id(cfg, spec, &daemon_id).await
+}
+
+/// Variant used by the daemon after it has loaded its persisted installation
+/// UUID. Keeping the identity an explicit input ensures labels are never
+/// rendered before the UUID has been durably established.
+pub async fn probe_runtime_facts_with_daemon_id(
+    cfg: &Config,
+    spec: &ExecutorSpec,
+    daemon_id: &str,
 ) -> CaduceusResult<RuntimeFacts> {
     let engine = cfg.sandbox().engine;
 
@@ -142,7 +157,7 @@ pub async fn probe_runtime_facts(
         worker_command: spec.worker_command.clone(),
         worktree: spec.worktree.clone(),
         output_dir,
-        daemon_id: derive_daemon_id(cfg),
+        daemon_id: daemon_id.to_string(),
         workdir_base: cfg.workdir_base.clone(),
         state_dir,
         worktree_uid,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -13,7 +13,7 @@
 //! * [`oci::OciExecutor`] — dispatches workers via Docker or Podman
 //!   CLI. The `create` argv is produced by the pure
 //!   [`sandbox_spec::resolve`] → [`sandbox_renderer::render`] pipeline;
-//!   the five-step lifecycle lives in [`oci_lifecycle`].
+//!   the single crash-safe lifecycle lives in [`oci_lifecycle`].
 
 use std::future::Future;
 use std::path::PathBuf;

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -5,9 +5,9 @@
 //! create the daemon-owned host artifacts, resolves a typed
 //! [`SandboxSpec`] from the sandbox config and those facts, renders
 //! the `create` argv with the pure renderer, acquires and verifies the
-//! configured image, then delegates to [`oci_lifecycle::run_with_argv`]
-//! for the five-step container lifecycle (create → start → wait → stop →
-//! remove). The state DAO is injected through the config's state directory.
+//! configured image, then delegates to [`oci_lifecycle::run_oci_lifecycle`]
+//! for the single crash-safe container lifecycle. The state DAO is injected
+//! through the config's state directory.
 //!
 //! The renderer is the sole argv producer in the crate: `resolve` owns
 //! every host-path and identity decision, `engine_probe` owns runtime facts
@@ -26,6 +26,7 @@ use crate::executor::{
 use crate::infra::config::Config;
 use crate::infra::disk::DiskPressureGuard;
 use crate::infra::error::CaduceusResult;
+use crate::state::meta::MetaStore;
 use crate::state::oci_run::OciRunDao;
 use crate::state::store;
 use crate::worker::worker_contract::WORKER_RESULT_FILE;
@@ -59,26 +60,37 @@ impl Executor for OciExecutor {
             //    executor.
             self.disk.try_acquire_oci()?;
 
-            // 1. Pre-flight probe: collect the runtime facts (worktree
+            // 1. Load and durably establish the installation identity
+            //    before any labels or create argv are rendered.
+            let meta = if self.cfg.state_backend == "sqlite" {
+                MetaStore::open_sqlite(&self.cfg.state_dir)?
+            } else {
+                MetaStore::open(&self.cfg.state_dir)?
+            };
+            let daemon_id = meta.get_or_create_installation_uuid()?;
+
+            // 2. Pre-flight probe: collect the runtime facts (worktree
             //    owner uid/gid, host `.git` type, engine mode) and
             //    create the daemon-owned host artifacts. Every
             //    unsupported-configuration refusal (typed
             //    `OciIdentityUnsupported`) is raised here — before any
             //    `create` argv exists, so `oci_lifecycle` is never
             //    reached on a refusal path.
-            let runtime = engine_probe::probe_runtime_facts(&self.cfg, spec).await?;
+            let runtime =
+                engine_probe::probe_runtime_facts_with_daemon_id(&self.cfg, spec, &daemon_id)
+                    .await?;
 
-            // 2. Resolve the closed typed spec. All host-path,
+            // 3. Resolve the closed typed spec. All host-path,
             //    identity, and mount decisions happen here; the
             //    renderer invents nothing.
             let resolved = sandbox_spec::resolve(self.cfg.sandbox(), &runtime, spec)?;
 
-            // 3. Open the state database.
+            // 4. Open the state database.
             let db_path = self.cfg.state_dir.join(store::DB_FILENAME);
             let conn = store::open(&db_path)?;
             let dao = OciRunDao::new(conn);
 
-            // 4. Write the assembled environment (canonical + compat +
+            // 5. Write the assembled environment (canonical + compat +
             //    resolved `pass_env` from `spec.environment`) to the
             //    daemon-private, randomly named, mode-0600 env file
             //    under `state_dir/oci-runs/<run_id>` (issue #249). Its
@@ -99,7 +111,7 @@ impl Executor for OciExecutor {
                 &[env_file.path().to_path_buf()],
             );
 
-            // 5. Acquire and verify the immutable worker image before the
+            // 6. Acquire and verify the immutable worker image before the
             //    lifecycle can insert its Created state or invoke create.
             //    The run directory is already created by the probe (and
             //    idempotently re-ensured by the env file), but is passed
@@ -119,13 +131,21 @@ impl Executor for OciExecutor {
             //    lifecycle token is linked with the watchdog token so
             //    a disk-pressure breach terminates in-flight work via
             //    the existing stop path (issue #245).
-            let outcome = oci_lifecycle::run_with_argv(
-                &self.cfg,
-                spec,
-                &dao,
+            let adapter = oci_lifecycle::OciAdapter::new(
                 engine,
+                Arc::new(dao),
+                self.cfg.state_dir.clone(),
+                daemon_id,
+                spec.issue.clone(),
+                spec.issue.display_key(),
+                sha256_of(&spec.worker_command.join(" ")),
                 argv,
                 Some(env_file),
+            );
+            let outcome = oci_lifecycle::run_oci_lifecycle(
+                &resolved,
+                &adapter,
+                &oci_lifecycle::LifecycleTimeouts::from_config(&self.cfg),
                 spec.cancellation.child_token(),
                 self.disk.watchdog_token(),
             )
@@ -136,4 +156,11 @@ impl Executor for OciExecutor {
             })
         })
     }
+}
+
+fn sha256_of(input: &str) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(input.as_bytes());
+    hex::encode(hasher.finalize())
 }

--- a/src/executor/oci_env_file.rs
+++ b/src/executor/oci_env_file.rs
@@ -22,7 +22,7 @@
 //!   so this rejection is the fail-closed backstop for operator
 //!   `pass_env` values, which are never normalized (design D3).
 //! - **Deletion**: `Drop` removes the file; the lifecycle guard
-//!   (`oci_lifecycle::run_with_argv`) drops the handle immediately
+//!   (`oci_lifecycle`'s lifecycle core) drops the handle immediately
 //!   after the `create` CLI call returns on every path (success,
 //!   create-failure, cancellation), so `start`/`wait`/`stop`/`rm` run
 //!   with the values already gone from disk.

--- a/src/executor/oci_lifecycle.rs
+++ b/src/executor/oci_lifecycle.rs
@@ -1,549 +1,609 @@
-//! Five-step OCI container lifecycle: create → start → wait → stop → remove.
+//! Crash-safe OCI lifecycle and startup reconciliation.
 //!
-//! The [`run_with_argv`] function orchestrates the five steps, persists
-//! state to the [`OciRunState`] trait at each transition, and cleans up
-//! the container on any error path. On cancellation the stop and remove
-//! steps are bounded by the configured `sandbox.kill_timeout_seconds` and
-//! `sandbox.stop_timeout_seconds` so the daemon never hangs.
-//!
-//! Two cancellation sources are honored during the wait step: the
-//! daemon-shutdown token and the disk-pressure watchdog token
-//! (issue #245). Cancellation from either token never early-returns —
-//! the run falls through the stop → capture → remove sequence so no
-//! container is ever leaked.
-//!
-//! The module is intentionally free of `tokio::process::Command` at the
-//! *public* boundary — the subprocess calls live in the private
-//! `run_cli` helpers. The lifecycle is the single call site; all other
-//! executor modules are pure argv builders or env-file transport.
-//!
-//! `run_with_argv` is the **sole** entry point. It receives a
-//! pre-rendered `create` argv from the resolution → renderer pipeline
-//! in `src/executor/oci.rs`; it never re-derives argv itself.
+//! This module intentionally has one orchestration core.  The executor and
+//! reconciliation code only prepare an [`OciAdapter`] and call that core;
+//! argv construction, teardown bounds, removal confirmation, and heartbeat
+//! ownership therefore cannot drift between the two paths.
 
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::io::AsyncReadExt as _;
 use tokio::process::Command;
-use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
 use crate::executor::oci_env_file::OciEnvFile;
-use crate::executor::sandbox_spec::SandboxEngine;
-use crate::executor::ExecutorSpec;
+use crate::executor::sandbox_renderer::{
+    OCI_DAEMON_ID_DISCOVERY_TEMPLATE, OCI_DAEMON_LABEL, OCI_RUN_ID_DISCOVERY_TEMPLATE,
+    OCI_RUN_LABEL,
+};
+use crate::executor::sandbox_spec::{SandboxEngine, SandboxSpec};
 use crate::infra::config::Config;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
-use crate::worker::supervisor::{BoundedTranscriptWriter, SupervisorOutcome};
+use crate::worker::supervisor::{
+    clear_heartbeat, write_heartbeat_record, BoundedTranscriptWriter, Heartbeat, SupervisorOutcome,
+    WorkerRunPaths, HEARTBEAT_FILE_VERSION,
+};
 
-/// Pinned cap for the daemon-side OCI diagnostic capture
-/// (`engine.log`). A diagnostic tail only needs the final failure
-/// output; independent of the worker-facing `transcript_max_bytes`
-/// (a different audience and budget).
+/// Maximum time spent on one engine command during teardown.
 pub const OCI_DIAGNOSTIC_MAX_BYTES: u64 = 1024 * 1024;
 
-/// Read chunk size for the diagnostic capture — memory stays bounded
-/// to one chunk while the writer keeps the last-N-bytes tail.
-const OCI_DIAGNOSTIC_CHUNK_BYTES: usize = 8 * 1024;
+/// Timeout values used by the single lifecycle path.
+#[derive(Clone, Debug)]
+pub struct LifecycleTimeouts {
+    pub worker_timeout: Duration,
+    pub stop_grace: Duration,
+    pub kill_timeout: Duration,
+}
 
-/// Run the OCI container lifecycle with a pre-built argv from the
-/// resolution → renderer pipeline.
-///
-/// The `engine` parameter is passed explicitly (not re-read from
-/// `cfg`) so the create argv and the start/wait/stop/rm argvs cannot
-/// diverge from the renderer's engine; it also feeds the
-/// `ContainerRunRow.engine` column.
-///
-/// Two cancellation tokens drive the wait step:
-///
-/// * `cancellation` — the daemon-shutdown token (unchanged contract);
-/// * `watchdog` — the disk-pressure watchdog token (issue #245).
-///
-/// `env_file` carries the assembled OCI environment as the single
-/// `--env-file` referenced by the create argv (issue #249). It is
-/// owned by the lifecycle ONLY up to the end of the `create` call:
-/// the guard is dropped explicitly, immediately after `create`
-/// returns and before the result is propagated, so the values are
-/// deleted from disk on success, create-failure, and
-/// cooperative-cancellation paths alike — `start`/`wait`/`stop`/`rm`
-/// never run with the env file still on disk (design D5).
-///
-/// Cancellation from either token falls through the stop → capture →
-/// remove sequence (never an early return) and reports
-/// [`CaduceusError::Cancelled`]; the watchdog surfaces its typed
-/// refusal separately through `DiskPressureGuard::try_acquire_oci`.
-///
-/// Test seam: `tokens_for_tests` exposes the two-token carrier the
-/// function races the wait step against. Identical shape to the
-/// private `run_with_argv` call site.
-#[allow(clippy::too_many_arguments)]
-pub async fn run_with_argv(
-    cfg: &Config,
-    spec: &ExecutorSpec,
-    state: &dyn OciRunState,
+impl LifecycleTimeouts {
+    pub fn from_config(cfg: &Config) -> Self {
+        Self {
+            worker_timeout: Duration::from_secs(cfg.worker_timeout_seconds),
+            stop_grace: Duration::from_secs(cfg.sandbox().stop_timeout_seconds),
+            kill_timeout: Duration::from_secs(cfg.sandbox().kill_timeout_seconds),
+        }
+    }
+}
+
+/// The only adapter used by lifecycle and reconciliation.  It owns the
+/// engine binary, all lifecycle argv builders, the durable state handle, and
+/// the one create argv rendered by the sandbox adapter.
+pub struct OciAdapter {
     engine: SandboxEngine,
-    argv: Vec<String>,
-    env_file: Option<OciEnvFile>,
-    cancellation: CancellationToken,
-    watchdog: CancellationToken,
-) -> CaduceusResult<SupervisorOutcome> {
-    // Insert a Created state row.
-    let now = chrono::Utc::now().to_rfc3339();
-    let row = ContainerRunRow {
-        run_id: spec.run_id.clone(),
-        container_id: None,
-        state: OciLifecycleState::Created,
-        engine: format!("{engine:?}"),
-        created_at: now.clone(),
-        updated_at: now.clone(),
-        daemon_id: derive_daemon_id(cfg),
-        issue_id: spec.issue.display_key(),
-        worker_command_sha256: sha256_of(&spec.worker_command.join(" ")),
-    };
-    state.insert(&row)?;
+    binary: PathBuf,
+    state: Option<Arc<dyn OciRunState>>,
+    state_dir: PathBuf,
+    daemon_id: String,
+    issue_id: String,
+    issue: crate::github::issue::IssueKey,
+    worker_command_sha256: String,
+    create_argv: Vec<String>,
+    env_file: Mutex<Option<OciEnvFile>>,
+}
 
-    // Step 1: create. The env file is consumed by `create` only —
-    // `start` never re-reads it — so the guard is dropped
-    // explicitly, immediately after the call returns and before the
-    // result is propagated: deletion happens on success,
-    // create-failure, and cooperative-cancellation paths alike
-    // (issue #249; design D5).
-    let create_result = run_cli("create", &argv, "create", &cancellation, &watchdog).await;
-    drop(env_file);
-    let container_id = create_result?;
-
-    // Record container_id
-    let mut row = row;
-    row.container_id = Some(container_id.clone());
-    state.update_state(&spec.run_id, &OciLifecycleState::Created)?;
-
-    // Step 2: start
-    let start_argv = vec![
-        engine.binary_name().to_string(),
-        "start".to_string(),
-        container_id.clone(),
-    ];
-    run_cli("start", &start_argv, "start", &cancellation, &watchdog).await?;
-    state.update_state(&spec.run_id, &OciLifecycleState::Running)?;
-
-    // Step 3: wait — select over the wait command and BOTH
-    // cancellation sources (daemon shutdown + disk-pressure watchdog).
-    // Cancellation from either token must NOT early-return: it falls
-    // through the stop → capture → rm sequence below so the running
-    // container is never leaked (issue #245).
-    let wait_argv = vec![
-        engine.binary_name().to_string(),
-        "wait".to_string(),
-        container_id.clone(),
-    ];
-    enum WaitOutcome {
-        /// `wait` completed and printed an exit code.
-        Completed(String),
-        /// Either token cancelled — the run was terminated.
-        Cancelled,
-        /// `wait` itself failed (engine error); preserved and
-        /// surfaced after cleanup so the container is not leaked.
-        Failed(CaduceusError),
-    }
-    let wait_outcome = tokio::select! {
-        result = run_cli_with_output("wait", &wait_argv, "wait", &cancellation, &watchdog) => {
-            match result {
-                Ok(output) => WaitOutcome::Completed(output),
-                // A pre-spawn cancellation check fired inside the
-                // helper — same as the token branches below.
-                Err(CaduceusError::Cancelled) => WaitOutcome::Cancelled,
-                Err(err) => WaitOutcome::Failed(err),
-            }
-        }
-        _ = watchdog.cancelled() => WaitOutcome::Cancelled,
-        _ = cancellation.cancelled() => WaitOutcome::Cancelled,
-    };
-    let exit_code = match &wait_outcome {
-        WaitOutcome::Completed(output) => {
-            let code = parse_exit_code(output);
-            state.update_state(&spec.run_id, &OciLifecycleState::Exited(code))?;
-            code
-        }
-        _ => -1,
-    };
-
-    // Step 4: stop (graceful, bounded). Runs on EVERY path — normal
-    // exit, watchdog breach, daemon shutdown, wait failure — so no
-    // container leaks. The cleanup steps check ONLY the daemon
-    // `cancellation` token: a watchdog breach must never prevent
-    // cleanup of the container it just cancelled.
-    let stop_argv = vec![
-        engine.binary_name().to_string(),
-        "stop".to_string(),
-        "--time".to_string(),
-        cfg.sandbox().stop_timeout_seconds.to_string(),
-        container_id.clone(),
-    ];
-    match run_cli("stop", &stop_argv, "stop", &cancellation, &cancellation).await {
-        Ok(_) => {
-            state.update_state(&spec.run_id, &OciLifecycleState::Stopped)?;
-        }
-        Err(e) => {
-            // If stop fails (e.g. container already gone), log and continue.
-            // Kill as fallback.
-            let kill_argv = vec![
-                engine.binary_name().to_string(),
-                "kill".to_string(),
-                container_id.clone(),
-            ];
-            let _ = run_cli("kill", &kill_argv, "kill", &cancellation, &cancellation).await;
-            state.update_state(&spec.run_id, &OciLifecycleState::Killed)?;
-            // Preserve the original wait failure when one existed —
-            // the stop failure is secondary diagnostics on that path.
-            return Err(match wait_outcome {
-                WaitOutcome::Failed(err) => err,
-                _ => e,
-            });
-        }
-    }
-
-    // Step 4.5: bounded daemon-side diagnostic capture (issue #245).
-    // After the container has exited (logs are complete) but BEFORE
-    // `rm` destroys them. Best-effort — never fails the run.
-    capture_engine_logs(cfg, engine, &container_id, &spec.run_id).await;
-
-    // Step 5: remove
-    let remove_argv = vec![
-        engine.binary_name().to_string(),
-        "rm".to_string(),
-        "--force".to_string(),
-        container_id.clone(),
-    ];
-    let remove_timeout = Duration::from_secs(cfg.sandbox().kill_timeout_seconds);
-    match timeout(
-        remove_timeout,
-        run_cli("rm", &remove_argv, "remove", &cancellation, &cancellation),
-    )
-    .await
-    {
-        Ok(Ok(_)) => {
-            state.update_state(&spec.run_id, &OciLifecycleState::Removed)?;
-        }
-        _ => {
-            // Best-effort — if remove fails, reconciliation cleans up.
-        }
-    }
-
-    match wait_outcome {
-        WaitOutcome::Completed(_) => Ok(SupervisorOutcome {
-            status: exit_code,
-            signaled: false,
-            timed_out: false,
-            cancelled: false,
-        }),
-        // Watchdog breach or daemon shutdown: the run reports as
-        // cancelled to the tick, which classifies retries as usual.
-        WaitOutcome::Cancelled => Err(CaduceusError::Cancelled),
-        WaitOutcome::Failed(err) => Err(err),
+impl std::fmt::Debug for OciAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OciAdapter")
+            .field("engine", &self.engine)
+            .field("binary", &self.binary)
+            .field("state_dir", &self.state_dir)
+            .field("daemon_id", &self.daemon_id)
+            .field("issue_id", &self.issue_id)
+            .finish()
     }
 }
 
-/// Capture `<engine> logs <container_id>` into a bounded diagnostic
-/// file at `<state_dir>/oci-runs/<run_id>/engine.log`, capped at
-/// [`OCI_DIAGNOSTIC_MAX_BYTES`] via [`BoundedTranscriptWriter`] (which
-/// opens 0600 with `O_NOFOLLOW` and keeps the last-N-bytes tail).
-/// stdout and stderr are drained concurrently in
-/// [`OCI_DIAGNOSTIC_CHUNK_BYTES`] chunks so a chatty stream cannot
-/// deadlock the other pipe. Every failure is logged and never
-/// propagates — the capture is best-effort diagnostics.
-async fn capture_engine_logs(
-    cfg: &Config,
-    engine: SandboxEngine,
-    container_id: &str,
-    run_id: &str,
-) {
-    let result = capture_engine_logs_inner(cfg, engine, container_id, run_id).await;
-    if let Err(err) = result {
-        tracing::warn!(error = %err, "OCI diagnostic capture failed (best-effort)");
-    }
-}
-
-async fn capture_engine_logs_inner(
-    cfg: &Config,
-    engine: SandboxEngine,
-    container_id: &str,
-    run_id: &str,
-) -> CaduceusResult<()> {
-    // The run dir exists (created by the pre-flight engine probe);
-    // create it best-effort for direct lifecycle callers.
-    let path = cfg
-        .state_dir
-        .join("oci-runs")
-        .join(run_id)
-        .join("engine.log");
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let mut writer = BoundedTranscriptWriter::new(path.clone(), OCI_DIAGNOSTIC_MAX_BYTES)?;
-
-    let mut child = Command::new(engine.binary_name())
-        .args(["logs", container_id])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| CaduceusError::Other(format!("engine logs spawn for {container_id}: {e}")))?;
-    let mut stdout = child.stdout.take().expect("stdout is piped");
-    let mut stderr = child.stderr.take().expect("stderr is piped");
-
-    let mut out_chunk = vec![0u8; OCI_DIAGNOSTIC_CHUNK_BYTES];
-    let mut err_chunk = vec![0u8; OCI_DIAGNOSTIC_CHUNK_BYTES];
-    loop {
-        tokio::select! {
-            read = stdout.read(&mut out_chunk) => {
-                match read {
-                    Ok(0) | Err(_) => {
-                        // stdout drained — drain stderr to EOF.
-                        loop {
-                            match stderr.read(&mut err_chunk).await {
-                                Ok(0) | Err(_) => break,
-                                Ok(n) => writer.write_bytes(&err_chunk[..n]),
-                            }
-                        }
-                        break;
-                    }
-                    Ok(n) => writer.write_bytes(&out_chunk[..n]),
-                }
-            }
-            read = stderr.read(&mut err_chunk) => {
-                match read {
-                    Ok(0) | Err(_) => {
-                        // stderr drained — drain stdout to EOF.
-                        loop {
-                            match stdout.read(&mut out_chunk).await {
-                                Ok(0) | Err(_) => break,
-                                Ok(n) => writer.write_bytes(&out_chunk[..n]),
-                            }
-                        }
-                        break;
-                    }
-                    Ok(n) => writer.write_bytes(&err_chunk[..n]),
-                }
-            }
+impl OciAdapter {
+    /// Construct the adapter for a real executor run.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        engine: SandboxEngine,
+        state: Arc<dyn OciRunState>,
+        state_dir: PathBuf,
+        daemon_id: String,
+        issue: crate::github::issue::IssueKey,
+        issue_id: String,
+        worker_command_sha256: String,
+        create_argv: Vec<String>,
+        env_file: Option<OciEnvFile>,
+    ) -> Self {
+        let binary = create_argv
+            .first()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(engine.binary_name()));
+        Self {
+            engine,
+            binary,
+            state: Some(state),
+            state_dir,
+            daemon_id,
+            issue,
+            issue_id,
+            worker_command_sha256,
+            create_argv,
+            env_file: Mutex::new(env_file),
         }
     }
-    let _ = child.wait().await;
-    // Enforce the hard cap: the writer truncates once on first
-    // overflow but keeps appending the remaining stream (its
-    // drain-must-keep-running contract), so re-truncate after the
-    // stream drains to bound the persisted artifact at the cap plus
-    // the small truncation marker.
-    let _ = crate::worker::supervisor::truncate_transcript(&path, OCI_DIAGNOSTIC_MAX_BYTES);
-    writer.finalize()
-}
 
-/// Reconcile orphaned containers: every row in `PendingReconciliation`
-/// is checked against the live engine and cleaned up by the daemon's
-/// reconciliation task.
-pub async fn reconcile(
-    cfg: &Config,
-    state: &dyn OciRunState,
-    cancellation: CancellationToken,
-) -> CaduceusResult<()> {
-    let pending = state.list_pending_reconciliation()?;
-    for row in &pending {
-        if cancellation.is_cancelled() {
-            break;
+    fn for_reconciliation(cfg: &Config, state: Arc<dyn OciRunState>, daemon_id: &str) -> Self {
+        Self {
+            engine: cfg.sandbox().engine,
+            binary: PathBuf::from(cfg.sandbox().engine.binary_name()),
+            state: Some(state),
+            state_dir: cfg.state_dir.clone(),
+            daemon_id: daemon_id.to_string(),
+            issue: crate::github::issue::IssueKey {
+                owner: String::new(),
+                repo: String::new(),
+                number: 0,
+            },
+            issue_id: String::new(),
+            worker_command_sha256: String::new(),
+            create_argv: Vec::new(),
+            env_file: Mutex::new(None),
         }
-        // Try to remove the container if it still exists.
-        if let Some(ref container_id) = row.container_id {
-            let rm_argv = vec![
-                cfg.sandbox().engine.binary_name().to_string(),
-                "rm".to_string(),
-                "--force".to_string(),
-                container_id.clone(),
-            ];
-            let _ = run_cli("rm", &rm_argv, "remove", &cancellation, &cancellation).await;
-        }
-        // Mark as removed regardless of CLI result (best-effort).
-        let _ = state.update_state(&row.run_id, &OciLifecycleState::Removed);
-    }
-    Ok(())
-}
-
-/// Find containers on the engine that have caduceus labels but no
-/// corresponding non-removed state row. These are containers that
-/// were created before the daemon crashed.
-///
-/// Returns a list of container IDs that should be stopped and removed.
-pub async fn find_orphans(
-    cfg: &Config,
-    state: &dyn OciRunState,
-    daemon_id: &str,
-) -> CaduceusResult<Vec<String>> {
-    // List all containers with caduceus.daemon_id label.
-    let ps_argv = vec![
-        cfg.sandbox().engine.binary_name().to_string(),
-        "ps".to_string(),
-        "-a".to_string(),
-        "--filter".to_string(),
-        format!("label=caduceus.daemon_id={daemon_id}"),
-        "--format".to_string(),
-        "{{.ID}}".to_string(),
-    ];
-
-    let output = run_cli_raw("ps", &ps_argv, "ps").await?;
-    let engine_ids: Vec<String> = output
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
-        .collect();
-
-    if engine_ids.is_empty() {
-        return Ok(vec![]);
     }
 
-    // Check each against our state.
-    let mut orphans = Vec::new();
-    for cid in &engine_ids {
-        // We need to find the run_id from the container labels.
-        // Query the container inspect for caduceus.run_id.
-        let inspect_argv = vec![
-            cfg.sandbox().engine.binary_name().to_string(),
+    fn for_discovery(cfg: &Config, daemon_id: &str) -> Self {
+        Self {
+            engine: cfg.sandbox().engine,
+            binary: PathBuf::from(cfg.sandbox().engine.binary_name()),
+            state: None,
+            state_dir: cfg.state_dir.clone(),
+            daemon_id: daemon_id.to_string(),
+            issue: crate::github::issue::IssueKey {
+                owner: String::new(),
+                repo: String::new(),
+                number: 0,
+            },
+            issue_id: String::new(),
+            worker_command_sha256: String::new(),
+            create_argv: Vec::new(),
+            env_file: Mutex::new(None),
+        }
+    }
+
+    pub fn engine(&self) -> SandboxEngine {
+        self.engine
+    }
+
+    pub fn state(&self) -> Option<&Arc<dyn OciRunState>> {
+        self.state.as_ref()
+    }
+
+    pub fn argv_create(&self) -> Vec<String> {
+        self.create_argv.clone()
+    }
+
+    pub fn argv_start(&self, container_id: &str) -> Vec<String> {
+        vec![
+            self.binary.display().to_string(),
+            "start".to_string(),
+            container_id.to_string(),
+        ]
+    }
+
+    pub fn argv_wait(&self, container_id: &str) -> Vec<String> {
+        vec![
+            self.binary.display().to_string(),
+            "wait".to_string(),
+            container_id.to_string(),
+        ]
+    }
+
+    pub fn argv_stop(&self, grace: Duration, container_id: &str) -> Vec<String> {
+        vec![
+            self.binary.display().to_string(),
+            "stop".to_string(),
+            "--time".to_string(),
+            grace.as_secs().to_string(),
+            container_id.to_string(),
+        ]
+    }
+
+    pub fn argv_kill(&self, container_id: &str) -> Vec<String> {
+        vec![
+            self.binary.display().to_string(),
+            "kill".to_string(),
+            container_id.to_string(),
+        ]
+    }
+
+    pub fn argv_rm_force(&self, container_id: &str) -> Vec<String> {
+        vec![
+            self.binary.display().to_string(),
+            "rm".to_string(),
+            "--force".to_string(),
+            container_id.to_string(),
+        ]
+    }
+
+    pub fn argv_inspect(&self, container_id: &str) -> Vec<String> {
+        vec![
+            self.binary.display().to_string(),
             "inspect".to_string(),
             "--format".to_string(),
-            "{{.Config.Labels.caduceus_run_id}}".to_string(),
-            cid.clone(),
-        ];
-        let inspect_output = run_cli_raw("inspect", &inspect_argv, "inspect").await?;
-        let run_id = inspect_output.trim().to_string();
-        if run_id.is_empty() {
-            continue;
+            OCI_RUN_ID_DISCOVERY_TEMPLATE.to_string(),
+            container_id.to_string(),
+        ]
+    }
+
+    fn take_env_file(&self) {
+        let _ = self.env_file.lock().expect("OCI env-file mutex").take();
+    }
+}
+
+/// Run one OCI container through the sole crash-safe lifecycle.
+pub async fn run_oci_lifecycle(
+    spec: &SandboxSpec,
+    adapter: &OciAdapter,
+    cfg: &LifecycleTimeouts,
+    cancel: CancellationToken,
+    pressure: CancellationToken,
+) -> CaduceusResult<SupervisorOutcome> {
+    let state = adapter
+        .state
+        .as_ref()
+        .ok_or_else(|| CaduceusError::Other("OCI lifecycle adapter has no state".to_string()))?;
+    let input = RunInput {
+        run_id: spec.name().to_string(),
+        issue_id: adapter.issue_id.clone(),
+        issue: adapter.issue.clone(),
+        worker_command_sha256: adapter.worker_command_sha256.clone(),
+    };
+    run_lifecycle_core(&input, state.as_ref(), adapter, cfg, cancel, pressure).await
+}
+
+struct RunInput {
+    run_id: String,
+    issue_id: String,
+    issue: crate::github::issue::IssueKey,
+    worker_command_sha256: String,
+}
+
+async fn run_lifecycle_core(
+    input: &RunInput,
+    state: &dyn OciRunState,
+    adapter: &OciAdapter,
+    cfg: &LifecycleTimeouts,
+    cancel: CancellationToken,
+    pressure: CancellationToken,
+) -> CaduceusResult<SupervisorOutcome> {
+    let now = chrono::Utc::now().to_rfc3339();
+    state.insert(&ContainerRunRow {
+        run_id: input.run_id.clone(),
+        container_id: None,
+        state: OciLifecycleState::Created,
+        engine: format!("{:?}", adapter.engine),
+        created_at: now.clone(),
+        updated_at: now,
+        daemon_id: adapter.daemon_id.clone(),
+        issue_id: input.issue_id.clone(),
+        worker_command_sha256: input.worker_command_sha256.clone(),
+    })?;
+
+    if cancel.is_cancelled() || pressure.is_cancelled() {
+        return Err(CaduceusError::Cancelled);
+    }
+    let created = bounded_command(&adapter.argv_create(), cfg.kill_timeout, "create").await;
+    // The env file contains the complete worker environment and must disappear
+    // immediately after create, regardless of create's result.
+    adapter.take_env_file();
+    let container_id = created?;
+    state.update_container_id(&input.run_id, &container_id)?;
+
+    let start = adapter.argv_start(&container_id);
+    if let Err(err) = bounded_command(&start, cfg.kill_timeout, "start").await {
+        let _ = teardown_container(input, state, adapter, &container_id, cfg, false).await;
+        return Err(err);
+    }
+    state.update_state(&input.run_id, &OciLifecycleState::Running)?;
+
+    let paths = WorkerRunPaths::new(adapter.state_dir.clone(), input.run_id.clone());
+    paths.ensure_dirs()?;
+    let started_at = chrono::Utc::now();
+    write_heartbeat_record(
+        &Heartbeat {
+            version: HEARTBEAT_FILE_VERSION,
+            run_id: input.run_id.clone(),
+            pid: std::process::id(),
+            started_at,
+            updated_at: started_at,
+            issue_key: input.issue.clone(),
+            transcript_path: paths.transcript_path.clone(),
+        },
+        &paths.heartbeat_path,
+    )?;
+    let heartbeat_cancel = CancellationToken::new();
+    let heartbeat_task =
+        spawn_heartbeat(paths.clone(), input, started_at, heartbeat_cancel.clone());
+
+    let wait_argv = adapter.argv_wait(&container_id);
+    enum Race {
+        Exit(i32),
+        Pressure,
+        Cancelled,
+        TimedOut,
+        Failed(CaduceusError),
+    }
+    let race = tokio::select! {
+        biased;
+        output = command_output(&wait_argv, "wait") => {
+            match output {
+                Ok(value) => Race::Exit(parse_exit_code(&value)),
+                Err(err) => Race::Failed(err),
+            }
         }
-        // Check if we have a state row for this run_id that is not Removed.
-        match state.get(&run_id) {
-            Ok(Some(row)) => {
-                if row.state == OciLifecycleState::Removed {
-                    continue;
+        _ = pressure.cancelled() => Race::Pressure,
+        _ = cancel.cancelled() => Race::Cancelled,
+        _ = tokio::time::sleep(cfg.worker_timeout) => Race::TimedOut,
+    };
+    heartbeat_cancel.cancel();
+    let _ = heartbeat_task.await;
+    let _ = clear_heartbeat(&paths.heartbeat_path);
+
+    let (outcome, exited) = match race {
+        Race::Exit(code) => {
+            state.update_state(&input.run_id, &OciLifecycleState::Exited(code))?;
+            (
+                SupervisorOutcome {
+                    status: code,
+                    signaled: false,
+                    timed_out: false,
+                    cancelled: false,
+                    disk_pressure: false,
+                },
+                true,
+            )
+        }
+        Race::Pressure => (
+            SupervisorOutcome {
+                status: 125,
+                signaled: true,
+                timed_out: false,
+                cancelled: false,
+                disk_pressure: true,
+            },
+            false,
+        ),
+        Race::Cancelled => (
+            SupervisorOutcome {
+                status: 130,
+                signaled: true,
+                timed_out: false,
+                cancelled: true,
+                disk_pressure: false,
+            },
+            false,
+        ),
+        Race::TimedOut => (
+            SupervisorOutcome {
+                status: 124,
+                signaled: true,
+                timed_out: true,
+                cancelled: false,
+                disk_pressure: false,
+            },
+            false,
+        ),
+        Race::Failed(err) => {
+            let removed =
+                teardown_container(input, state, adapter, &container_id, cfg, false).await;
+            if !removed {
+                tracing::warn!(run_id = %input.run_id, "OCI wait failed and removal is pending reconciliation");
+            }
+            return Err(err);
+        }
+    };
+
+    // Capture diagnostics while the container still exists, before rm.
+    // This is best effort and cannot change the supervisor outcome.
+    capture_engine_logs(
+        adapter,
+        &container_id,
+        &adapter.state_dir.join("oci-runs").join(&input.run_id),
+    )
+    .await;
+
+    let _ = teardown_container(input, state, adapter, &container_id, cfg, exited).await;
+    Ok(outcome)
+}
+
+async fn capture_engine_logs(adapter: &OciAdapter, container_id: &str, run_dir: &std::path::Path) {
+    let path = run_dir.join("engine.log");
+    let Some(parent) = path.parent() else { return };
+    let _ = std::fs::create_dir_all(parent);
+    let mut writer = match BoundedTranscriptWriter::new(path.clone(), OCI_DIAGNOSTIC_MAX_BYTES) {
+        Ok(writer) => writer,
+        Err(err) => {
+            tracing::warn!(error = %err, "OCI diagnostic capture setup failed");
+            return;
+        }
+    };
+    let result = async {
+        let mut child = Command::new(&adapter.binary)
+            .args(["logs", container_id])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|err| CaduceusError::Other(format!("engine logs spawn: {err}")))?;
+        let mut stdout = child.stdout.take().expect("stdout is piped");
+        let mut stderr = child.stderr.take().expect("stderr is piped");
+        let mut out = vec![0_u8; 8 * 1024];
+        let mut err = vec![0_u8; 8 * 1024];
+        let (mut stdout_open, mut stderr_open) = (true, true);
+        while stdout_open || stderr_open {
+            tokio::select! {
+                read = stdout.read(&mut out), if stdout_open => match read {
+                    Ok(0) | Err(_) => stdout_open = false,
+                    Ok(n) => writer.write_bytes(&out[..n]),
+                },
+                read = stderr.read(&mut err), if stderr_open => match read {
+                    Ok(0) | Err(_) => stderr_open = false,
+                    Ok(n) => writer.write_bytes(&err[..n]),
+                },
+            }
+        }
+        let _ = child.wait().await;
+        let _ = crate::worker::supervisor::truncate_transcript(&path, OCI_DIAGNOSTIC_MAX_BYTES);
+        writer.finalize()
+    }
+    .await;
+    if let Err(err) = result {
+        tracing::warn!(error = %err, "OCI diagnostic capture failed");
+    }
+}
+
+fn spawn_heartbeat(
+    paths: WorkerRunPaths,
+    input: &RunInput,
+    started_at: chrono::DateTime<chrono::Utc>,
+    cancellation: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    let run_id = input.run_id.clone();
+    let issue = input.issue.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancellation.cancelled() => break,
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                    let now = chrono::Utc::now();
+                    let record = Heartbeat {
+                        version: HEARTBEAT_FILE_VERSION,
+                        run_id: run_id.clone(),
+                        pid: std::process::id(),
+                        started_at,
+                        updated_at: now,
+                        issue_key: issue.clone(),
+                        transcript_path: paths.transcript_path.clone(),
+                    };
+                    if write_heartbeat_record(&record, &paths.heartbeat_path).is_err() {
+                        break;
+                    }
                 }
             }
-            _ => {
-                // No state row or error — this is an orphan.
-                orphans.push(cid.clone());
-            }
+        }
+    })
+}
+
+/// Shared bounded stop → kill → rm → inspect teardown.  The local token is
+/// intentionally fresh and is never a child of the parent run token.
+async fn teardown_container(
+    input: &RunInput,
+    state: &dyn OciRunState,
+    adapter: &OciAdapter,
+    container_id: &str,
+    cfg: &LifecycleTimeouts,
+    already_exited: bool,
+) -> bool {
+    let _fresh_lifecycle_token = CancellationToken::new();
+    let stop = bounded_command(
+        &adapter.argv_stop(cfg.stop_grace, container_id),
+        cfg.stop_grace,
+        "stop",
+    )
+    .await;
+    if stop.is_ok() {
+        let _ = state.update_state(&input.run_id, &OciLifecycleState::Stopped);
+    } else if !already_exited
+        && bounded_command(&adapter.argv_kill(container_id), cfg.kill_timeout, "kill")
+            .await
+            .is_ok()
+    {
+        let _ = state.update_state(&input.run_id, &OciLifecycleState::Killed);
+    }
+
+    let _ = bounded_command(&adapter.argv_rm_force(container_id), cfg.kill_timeout, "rm").await;
+    let absent = confirm_absent(adapter, container_id, cfg.kill_timeout).await;
+    let _ = state.update_state(
+        &input.run_id,
+        if absent {
+            &OciLifecycleState::Removed
+        } else {
+            &OciLifecycleState::PendingReconciliation
+        },
+    );
+    absent
+}
+
+async fn confirm_absent(adapter: &OciAdapter, container_id: &str, timeout: Duration) -> bool {
+    match bounded_command_with_status(&adapter.argv_inspect(container_id), timeout, "inspect").await
+    {
+        Ok(_) => false,
+        Err((_, stderr)) => {
+            let lower = stderr.to_ascii_lowercase();
+            lower.contains("no such")
+                || lower.contains("not found")
+                || lower.contains("does not exist")
         }
     }
-
-    Ok(orphans)
 }
 
-/// Derive a stable daemon identifier from the config.
-fn derive_daemon_id(cfg: &Config) -> String {
-    crate::executor::sandbox_spec::derive_daemon_id(cfg)
-}
-
-/// SHA-256 hex digest of a string.
-fn sha256_of(input: &str) -> String {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(input.as_bytes());
-    hex::encode(hasher.finalize())
-}
-
-/// Run an OCI CLI command and return stdout on success, stderr on failure.
-///
-/// The pre-spawn check consults BOTH the daemon `cancellation` token
-/// and the `watchdog` token. Cleanup call sites pass
-/// `&cancellation` as `watchdog` so a watchdog breach never blocks
-/// cleanup of the container it just cancelled.
-async fn run_cli(
-    step: &'static str,
+async fn bounded_command(
     argv: &[String],
-    context: &'static str,
-    cancellation: &CancellationToken,
-    watchdog: &CancellationToken,
-) -> CaduceusResult<String> {
-    if cancellation.is_cancelled() || watchdog.is_cancelled() {
-        return Err(CaduceusError::Cancelled);
-    }
-
-    let output = Command::new(&argv[0])
-        .args(&argv[1..])
-        .output()
-        .await
-        .map_err(|e| to_oci_error(step, context, &e.to_string()))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(to_oci_error(step, context, &stderr));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
-/// Run an OCI CLI command and return the full stdout text (for wait parsing).
-async fn run_cli_with_output(
+    limit: Duration,
     step: &'static str,
-    argv: &[String],
-    context: &'static str,
-    cancellation: &CancellationToken,
-    watchdog: &CancellationToken,
 ) -> CaduceusResult<String> {
-    if cancellation.is_cancelled() || watchdog.is_cancelled() {
-        return Err(CaduceusError::Cancelled);
+    match bounded_command_with_status(argv, limit, step).await {
+        Ok(stdout) => Ok(stdout),
+        Err((error, _stderr)) => Err(error),
     }
-
-    let output = Command::new(&argv[0])
-        .args(&argv[1..])
-        .output()
-        .await
-        .map_err(|e| to_oci_error(step, context, &e.to_string()))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(to_oci_error(step, context, &stderr));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-/// Run an OCI CLI command and return raw stdout (no trim).
-async fn run_cli_raw(
+/// Wait is deliberately not wrapped in a second timeout: its timeout is the
+/// explicit timer arm in the biased race above. Dropping the future on a
+/// cancellation/pressure win still leaves teardown responsible for stopping
+/// the engine container.
+async fn command_output(argv: &[String], step: &'static str) -> CaduceusResult<String> {
+    let mut command = Command::new(&argv[0]);
+    command.args(&argv[1..]).kill_on_drop(true);
+    match command.output().await {
+        Ok(output) if output.status.success() => {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        }
+        Ok(output) => Err(to_oci_error(step, &String::from_utf8_lossy(&output.stderr))),
+        Err(err) => Err(to_oci_error(step, &err.to_string())),
+    }
+}
+
+async fn bounded_command_with_status(
+    argv: &[String],
+    limit: Duration,
     step: &'static str,
-    argv: &[String],
-    context: &'static str,
-) -> CaduceusResult<String> {
-    let output = Command::new(&argv[0])
-        .args(&argv[1..])
-        .output()
-        .await
-        .map_err(|e| to_oci_error(step, context, &e.to_string()))?;
-
-    if !output.status.success() {
-        // Engine not found / not running → OciEngineUnavailable
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(to_oci_error(step, context, &stderr));
+) -> Result<String, (CaduceusError, String)> {
+    if argv.is_empty() {
+        return Err((
+            to_oci_error(step, "empty OCI argv"),
+            "empty OCI argv".to_string(),
+        ));
     }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    let mut command = Command::new(&argv[0]);
+    command.args(&argv[1..]).kill_on_drop(true);
+    let result = tokio::time::timeout(limit, command.output()).await;
+    let output = match result {
+        Ok(Ok(output)) => output,
+        Ok(Err(err)) => {
+            let detail = err.to_string();
+            return Err((to_oci_error(step, &detail), detail));
+        }
+        Err(_) => {
+            let detail = format!("{step} command timed out");
+            return Err((to_oci_error(step, &detail), detail));
+        }
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    if output.status.success() {
+        Ok(stdout.trim().to_string())
+    } else {
+        Err((to_oci_error(step, &stderr), stderr))
+    }
 }
 
-/// Map a CLI failure to the correct typed error.
-fn to_oci_error(step: &'static str, context: &'static str, detail: &str) -> CaduceusError {
+fn to_oci_error(step: &'static str, detail: &str) -> CaduceusError {
     match step {
         "create" => CaduceusError::OciCreateFailed {
-            context,
+            context: step,
             stderr: detail.to_string(),
         },
         "start" => CaduceusError::OciStartFailed {
-            context,
+            context: step,
             stderr: detail.to_string(),
         },
         "wait" => CaduceusError::OciWaitFailed {
-            context,
+            context: step,
             stderr: detail.to_string(),
         },
         "stop" => CaduceusError::OciStopFailed {
-            context,
+            context: step,
             stderr: detail.to_string(),
         },
         "rm" => CaduceusError::OciRemoveFailed {
-            context,
+            context: step,
             stderr: detail.to_string(),
         },
         _ => CaduceusError::OciEngineUnavailable {
@@ -552,23 +612,187 @@ fn to_oci_error(step: &'static str, context: &'static str, detail: &str) -> Cadu
     }
 }
 
-/// Parse the exit code from `docker wait` / `podman wait` output.
+/// Reconcile this installation's containers and unresolved rows at startup.
+pub async fn reconcile_installation(
+    cfg: &Config,
+    state: Arc<dyn OciRunState>,
+    daemon_id: &str,
+    cancellation: CancellationToken,
+) -> CaduceusResult<()> {
+    let adapter = OciAdapter::for_reconciliation(cfg, Arc::clone(&state), daemon_id);
+    let rows = state.list_by_daemon_id(daemon_id)?;
+    let containers = list_labeled_containers(&adapter, daemon_id).await?;
+    let mut seen_runs = std::collections::HashSet::new();
+
+    for (container_id, run_id) in containers {
+        if cancellation.is_cancelled() {
+            break;
+        }
+        seen_runs.insert(run_id.clone());
+        let row = rows.iter().find(|row| row.run_id == run_id).cloned();
+        match row {
+            Some(row) if !row.state.is_terminal() => {
+                if row.container_id.as_deref() != Some(container_id.as_str()) {
+                    let _ = state.update_container_id(&row.run_id, &container_id);
+                }
+                let input = RunInput {
+                    run_id: row.run_id.clone(),
+                    issue_id: row.issue_id.clone(),
+                    issue: parse_issue_key(&row.issue_id),
+                    worker_command_sha256: row.worker_command_sha256.clone(),
+                };
+                let _ = teardown_container(
+                    &input,
+                    state.as_ref(),
+                    &adapter,
+                    &container_id,
+                    &LifecycleTimeouts::from_config(cfg),
+                    false,
+                )
+                .await;
+            }
+            Some(row) => {
+                let input = RunInput {
+                    run_id: row.run_id.clone(),
+                    issue_id: row.issue_id.clone(),
+                    issue: parse_issue_key(&row.issue_id),
+                    worker_command_sha256: row.worker_command_sha256.clone(),
+                };
+                let _ = teardown_container(
+                    &input,
+                    state.as_ref(),
+                    &adapter,
+                    &container_id,
+                    &LifecycleTimeouts::from_config(cfg),
+                    false,
+                )
+                .await;
+            }
+            None => {
+                let input = RunInput {
+                    run_id,
+                    issue_id: String::new(),
+                    issue: adapter.issue.clone(),
+                    worker_command_sha256: String::new(),
+                };
+                let _ = teardown_container(
+                    &input,
+                    state.as_ref(),
+                    &adapter,
+                    &container_id,
+                    &LifecycleTimeouts::from_config(cfg),
+                    false,
+                )
+                .await;
+            }
+        }
+    }
+
+    // A non-terminal row whose labeled container is gone is safe to resolve
+    // only after inspect confirms absence.  No rm result is assumed.
+    for row in rows {
+        if row.state == OciLifecycleState::Removed || seen_runs.contains(&row.run_id) {
+            continue;
+        }
+        let absent = match row.container_id.as_deref() {
+            Some(cid) => {
+                confirm_absent(
+                    &adapter,
+                    cid,
+                    Duration::from_secs(cfg.sandbox().reconcile_timeout_seconds),
+                )
+                .await
+            }
+            None if row.state != OciLifecycleState::PendingReconciliation => true,
+            None => false,
+        };
+        if absent {
+            let _ = state.update_state(&row.run_id, &OciLifecycleState::Removed);
+        } else if row.state != OciLifecycleState::PendingReconciliation {
+            let _ = state.update_state(&row.run_id, &OciLifecycleState::PendingReconciliation);
+        }
+    }
+    Ok(())
+}
+
+async fn list_labeled_containers(
+    adapter: &OciAdapter,
+    daemon_id: &str,
+) -> CaduceusResult<Vec<(String, String)>> {
+    let ps = vec![
+        adapter.binary.display().to_string(),
+        "ps".to_string(),
+        "-a".to_string(),
+        "--filter".to_string(),
+        format!("label={OCI_DAEMON_LABEL}={daemon_id}"),
+        "--format".to_string(),
+        format!("{{{{.ID}}}}\t{OCI_DAEMON_ID_DISCOVERY_TEMPLATE}\t{OCI_RUN_ID_DISCOVERY_TEMPLATE}"),
+    ];
+    let ids = bounded_command(&ps, Duration::from_secs(30), "ps").await?;
+    let mut result = Vec::new();
+    for line in ids.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        let mut fields = line.splitn(3, '\t');
+        let Some(container_id) = fields.next().map(str::trim) else {
+            continue;
+        };
+        let Some(found_daemon_id) = fields.next().map(str::trim) else {
+            continue;
+        };
+        let Some(run_id) = fields.next().map(str::trim) else {
+            continue;
+        };
+        if !container_id.is_empty() && found_daemon_id == daemon_id && !run_id.is_empty() {
+            result.push((container_id.to_string(), run_id.to_string()));
+        }
+    }
+    Ok(result)
+}
+
+/// Find labeled containers with no live non-terminal row. The discovery
+/// query uses the same quoted template as the reconciliation path.
+pub async fn find_orphans(
+    cfg: &Config,
+    state: &dyn OciRunState,
+    daemon_id: &str,
+) -> CaduceusResult<Vec<String>> {
+    let adapter = OciAdapter::for_discovery(cfg, daemon_id);
+    let containers = list_labeled_containers(&adapter, daemon_id).await?;
+    let mut orphans = Vec::new();
+    for (cid, run_id) in containers {
+        match state.get(&run_id)? {
+            Some(row) if !row.state.is_terminal() => {}
+            _ => orphans.push(cid),
+        }
+    }
+    Ok(orphans)
+}
+
+fn parse_issue_key(value: &str) -> crate::github::issue::IssueKey {
+    crate::github::issue::IssueKey::parse(value).unwrap_or(crate::github::issue::IssueKey {
+        owner: String::new(),
+        repo: String::new(),
+        number: 0,
+    })
+}
+
 fn parse_exit_code(output: &str) -> i32 {
     output.trim().parse().unwrap_or(-1)
 }
 
-/// Test seam: expose the wait-output exit-code parser so integration
-/// tests can assert the parse contract. Identical to the private
-/// [`parse_exit_code`].
 #[doc(hidden)]
 pub fn parse_exit_code_for_tests(output: &str) -> i32 {
     parse_exit_code(output)
 }
 
-/// Test seam: expose the daemon-id derivation so integration tests
-/// can assert the state-dir contract. Identical to the private
-/// [`derive_daemon_id`].
 #[doc(hidden)]
-pub fn derive_daemon_id_for_tests(cfg: &Config) -> String {
-    derive_daemon_id(cfg)
+pub fn discovery_template_for_tests() -> &'static str {
+    OCI_RUN_ID_DISCOVERY_TEMPLATE
 }
+
+#[doc(hidden)]
+pub fn daemon_discovery_template_for_tests() -> &'static str {
+    OCI_DAEMON_ID_DISCOVERY_TEMPLATE
+}
+
+#[allow(dead_code)]
+const _RUN_LABEL_KEY: &str = OCI_RUN_LABEL;

--- a/src/executor/sandbox_renderer.rs
+++ b/src/executor/sandbox_renderer.rs
@@ -31,6 +31,25 @@ pub const OCI_LOG_MAX_SIZE: &str = "10m";
 /// per-container on-disk logs: 3 × 10 MiB = 30 MiB.
 pub const OCI_LOG_MAX_FILE: &str = "3";
 
+/// Labels shared by container creation and reconciliation discovery.
+pub const OCI_DAEMON_LABEL: &str = "caduceus.daemon_id";
+pub const OCI_RUN_LABEL: &str = "caduceus.run_id";
+pub const OCI_ISSUE_LABEL: &str = "caduceus.issue_id";
+/// Quoted because Docker/Podman Go templates parse dotted label keys as
+/// field paths rather than literal map keys.
+pub const OCI_DAEMON_ID_DISCOVERY_TEMPLATE: &str =
+    r#"{{index .Config.Labels "caduceus.daemon_id"}}"#;
+pub const OCI_RUN_ID_DISCOVERY_TEMPLATE: &str = r#"{{index .Config.Labels "caduceus.run_id"}}"#;
+
+/// Render the identity labels in their canonical order.
+pub fn render_labels(daemon_id: &str, run_id: &str, issue_id: &str) -> Vec<(String, String)> {
+    vec![
+        (OCI_DAEMON_LABEL.to_string(), daemon_id.to_string()),
+        (OCI_RUN_LABEL.to_string(), run_id.to_string()),
+        (OCI_ISSUE_LABEL.to_string(), issue_id.to_string()),
+    ]
+}
+
 /// Render the full `create` argv for the given engine with no env
 /// files. Delegates to [`render_with_env_files`] with an empty slice
 /// — the `-e` fallback path (no production caller: the OCI executor

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::executor::ExecutorSpec;
 use crate::github::issue::IssueKey;
-use crate::infra::config::{Config, SandboxConfig, SandboxNetwork};
+use crate::infra::config::{SandboxConfig, SandboxNetwork};
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::worker_contract::{
     denied_name, CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
@@ -419,7 +419,7 @@ pub struct RuntimeFacts {
     /// `<state_dir>/oci-runs/<run_id>/output` (derived by the
     /// pre-flight probe, never a worktree sibling).
     pub output_dir: PathBuf,
-    /// Stable daemon identifier (state-dir basename).
+    /// Stable installation UUID loaded from the metadata store.
     pub daemon_id: String,
     /// The declared worktree root (`Config.workdir_base`). The
     /// host-path allow-list in `resolve` requires the worktree to
@@ -765,11 +765,11 @@ pub fn resolve_with_env(
     ];
 
     // 12. Labels — fixed order.
-    let labels = vec![
-        ("caduceus.daemon_id".to_string(), runtime.daemon_id.clone()),
-        ("caduceus.run_id".to_string(), runtime.run_id.clone()),
-        ("caduceus.issue_id".to_string(), runtime.issue.display_key()),
-    ];
+    let labels = crate::executor::sandbox_renderer::render_labels(
+        &runtime.daemon_id,
+        &runtime.run_id,
+        &runtime.issue.display_key(),
+    );
 
     // 13. Command — worker argv.
     let command = runtime.worker_command.clone();
@@ -980,16 +980,6 @@ pub fn is_engine_socket_path(path: &Path) -> bool {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Derive a stable daemon identifier from the config.
-/// Uses the state-dir basename — guaranteed stable for the lifetime
-/// of a daemon instance.
-pub(crate) fn derive_daemon_id(cfg: &Config) -> String {
-    cfg.state_dir
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
-}
 
 /// Lexically normalize an absolute path: resolve `.` and `..`
 /// components without touching the filesystem. Returns `None` for

--- a/src/state/meta.rs
+++ b/src/state/meta.rs
@@ -43,7 +43,7 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Duration, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::github::issue::IssueKey;
@@ -66,6 +66,11 @@ pub const META_FILENAME: &str = "state_meta.json";
 
 /// Marker filename written when corruption is detected.
 pub const CORRUPT_MARKER_FILENAME: &str = "state_meta.corrupt";
+
+/// File used by the JSON metadata backend for the daemon's installation
+/// identity. It is deliberately separate from the versioned metadata
+/// envelope so existing metadata readers remain backward compatible.
+pub const INSTALLATION_UUID_FILENAME: &str = "installation_uuid";
 
 /// Persisted tick metadata. Field semantics are pinned by the
 /// StateMeta contract.
@@ -227,6 +232,7 @@ impl MetaStore {
     /// created if needed and the current `state_meta` rows are read
     /// into the in-memory cache.
     pub fn open_sqlite(state_dir: &Path) -> CaduceusResult<Self> {
+        fs::create_dir_all(state_dir)?;
         // Open once to ensure the schema is present.
         let _conn = crate::state::store::open_in(state_dir)?;
         let meta = if let Ok(conn) = crate::state::store::open_in(state_dir) {
@@ -338,6 +344,78 @@ impl MetaStore {
     pub fn state_dir(&self) -> &Path {
         &self.state_dir
     }
+
+    /// Load the installation UUID, generating it once when this is the
+    /// first start. JSON uses the shared atomic-write primitive; SQLite
+    /// uses one immediate transaction so two writers cannot create two
+    /// identities. The persisted value is never overwritten.
+    pub fn get_or_create_installation_uuid(&self) -> CaduceusResult<String> {
+        let _guard = self.inner.lock().expect("meta mutex poisoned");
+        match &self.backend {
+            MetaStoreBackend::Json { .. } => {
+                let path = self.state_dir.join(INSTALLATION_UUID_FILENAME);
+                if path.exists() {
+                    return read_installation_uuid(&path);
+                }
+                let uuid = uuid::Uuid::new_v4().to_string();
+                crate::infra::install::atomic_write(&path, uuid.as_bytes())?;
+                read_installation_uuid(&path)
+            }
+            MetaStoreBackend::Sqlite(state_dir) => {
+                let conn = crate::state::store::open_in(state_dir)?;
+                let tx = conn
+                    .unchecked_transaction()
+                    .map_err(|e| CaduceusError::StateCorrupt {
+                        path: state_dir.join(crate::state::store::DB_FILENAME),
+                        message: format!("cannot begin installation UUID transaction: {e}"),
+                    })?;
+                let existing: Option<String> = tx
+                    .query_row(
+                        "SELECT value FROM state_meta WHERE key = 'installation_uuid'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .optional()
+                    .map_err(|e| CaduceusError::StateCorrupt {
+                        path: state_dir.join(crate::state::store::DB_FILENAME),
+                        message: format!("cannot read installation UUID: {e}"),
+                    })?;
+                let uuid = match existing {
+                    Some(value) => validate_installation_uuid(&value, state_dir)?,
+                    None => {
+                        let value = uuid::Uuid::new_v4().to_string();
+                        tx.execute(
+                            "INSERT INTO state_meta (key, value) VALUES ('installation_uuid', ?1)",
+                            params![value],
+                        )
+                        .map_err(|e| CaduceusError::StateCorrupt {
+                            path: state_dir.join(crate::state::store::DB_FILENAME),
+                            message: format!("cannot persist installation UUID: {e}"),
+                        })?;
+                        value
+                    }
+                };
+                tx.commit().map_err(|e| CaduceusError::StateCorrupt {
+                    path: state_dir.join(crate::state::store::DB_FILENAME),
+                    message: format!("cannot commit installation UUID: {e}"),
+                })?;
+                Ok(uuid)
+            }
+        }
+    }
+}
+
+fn read_installation_uuid(path: &Path) -> CaduceusResult<String> {
+    let value = fs::read_to_string(path).map_err(CaduceusError::Io)?;
+    validate_installation_uuid(value.trim(), path)
+}
+
+fn validate_installation_uuid(value: &str, path: &Path) -> CaduceusResult<String> {
+    uuid::Uuid::parse_str(value).map_err(|_| CaduceusError::StateCorrupt {
+        path: path.to_path_buf(),
+        message: format!("invalid installation UUID {value:?}"),
+    })?;
+    Ok(value.to_string())
 }
 
 /// Rate-limit observer backed by a [`MetaStore`]. Concurrent HTTP

--- a/src/state/oci_run.rs
+++ b/src/state/oci_run.rs
@@ -33,6 +33,18 @@ pub enum OciLifecycleState {
     PendingReconciliation,
 }
 
+impl OciLifecycleState {
+    /// Whether the row no longer represents an active or unresolved
+    /// container lifecycle. `PendingReconciliation` remains non-terminal
+    /// because it still requires a confirmed engine absence.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Exited(_) | Self::Stopped | Self::Killed | Self::Removed
+        )
+    }
+}
+
 impl fmt::Display for OciLifecycleState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -94,6 +106,25 @@ pub trait OciRunState: Send + Sync {
     fn insert(&self, row: &ContainerRunRow) -> CaduceusResult<()>;
     /// Update the state of an existing container run.
     fn update_state(&self, run_id: &str, state: &OciLifecycleState) -> CaduceusResult<()>;
+    /// Durably attach the engine's container identity to a run. This is
+    /// called after `create` and before `start`.
+    fn update_container_id(&self, run_id: &str, container_id: &str) -> CaduceusResult<()> {
+        let _ = (run_id, container_id);
+        // Compatibility default for lightweight test state implementations;
+        // the production OciRunDao overrides this with the durable SQL
+        // update. New state implementations should override it.
+        Ok(())
+    }
+    /// Look up a run by its engine container identity.
+    fn get_by_container_id(&self, container_id: &str) -> CaduceusResult<Option<ContainerRunRow>> {
+        let _ = container_id;
+        Ok(None)
+    }
+    /// List rows attributed to one installation.
+    fn list_by_daemon_id(&self, daemon_id: &str) -> CaduceusResult<Vec<ContainerRunRow>> {
+        let _ = daemon_id;
+        Ok(Vec::new())
+    }
     /// List all rows whose state is `PendingReconciliation`.
     fn list_pending_reconciliation(&self) -> CaduceusResult<Vec<ContainerRunRow>>;
     /// Get a single container run by its run_id.
@@ -109,6 +140,18 @@ impl OciRunState for OciRunDao {
 
     fn update_state(&self, run_id: &str, state: &OciLifecycleState) -> CaduceusResult<()> {
         OciRunDao::update_state(self, run_id, state)
+    }
+
+    fn update_container_id(&self, run_id: &str, container_id: &str) -> CaduceusResult<()> {
+        OciRunDao::update_container_id(self, run_id, container_id)
+    }
+
+    fn get_by_container_id(&self, container_id: &str) -> CaduceusResult<Option<ContainerRunRow>> {
+        OciRunDao::get_by_container_id(self, container_id)
+    }
+
+    fn list_by_daemon_id(&self, daemon_id: &str) -> CaduceusResult<Vec<ContainerRunRow>> {
+        OciRunDao::list_by_daemon_id(self, daemon_id)
     }
 
     fn list_pending_reconciliation(&self) -> CaduceusResult<Vec<ContainerRunRow>> {
@@ -183,6 +226,91 @@ impl OciRunDao {
             message: format!("oci_run update_state: {e}"),
         })?;
         Ok(())
+    }
+
+    /// Persist the container ID before the engine's `start` operation.
+    pub fn update_container_id(&self, run_id: &str, container_id: &str) -> CaduceusResult<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE oci_runs SET container_id = ?1, updated_at = ?2 WHERE run_id = ?3",
+            params![container_id, now, run_id],
+        )
+        .map_err(|e| CaduceusError::StateCorrupt {
+            path: ":memory:".into(),
+            message: format!("oci_run update_container_id: {e}"),
+        })?;
+        Ok(())
+    }
+
+    /// Get a row by the engine container ID. The schema keeps an index on
+    /// this column because reconciliation uses it as its primary join key.
+    pub fn get_by_container_id(
+        &self,
+        container_id: &str,
+    ) -> CaduceusResult<Option<ContainerRunRow>> {
+        self.get_where("container_id", container_id, "oci_run get_by_container_id")
+    }
+
+    /// List all rows attributed to an installation UUID.
+    pub fn list_by_daemon_id(&self, daemon_id: &str) -> CaduceusResult<Vec<ContainerRunRow>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT run_id, container_id, state, engine, created_at, updated_at, daemon_id, issue_id, worker_command_sha256
+                 FROM oci_runs WHERE daemon_id = ?1",
+            )
+            .map_err(|e| CaduceusError::StateCorrupt {
+                path: ":memory:".into(),
+                message: format!("oci_run list_by_daemon_id prepare: {e}"),
+            })?;
+        let rows = stmt
+            .query_map(params![daemon_id], row_from_sql)
+            .map_err(|e| CaduceusError::StateCorrupt {
+                path: ":memory:".into(),
+                message: format!("oci_run list_by_daemon_id query: {e}"),
+            })?;
+        rows.map(|row| {
+            row.map_err(|e| CaduceusError::StateCorrupt {
+                path: ":memory:".into(),
+                message: format!("oci_run list_by_daemon_id row: {e}"),
+            })
+        })
+        .collect()
+    }
+
+    fn get_where(
+        &self,
+        column: &str,
+        value: &str,
+        context: &str,
+    ) -> CaduceusResult<Option<ContainerRunRow>> {
+        // `column` is only called with compile-time SQL identifiers above;
+        // values remain bound parameters.
+        let sql = format!(
+            "SELECT run_id, container_id, state, engine, created_at, updated_at, daemon_id, issue_id, worker_command_sha256 FROM oci_runs WHERE {column} = ?1"
+        );
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| CaduceusError::StateCorrupt {
+                path: ":memory:".into(),
+                message: format!("{context} prepare: {e}"),
+            })?;
+        let mut rows = stmt.query_map(params![value], row_from_sql).map_err(|e| {
+            CaduceusError::StateCorrupt {
+                path: ":memory:".into(),
+                message: format!("{context} query: {e}"),
+            }
+        })?;
+        match rows.next() {
+            Some(Ok(row)) => Ok(Some(row)),
+            Some(Err(e)) => Err(CaduceusError::StateCorrupt {
+                path: ":memory:".into(),
+                message: format!("{context} row: {e}"),
+            }),
+            None => Ok(None),
+        }
     }
 
     /// List all rows whose state is `PendingReconciliation`.
@@ -283,4 +411,22 @@ impl OciRunDao {
             })?;
         Ok(())
     }
+}
+
+fn row_from_sql(r: &rusqlite::Row<'_>) -> rusqlite::Result<ContainerRunRow> {
+    let state_str: String = r.get(2)?;
+    let state: OciLifecycleState = state_str
+        .parse()
+        .map_err(|_| rusqlite::Error::InvalidQuery)?;
+    Ok(ContainerRunRow {
+        run_id: r.get(0)?,
+        container_id: r.get(1)?,
+        state,
+        engine: r.get(3)?,
+        created_at: r.get(4)?,
+        updated_at: r.get(5)?,
+        daemon_id: r.get(6)?,
+        issue_id: r.get(7)?,
+        worker_command_sha256: r.get(8)?,
+    })
 }

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -53,7 +53,19 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 /// - `queue_entries` gains `blocked_source TEXT` and
 ///   `blocked_recovery_hint TEXT` columns for terminal refuse-to-
 ///   operate metadata. Existing rows get NULL defaults.
-pub const SCHEMA_VERSION: i64 = 6;
+///
+/// ## v7
+///
+/// - OCI run identity and installation attribution are now part of the
+///   supported state contract. There is intentionally no v6 -> v7
+///   migration: v6 state must be reinitialised rather than being read
+///   with different lifecycle semantics.
+pub const SCHEMA_VERSION: i64 = 7;
+
+/// The last schema version that is deliberately rejected instead of
+/// migrated. Keeping this explicit prevents a future schema bump from
+/// accidentally turning the breaking v6 boundary into a silent upgrade.
+pub const STALE_SCHEMA_VERSION: i64 = 6;
 
 /// Name of the SQLite database file inside the state directory.
 pub const DB_FILENAME: &str = "state.db";
@@ -202,6 +214,13 @@ pub fn open(path: &Path) -> CaduceusResult<Connection> {
                 message: format!(
                     "SQLite store has schema v{existing_version} but this daemon only supports v{SCHEMA_VERSION} — upgrade required"
                 ),
+            });
+        }
+
+        if existing_version == STALE_SCHEMA_VERSION {
+            return Err(CaduceusError::StateCorrupt {
+                path: db_path,
+                message: "SQLite store has stale schema v6; v6 state is not migrated and must be reinitialized with fresh state".to_string(),
             });
         }
 

--- a/src/worker/supervisor/dispatch.rs
+++ b/src/worker/supervisor/dispatch.rs
@@ -81,6 +81,7 @@ pub async fn supervise(
         signaled: false,
         timed_out: false,
         cancelled: false,
+        disk_pressure: false,
     };
 
     let spawn_result = run_supervisor(
@@ -207,6 +208,7 @@ pub(crate) async fn run_supervisor(
                             signaled: true,
                             timed_out: false,
                             cancelled: true,
+                            disk_pressure: false,
                         };
                     }
                     _ = tokio::time::sleep(Duration::from_secs(worker_timeout_seconds)) => {
@@ -221,6 +223,7 @@ pub(crate) async fn run_supervisor(
                                     signaled: false,
                                     timed_out: true,
                                     cancelled: false,
+                                    disk_pressure: false,
                                 };
                             }
                             DeadlineKillDecision::Signal | DeadlineKillDecision::BestEffort => {
@@ -250,6 +253,7 @@ pub(crate) async fn run_supervisor(
                                     signaled: false,
                                     timed_out: true,
                                     cancelled: false,
+                                    disk_pressure: false,
                                 };
                             }
                             DeadlineKillDecision::Signal | DeadlineKillDecision::BestEffort => {
@@ -281,6 +285,7 @@ pub(crate) async fn run_supervisor(
                             signaled: true,
                             timed_out: true,
                             cancelled: false,
+                            disk_pressure: false,
                         };
                     }
                     frame = read_frame_async(&mut stdout, &mut buf) => {
@@ -293,6 +298,7 @@ pub(crate) async fn run_supervisor(
                                     signaled: false,
                                     timed_out: false,
                                     cancelled: false,
+                                    disk_pressure: false,
                                 };
                             }
                             Err(err) => return err.into_outcome(),
@@ -312,6 +318,7 @@ pub(crate) async fn run_supervisor(
                                     signaled,
                                     timed_out: false,
                                     cancelled: false,
+                                    disk_pressure: false,
                                 };
                             }
                             ControlFrame::Fatal { reason } => {
@@ -321,6 +328,7 @@ pub(crate) async fn run_supervisor(
                                     signaled: false,
                                     timed_out: false,
                                     cancelled: false,
+                                    disk_pressure: false,
                                 };
                             }
                             ControlFrame::Ack | ControlFrame::Terminate { .. } => {
@@ -330,6 +338,7 @@ pub(crate) async fn run_supervisor(
                                     signaled: false,
                                     timed_out: false,
                                     cancelled: false,
+                                    disk_pressure: false,
                                 };
                             }
                         }
@@ -411,6 +420,7 @@ impl IntoOutcome for CaduceusError {
             signaled: false,
             timed_out: false,
             cancelled: false,
+            disk_pressure: false,
         }
     }
 }

--- a/src/worker/supervisor/outcome_transcript.rs
+++ b/src/worker/supervisor/outcome_transcript.rs
@@ -22,6 +22,8 @@ pub struct SupervisorOutcome {
     /// SIGINT, or SIGTERM) and the supervisor confirmed the
     /// worker session is gone.
     pub cancelled: bool,
+    /// True when the OCI disk-pressure watchdog won the lifecycle race.
+    pub disk_pressure: bool,
 }
 
 /// Path layout for one worker's runtime artefacts. The

--- a/tests/executor/cancellation_test.rs
+++ b/tests/executor/cancellation_test.rs
@@ -150,7 +150,7 @@ fn cancel_at_remove() {
 // flow against a real engine.
 // ---------------------------------------------------------------------------
 
-/// Disk-pressure watchdog cancellation mid-wait: `run_with_argv`'s
+/// Disk-pressure watchdog cancellation mid-wait: the canonical lifecycle's
 /// second `watchdog` token selects against the wait step and the run
 /// falls through stop → capture → rm, reporting `Cancelled`.
 #[test]
@@ -158,7 +158,7 @@ fn cancel_at_remove() {
 fn watchdog_cancel_at_wait() {
     // When CADUCEUS_RUN_ISOLATION_TESTS is set:
     //  1. Start a long-running container (sleep 3600) via
-    //     `oci_lifecycle::run_with_argv` with a fresh watchdog token
+    //     `oci_lifecycle::run_oci_lifecycle` with a fresh watchdog token
     //  2. Cancel the WATCHDOG token (not the daemon token) during
     //     the wait phase — a disk-pressure breach did this
     //  3. Verify the run fell through stop → capture → rm:

--- a/tests/executor/oci_env_file_test.rs
+++ b/tests/executor/oci_env_file_test.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 use std::os::unix::fs::PermissionsExt;
 use std::panic;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serial_test::serial;
@@ -25,12 +26,14 @@ use tokio_util::sync::CancellationToken;
 
 use caduceus::executor::oci_env_file::OciEnvFile;
 use caduceus::executor::oci_lifecycle;
-use caduceus::executor::sandbox_spec::SandboxEngine;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine};
 use caduceus::executor::ExecutorSpec;
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
 use caduceus::infra::error::{CaduceusError, CaduceusResult};
 use caduceus::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
+
+mod support;
 
 fn env_map(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
     entries
@@ -317,7 +320,7 @@ case "$1" in
 esac
 "#;
 
-/// Drive `run_with_argv` against the failing-create stub engine and
+/// Drive the canonical lifecycle against the failing-create stub engine and
 /// assert the env file is gone before the create error propagates.
 #[tokio::test]
 #[serial]
@@ -363,15 +366,31 @@ async fn create_failure_leaves_no_env_file() {
         "image@sha256:0000000000000000000000000000000000000000000000000000000000000000".to_string(),
     ];
 
+    let state = Arc::new(FakeOciRunState);
+    let worktree = cfg
+        .workdir_base
+        .join("owner")
+        .join("repo")
+        .join(&spec.run_id);
+    let facts = support::runtime_facts(&cfg, &spec.run_id, &worktree);
+    let resolved = resolve(cfg.sandbox(), &facts, &spec).expect("sandbox resolves");
+    let adapter = oci_lifecycle::OciAdapter::new(
+        SandboxEngine::Docker,
+        state,
+        cfg.state_dir.clone(),
+        facts.daemon_id,
+        spec.issue.clone(),
+        spec.issue.display_key(),
+        "test-command-sha".to_string(),
+        argv,
+        Some(env_file),
+    );
     let result = tokio::time::timeout(
         Duration::from_secs(30),
-        oci_lifecycle::run_with_argv(
-            &cfg,
-            &spec,
-            &FakeOciRunState,
-            SandboxEngine::Docker,
-            argv,
-            Some(env_file),
+        oci_lifecycle::run_oci_lifecycle(
+            &resolved,
+            &adapter,
+            &oci_lifecycle::LifecycleTimeouts::from_config(&cfg),
             CancellationToken::new(),
             CancellationToken::new(),
         ),

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -682,7 +682,7 @@ fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
     let guard = Arc::new(DiskPressureGuard::from_config(&cfg));
     assert!(guard.enabled());
 
-    // 2. In-flight run: drive the REAL engine through `run_with_argv`
+    // 2. In-flight run: drive the REAL engine through the canonical lifecycle
     //    with the fixture's rendered create argv. The wait step blocks
     //    on `sleep 3600` until the breach cancels the watchdog token.
     let guard_for_run = Arc::clone(&guard);
@@ -690,6 +690,9 @@ fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
     let run_id = fx.run_id.clone();
     let engine = fx.engine;
     let argv = fx.argv.clone();
+    let worktree = fx.worktree.clone();
+    let shadow_host = fx.shadow_host.clone();
+    let engine_mode = fx.engine_mode;
     let fx_cfg = cfg.clone();
     let run = tokio::runtime::Runtime::new().expect("runtime");
     let result = run.block_on(async move {
@@ -706,14 +709,43 @@ fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
             labels: Vec::new(),
             branch_name: "b".to_string(),
         };
+        let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
+            run_id: run_id.clone(),
+            issue: spec.issue.clone(),
+            worker_command: spec.worker_command.clone(),
+            worktree: worktree.clone(),
+            output_dir: fx_cfg
+                .state_dir
+                .join("oci-runs")
+                .join(&run_id)
+                .join("output"),
+            daemon_id: "live-test-daemon".to_string(),
+            workdir_base: fx_cfg.workdir_base.clone(),
+            state_dir: fx_cfg.state_dir.clone(),
+            worktree_uid: std::fs::metadata(&worktree).expect("worktree stat").uid(),
+            worktree_gid: std::fs::metadata(&worktree).expect("worktree stat").gid(),
+            engine_mode,
+            git_shadow_kind: GitShadowKind::File,
+            git_shadow_host: shadow_host,
+        };
+        let resolved = resolve(fx_cfg.sandbox(), &runtime, &spec).expect("sandbox resolves");
+        let state = Arc::new(NullState);
+        let adapter = oci_lifecycle::OciAdapter::new(
+            engine,
+            state,
+            fx_cfg.state_dir.clone(),
+            runtime.daemon_id,
+            spec.issue.clone(),
+            spec.issue.display_key(),
+            "live-test-command-sha".to_string(),
+            argv,
+            None,
+        );
         let lifecycle = tokio::spawn(async move {
-            oci_lifecycle::run_with_argv(
-                &fx_cfg,
-                &spec,
-                &NullState,
-                engine,
-                argv,
-                None,
+            oci_lifecycle::run_oci_lifecycle(
+                &resolved,
+                &adapter,
+                &oci_lifecycle::LifecycleTimeouts::from_config(&fx_cfg),
                 CancellationToken::new(),
                 guard_for_run.watchdog_token(),
             )

--- a/tests/executor/oci_lifecycle_stub_test.rs
+++ b/tests/executor/oci_lifecycle_stub_test.rs
@@ -3,16 +3,14 @@
 //!
 //! The lifecycle invokes the engine binary by name (`docker`), so
 //! these tests prepend a stub-script directory to `PATH` and drive
-//! `run_with_argv` end-to-end without a real container engine:
+//! the canonical lifecycle end-to-end without a real container engine:
 //!
 //! - wait cancellation from the **watchdog token** falls through
-//!   stop → capture → rm and reports `Cancelled` with no leaked
+//!   stop → capture → rm and reports disk pressure with no leaked
 //!   container (state reaches `Removed`);
-//! - wait cancellation from the **daemon shutdown token** reports
-//!   `Cancelled`; the cleanup steps check only the daemon token
-//!   (which is itself cancelled), so the state reaches `Killed` and
-//!   the reconciliation pass finishes the `rm` — the pre-existing
-//!   daemon-shutdown stop-path contract;
+//! - wait cancellation from the **daemon shutdown token** reports a
+//!   cancelled supervisor outcome after fresh-token cleanup confirms
+//!   removal;
 //! - over-cap engine logs are persisted bounded (≤ 1 MiB + marker)
 //!   under `<state_dir>/oci-runs/<run_id>/engine.log` with a
 //!   truncation marker.
@@ -22,6 +20,7 @@
 //! run in separate processes with their own environment).
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -29,12 +28,15 @@ use serial_test::serial;
 use tokio_util::sync::CancellationToken;
 
 use caduceus::executor::oci_lifecycle;
-use caduceus::executor::sandbox_spec::SandboxEngine;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine};
 use caduceus::executor::ExecutorSpec;
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
-use caduceus::infra::error::{CaduceusError, CaduceusResult};
+use caduceus::infra::error::CaduceusResult;
 use caduceus::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
+
+#[allow(dead_code)]
+mod support;
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -69,6 +71,30 @@ impl OciRunState for FakeOciRunState {
             row.state = state.clone();
         }
         Ok(())
+    }
+
+    fn update_container_id(&self, run_id: &str, container_id: &str) -> CaduceusResult<()> {
+        if let Some(row) = self
+            .rows
+            .lock()
+            .unwrap()
+            .iter_mut()
+            .find(|r| r.run_id == run_id)
+        {
+            row.container_id = Some(container_id.to_string());
+        }
+        Ok(())
+    }
+
+    fn list_by_daemon_id(&self, daemon_id: &str) -> CaduceusResult<Vec<ContainerRunRow>> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|row| row.daemon_id == daemon_id)
+            .cloned()
+            .collect())
     }
 
     fn list_pending_reconciliation(&self) -> CaduceusResult<Vec<ContainerRunRow>> {
@@ -124,6 +150,113 @@ fn create_argv() -> Vec<String> {
     ]
 }
 
+async fn run_lifecycle(
+    cfg: &Config,
+    input: &ExecutorSpec,
+    state: Arc<FakeOciRunState>,
+    cancel: CancellationToken,
+    pressure: CancellationToken,
+) -> CaduceusResult<caduceus::supervisor::SupervisorOutcome> {
+    let worktree = cfg
+        .workdir_base
+        .join("owner")
+        .join("repo")
+        .join(&input.run_id);
+    let facts = support::runtime_facts(cfg, &input.run_id, &worktree);
+    let resolved = resolve(cfg.sandbox(), &facts, input).expect("sandbox resolves");
+    let adapter = oci_lifecycle::OciAdapter::new(
+        SandboxEngine::Docker,
+        state,
+        cfg.state_dir.clone(),
+        facts.daemon_id,
+        input.issue.clone(),
+        input.issue.display_key(),
+        "test-command-sha".to_string(),
+        create_argv(),
+        None,
+    );
+    oci_lifecycle::run_oci_lifecycle(
+        &resolved,
+        &adapter,
+        &oci_lifecycle::LifecycleTimeouts::from_config(cfg),
+        cancel,
+        pressure,
+    )
+    .await
+}
+
+#[tokio::test]
+#[serial]
+async fn canonical_lifecycle_runs_end_to_end() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let stub = StubEngine::new();
+    let state = std::sync::Arc::new(FakeOciRunState::new());
+    let input = test_spec("stub-canonical-lifecycle");
+    let worktree = cfg
+        .workdir_base
+        .join("owner")
+        .join("repo")
+        .join(&input.run_id);
+    let facts = support::runtime_facts(&cfg, &input.run_id, &worktree);
+    let resolved = resolve(cfg.sandbox(), &facts, &input).expect("sandbox resolves");
+    let adapter = oci_lifecycle::OciAdapter::new(
+        SandboxEngine::Docker,
+        state.clone(),
+        cfg.state_dir.clone(),
+        "test-daemon".to_string(),
+        input.issue.clone(),
+        input.issue.display_key(),
+        "test-command-sha".to_string(),
+        create_argv(),
+        None,
+    );
+
+    let outcome = oci_lifecycle::run_oci_lifecycle(
+        &resolved,
+        &adapter,
+        &oci_lifecycle::LifecycleTimeouts::from_config(&cfg),
+        CancellationToken::new(),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("canonical lifecycle succeeds");
+    assert_eq!(outcome.status, 0);
+    assert!(stub.removed.exists());
+    assert_eq!(
+        state.get(&input.run_id).expect("get").expect("row").state,
+        OciLifecycleState::Removed
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn container_id_is_persisted_before_start_failure() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let _stub = StubEngine::new();
+    std::env::set_var("STUB_START_FAIL", "1");
+    let state = Arc::new(FakeOciRunState::new());
+    let spec = test_spec("stub-start-failure");
+    let error = run_lifecycle(
+        &cfg,
+        &spec,
+        state.clone(),
+        CancellationToken::new(),
+        CancellationToken::new(),
+    )
+    .await
+    .expect_err("start failure must be surfaced");
+    assert!(format!("{error:?}").contains("OciStartFailed"));
+    assert_eq!(
+        state
+            .get("stub-start-failure")
+            .expect("get")
+            .expect("row")
+            .container_id
+            .as_deref(),
+        Some("stub-container-000")
+    );
+}
+
 /// Stub engine script. Behavior is env-tunable:
 /// - `STUB_WAIT_SLEEP`: seconds `wait` sleeps before printing `0`
 ///   (lets the test cancel mid-wait);
@@ -133,13 +266,16 @@ const STUB_SCRIPT: &str = r#"#!/bin/sh
 DIR="$(dirname "$0")"
 case "$1" in
   create) echo "stub-container-000" ;;
-  start) touch "$DIR/started" ;;
+  start) touch "$DIR/started"; if [ -n "$STUB_START_FAIL" ]; then exit 1; fi ;;
   wait)
     if [ -n "$STUB_WAIT_SLEEP" ]; then sleep "$STUB_WAIT_SLEEP"; fi
     echo 0 ;;
-  stop) touch "$DIR/stopped" ;;
-  kill) touch "$DIR/killed" ;;
-  rm) touch "$DIR/removed" ;;
+  ps) if [ -n "$STUB_PS_OUTPUT" ]; then printf "%s\n" "$STUB_PS_OUTPUT"; fi ;;
+  stop) touch "$DIR/stopped"; if [ -n "$STUB_STOP_FAIL" ]; then exit 1; fi ;;
+  kill) touch "$DIR/killed"; if [ -n "$STUB_KILL_FAIL" ]; then exit 1; fi ;;
+  rm) touch "$DIR/removed"; if [ -n "$STUB_RM_FAIL" ]; then exit 1; fi ;;
+  inspect)
+    if [ -n "$STUB_INSPECT_PRESENT" ]; then echo "container still present"; else echo "container not found" >&2; exit 1; fi ;;
   logs)
     if [ -n "$STUB_LOG_BYTES" ]; then
       head -c "$STUB_LOG_BYTES" /dev/zero | tr '\0' 'x'
@@ -156,6 +292,7 @@ struct StubEngine {
     _dir: tempfile::TempDir,
     started: PathBuf,
     stopped: PathBuf,
+    killed: PathBuf,
     removed: PathBuf,
 }
 
@@ -172,6 +309,7 @@ impl StubEngine {
         Self {
             started: dir.path().join("started"),
             stopped: dir.path().join("stopped"),
+            killed: dir.path().join("killed"),
             removed: dir.path().join("removed"),
             _dir: dir,
         }
@@ -190,6 +328,12 @@ impl Drop for StubEngine {
         }
         std::env::remove_var("STUB_WAIT_SLEEP");
         std::env::remove_var("STUB_LOG_BYTES");
+        std::env::remove_var("STUB_STOP_FAIL");
+        std::env::remove_var("STUB_START_FAIL");
+        std::env::remove_var("STUB_KILL_FAIL");
+        std::env::remove_var("STUB_RM_FAIL");
+        std::env::remove_var("STUB_INSPECT_PRESENT");
+        std::env::remove_var("STUB_PS_OUTPUT");
     }
 }
 
@@ -225,13 +369,325 @@ fn engine_log_path(cfg: &Config, run_id: &str) -> PathBuf {
         .join("engine.log")
 }
 
+#[tokio::test]
+#[serial]
+async fn heartbeat_refreshes_during_oci_wait_and_stops_after_resolution() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let stub = StubEngine::new();
+    std::env::set_var("STUB_WAIT_SLEEP", "10");
+    let state = std::sync::Arc::new(FakeOciRunState::new());
+    let spec = test_spec("stub-heartbeat-refresh");
+    let watchdog = CancellationToken::new();
+
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+    let lifecycle = tokio::spawn({
+        let cfg = cfg.clone();
+        let state = std::sync::Arc::clone(&state);
+        let watchdog = watchdog.clone();
+        async move {
+            let outcome =
+                run_lifecycle(&cfg, &spec, state, CancellationToken::new(), watchdog).await;
+            let _ = result_tx.send(format!("{outcome:?}")).await;
+            outcome
+        }
+    });
+
+    wait_for_marker(&stub.started, Duration::from_secs(10), &mut result_rx).await;
+    let heartbeat = cfg.state_dir.join("runs/stub-heartbeat-refresh.heartbeat");
+    let first = std::fs::read_to_string(&heartbeat).expect("initial heartbeat");
+    tokio::time::sleep(Duration::from_millis(5_500)).await;
+    let refreshed = std::fs::read_to_string(&heartbeat).expect("refreshed heartbeat");
+    assert_ne!(
+        first, refreshed,
+        "OCI heartbeat must refresh at the trusted cadence"
+    );
+
+    watchdog.cancel();
+    lifecycle
+        .await
+        .expect("lifecycle task joins")
+        .expect("cleanup completes");
+    assert!(
+        !heartbeat.exists(),
+        "heartbeat must stop and be removed after resolution"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn teardown_escalates_and_requires_confirmed_absence() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let stub = StubEngine::new();
+    std::env::set_var("STUB_WAIT_SLEEP", "10");
+    std::env::set_var("STUB_STOP_FAIL", "1");
+    std::env::set_var("STUB_KILL_FAIL", "1");
+    let state = std::sync::Arc::new(FakeOciRunState::new());
+    let spec = test_spec("stub-teardown-escalation");
+    let watchdog = CancellationToken::new();
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+    let lifecycle = tokio::spawn({
+        let cfg = cfg.clone();
+        let state = std::sync::Arc::clone(&state);
+        let watchdog = watchdog.clone();
+        async move {
+            let outcome =
+                run_lifecycle(&cfg, &spec, state, CancellationToken::new(), watchdog).await;
+            let _ = result_tx.send(format!("{outcome:?}")).await;
+            outcome
+        }
+    });
+    wait_for_marker(&stub.started, Duration::from_secs(10), &mut result_rx).await;
+    watchdog.cancel();
+    lifecycle
+        .await
+        .expect("lifecycle task joins")
+        .expect("cleanup completes");
+    assert!(stub.stopped.exists());
+    assert!(stub.killed.exists());
+    assert!(stub.removed.exists());
+    assert_eq!(
+        state
+            .get("stub-teardown-escalation")
+            .expect("get")
+            .expect("row")
+            .state,
+        OciLifecycleState::Removed
+    );
+
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let stub = StubEngine::new();
+    std::env::set_var("STUB_WAIT_SLEEP", "10");
+    std::env::set_var("STUB_INSPECT_PRESENT", "1");
+    let state = std::sync::Arc::new(FakeOciRunState::new());
+    let spec = test_spec("stub-teardown-pending");
+    let watchdog = CancellationToken::new();
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+    let lifecycle = tokio::spawn({
+        let cfg = cfg.clone();
+        let state = std::sync::Arc::clone(&state);
+        let watchdog = watchdog.clone();
+        async move {
+            let outcome =
+                run_lifecycle(&cfg, &spec, state, CancellationToken::new(), watchdog).await;
+            let _ = result_tx.send(format!("{outcome:?}")).await;
+            outcome
+        }
+    });
+    wait_for_marker(&stub.started, Duration::from_secs(10), &mut result_rx).await;
+    watchdog.cancel();
+    lifecycle
+        .await
+        .expect("lifecycle task joins")
+        .expect("cleanup completes");
+    assert_eq!(
+        state
+            .get("stub-teardown-pending")
+            .expect("get")
+            .expect("row")
+            .state,
+        OciLifecycleState::PendingReconciliation
+    );
+}
+
+fn reconciliation_row(
+    run_id: &str,
+    container_id: Option<&str>,
+    state: OciLifecycleState,
+) -> ContainerRunRow {
+    ContainerRunRow {
+        run_id: run_id.to_string(),
+        container_id: container_id.map(str::to_string),
+        state,
+        engine: "Docker".to_string(),
+        created_at: "2026-01-01T00:00:00Z".to_string(),
+        updated_at: "2026-01-01T00:00:00Z".to_string(),
+        daemon_id: "test-daemon".to_string(),
+        issue_id: "owner/repo#1".to_string(),
+        worker_command_sha256: "test-command-sha".to_string(),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn startup_reconciliation_repairs_rows_and_removes_orphans() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let stub = StubEngine::new();
+    let state = Arc::new(FakeOciRunState::new());
+
+    // A labeled container without a row is an orphan and must use the
+    // same stop -> kill -> rm path as an active lifecycle.
+    std::env::set_var(
+        "STUB_PS_OUTPUT",
+        "orphan-container\ttest-daemon\torphan-run",
+    );
+    std::env::set_var("STUB_STOP_FAIL", "1");
+    std::env::set_var("STUB_KILL_FAIL", "1");
+    oci_lifecycle::reconcile_installation(
+        &cfg,
+        Arc::clone(&state) as Arc<dyn OciRunState>,
+        "test-daemon",
+        CancellationToken::new(),
+    )
+    .await
+    .expect("orphan reconciliation");
+    assert!(stub.stopped.exists(), "orphan stop must be attempted");
+    assert!(stub.killed.exists(), "orphan stop must escalate to kill");
+    assert!(stub.removed.exists(), "orphan must be force removed");
+
+    // A restarted non-terminal row with no persisted ID adopts the ID
+    // from the caduceus.run_id label before teardown.
+    std::env::set_var(
+        "STUB_PS_OUTPUT",
+        "repair-container\ttest-daemon\trepair-run",
+    );
+    state
+        .insert(&reconciliation_row(
+            "repair-run",
+            None,
+            OciLifecycleState::Running,
+        ))
+        .expect("insert repair row");
+    oci_lifecycle::reconcile_installation(
+        &cfg,
+        Arc::clone(&state) as Arc<dyn OciRunState>,
+        "test-daemon",
+        CancellationToken::new(),
+    )
+    .await
+    .expect("row repair reconciliation");
+    let repaired = state
+        .get("repair-run")
+        .expect("get repaired row")
+        .expect("repaired row exists");
+    assert_eq!(repaired.container_id.as_deref(), Some("repair-container"));
+    assert_eq!(repaired.state, OciLifecycleState::Removed);
+}
+
+#[tokio::test]
+#[serial]
+async fn reconciliation_confirms_pending_absence_before_resolving() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let _stub = StubEngine::new();
+    let state = Arc::new(FakeOciRunState::new());
+    state
+        .insert(&reconciliation_row(
+            "pending-confirmation",
+            Some("pending-container"),
+            OciLifecycleState::PendingReconciliation,
+        ))
+        .expect("insert pending row");
+
+    // The engine still reports the container: a failed rm must not be
+    // interpreted as a confirmed absence, and the row remains pending.
+    std::env::set_var("STUB_INSPECT_PRESENT", "1");
+    oci_lifecycle::reconcile_installation(
+        &cfg,
+        Arc::clone(&state) as Arc<dyn OciRunState>,
+        "test-daemon",
+        CancellationToken::new(),
+    )
+    .await
+    .expect("pending reconciliation");
+    assert_eq!(
+        state
+            .get("pending-confirmation")
+            .expect("get pending")
+            .expect("pending row")
+            .state,
+        OciLifecycleState::PendingReconciliation
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn label_round_trip_discovers_only_this_installation() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let _stub = StubEngine::new();
+    let state = FakeOciRunState::new();
+    std::env::set_var(
+        "STUB_PS_OUTPUT",
+        "own-container\ttest-daemon\town-run\nforeign-container\tother-daemon\tforeign-run\nunlabeled-container\t\tunlabeled-run",
+    );
+
+    let orphans = oci_lifecycle::find_orphans(&cfg, &state, "test-daemon")
+        .await
+        .expect("enumerate labeled containers");
+    assert_eq!(orphans, vec!["own-container"]);
+    assert_eq!(
+        oci_lifecycle::daemon_discovery_template_for_tests(),
+        r#"{{index .Config.Labels "caduceus.daemon_id"}}"#
+    );
+    assert_eq!(
+        oci_lifecycle::discovery_template_for_tests(),
+        r#"{{index .Config.Labels "caduceus.run_id"}}"#
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn crash_window_matrix_leaves_reconciliation_safe_residuals() {
+    let cfg = Config::test_defaults(Path::new("/tmp"));
+    let _stub = StubEngine::new();
+    let state = Arc::new(FakeOciRunState::new());
+    let cases = [
+        ("before-create", None, OciLifecycleState::Created, ""),
+        (
+            "after-create-before-update",
+            None,
+            OciLifecycleState::Created,
+            "created-container\ttest-daemon\tafter-create-before-update",
+        ),
+        (
+            "during-run",
+            Some("running-container"),
+            OciLifecycleState::Running,
+            "running-container\ttest-daemon\tduring-run",
+        ),
+        (
+            "during-teardown",
+            Some("teardown-container"),
+            OciLifecycleState::PendingReconciliation,
+            "teardown-container\ttest-daemon\tduring-teardown",
+        ),
+        (
+            "after-rm-before-removed",
+            Some("removed-container"),
+            OciLifecycleState::Running,
+            "",
+        ),
+    ];
+
+    for (run_id, container_id, lifecycle_state, ps_output) in cases {
+        state
+            .insert(&reconciliation_row(run_id, container_id, lifecycle_state))
+            .expect("insert crash residual");
+        std::env::set_var("STUB_PS_OUTPUT", ps_output);
+        oci_lifecycle::reconcile_installation(
+            &cfg,
+            Arc::clone(&state) as Arc<dyn OciRunState>,
+            "test-daemon",
+            CancellationToken::new(),
+        )
+        .await
+        .expect("reconcile crash residual");
+        let repaired = state
+            .get(run_id)
+            .expect("get residual")
+            .expect("residual row");
+        assert_eq!(repaired.state, OciLifecycleState::Removed);
+        if run_id == "after-create-before-update" {
+            assert_eq!(repaired.container_id.as_deref(), Some("created-container"));
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Wait cancellation — both token sources through the same stop path
 // ---------------------------------------------------------------------------
 
 /// Watchdog-token cancellation mid-wait: the run falls through the
 /// stop → capture → rm sequence (never an early return), reports
-/// `Cancelled`, and reaches `Removed` — no container leak.
+/// disk pressure, and reaches `Removed` — no container leak.
 #[tokio::test]
 #[serial]
 async fn watchdog_cancellation_proceeds_through_stop_capture_rm() {
@@ -250,17 +706,7 @@ async fn watchdog_cancellation_proceeds_through_stop_capture_rm() {
         let shutdown = shutdown.clone();
         let watchdog = watchdog.clone();
         async move {
-            let outcome = oci_lifecycle::run_with_argv(
-                &cfg,
-                &spec,
-                &*state,
-                SandboxEngine::Docker,
-                create_argv(),
-                None,
-                shutdown,
-                watchdog,
-            )
-            .await;
+            let outcome = run_lifecycle(&cfg, &spec, state, shutdown, watchdog).await;
             let _ = result_tx.send(format!("{outcome:?}")).await;
             outcome
         }
@@ -274,15 +720,19 @@ async fn watchdog_cancellation_proceeds_through_stop_capture_rm() {
     let result = lifecycle
         .await
         .expect("lifecycle task joins")
-        .expect_err("watchdog cancellation must report Cancelled");
+        .expect("fresh-token cleanup must complete");
     assert!(
-        matches!(result, CaduceusError::Cancelled),
-        "expected Cancelled; got: {result:?}"
+        result.disk_pressure,
+        "watchdog outcome must remain distinct"
     );
 
     // Cleanup ran: stop and rm markers exist, state is Removed, and
     // the bounded diagnostic capture was persisted.
     assert!(stub.stopped.exists(), "stop step must run");
+    assert!(
+        !stub.killed.exists(),
+        "kill must be skipped after graceful stop"
+    );
     assert!(stub.removed.exists(), "rm step must run after cancellation");
     let row = state
         .get("stub-watchdog-cancel")
@@ -293,11 +743,9 @@ async fn watchdog_cancellation_proceeds_through_stop_capture_rm() {
 }
 
 /// Daemon-shutdown-token cancellation mid-wait: the run also falls
-/// through to the cleanup sequence and reports `Cancelled`. The
-/// cleanup steps check ONLY the daemon token — which is itself
-/// cancelled — so the state lands in `Killed` and the reconciliation
-/// pass finishes the `rm` (the pre-existing daemon-shutdown stop-path
-/// contract; no early return, no hang).
+/// through to the cleanup sequence and reports `Cancelled`. Cleanup
+/// runs under a fresh lifecycle token even though the parent token is
+/// cancelled.
 #[tokio::test]
 #[serial]
 async fn shutdown_cancellation_falls_through_cleanup_and_reports_cancelled() {
@@ -315,17 +763,7 @@ async fn shutdown_cancellation_falls_through_cleanup_and_reports_cancelled() {
         let state = std::sync::Arc::clone(&state);
         let shutdown = shutdown.clone();
         async move {
-            let outcome = oci_lifecycle::run_with_argv(
-                &cfg,
-                &spec,
-                &*state,
-                SandboxEngine::Docker,
-                create_argv(),
-                None,
-                shutdown,
-                watchdog,
-            )
-            .await;
+            let outcome = run_lifecycle(&cfg, &spec, state, shutdown, watchdog).await;
             let _ = result_tx.send(format!("{outcome:?}")).await;
             outcome
         }
@@ -337,23 +775,49 @@ async fn shutdown_cancellation_falls_through_cleanup_and_reports_cancelled() {
     let result = lifecycle
         .await
         .expect("lifecycle task joins")
-        .expect_err("shutdown cancellation must report Cancelled");
-    assert!(
-        matches!(result, CaduceusError::Cancelled),
-        "expected Cancelled; got: {result:?}"
-    );
+        .expect("fresh-token cleanup must complete");
+    assert!(result.cancelled, "shutdown outcome must remain cancelled");
 
-    // The wait cancellation did not early-return: the stop step was
-    // reached (its pre-spawn check refused to spawn because the daemon
-    // token is cancelled) and the kill fallback recorded Killed.
+    // The wait cancellation did not early-return: stop and rm ran on
+    // the fresh lifecycle token and removal was confirmed.
     let row = state
         .get("stub-shutdown-cancel")
         .expect("get")
         .expect("row");
-    assert_eq!(row.state, OciLifecycleState::Killed);
+    assert_eq!(row.state, OciLifecycleState::Removed);
     assert!(
-        !stub.removed.exists(),
-        "rm is left to reconciliation when the daemon token is cancelled"
+        stub.removed.exists(),
+        "rm must run despite parent cancellation"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn worker_timeout_reports_timed_out_after_cleanup() {
+    let mut cfg = Config::test_defaults(Path::new("/tmp"));
+    cfg.worker_timeout_seconds = 1;
+    let stub = StubEngine::new();
+    std::env::set_var("STUB_WAIT_SLEEP", "10");
+    let state = std::sync::Arc::new(FakeOciRunState::new());
+    let spec = test_spec("stub-worker-timeout");
+    let result = run_lifecycle(
+        &cfg,
+        &spec,
+        state.clone(),
+        CancellationToken::new(),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("timeout cleanup must complete");
+    assert!(result.timed_out);
+    assert!(stub.removed.exists());
+    assert_eq!(
+        state
+            .get("stub-worker-timeout")
+            .expect("get")
+            .expect("row")
+            .state,
+        OciLifecycleState::Removed
     );
 }
 
@@ -375,13 +839,10 @@ async fn diagnostic_capture_is_bounded_with_truncation_marker() {
     let state = FakeOciRunState::new();
     let spec = test_spec("stub-capture-bounded");
 
-    let outcome = oci_lifecycle::run_with_argv(
+    let outcome = run_lifecycle(
         &cfg,
         &spec,
-        &state,
-        SandboxEngine::Docker,
-        create_argv(),
-        None,
+        Arc::new(state),
         CancellationToken::new(),
         CancellationToken::new(),
     )

--- a/tests/executor/oci_lifecycle_test.rs
+++ b/tests/executor/oci_lifecycle_test.rs
@@ -2,21 +2,23 @@
 //!
 //! Tests use unique keys per test for parallel safety and verify the
 //! typed errors, cancellation handling, cleanup guarantees, and the
-//! `ContainerRunRow.engine` column wiring from `run_with_argv`'s
+//! `ContainerRunRow.engine` column wiring from the canonical lifecycle's
 //! explicit `SandboxEngine` parameter.
 
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use tokio_util::sync::CancellationToken;
 
 use caduceus::executor::oci_lifecycle;
-use caduceus::executor::sandbox_spec::SandboxEngine;
+use caduceus::executor::sandbox_spec::{resolve, SandboxEngine};
 use caduceus::executor::ExecutorSpec;
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
 use caduceus::infra::error::{CaduceusError, CaduceusResult};
 use caduceus::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
+
+mod support;
 
 // FakeOciRunState — in-memory state for testing
 
@@ -43,6 +45,14 @@ impl OciRunState for FakeOciRunState {
         let mut rows = self.rows.lock().unwrap();
         if let Some(row) = rows.iter_mut().find(|r| r.run_id == run_id) {
             row.state = state.clone();
+        }
+        Ok(())
+    }
+
+    fn update_container_id(&self, run_id: &str, container_id: &str) -> CaduceusResult<()> {
+        let mut rows = self.rows.lock().unwrap();
+        if let Some(row) = rows.iter_mut().find(|r| r.run_id == run_id) {
+            row.container_id = Some(container_id.to_string());
         }
         Ok(())
     }
@@ -101,6 +111,43 @@ fn create_argv() -> Vec<String> {
     ]
 }
 
+async fn run_lifecycle(
+    cfg: &Config,
+    input: &ExecutorSpec,
+    state: Arc<FakeOciRunState>,
+    engine: SandboxEngine,
+    argv: Vec<String>,
+    cancel: CancellationToken,
+    pressure: CancellationToken,
+) -> CaduceusResult<caduceus::supervisor::SupervisorOutcome> {
+    let worktree = cfg
+        .workdir_base
+        .join("owner")
+        .join("repo")
+        .join(&input.run_id);
+    let runtime = support::runtime_facts(cfg, &input.run_id, &worktree);
+    let resolved = resolve(cfg.sandbox(), &runtime, input)?;
+    let adapter = oci_lifecycle::OciAdapter::new(
+        engine,
+        state,
+        cfg.state_dir.clone(),
+        runtime.daemon_id,
+        input.issue.clone(),
+        input.issue.display_key(),
+        "test-command-sha".to_string(),
+        argv,
+        None,
+    );
+    oci_lifecycle::run_oci_lifecycle(
+        &resolved,
+        &adapter,
+        &oci_lifecycle::LifecycleTimeouts::from_config(cfg),
+        cancel,
+        pressure,
+    )
+    .await
+}
+
 // cleanup_on_cancel_and_timeout (AC-03)
 
 /// Cancel mid-wait → no orphan container is left behind.
@@ -110,17 +157,16 @@ async fn cleanup_on_cancel_and_timeout() {
     // step with a typed OCI error. The state row should be
     // inserted (Created) before the error is returned.
     let cfg = test_cfg();
-    let state = FakeOciRunState::new();
+    let state = Arc::new(FakeOciRunState::new());
     let spec = test_spec("lifecycle-cancel-001");
     let cancel = CancellationToken::new();
 
-    let result = oci_lifecycle::run_with_argv(
+    let result = run_lifecycle(
         &cfg,
         &spec,
-        &state,
+        state.clone(),
         SandboxEngine::Docker,
         create_argv(),
-        None,
         cancel.clone(),
         CancellationToken::new(),
     )
@@ -147,17 +193,16 @@ async fn cleanup_on_cancel_and_timeout() {
 #[tokio::test]
 async fn engine_unavailable_surfaces_structured() {
     let cfg = test_cfg();
-    let state = FakeOciRunState::new();
+    let state = Arc::new(FakeOciRunState::new());
     let spec = test_spec("lifecycle-eng-001");
     let cancel = CancellationToken::new();
 
-    let err = oci_lifecycle::run_with_argv(
+    let err = run_lifecycle(
         &cfg,
         &spec,
-        &state,
+        state.clone(),
         SandboxEngine::Docker,
         create_argv(),
-        None,
         cancel.clone(),
         CancellationToken::new(),
     )
@@ -183,20 +228,19 @@ async fn stop_kill_remove_bounded() {
     // Without Docker, the lifecycle should fail at create step
     // (fast), not hang.
     let cfg = test_cfg();
-    let state = FakeOciRunState::new();
+    let state = Arc::new(FakeOciRunState::new());
     let spec = test_spec("lifecycle-bounded-001");
     let cancel = CancellationToken::new();
 
     // Use tokio::time::timeout to ensure we don't hang.
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(30),
-        oci_lifecycle::run_with_argv(
+        run_lifecycle(
             &cfg,
             &spec,
-            &state,
+            state.clone(),
             SandboxEngine::Docker,
             create_argv(),
-            None,
             cancel,
             CancellationToken::new(),
         ),
@@ -225,27 +269,26 @@ async fn stop_kill_remove_bounded() {
     }
 }
 
-// run_with_argv_wires_engine_into_state_row (task 4.7)
+// lifecycle_wires_engine_into_state_row
 
-/// The `engine` passed to `run_with_argv` feeds the
+/// The engine passed to the lifecycle adapter feeds the
 /// `ContainerRunRow.engine` column — the same engine the renderer
 /// used, so the create argv and the state row cannot diverge.
 #[tokio::test]
-async fn run_with_argv_wires_engine_into_state_row() {
+async fn lifecycle_wires_engine_into_state_row() {
     let cfg = test_cfg();
-    let state = FakeOciRunState::new();
+    let state = Arc::new(FakeOciRunState::new());
     let spec = test_spec("lifecycle-engine-row-001");
     let cancel = CancellationToken::new();
 
     // Podman engine: the renderer would have emitted `podman create`,
     // and the state row must say "Podman".
-    let _ = oci_lifecycle::run_with_argv(
+    let _ = run_lifecycle(
         &cfg,
         &spec,
-        &state,
+        state.clone(),
         SandboxEngine::Podman,
         create_argv(),
-        None,
         cancel,
         CancellationToken::new(),
     )
@@ -255,17 +298,16 @@ async fn run_with_argv_wires_engine_into_state_row() {
     let row = row.expect("row must be inserted before create");
     assert_eq!(
         row.engine, "Podman",
-        "ContainerRunRow.engine must match the engine passed to run_with_argv"
+        "ContainerRunRow.engine must match the engine passed to the adapter"
     );
 }
 
 // crash_recovery (AC-05)
 
-/// Simulate crash recovery: insert a row in PendingReconciliation,
-/// call reconcile, verify the row is marked Removed.
+/// Simulate a durable crash residual: insert a row in
+/// `PendingReconciliation` and retain it for startup recovery.
 #[tokio::test]
 async fn crash_recovery() {
-    let cfg = test_cfg();
     let state = FakeOciRunState::new();
 
     // Insert a row as if it was created before a crash.
@@ -282,14 +324,7 @@ async fn crash_recovery() {
     };
     state.insert(&row).expect("insert row");
 
-    // Reconcile — this should try to remove the container (will fail
-    // without Docker) and mark the row as Removed.
-    let cancel = CancellationToken::new();
-    oci_lifecycle::reconcile(&cfg, &state, cancel)
-        .await
-        .expect("reconcile should succeed");
-
-    // The row should still exist.
+    // The row remains available for the startup reconciliation pass.
     let row = state.get("crash-rec-001").expect("get row");
     assert!(row.is_some(), "row must still exist");
 }
@@ -300,7 +335,6 @@ async fn crash_recovery() {
 /// are left untouched.
 #[tokio::test]
 async fn reconcile_does_not_remove_unrelated() {
-    let _cfg = test_cfg();
     let state = FakeOciRunState::new();
 
     // Insert a row with a different run_id pattern.
@@ -338,12 +372,9 @@ fn parse_exit_code_parses_number() {
     assert_eq!(oci_lifecycle::parse_exit_code_for_tests("not-a-number"), -1);
 }
 
-// derive_daemon_id (moved from src/executor/oci_lifecycle.rs inline tests)
-
 #[test]
-fn derive_daemon_id_from_state_dir() {
-    let mut cfg = Config::test_defaults(Path::new("/tmp"));
-    cfg.state_dir = Path::new("/tmp").join("my-daemon");
-    let id = oci_lifecycle::derive_daemon_id_for_tests(&cfg);
-    assert_eq!(id, "my-daemon");
+fn discovery_uses_the_quoted_run_label_template() {
+    let template = oci_lifecycle::discovery_template_for_tests();
+    assert_eq!(template, r#"{{index .Config.Labels "caduceus.run_id"}}"#);
+    assert!(!template.contains("caduceus_run_id"));
 }

--- a/tests/executor/support/mod.rs
+++ b/tests/executor/support/mod.rs
@@ -59,6 +59,7 @@ pub fn runtime_facts(cfg: &Config, run_id: &str, worktree: &Path) -> RuntimeFact
 /// `RuntimeFacts` defaults: same run id and issue key, with fixed
 /// representative title/body/labels/branch/context values. Tests
 /// needing non-default spec inputs mutate the returned struct.
+#[allow(dead_code)]
 pub fn executor_spec(runtime: &RuntimeFacts) -> caduceus::executor::ExecutorSpec {
     caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),

--- a/tests/fixtures/scenario-10-golden.json
+++ b/tests/fixtures/scenario-10-golden.json
@@ -1,5 +1,5 @@
 {
-  "schema_version_after_open": 6,
-  "schema_version_again": 6,
+  "schema_version_after_open": 7,
+  "schema_version_again": 7,
   "oci_runs_table_exists": true
 }

--- a/tests/integration/integration_scenarios.rs
+++ b/tests/integration/integration_scenarios.rs
@@ -962,16 +962,16 @@ async fn test_scenario_9_config_bootstrap_cadence_default() {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 10: schema migration from v4 to v5 (idempotent).
+// Scenario 10: schema initialization at v7 (idempotent).
 //
 // We don't drive this through `caduceus run` because the
 // schema migration lives in `caduceus migrate-state`. We
 // invoke that subcommand and assert the migration is a
-// no-op when the database is already at v6.
+// no-op when the database is already at v7.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_scenario_10_schema_migration_v5_to_v6_idempotent() {
+async fn test_scenario_10_schema_v7_idempotent() {
     use caduceus::state::store::{open_in, SCHEMA_VERSION};
 
     let state = IsolatedState::new("http://127.0.0.1:1".to_string());
@@ -989,7 +989,7 @@ async fn test_scenario_10_schema_migration_v5_to_v6_idempotent() {
         v_after_open, SCHEMA_VERSION,
         "fresh DB must be at SCHEMA_VERSION"
     );
-    assert_eq!(v_after_open, 6, "v6 is the canonical current schema");
+    assert_eq!(v_after_open, 7, "v7 is the canonical current schema");
 
     // Second open: idempotent — no migration, schema_version
     // table is unchanged, oci_runs table still exists.
@@ -1007,8 +1007,8 @@ async fn test_scenario_10_schema_migration_v5_to_v6_idempotent() {
         )
         .expect("query oci_runs");
     drop(conn2);
-    assert_eq!(v_again, 6, "second open must remain v6 (idempotent)");
-    assert_eq!(oci_runs_count, 1, "oci_runs table must exist at v6");
+    assert_eq!(v_again, 7, "second open must remain v7 (idempotent)");
+    assert_eq!(oci_runs_count, 1, "oci_runs table must exist at v7");
 
     let observed = serde_json::json!({
         "schema_version_after_open": v_after_open,

--- a/tests/state/meta_test.rs
+++ b/tests/state/meta_test.rs
@@ -77,6 +77,71 @@ fn empty_meta_round_trips_sqlite() {
 }
 
 #[test]
+fn installation_uuid_is_generated_once_and_reused_for_json() {
+    let root = tempdir("installation-uuid-json");
+    let store = MetaStore::open(&root).expect("open json meta store");
+    let first = store
+        .get_or_create_installation_uuid()
+        .expect("generate UUID");
+    let second = MetaStore::open(&root)
+        .expect("reopen json meta store")
+        .get_or_create_installation_uuid()
+        .expect("reuse UUID");
+    assert_eq!(first, second);
+    assert!(uuid::Uuid::parse_str(&first).is_ok());
+    assert!(root
+        .join(caduceus::meta::INSTALLATION_UUID_FILENAME)
+        .is_file());
+}
+
+#[test]
+fn installation_uuid_is_generated_once_and_reused_for_sqlite() {
+    let root = tempdir("installation-uuid-sqlite");
+    let first = MetaStore::open_sqlite(&root)
+        .expect("open sqlite meta store")
+        .get_or_create_installation_uuid()
+        .expect("generate UUID");
+    let second = MetaStore::open_sqlite(&root)
+        .expect("reopen sqlite meta store")
+        .get_or_create_installation_uuid()
+        .expect("reuse UUID");
+    assert_eq!(first, second);
+    assert!(uuid::Uuid::parse_str(&first).is_ok());
+}
+
+#[test]
+fn same_basename_installations_get_distinct_json_identities() {
+    let root = tempdir("same-basename");
+    let first_dir = root.join("first").join("daemon");
+    let second_dir = root.join("second").join("daemon");
+    let first = MetaStore::open(&first_dir)
+        .expect("open first installation")
+        .get_or_create_installation_uuid()
+        .expect("first UUID");
+    let second = MetaStore::open(&second_dir)
+        .expect("open second installation")
+        .get_or_create_installation_uuid()
+        .expect("second UUID");
+    assert_ne!(first, second, "installation identity must not use basename");
+}
+
+#[test]
+fn same_basename_installations_get_distinct_sqlite_identities() {
+    let root = tempdir("same-basename-sqlite");
+    let first_dir = root.join("first").join("daemon");
+    let second_dir = root.join("second").join("daemon");
+    let first = MetaStore::open_sqlite(&first_dir)
+        .expect("open first installation")
+        .get_or_create_installation_uuid()
+        .expect("first UUID");
+    let second = MetaStore::open_sqlite(&second_dir)
+        .expect("open second installation")
+        .get_or_create_installation_uuid()
+        .expect("second UUID");
+    assert_ne!(first, second, "installation identity must not use basename");
+}
+
+#[test]
 fn full_meta_round_trips_sqlite() {
     let root = tempdir("full-sqlite");
     let store = MetaStore::open_sqlite(&root).expect("open sqlite");

--- a/tests/state/oci_run_test.rs
+++ b/tests/state/oci_run_test.rs
@@ -73,6 +73,38 @@ fn update_oci_run_state() {
     assert_eq!(loaded.state, OciLifecycleState::Running);
 }
 
+#[test]
+fn container_id_is_durably_updatable_and_indexed() {
+    let dao = dao();
+    dao.insert(&sample_row("run-id", OciLifecycleState::Created))
+        .expect("insert");
+    dao.update_container_id("run-id", "created-before-start")
+        .expect("persist container id");
+    let row = dao
+        .get_by_container_id("created-before-start")
+        .expect("lookup")
+        .expect("row exists");
+    assert_eq!(row.run_id, "run-id");
+    assert_eq!(row.container_id.as_deref(), Some("created-before-start"));
+}
+
+#[test]
+fn daemon_id_lookup_is_scoped_to_installation() {
+    let dao = dao();
+    let mut own = sample_row("run-own", OciLifecycleState::Running);
+    own.daemon_id = "installation-a".to_string();
+    let mut foreign = sample_row("run-foreign", OciLifecycleState::Running);
+    foreign.daemon_id = "installation-b".to_string();
+    dao.insert(&own).expect("insert own row");
+    dao.insert(&foreign).expect("insert foreign row");
+
+    let rows = dao
+        .list_by_daemon_id("installation-a")
+        .expect("installation lookup");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].run_id, "run-own");
+}
+
 // list_pending_reconciliation_returns_only_pending
 
 #[test]

--- a/tests/state/sqlite_store_test.rs
+++ b/tests/state/sqlite_store_test.rs
@@ -53,6 +53,31 @@ fn open_rejects_future_schema() {
 }
 
 #[test]
+fn open_rejects_v6_without_migration() {
+    let path = db_path();
+    let conn = Connection::open(&path).expect("open raw");
+    conn.execute_batch(
+        "CREATE TABLE schema_version (version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+         INSERT INTO schema_version VALUES (6, '2026-01-01T00:00:00Z');",
+    )
+    .expect("create v6 fixture");
+    drop(conn);
+
+    let err = open(&path).expect_err("v6 must be rejected");
+    let text = err.to_string();
+    assert!(text.contains("stale schema v6"), "got: {text}");
+
+    let conn = Connection::open(&path).expect("reopen raw");
+    let version: i64 = conn
+        .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+            row.get(0)
+        })
+        .expect("read unchanged version");
+    assert_eq!(version, 6, "rejection must not record v7");
+    let _ = fs::remove_file(&path);
+}
+
+#[test]
 fn schema_tables_are_created() {
     let path = db_path();
     let conn = open(&path).expect("open fresh db");
@@ -305,13 +330,16 @@ fn migrates_v5_to_v6_adds_block_columns() {
         conn.close().expect("close");
     }
 
-    let conn = open(&path).expect("open v6");
+    let conn = open(&path).expect("open current schema");
     let version: i64 = conn
         .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
             row.get(0)
         })
         .expect("read version");
-    assert_eq!(version, 6, "schema version must be v6 after migration");
+    assert_eq!(
+        version, SCHEMA_VERSION,
+        "schema version must be current after migration"
+    );
 
     let cols: Vec<String> = conn
         .prepare("SELECT name FROM pragma_table_info('queue_entries') ORDER BY name")


### PR DESCRIPTION
Closes #247

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Rebuild the OCI container lifecycle as one crash-safe path: resolve/pull/verify → create → **persist container ID** → start → race{exit, timeout, cancellation, disk-pressure} → bounded stop → bounded kill → remove → **confirm removal** → persist `Removed`
- Introduce a persisted installation UUID for identity/labels, wire startup reconciliation that actually runs, and maintain run-heartbeat continuity for OCI runs
- Consolidate the duplicate run paths (`run`/`run_with_argv` clones) into a single lifecycle function with adapter-owned argv helpers

## Changes Table

| File | Change |
|------|--------|
| `src/state/store.rs` | Schema v6 → v7 (BREAKING, no legacy migration; v6 rejected with stale-schema error), new `oci_runs` indices |
| `src/state/oci_run.rs` | Add `update_container_id`, `is_terminal`, durable lookup by `container_id` |
| `src/state/meta.rs` | Installation UUID generated once, persisted atomically (Json temp+fsync+rename / SQLite transaction) |
| `src/executor/oci_lifecycle.rs` | Single `run_oci_lifecycle`: durable container ID before start, biased `select!` race, fresh bounded teardown with confirmed removal, heartbeat continuity, `reconcile_installation`, label discovery |
| `src/executor/oci.rs` | Rewire `OciExecutor::run` to the single lifecycle path with child/watchdog tokens |
| `src/executor/sandbox_renderer.rs` | Single label constant pair + quoted Go-template discovery (`{{index .Config.Labels "caduceus.daemon_id"}}`) |
| `src/daemon/tick/mod.rs` | Startup reconciliation wired before claim acceptance (UUID load-or-generate, orphan removal, row repair) |
| `src/daemon/tick/per_claim.rs` | Consume honest `SupervisorOutcome` (timed_out/cancelled/disk_pressure) in verdict logic |
| `src/worker/supervisor/outcome_transcript.rs` | Add `disk_pressure` outcome field (trusted-host path otherwise untouched) |
| `tests/**` | Failure-injection crash-window matrix, label round-trip, UUID/schema tests, teardown escalation, heartbeat, gated live-engine suites |
| `README.md` | Crash-recovery behavior, heartbeat semantics, UUID location, v6 stale-schema operator recovery |

## Test Plan

- [x] `cargo test --locked --all-targets` passes (failure-injection matrix, label consistency, UUID idempotence, schema v7/v6 rejection, trusted-host regression suites green)
- [x] `cargo clippy --locked --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Gated integration tests (real engine) authored; correctly skipped where no engine is available
- [x] OpenSpec change validated and archived (`2026-08-30-fix-oci-crash-safe-lifecycle`)

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (N/A — Rust only)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers