### PR TITLE
build(oci): minimal Caduceus reference/test worker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,200 @@ jobs:
           path: pytest-junit.xml
           retention-days: 14
           if-no-files-found: error
+
+  oci-reference-image:
+    # Local build + contract smoke only (D4): the reference worker
+    # image is never pushed from CI, and PRs/forks get no registry
+    # credentials. Publication happens exclusively from the
+    # release-worker-image workflow on `v*` tags. Not a required
+    # branch-protection check; existing required names are unchanged.
+    name: oci-reference-image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: build reference image locally (never pushed)
+        run: |
+          set -euo pipefail
+          docker build --pull \
+            -f plugin-assets/worker-reference-image/Containerfile \
+            -t caduceus-worker-reference:ci \
+            plugin-assets/worker-reference-image
+      - name: smoke — default CMD contract summary
+        run: |
+          set -euo pipefail
+          summary="$(docker run --rm caduceus-worker-reference:ci)"
+          printf '%s\n' "$summary" | grep -q "caduceus-worker-reference" || {
+            echo "expected the default contract summary line" >&2
+            exit 1
+          }
+      - name: smoke — caduceus-env.sh (WR-2)
+        run: |
+          set -euo pipefail
+          full_env=(
+            -e CADUCEUS_RUN_ID=ci-smoke
+            -e CADUCEUS_ISSUE_ID=ci-smoke
+            -e CADUCEUS_ISSUE_NUMBER=1
+            -e CADUCEUS_ISSUE_REPO=example/example
+            -e CADUCEUS_ISSUE_TITLE="Smoke test"
+            -e CADUCEUS_ISSUE_BODY="Smoke body"
+            -e 'CADUCEUS_ISSUE_LABELS_JSON=["smoke"]'
+            -e 'CADUCEUS_CONTEXT_JSON={"run":"smoke"}'
+            -e CADUCEUS_BRANCH_NAME=main
+            -e CADUCEUS_WORKTREE_PATH=/workspace
+            -e CADUCEUS_RESULT_PATH=/output/worker-result.json
+          )
+          # names-only: all eleven canonical names, sorted.
+          names="$(docker run --rm "${full_env[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/caduceus-env.sh --names-only)"
+          test "$(printf '%s\n' "$names" | wc -l)" -eq 11
+          for name in \
+            CADUCEUS_BRANCH_NAME CADUCEUS_CONTEXT_JSON CADUCEUS_ISSUE_BODY \
+            CADUCEUS_ISSUE_ID CADUCEUS_ISSUE_LABELS_JSON CADUCEUS_ISSUE_NUMBER \
+            CADUCEUS_ISSUE_REPO CADUCEUS_ISSUE_TITLE CADUCEUS_RESULT_PATH \
+            CADUCEUS_RUN_ID CADUCEUS_WORKTREE_PATH
+          do
+            printf '%s\n' "$names" | grep -qx "$name" || {
+              echo "names-only output missing $name" >&2
+              exit 1
+            }
+          done
+          # Full mode: NAME=VALUE per line.
+          pairs="$(docker run --rm "${full_env[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/caduceus-env.sh)"
+          printf '%s\n' "$pairs" | grep -qx 'CADUCEUS_RUN_ID=ci-smoke' || {
+            echo "NAME=VALUE output missing CADUCEUS_RUN_ID=ci-smoke" >&2
+            exit 1
+          }
+          # A missing canonical variable must fail loudly and name it.
+          missing_env=(
+            -e CADUCEUS_RUN_ID=ci-smoke
+            -e CADUCEUS_ISSUE_ID=ci-smoke
+            -e CADUCEUS_ISSUE_NUMBER=1
+            -e CADUCEUS_ISSUE_REPO=example/example
+            -e CADUCEUS_ISSUE_TITLE="Smoke test"
+            -e CADUCEUS_ISSUE_BODY="Smoke body"
+            -e 'CADUCEUS_ISSUE_LABELS_JSON=["smoke"]'
+            -e 'CADUCEUS_CONTEXT_JSON={"run":"smoke"}'
+            -e CADUCEUS_BRANCH_NAME=main
+            -e CADUCEUS_WORKTREE_PATH=/workspace
+          )
+          if docker run --rm "${missing_env[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/caduceus-env.sh \
+            >/dev/null 2>caduceus-env.err; then
+            echo "caduceus-env.sh must fail when CADUCEUS_RESULT_PATH is unset" >&2
+            exit 1
+          fi
+          grep -q "CADUCEUS_RESULT_PATH" caduceus-env.err || {
+            echo "missing-variable diagnostic must name CADUCEUS_RESULT_PATH" >&2
+            exit 1
+          }
+      - name: smoke — write-result.sh (WR-3)
+        run: |
+          set -euo pipefail
+          out="$(mktemp -d)"
+          trap 'rm -rf "$out"' EXIT
+          env=(
+            -e CADUCEUS_RUN_ID=ci-smoke
+            -e CADUCEUS_ISSUE_ID=ci-smoke
+            -e CADUCEUS_ISSUE_NUMBER=1
+            -e CADUCEUS_ISSUE_REPO=example/example
+            -e CADUCEUS_ISSUE_TITLE="Smoke test"
+            -e CADUCEUS_ISSUE_BODY="Smoke body"
+            -e 'CADUCEUS_ISSUE_LABELS_JSON=["smoke"]'
+            -e 'CADUCEUS_CONTEXT_JSON={"run":"smoke"}'
+            -e CADUCEUS_BRANCH_NAME=main
+            -e CADUCEUS_WORKTREE_PATH=/workspace
+            -e CADUCEUS_RESULT_PATH=/output/worker-result.json
+          )
+          # write-result.sh only reads CADUCEUS_RESULT_PATH, but keep the
+          # canonical set complete apart from the unset result path.
+          env_without_result=(
+            -e CADUCEUS_RUN_ID=ci-smoke
+            -e CADUCEUS_ISSUE_ID=ci-smoke
+            -e CADUCEUS_ISSUE_NUMBER=1
+            -e CADUCEUS_ISSUE_REPO=example/example
+            -e CADUCEUS_ISSUE_TITLE="Smoke test"
+            -e CADUCEUS_ISSUE_BODY="Smoke body"
+            -e 'CADUCEUS_ISSUE_LABELS_JSON=["smoke"]'
+            -e 'CADUCEUS_CONTEXT_JSON={"run":"smoke"}'
+            -e CADUCEUS_BRANCH_NAME=main
+            -e CADUCEUS_WORKTREE_PATH=/workspace
+          )
+          # Honor CADUCEUS_RESULT_PATH: schema-valid document.
+          docker run --rm --read-only --tmpfs /tmp:size=64m \
+            -v "$out":/output:rw "${env[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/write-result.sh
+          python3 - "$out/worker-result.json" <<'PY'
+          import json
+          import sys
+          doc = json.load(open(sys.argv[1], encoding="utf-8"))
+          assert doc["status"] == "success", doc
+          for field in ("summary", "commit_message", "pull_request_title"):
+              assert isinstance(doc[field], str) and doc[field].strip(), field
+          PY
+          # Default path: no CADUCEUS_RESULT_PATH -> /output/worker-result.json.
+          rm -f "$out/worker-result.json"
+          docker run --rm --read-only --tmpfs /tmp:size=64m \
+            -v "$out":/output:rw "${env_without_result[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/write-result.sh
+          test -f "$out/worker-result.json"
+          # --status failure stays schema-valid.
+          docker run --rm --read-only --tmpfs /tmp:size=64m \
+            -v "$out":/output:rw "${env[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/write-result.sh --status failure
+          python3 - "$out/worker-result.json" <<'PY'
+          import json
+          import sys
+          doc = json.load(open(sys.argv[1], encoding="utf-8"))
+          assert doc["status"] == "failure", doc
+          PY
+          # Unwritable target: non-zero exit, no partial file.
+          if docker run --rm --read-only --tmpfs /tmp:size=64m \
+            -v "$out":/output:rw \
+            -e CADUCEUS_RESULT_PATH=/proc/worker-result.json \
+            -e CADUCEUS_RUN_ID=ci-smoke \
+            caduceus-worker-reference:ci /usr/local/bin/write-result.sh \
+            >/dev/null 2>&1; then
+            echo "write-result.sh must fail on an unwritable target" >&2
+            exit 1
+          fi
+      - name: smoke — probes (WR-4)
+        run: |
+          set -euo pipefail
+          ws="$(mktemp -d)"
+          out="$(mktemp -d)"
+          trap 'rm -rf "$ws" "$out"' EXIT
+          printf 'ci-sentinel\n' > "$ws/sentinel.txt"
+          restricted=(
+            --read-only --network none --tmpfs /tmp:size=64m
+            -v "$ws":/workspace:rw -v "$out":/output:rw
+          )
+          open=(
+            --read-only --tmpfs /tmp:size=64m
+            -v "$ws":/workspace:rw -v "$out":/output:rw
+          )
+          docker run --rm "${restricted[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/worker-probe sentinel-read
+          docker run --rm "${restricted[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/worker-probe mount-probe
+          docker run --rm "${restricted[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/worker-probe resource-hog 1 1024
+          docker run --rm "${restricted[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/worker-probe network-probe none
+          # Default network reports reachability either way.
+          docker run --rm "${open[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/worker-probe network-probe auto
+          # Arbitrary --entrypoint argv is the contract.
+          docker run --rm --entrypoint /bin/sh \
+            caduceus-worker-reference:ci -c 'echo arbitrary-entrypoint-ok' \
+            | grep -q arbitrary-entrypoint-ok
+          # Probe failure paths: non-zero exits fail this step.
+          rm -f "$ws/sentinel.txt"
+          if docker run --rm "${restricted[@]}" \
+            caduceus-worker-reference:ci /usr/local/bin/worker-probe sentinel-read \
+            </dev/null >/dev/null 2>&1; then
+            echo "sentinel-read must fail when the sentinel is missing" >&2
+            exit 1
+          fi

--- a/.github/workflows/release-worker-image.yml
+++ b/.github/workflows/release-worker-image.yml
@@ -1,0 +1,88 @@
+name: release-worker-image
+
+# Digest-pinned publication of the Caduceus OCI worker reference image.
+#
+# Runs ONLY on version tags from the canonical repository; main CI
+# (ci.yml, job `oci-reference-image`) builds the same Containerfile
+# locally and never pushes, and forks never get registry credentials.
+# Publication is therefore exclusive to this workflow (D5).
+#
+# The published digest is echoed into the workflow summary and appended
+# to the GitHub release notes so every publication is digest-pinned and
+# auditable.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push (same Containerfile, digest-pinned base)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: plugin-assets/worker-reference-image
+          file: plugin-assets/worker-reference-image/Containerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/barkley-assistant/caduceus-worker-reference:${{ steps.version.outputs.version }}
+            ghcr.io/barkley-assistant/caduceus-worker-reference:latest
+          # Provenance attestation makes the publication auditable; the
+          # base image itself is already pinned by its manifest digest.
+          provenance: mode=max
+          sbom: false
+
+      - name: Echo digest into workflow summary
+        run: |
+          {
+            echo "## Published caduceus-worker-reference"
+            echo ""
+            echo "- Version: \`${{ steps.version.outputs.version }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Tags: \`ghcr.io/barkley-assistant/caduceus-worker-reference:${{ steps.version.outputs.version }}\`, \`ghcr.io/barkley-assistant/caduceus-worker-reference:latest\`"
+            echo "- Image ref (digest-pinned): \`ghcr.io/barkley-assistant/caduceus-worker-reference:${{ steps.version.outputs.version }}@${{ steps.build.outputs.digest }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append digest to release notes (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          digest="${{ steps.build.outputs.digest }}"
+          marker="Reference worker image digest: \`$digest\`"
+          body="$(gh release view "$GITHUB_REF_NAME" --json body -q .body 2>/dev/null || true)"
+          if [ -n "$body" ]; then
+            if ! grep -qF "$digest" <<<"$body"; then
+              gh release edit "$GITHUB_REF_NAME" --notes "$body"$'\n\n'"$marker"
+            fi
+          else
+            # The release.yml workflow may not have created the GitHub
+            # release yet; the digest is always in the workflow summary.
+            echo "note: GitHub release for $GITHUB_REF_NAME not found yet; digest is recorded in the workflow summary" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -636,6 +636,14 @@ name = "fixtures_self_test"
 path = "tests/architecture/fixtures_self_test.rs"
 
 [[test]]
+name = "oci_fixture_parity_test"
+path = "tests/architecture/oci_fixture_parity_test.rs"
+
+[[test]]
+name = "oci_independence_test"
+path = "tests/architecture/oci_independence_test.rs"
+
+[[test]]
 name = "awaiting_review_test"
 path = "tests/daemon/awaiting_review_test.rs"
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,67 @@ latency is bounded by the 30 s sampling interval plus the
 stop/kill timeouts). The watchdog bounds the damage and
 stops the bleeding; it does not isolate storage per run.
 
+### The reference worker image
+
+Caduceus ships a minimal, deterministic reference worker
+image that proves the worker contract end to end:
+`plugin-assets/worker-reference-image/` (see its
+[README](plugin-assets/worker-reference-image/README.md)).
+It pins `busybox:1.36.1` by SHA256 digest (no package
+manager, compiler, or LLM tooling) and contains only the
+contract helper (`caduceus-env.sh`), the result writer
+(`write-result.sh`), the certification probes
+(`worker-probe sentinel-read|mount-probe|resource-hog|
+network-probe`), and the busybox runtime. The image is a
+test fixture and an operator example — never a production
+dependency of the executor (an independence test keeps
+`src/` free of any reference to it).
+
+CI builds the image locally and runs the contract smoke in
+the `oci-reference-image` job of `.github/workflows/ci.yml`
+(no push). Publication happens only from the
+`release-worker-image` workflow on `v*` tags, which pushes
+`ghcr.io/barkley-assistant/caduceus-worker-reference:
+vX.Y.Z` and `latest` with provenance and echoes the
+published digest into the workflow summary and release
+notes.
+
+Operator example — run it exactly like the executor does:
+read-only rootfs, `/workspace` and `/output` bind mounts, a
+bounded `/tmp` tmpfs, the canonical environment, and
+arbitrary `--entrypoint` argv:
+
+```sh
+ws="$(mktemp -d)" && out="$(mktemp -d)"
+echo "example-sentinel" > "$ws/sentinel.txt"
+
+docker run --rm --read-only --network none --tmpfs /tmp:size=256m \
+  -v "$ws":/workspace:rw -v "$out":/output:rw \
+  -e CADUCEUS_RUN_ID=example \
+  -e CADUCEUS_ISSUE_ID=example \
+  -e CADUCEUS_ISSUE_NUMBER=1 \
+  -e CADUCEUS_ISSUE_REPO=owner/repo \
+  -e CADUCEUS_ISSUE_TITLE="Example run" \
+  -e CADUCEUS_ISSUE_BODY="Example body" \
+  -e 'CADUCEUS_ISSUE_LABELS_JSON=["example"]' \
+  -e 'CADUCEUS_CONTEXT_JSON={}' \
+  -e CADUCEUS_BRANCH_NAME=main \
+  -e CADUCEUS_WORKTREE_PATH=/workspace \
+  -e CADUCEUS_RESULT_PATH=/output/worker-result.json \
+  --entrypoint /bin/sh \
+  caduceus-worker-reference:local -c '
+    /usr/local/bin/caduceus-env.sh --names-only &&
+    /usr/local/bin/worker-probe sentinel-read &&
+    /usr/local/bin/write-result.sh &&
+    cat /output/worker-result.json
+  '
+```
+
+OCI tests that need a real container use the **unrelated**
+fixture image (`tests/fixtures/oci-fixture-image/`), never
+the reference image; the fixture-parity test enforces the
+separation.
+
 ## The 60-Second Orientation
 
 1. `git clone`, `cargo build`, `hermes caduceus setup`

--- a/plugin-assets/worker-reference-image/Containerfile
+++ b/plugin-assets/worker-reference-image/Containerfile
@@ -1,0 +1,45 @@
+# Caduceus OCI worker reference image.
+#
+# The minimal deterministic worker image that proves the OCI worker
+# contract end to end (canonical CADUCEUS_* environment, /workspace,
+# schema-valid /output/worker-result.json, certification probes). It is
+# a test fixture, a CI artifact, and an operator example — never a
+# production dependency of the executor (see README.md in this
+# directory).
+#
+# Determinism: the base is busybox 1.36.1 pinned by its linux/amd64
+# manifest digest (verified 2026-08-30 via `docker buildx imagetools
+# inspect`), so the build never floats on a mutable tag. Busybox ships
+# POSIX sh plus coreutils in one static binary: no package manager, no
+# compiler, no language runtime, no LLM tooling, no install step.
+FROM docker.io/library/busybox:1.36.1@sha256:b7f3d86d6e84fc17718c48bcde1450807faa2d56704205c697b4bd5df7b9e29f
+
+# Contract helper, result writer, probe dispatcher, and the four
+# certification probes, copied at fixed paths (design D1/D3). The
+# executor passes arbitrary --entrypoint argv, so nothing relies on the
+# default command below.
+COPY scripts/caduceus-env.sh /usr/local/bin/caduceus-env.sh
+COPY scripts/write-result.sh /usr/local/bin/write-result.sh
+COPY scripts/worker-probe /usr/local/bin/worker-probe
+COPY scripts/probes/sentinel-read.sh /usr/local/bin/probes/sentinel-read.sh
+COPY scripts/probes/mount-probe.sh /usr/local/bin/probes/mount-probe.sh
+COPY scripts/probes/resource-hog.sh /usr/local/bin/probes/resource-hog.sh
+COPY scripts/probes/network-probe.sh /usr/local/bin/probes/network-probe.sh
+
+# World-readable and executable at fixed paths; the only RUN step.
+RUN chmod 0755 \
+    /usr/local/bin/caduceus-env.sh \
+    /usr/local/bin/write-result.sh \
+    /usr/local/bin/worker-probe \
+    /usr/local/bin/probes/sentinel-read.sh \
+    /usr/local/bin/probes/mount-probe.sh \
+    /usr/local/bin/probes/resource-hog.sh \
+    /usr/local/bin/probes/network-probe.sh
+
+LABEL org.opencontainers.image.title="caduceus-worker-reference" \
+      org.opencontainers.image.description="Minimal contract-correct reference worker image for Caduceus OCI" \
+      org.opencontainers.image.source="https://github.com/barkley-assistant/caduceus"
+
+# Default command: a one-line contract summary. Nothing depends on it —
+# the executor overrides the command with arbitrary argv.
+CMD ["sh", "-c", "echo caduceus-worker-reference: contract helper, result writer, and probes at /usr/local/bin"]

--- a/plugin-assets/worker-reference-image/README.md
+++ b/plugin-assets/worker-reference-image/README.md
@@ -1,0 +1,136 @@
+# caduceus-worker-reference image
+
+The minimal deterministic reference worker image for the Caduceus OCI
+worker contract. It proves the contract end to end — canonical
+`CADUCEUS_*` environment reading, `/workspace` access, schema-valid
+`/output/worker-result.json` writing, and the certification probes —
+and is used as a test fixture, a CI artifact, and an operator example.
+It is **never** a production dependency of the executor: the production
+code in `src/` does not reference the image (an independence test
+enforces this), and a future Doctor diagnostic may optionally run it as
+an isolated canary.
+
+## What the image contains
+
+Everything is copied at fixed paths into a `busybox:1.36.1` base that
+is pinned by its linux/amd64 SHA256 manifest digest, so the build never
+floats on a mutable tag. There is no package manager, compiler,
+language runtime, or LLM tooling — busybox POSIX `sh` and coreutils are
+the entire runtime.
+
+| Path | Purpose |
+|---|---|
+| `/usr/local/bin/caduceus-env.sh` | Contract helper (WR-2) |
+| `/usr/local/bin/write-result.sh` | Result writer (WR-3) |
+| `/usr/local/bin/worker-probe` | Probe subcommand dispatcher (WR-4) |
+| `/usr/local/bin/probes/sentinel-read.sh` | Reads a sentinel from `/workspace` |
+| `/usr/local/bin/probes/mount-probe.sh` | Verifies `/workspace`, `/output`, `/tmp` |
+| `/usr/local/bin/probes/resource-hog.sh` | Bounded CPU + memory allocation |
+| `/usr/local/bin/probes/network-probe.sh` | Reachability per network mode |
+
+The default command prints a one-line contract summary. Nothing relies
+on it: the executor passes arbitrary `--entrypoint` argv, and every
+script is reachable at its fixed path.
+
+## The contract it proves
+
+- **WR-1 — deterministic, minimal contents.** Digest-pinned base;
+  only the helper, writer, probes, and busybox utilities.
+- **WR-2 — canonical environment.** `caduceus-env.sh` reads the eleven
+  canonical `CADUCEUS_*` variables (mirroring
+  `src/executor/sandbox_spec.rs::CANONICAL_ENV_KEYS`). Without options
+  it prints `NAME=VALUE` per line — multi-line values (e.g.
+  `CADUCEUS_ISSUE_BODY` in real worker runs) are collapsed to spaces so
+  every variable stays on exactly one line; `--names-only` prints the
+  sorted names; any unset variable exits non-zero and names it.
+- **WR-3 — schema-valid result.** `write-result.sh` honors
+  `CADUCEUS_RESULT_PATH` (default `/output/worker-result.json`),
+  writes `status`/`summary`/`commit_message`/`pull_request_title`, uses
+  a temp file + atomic rename so no partial file survives, and exits
+  non-zero with a diagnostic when the target is not writable.
+  `--status failure` writes a schema-valid failure document.
+- **WR-4 — certification probes.** Each probe prints a single-line
+  `PASS` report and exits zero on success, or a diagnostic and non-zero
+  on failure:
+
+  - `worker-probe sentinel-read [path]` — reports the contents of
+    `/workspace/sentinel.txt` (or the given path).
+  - `worker-probe mount-probe` — verifies `/workspace` and `/output`
+    are writable and `/tmp` is a writable bounded tmpfs.
+  - `worker-probe resource-hog [cpu_seconds] [memory_kib]` — allocates
+    within hard bounds (10 s CPU, 32 MiB memory).
+  - `worker-probe network-probe [none|unrestricted|auto]` — requires
+    no reachability for `none`, requires reachability for
+    `unrestricted`, and reports either way for `auto` (default).
+
+## Build
+
+```sh
+docker build --pull \
+  -f plugin-assets/worker-reference-image/Containerfile \
+  -t caduceus-worker-reference:local \
+  plugin-assets/worker-reference-image
+```
+
+CI builds the same image locally and runs the contract smoke in the
+`oci-reference-image` job of `.github/workflows/ci.yml`; it never
+pushes. Publication happens only from the release workflow
+(`.github/workflows/release-worker-image.yml`) on `v*` tags, which
+pushes `ghcr.io/barkley-assistant/caduceus-worker-reference:vX.Y.Z`
+and `latest` with provenance and echoes the published digest into the
+workflow summary and release notes.
+
+## Operator example
+
+Run the image like the executor does: read-only rootfs, `/workspace`
+and `/output` bind mounts, bounded `/tmp` tmpfs, and arbitrary
+`--entrypoint` argv with the canonical environment:
+
+```sh
+ws="$(mktemp -d)" && out="$(mktemp -d)"
+echo "example-sentinel" > "$ws/sentinel.txt"
+
+docker run --rm --read-only \
+  --network none --tmpfs /tmp:size=256m \
+  -v "$ws":/workspace:rw -v "$out":/output:rw \
+  -e CADUCEUS_RUN_ID=example \
+  -e CADUCEUS_ISSUE_ID=example \
+  -e CADUCEUS_ISSUE_NUMBER=1 \
+  -e CADUCEUS_ISSUE_REPO=owner/repo \
+  -e CADUCEUS_ISSUE_TITLE="Example run" \
+  -e CADUCEUS_ISSUE_BODY="Example body" \
+  -e 'CADUCEUS_ISSUE_LABELS_JSON=["example"]' \
+  -e 'CADUCEUS_CONTEXT_JSON={}' \
+  -e CADUCEUS_BRANCH_NAME=main \
+  -e CADUCEUS_WORKTREE_PATH=/workspace \
+  -e CADUCEUS_RESULT_PATH=/output/worker-result.json \
+  --entrypoint /bin/sh \
+  caduceus-worker-reference:local -c '
+    /usr/local/bin/caduceus-env.sh --names-only &&
+    /usr/local/bin/worker-probe sentinel-read &&
+    /usr/local/bin/worker-probe mount-probe &&
+    /usr/local/bin/worker-probe resource-hog 1 1024 &&
+    /usr/local/bin/worker-probe network-probe none &&
+    /usr/local/bin/write-result.sh &&
+    cat /output/worker-result.json
+  '
+```
+
+## Fixture separation
+
+OCI tests that need a real container must use the unrelated fixture
+image (`tests/fixtures/oci-fixture-image/`), not this reference image.
+The fixture is Debian-slim based so it shares no layers with this
+busybox image, and the fixture-parity test
+(`tests/architecture/oci_fixture_parity_test.rs`) enforces the
+separation.
+
+## Canary isolation
+
+The image is stateless and self-contained: it reads only the canonical
+environment and the sandboxed `/workspace`, `/output`, `/tmp` surfaces
+and writes only the result document. A future Doctor diagnostic may
+optionally run it as an isolated canary subject without creating an
+executor dependency — the independence test
+(`tests/architecture/oci_independence_test.rs`) keeps `src/` free of
+any reference to the image.

--- a/plugin-assets/worker-reference-image/scripts/caduceus-env.sh
+++ b/plugin-assets/worker-reference-image/scripts/caduceus-env.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Caduceus OCI worker contract helper (WR-2).
+#
+# Reads the canonical CADUCEUS_* variable set from the environment and
+# prints it. The set is the frozen worker-environment contract:
+# src/executor/sandbox_spec.rs::CANONICAL_ENV_KEYS (mirrored by the
+# fixture-parity test).
+#
+#   caduceus-env.sh               print each variable as NAME=VALUE,
+#                                 one per line (multi-line values are
+#                                 collapsed to spaces)
+#   caduceus-env.sh --names-only  print only the sorted variable names
+#
+# If any canonical variable is unset, the helper exits non-zero and
+# names the missing variable(s) on stderr.
+#
+# Strict POSIX sh: no bashisms, no GNU-only flags, only utilities
+# bundled with busybox.
+
+# Canonical CADUCEUS_* names, one per line. Keep in sync with
+# CANONICAL_ENV_KEYS in src/executor/sandbox_spec.rs; the
+# fixture-parity test (tests/architecture/oci_fixture_parity_test.rs)
+# compares --names-only output against that Rust constant.
+CANONICAL_VARS="
+CADUCEUS_BRANCH_NAME
+CADUCEUS_CONTEXT_JSON
+CADUCEUS_ISSUE_BODY
+CADUCEUS_ISSUE_ID
+CADUCEUS_ISSUE_LABELS_JSON
+CADUCEUS_ISSUE_NUMBER
+CADUCEUS_ISSUE_REPO
+CADUCEUS_ISSUE_TITLE
+CADUCEUS_RESULT_PATH
+CADUCEUS_RUN_ID
+CADUCEUS_WORKTREE_PATH
+"
+
+names_only=false
+case "${1:-}" in
+  --names-only) names_only=true ;;
+  "")
+    ;;
+  *)
+    echo "usage: caduceus-env.sh [--names-only]" >&2
+    exit 2
+    ;;
+esac
+
+missing=""
+for name in $CANONICAL_VARS; do
+  if ! eval "[ -n \"\${$name+x}\" ]"; then
+    missing="$missing $name"
+  fi
+done
+
+if [ -n "$missing" ]; then
+  echo "caduceus-env.sh: missing canonical variables:$missing" >&2
+  exit 1
+fi
+
+if $names_only; then
+  printf '%s\n' $CANONICAL_VARS | sort
+else
+  for name in $CANONICAL_VARS; do
+    eval "value=\${$name}"
+    # Collapse newlines to spaces so every variable prints on exactly
+    # one line even when a canonical value is multi-line in a real
+    # worker run (e.g. CADUCEUS_ISSUE_BODY; WR-2 scenario "Print all
+    # canonical variables").
+    value=$(printf '%s' "$value" | tr '\n' ' ')
+    printf '%s=%s\n' "$name" "$value"
+  done
+fi

--- a/plugin-assets/worker-reference-image/scripts/probes/mount-probe.sh
+++ b/plugin-assets/worker-reference-image/scripts/probes/mount-probe.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# mount-probe probe (WR-4): verifies /workspace and /output are
+# writable and /tmp is writable and bounded — a tmpfs, per the worker
+# filesystem contract in src/worker/worker_contract.rs.
+#
+# Strict POSIX sh: only utilities bundled with busybox.
+
+fail() {
+  echo "mount-probe: FAIL $*" >&2
+  exit 1
+}
+
+for dir in /workspace /output /tmp; do
+  [ -d "$dir" ] || fail "directory missing: $dir"
+  [ -w "$dir" ] || fail "directory not writable: $dir"
+  probe_file="$dir/.mount-probe.$$"
+  if ! : > "$probe_file" 2>/dev/null; then
+    fail "cannot create a file in $dir"
+  fi
+  rm -f "$probe_file" 2>/dev/null || fail "cannot remove probe file in $dir"
+done
+
+# /tmp must be a bounded tmpfs, not a host-backed bind mount.
+tmp_fstype=$(awk '$2 == "/tmp" { print $3; exit }' /proc/mounts 2>/dev/null)
+[ "$tmp_fstype" = "tmpfs" ] || fail "/tmp is not a bounded tmpfs (fstype: ${tmp_fstype:-<none>})"
+
+echo "PASS mount-probe: /workspace and /output writable; /tmp writable bounded tmpfs"

--- a/plugin-assets/worker-reference-image/scripts/probes/network-probe.sh
+++ b/plugin-assets/worker-reference-image/scripts/probes/network-probe.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# network-probe probe (WR-4): verifies network reachability consistent
+# with the configured network mode.
+#
+#   network-probe [none|unrestricted|auto]
+#     none           require no reachability (sandbox network: none)
+#     unrestricted   require reachability
+#     auto           report reachability either way (default)
+#
+# The probe target defaults to 1.1.1.1:53 (DNS over TCP) and can be
+# overridden with CADUCEUS_NETWORK_TARGET_HOST / CADUCEUS_NETWORK_TARGET_PORT.
+# Strict POSIX sh: only utilities bundled with busybox.
+
+mode="${1:-auto}"
+target_host="${CADUCEUS_NETWORK_TARGET_HOST:-1.1.1.1}"
+target_port="${CADUCEUS_NETWORK_TARGET_PORT:-53}"
+
+case "$mode" in
+  none | unrestricted | auto) ;;
+  *)
+    echo "network-probe: FAIL unknown network mode: $mode (expected none|unrestricted|auto)" >&2
+    exit 1
+    ;;
+esac
+
+# busybox nc has no -z flag; closing stdin immediately still proves the
+# TCP connect result. Exit status 0 means the connection succeeded.
+if nc -w 2 "$target_host" "$target_port" </dev/null >/dev/null 2>&1; then
+  reachable=yes
+else
+  reachable=no
+fi
+
+case "$mode" in
+  none)
+    if [ "$reachable" = yes ]; then
+      echo "network-probe: FAIL mode=none but $target_host:$target_port is reachable" >&2
+      exit 1
+    fi
+    echo "PASS network-probe: mode=none, no reachability to $target_host:$target_port"
+    ;;
+  unrestricted)
+    if [ "$reachable" = no ]; then
+      echo "network-probe: FAIL mode=unrestricted but $target_host:$target_port is unreachable" >&2
+      exit 1
+    fi
+    echo "PASS network-probe: mode=unrestricted, reachable to $target_host:$target_port"
+    ;;
+  auto)
+    echo "PASS network-probe: mode=auto, reachability=$reachable to $target_host:$target_port"
+    ;;
+esac

--- a/plugin-assets/worker-reference-image/scripts/probes/resource-hog.sh
+++ b/plugin-assets/worker-reference-image/scripts/probes/resource-hog.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# resource-hog probe (WR-4): allocates CPU and memory up to a bounded
+# amount and reports the result.
+#
+#   resource-hog [cpu_seconds] [memory_kib]
+#     cpu_seconds  default 1, hard bound 10
+#     memory_kib   default 1024, hard bound 32768
+#
+# A request beyond a bound fails with a diagnostic; the allocation
+# itself never exceeds the requested amount. Strict POSIX sh: only
+# utilities bundled with busybox.
+
+cpu_seconds="${1:-1}"
+memory_kib="${2:-1024}"
+max_cpu_seconds=10
+max_memory_kib=32768
+
+case "$cpu_seconds" in
+  '' | *[!0-9]*)
+    echo "resource-hog: FAIL cpu_seconds must be a non-negative integer: $cpu_seconds" >&2
+    exit 1
+    ;;
+esac
+case "$memory_kib" in
+  '' | *[!0-9]*)
+    echo "resource-hog: FAIL memory_kib must be a non-negative integer: $memory_kib" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$cpu_seconds" -gt "$max_cpu_seconds" ]; then
+  echo "resource-hog: FAIL cpu bound of ${max_cpu_seconds}s exceeded: $cpu_seconds" >&2
+  exit 1
+fi
+if [ "$memory_kib" -gt "$max_memory_kib" ]; then
+  echo "resource-hog: FAIL memory bound of ${max_memory_kib} KiB exceeded: $memory_kib" >&2
+  exit 1
+fi
+
+# Bounded CPU: spin until the requested wall-clock seconds elapse.
+start=$(date +%s)
+while [ "$(($(date +%s) - start))" -lt "$cpu_seconds" ]; do
+  :
+done
+
+# Bounded memory: read memory_kib bytes of zeros from /dev/zero.
+payload=$(head -c "$((memory_kib * 1024))" /dev/zero 2>/dev/null) || {
+  echo "resource-hog: FAIL could not allocate $memory_kib KiB" >&2
+  exit 1
+}
+: "$payload"
+
+echo "PASS resource-hog: allocated ${cpu_seconds}s CPU and ${memory_kib} KiB memory"

--- a/plugin-assets/worker-reference-image/scripts/probes/sentinel-read.sh
+++ b/plugin-assets/worker-reference-image/scripts/probes/sentinel-read.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# sentinel-read probe (WR-4): reads a sentinel file from /workspace and
+# reports its contents in a single-line pass report.
+#
+#   sentinel-read [path]   default /workspace/sentinel.txt
+#
+# Strict POSIX sh: only utilities bundled with busybox.
+
+sentinel="${1:-/workspace/sentinel.txt}"
+
+if [ ! -f "$sentinel" ]; then
+  echo "sentinel-read: FAIL sentinel file not found: $sentinel" >&2
+  exit 1
+fi
+if [ ! -r "$sentinel" ]; then
+  echo "sentinel-read: FAIL sentinel file not readable: $sentinel" >&2
+  exit 1
+fi
+
+# Collapse newlines so the report stays on a single line.
+contents=$(cat "$sentinel" 2>/dev/null | tr '\n' ' ')
+
+echo "PASS sentinel-read: $contents"

--- a/plugin-assets/worker-reference-image/scripts/worker-probe
+++ b/plugin-assets/worker-reference-image/scripts/worker-probe
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Caduceus OCI worker certification probe dispatcher (WR-4).
+#
+# Maps subcommand names to the small POSIX sh probes at fixed paths:
+#
+#   worker-probe sentinel-read [path]  read a sentinel file from /workspace
+#   worker-probe mount-probe           verify /workspace /output writable,
+#                                      /tmp writable bounded tmpfs
+#   worker-probe resource-hog [cpu] [kib]  bounded CPU + memory allocation
+#   worker-probe network-probe [mode]  reachability per network mode
+#
+# Each probe prints a single-line pass report and exits zero on
+# success, or exits non-zero with a diagnostic on failure. The
+# dispatcher execs the probe so its exit status propagates unchanged.
+
+case "${1:-}" in
+  sentinel-read) shift; exec /usr/local/bin/probes/sentinel-read.sh "$@" ;;
+  mount-probe) shift; exec /usr/local/bin/probes/mount-probe.sh "$@" ;;
+  resource-hog) shift; exec /usr/local/bin/probes/resource-hog.sh "$@" ;;
+  network-probe) shift; exec /usr/local/bin/probes/network-probe.sh "$@" ;;
+  "")
+    echo "usage: worker-probe <sentinel-read|mount-probe|resource-hog|network-probe> [args...]" >&2
+    exit 2
+    ;;
+  *)
+    echo "worker-probe: unknown probe: $1" >&2
+    echo "usage: worker-probe <sentinel-read|mount-probe|resource-hog|network-probe> [args...]" >&2
+    exit 2
+    ;;
+esac

--- a/plugin-assets/worker-reference-image/scripts/write-result.sh
+++ b/plugin-assets/worker-reference-image/scripts/write-result.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Caduceus OCI worker result writer (WR-3).
+#
+# Writes a worker-result.json document honoring CADUCEUS_RESULT_PATH
+# (default /output/worker-result.json) via a temp file + atomic rename,
+# so no partial file survives. The document matches the worker-result
+# schema (src/worker/worker_contract.rs): status is "success" or
+# "failure", with non-empty summary, commit_message, and
+# pull_request_title strings.
+#
+#   write-result.sh                    status: success
+#   write-result.sh --status failure   status: failure
+#
+# If the target path is not writable, the writer exits non-zero with a
+# diagnostic and leaves no partial file.
+#
+# Strict POSIX sh: only utilities bundled with busybox.
+
+status="success"
+case "${1:-}" in
+  "")
+    ;;
+  --status)
+    case "${2:-}" in
+      success | failure) status="$2" ;;
+      *)
+        echo "usage: write-result.sh [--status success|failure]" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    echo "usage: write-result.sh [--status success|failure]" >&2
+    exit 2
+    ;;
+esac
+
+result_path="${CADUCEUS_RESULT_PATH:-/output/worker-result.json}"
+case "$result_path" in
+  /*) ;;
+  *)
+    echo "write-result.sh: CADUCEUS_RESULT_PATH must be absolute: $result_path" >&2
+    exit 1
+    ;;
+esac
+
+dir=$(dirname "$result_path")
+tmp="$result_path.tmp.$$"
+
+cleanup() {
+  rm -f "$tmp"
+}
+trap cleanup EXIT HUP INT TERM
+
+if ! mkdir -p "$dir" 2>/dev/null; then
+  echo "write-result.sh: cannot create result directory: $dir" >&2
+  exit 1
+fi
+
+{
+  printf '{\n'
+  printf '  "status": "%s",\n' "$status"
+  printf '  "summary": "%s",\n' "Reference worker completed with status $status"
+  printf '  "commit_message": "%s",\n' "caduceus-worker-reference: completed with status $status"
+  printf '  "pull_request_title": "%s"\n' "Caduceus reference worker: $status"
+  printf '}\n'
+} > "$tmp" 2>/dev/null || {
+  echo "write-result.sh: cannot write temporary result: $tmp" >&2
+  exit 1
+}
+
+if ! mv -f "$tmp" "$result_path" 2>/dev/null; then
+  echo "write-result.sh: cannot move result into place: $result_path" >&2
+  exit 1
+fi
+
+trap - EXIT HUP INT TERM
+echo "write-result.sh: wrote $result_path"

--- a/tests/architecture/oci_fixture_parity_test.rs
+++ b/tests/architecture/oci_fixture_parity_test.rs
@@ -1,0 +1,159 @@
+//! Fixture-parity contract for the OCI worker reference image.
+//!
+//! Design D6: the reference image
+//! (`plugin-assets/worker-reference-image/`) is a test fixture, a CI
+//! artifact, and an operator example, while OCI tests that need a real
+//! container use the *unrelated* fixture image
+//! (`tests/fixtures/oci-fixture-image/`). This file pins the
+//! separation:
+//!
+//! 1. No test outside the new smoke/parity/independence files
+//!    references the reference image path or image name.
+//! 2. The fixture image stays unrelated: its base is Debian (never the
+//!    reference base, never the reference image itself), and its
+//!    Containerfile never references the reference image path or name.
+//! 3. The reference image never references the fixture image.
+//! 4. `caduceus-env.sh --names-only` matches
+//!    `CANONICAL_ENV_KEYS` (design D3) — the helper mirrors the Rust
+//!    constant.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use caduceus::executor::sandbox_spec::CANONICAL_ENV_KEYS;
+
+const REFERENCE_IMAGE_DIR: &str = "plugin-assets/worker-reference-image";
+const REFERENCE_IMAGE_NAME: &str = "caduceus-worker-reference";
+const FIXTURE_IMAGE_DIR: &str = "tests/fixtures/oci-fixture-image";
+const CADUCEUS_ENV_SCRIPT: &str = "plugin-assets/worker-reference-image/scripts/caduceus-env.sh";
+
+/// The only test files allowed to reference the reference image: the
+/// new smoke, parity, and independence files.
+const ALLOWED_REFERENCE_REFERENCING_TESTS: &[&str] = &[
+    "tests/oci_reference_image_smoke_test.rs",
+    "tests/architecture/oci_fixture_parity_test.rs",
+    "tests/architecture/oci_independence_test.rs",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Recursively list every regular file under *dir*.
+fn walk_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("read_dir {}: {err}", dir.display()))
+        .map(|entry| entry.expect("directory entry").path())
+        .collect();
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            files.extend(walk_files(&path));
+        } else {
+            files.push(path);
+        }
+    }
+    files
+}
+
+#[test]
+fn no_test_outside_the_smoke_parity_independence_files_references_the_reference_image() {
+    let root = repo_root();
+    let mut offenders = Vec::new();
+    for file in walk_files(&root.join("tests")) {
+        // Test sources only; skip generated artifacts (e.g. __pycache__
+        // bytecode) and non-source fixtures such as the fixture image.
+        let is_test_source = matches!(
+            file.extension().and_then(|ext| ext.to_str()),
+            Some("rs") | Some("py")
+        );
+        if !is_test_source {
+            continue;
+        }
+        let rel = file
+            .strip_prefix(&root)
+            .expect("tests path under repo root")
+            .to_string_lossy()
+            .to_string();
+        if ALLOWED_REFERENCE_REFERENCING_TESTS.contains(&rel.as_str()) {
+            continue;
+        }
+        let content = fs::read_to_string(&file)
+            .unwrap_or_else(|err| panic!("read {}: {err}", file.display()));
+        if content.contains(REFERENCE_IMAGE_DIR) {
+            offenders.push(format!("{rel} references the reference image path"));
+        }
+        if content.contains(REFERENCE_IMAGE_NAME) {
+            offenders.push(format!("{rel} references the reference image name"));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "tests outside the smoke/parity/independence files must not reference the reference \
+         image:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn fixture_image_is_unrelated_to_the_reference_image() {
+    let fixture = fs::read_to_string(repo_root().join(FIXTURE_IMAGE_DIR).join("Containerfile"))
+        .expect("read fixture Containerfile");
+    assert!(
+        !fixture.contains(REFERENCE_IMAGE_DIR),
+        "fixture Containerfile must not reference the reference image path"
+    );
+    assert!(
+        !fixture.contains(REFERENCE_IMAGE_NAME),
+        "fixture Containerfile must not reference the reference image name"
+    );
+    assert!(
+        fixture.contains("FROM debian:"),
+        "fixture must stay on a Debian base so it shares no layers with the reference image"
+    );
+    assert!(
+        !fixture.contains("FROM docker.io/library/busybox") && !fixture.contains("FROM busybox"),
+        "fixture must not share the reference image base"
+    );
+}
+
+#[test]
+fn reference_image_never_references_the_fixture_image() {
+    let reference = fs::read_to_string(repo_root().join(REFERENCE_IMAGE_DIR).join("Containerfile"))
+        .expect("read reference Containerfile");
+    assert!(
+        !reference.contains("oci-fixture-image"),
+        "reference Containerfile must not reference the fixture image"
+    );
+}
+
+#[test]
+fn caduceus_env_names_only_matches_canonical_env_keys() {
+    let script = repo_root().join(CADUCEUS_ENV_SCRIPT);
+    let mut command = Command::new("sh");
+    command.arg(&script).arg("--names-only");
+    for name in CANONICAL_ENV_KEYS {
+        command.env(name, "present");
+    }
+    let output = command.output().expect("run caduceus-env.sh --names-only");
+    assert!(
+        output.status.success(),
+        "caduceus-env.sh --names-only failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("names-only output is UTF-8");
+    let actual: BTreeSet<&str> = stdout.lines().collect();
+    let expected: BTreeSet<&str> = CANONICAL_ENV_KEYS.iter().copied().collect();
+    assert_eq!(
+        actual, expected,
+        "caduceus-env.sh --names-only must mirror CANONICAL_ENV_KEYS"
+    );
+    // The names-only mode prints sorted names.
+    let mut sorted: Vec<&str> = CANONICAL_ENV_KEYS.to_vec();
+    sorted.sort_unstable();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines, sorted, "names-only output must be sorted");
+}

--- a/tests/architecture/oci_independence_test.rs
+++ b/tests/architecture/oci_independence_test.rs
@@ -1,0 +1,115 @@
+//! Production independence contract (isolation requirement I11, D6,
+//! D7).
+//!
+//! The production executor (`src/`) must never reference the reference
+//! image name, path, or scripts: the image is a test fixture and
+//! operator example, not a production dependency. A future Doctor may
+//! optionally run the image as an isolated canary subject; this test
+//! keeps `src/` free of any dependency so the canary can never become
+//! an executor dependency. The image itself stays self-contained and
+//! stateless (no declared volumes), so running it cannot affect
+//! production state.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const REFERENCE_IMAGE_DIR: &str = "plugin-assets/worker-reference-image";
+
+/// Substrings that must never appear in `src/`: the image name, the
+/// image path, and the fixed script paths the image ships.
+const FORBIDDEN_IN_SRC: &[&str] = &[
+    "worker-reference-image",
+    "caduceus-worker-reference",
+    "caduceus-env.sh",
+    "write-result.sh",
+    "worker-probe",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Recursively list every Rust source file under *dir*.
+fn walk_rs_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("read_dir {}: {err}", dir.display()))
+        .map(|entry| entry.expect("directory entry").path())
+        .collect();
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            files.extend(walk_rs_files(&path));
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+    files
+}
+
+/// Recursively list every file under *dir*.
+fn walk_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("read_dir {}: {err}", dir.display()))
+        .map(|entry| entry.expect("directory entry").path())
+        .collect();
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            files.extend(walk_files(&path));
+        } else {
+            files.push(path);
+        }
+    }
+    files
+}
+
+#[test]
+fn src_never_references_the_reference_image() {
+    let root = repo_root();
+    let mut offenders = Vec::new();
+    for file in walk_rs_files(&root.join("src")) {
+        let rel = file
+            .strip_prefix(&root)
+            .expect("src path under repo root")
+            .to_string_lossy()
+            .to_string();
+        let content = fs::read_to_string(&file)
+            .unwrap_or_else(|err| panic!("read {}: {err}", file.display()));
+        for needle in FORBIDDEN_IN_SRC {
+            if content.contains(needle) {
+                offenders.push(format!("{rel} contains `{needle}`"));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "src/ must not reference the reference image name, path, or scripts:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn reference_image_is_self_contained_and_stateless() {
+    let reference = fs::read_to_string(repo_root().join(REFERENCE_IMAGE_DIR).join("Containerfile"))
+        .expect("read reference Containerfile");
+    assert!(
+        !reference.contains("VOLUME"),
+        "the reference image must stay stateless (no VOLUME) so a Doctor can run it as an \
+         isolated canary without affecting production state"
+    );
+    // The image only touches the sandboxed surfaces; no production path
+    // or state directory is referenced anywhere in the image sources.
+    for file in walk_files(&repo_root().join(REFERENCE_IMAGE_DIR)) {
+        let content = fs::read_to_string(&file)
+            .unwrap_or_else(|err| panic!("read {}: {err}", file.display()));
+        for needle in ["/var/lib", "state_dir", "oci-runs"] {
+            assert!(
+                !content.contains(needle),
+                "{} must not reference production state paths (`{needle}`)",
+                file.display()
+            );
+        }
+    }
+}

--- a/tests/fixtures/oci-fixture-image/Containerfile
+++ b/tests/fixtures/oci-fixture-image/Containerfile
@@ -1,0 +1,15 @@
+# Unrelated fixture image for OCI tests that need a real container.
+#
+# Deliberately NOT the Caduceus reference worker image (D6): the base
+# here is Debian slim, so this fixture shares no layers with the
+# minimal static-base reference image and never imports it. Tests that
+# need a real container should build this image locally and pass its
+# digest to the live-test override (e.g. CADUCEUS_LIVE_TEST_IMAGE) —
+# never the reference image. The fixture-parity test
+# (tests/architecture/oci_fixture_parity_test.rs) enforces this
+# separation.
+FROM debian:bookworm-slim
+
+# Marker file so the fixture is distinguishable from the reference
+# image during inspection and in tests.
+COPY fixture-marker.txt /fixture-marker.txt

--- a/tests/fixtures/oci-fixture-image/fixture-marker.txt
+++ b/tests/fixtures/oci-fixture-image/fixture-marker.txt
@@ -1,0 +1,1 @@
+oci-test-fixture-image

--- a/tests/oci_reference_image_smoke_test.rs
+++ b/tests/oci_reference_image_smoke_test.rs
@@ -1,0 +1,572 @@
+//! Contract smoke tests for the locally built reference worker image
+//! (task 7.1; spec WR-2/WR-3/WR-4).
+//!
+//! Builds `plugin-assets/worker-reference-image` with `docker build
+//! --pull` once and runs the contract scenarios against the image: the
+//! canonical-env helper, the result writer (honoring
+//! `CADUCEUS_RESULT_PATH`, the default path, `--status failure`, and
+//! unwritable targets), every certification probe, and the arbitrary
+//! `--entrypoint` argv contract.
+//!
+//! The test skips with a printed notice when Docker is unavailable, so
+//! hosts without a daemon still run the rest of the suite. Set
+//! `CADUCEUS_SKIP_OCI_SMOKE=1` to skip explicitly (same pattern as
+//! `CADUCEUS_SKIP_LIFECYCLE`).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use caduceus::executor::sandbox_spec::CANONICAL_ENV_KEYS;
+use caduceus::github::issue::IssueKey;
+use caduceus::worker::parse_result_file;
+use tempfile::TempDir;
+
+const IMAGE_TAG: &str = "caduceus-worker-reference:smoke-test";
+const CONTAINERFILE_DIR: &str = "plugin-assets/worker-reference-image";
+
+/// Canonical environment every container run below receives, mirroring
+/// what the OCI executor injects (`CANONICAL_ENV_KEYS`).
+const CANONICAL_ENV: &[(&str, &str)] = &[
+    ("CADUCEUS_RUN_ID", "smoke-run"),
+    ("CADUCEUS_ISSUE_ID", "smoke-issue"),
+    ("CADUCEUS_ISSUE_NUMBER", "1"),
+    ("CADUCEUS_ISSUE_REPO", "owner/repo"),
+    ("CADUCEUS_ISSUE_TITLE", "Smoke title"),
+    ("CADUCEUS_ISSUE_BODY", "Smoke body"),
+    ("CADUCEUS_ISSUE_LABELS_JSON", "[\"smoke\"]"),
+    ("CADUCEUS_CONTEXT_JSON", "{}"),
+    ("CADUCEUS_BRANCH_NAME", "main"),
+    ("CADUCEUS_WORKTREE_PATH", "/workspace"),
+    ("CADUCEUS_RESULT_PATH", "/output/worker-result.json"),
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn skip_reason() -> Option<&'static str> {
+    if std::env::var("CADUCEUS_SKIP_OCI_SMOKE").as_deref() == Ok("1") {
+        return Some("CADUCEUS_SKIP_OCI_SMOKE=1");
+    }
+    let info = Command::new("docker").arg("info").output();
+    match info {
+        Ok(output) if output.status.success() => None,
+        _ => Some("docker daemon is unavailable"),
+    }
+}
+
+fn docker(args: &[&str]) -> Output {
+    Command::new("docker")
+        .args(args)
+        .output()
+        .expect("run docker")
+}
+
+/// Assert the docker invocation succeeded; on failure print the full
+/// stdout/stderr for diagnosis.
+fn assert_ok(output: &Output, what: &str) {
+    assert!(
+        output.status.success(),
+        "{what} failed\nstatus: {}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Assert the docker invocation failed (non-zero container exit).
+fn assert_failed(output: &Output, what: &str) {
+    assert!(
+        !output.status.success(),
+        "{what} must fail but exited successfully:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("container stdout is UTF-8")
+}
+
+/// Base `docker run` args modeling the executor sandbox: read-only
+/// rootfs, bounded /tmp tmpfs, /workspace and /output bind mounts, and
+/// (for the restricted runs) no network.
+fn run_args(workspace: &Path, output: &Path, network: Option<&str>) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "run".into(),
+        "--rm".into(),
+        "--read-only".into(),
+        "--tmpfs".into(),
+        "/tmp:size=64m".into(),
+    ];
+    if let Some(mode) = network {
+        args.push("--network".into());
+        args.push(mode.into());
+    }
+    args.push("-v".into());
+    args.push(format!("{}:/workspace:rw", workspace.display()));
+    args.push("-v".into());
+    args.push(format!("{}:/output:rw", output.display()));
+    args
+}
+
+/// Build the reference image once for the whole smoke run.
+fn build_image() {
+    let context = repo_root().join(CONTAINERFILE_DIR);
+    let output = docker(&[
+        "build",
+        "--pull",
+        "-f",
+        &context.join("Containerfile").to_string_lossy(),
+        "-t",
+        IMAGE_TAG,
+        &context.to_string_lossy(),
+    ]);
+    assert_ok(&output, "docker build of the reference image");
+}
+
+#[test]
+fn reference_image_contract_smoke() {
+    if let Some(reason) = skip_reason() {
+        println!("skipped: {reason}");
+        return;
+    }
+
+    build_image();
+
+    let ws = TempDir::new().expect("workspace tempdir");
+    let out = TempDir::new().expect("output tempdir");
+
+    // ------------------------------------------------------------------
+    // WR-2: contract helper reads the canonical CADUCEUS_* environment.
+    // ------------------------------------------------------------------
+    let names = run_container(
+        ws.path(),
+        out.path(),
+        None,
+        &["/usr/local/bin/caduceus-env.sh", "--names-only"],
+    );
+    assert_ok(&names, "caduceus-env.sh --names-only");
+    let names_out = stdout(&names);
+    let actual: BTreeSet<&str> = names_out.lines().collect();
+    let expected: BTreeSet<&str> = CANONICAL_ENV_KEYS.iter().copied().collect();
+    assert_eq!(
+        actual, expected,
+        "--names-only must mirror CANONICAL_ENV_KEYS"
+    );
+    let mut sorted: Vec<&str> = CANONICAL_ENV_KEYS.to_vec();
+    sorted.sort_unstable();
+    assert_eq!(
+        names_out.lines().collect::<Vec<_>>(),
+        sorted,
+        "--names-only output must be sorted"
+    );
+
+    let pairs = run_container(
+        ws.path(),
+        out.path(),
+        None,
+        &["/usr/local/bin/caduceus-env.sh"],
+    );
+    assert_ok(&pairs, "caduceus-env.sh");
+    let pairs_out = stdout(&pairs);
+    let pair_lines: BTreeSet<&str> = pairs_out.lines().collect();
+    assert_eq!(pair_lines.len(), CANONICAL_ENV_KEYS.len());
+    assert!(pair_lines.contains("CADUCEUS_RUN_ID=smoke-run"));
+
+    // A multi-line CADUCEUS_ISSUE_BODY (legitimate in real worker
+    // runs, see src/worker/worker_contract.rs) must still print one
+    // `NAME=VALUE` line per canonical variable, with the body's
+    // newlines collapsed onto its own line.
+    let multi_body = "First body line\nSecond body line\nThird body line";
+    let multi = run_container_with_body(ws.path(), out.path(), multi_body);
+    assert_ok(&multi, "caduceus-env.sh with a multi-line issue body");
+    let multi_out = stdout(&multi);
+    let multi_lines: Vec<&str> = multi_out.lines().collect();
+    assert_eq!(
+        multi_lines.len(),
+        CANONICAL_ENV_KEYS.len(),
+        "one output line per canonical variable despite a multi-line \
+         body:\n{multi_out}"
+    );
+    let keys: BTreeSet<&str> = multi_lines
+        .iter()
+        .map(|line| line.split('=').next().expect("NAME=VALUE line"))
+        .collect();
+    let expected_keys: BTreeSet<&str> = CANONICAL_ENV_KEYS.iter().copied().collect();
+    assert_eq!(
+        keys, expected_keys,
+        "every canonical key appears exactly once:\n{multi_out}"
+    );
+    assert!(
+        multi_lines
+            .contains(&"CADUCEUS_ISSUE_BODY=First body line Second body line Third body line"),
+        "multi-line body collapsed onto its own line:\n{multi_out}"
+    );
+
+    // A missing canonical variable must exit non-zero and name it.
+    let missing = run_container_missing_var(ws.path(), out.path());
+    assert_failed(&missing, "caduceus-env.sh with a missing variable");
+    let stderr = String::from_utf8_lossy(&missing.stderr);
+    assert!(
+        stderr.contains("CADUCEUS_RESULT_PATH"),
+        "missing-variable diagnostic must name the missing variable: {stderr}"
+    );
+
+    // ------------------------------------------------------------------
+    // WR-3: result writer honors CADUCEUS_RESULT_PATH with a
+    // schema-valid document (validated by the daemon's own parser).
+    // ------------------------------------------------------------------
+    let issue = IssueKey::parse("owner/repo#1").expect("valid issue key");
+
+    let write = run_container(
+        ws.path(),
+        out.path(),
+        None,
+        &["/usr/local/bin/write-result.sh"],
+    );
+    assert_ok(&write, "write-result.sh honoring CADUCEUS_RESULT_PATH");
+    let result_path = out.path().join("worker-result.json");
+    assert!(
+        result_path.exists(),
+        "result document written to CADUCEUS_RESULT_PATH"
+    );
+    let parsed = parse_result_file(&result_path, &issue).expect("schema-valid success document");
+    assert_eq!(parsed.status, caduceus::worker::WorkerStatus::Success);
+    assert!(!parsed.summary.is_empty());
+    assert!(!parsed.commit_message.is_empty());
+    assert!(!parsed.pull_request_title.is_empty());
+
+    // Default result path: CADUCEUS_RESULT_PATH unset ->
+    // /output/worker-result.json.
+    std::fs::remove_file(&result_path).expect("remove honored-path result");
+    let default_write = run_container_default_path(ws.path(), out.path());
+    assert_ok(&default_write, "write-result.sh default path");
+    assert!(
+        result_path.exists(),
+        "default path written to /output/worker-result.json"
+    );
+    let parsed =
+        parse_result_file(&result_path, &issue).expect("default-path document schema-valid");
+    assert_eq!(parsed.status, caduceus::worker::WorkerStatus::Success);
+
+    // --status failure stays schema-valid.
+    let failure_write = run_container(
+        ws.path(),
+        out.path(),
+        None,
+        &["/usr/local/bin/write-result.sh", "--status", "failure"],
+    );
+    assert_ok(&failure_write, "write-result.sh --status failure");
+    let parsed = parse_result_file(&result_path, &issue).expect("failure document schema-valid");
+    assert_eq!(parsed.status, caduceus::worker::WorkerStatus::Failure);
+
+    // Unwritable target: non-zero exit, no partial file.
+    let ro = TempDir::new().expect("read-only output tempdir");
+    let ro_write = run_container_with_result_path(
+        ws.path(),
+        ro.path(),
+        None,
+        &["/usr/local/bin/write-result.sh"],
+        "/output/worker-result.json",
+        ReadOnlyOutput::Yes,
+    );
+    assert_failed(&ro_write, "write-result.sh on an unwritable target");
+    let leftovers: Vec<_> = std::fs::read_dir(ro.path())
+        .expect("read read-only output dir")
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "no partial file may remain on a failed write: {leftovers:?}"
+    );
+
+    // ------------------------------------------------------------------
+    // WR-4: certification probes.
+    // ------------------------------------------------------------------
+    std::fs::write(ws.path().join("sentinel.txt"), "smoke-sentinel-42\n").expect("write sentinel");
+
+    // Restricted sandbox (network none) — every probe passes.
+    let sentinel = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/worker-probe", "sentinel-read"],
+    );
+    assert_ok(&sentinel, "sentinel-read");
+    assert!(
+        stdout(&sentinel).contains("PASS sentinel-read:")
+            && stdout(&sentinel).contains("smoke-sentinel-42"),
+        "sentinel-read single-line pass report: {}",
+        stdout(&sentinel)
+    );
+
+    let mount = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/worker-probe", "mount-probe"],
+    );
+    assert_ok(&mount, "mount-probe");
+    assert!(
+        stdout(&mount).contains("PASS mount-probe:"),
+        "mount-probe pass report: {}",
+        stdout(&mount)
+    );
+
+    let hog = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/worker-probe", "resource-hog", "1", "1024"],
+    );
+    assert_ok(&hog, "resource-hog");
+    assert!(
+        stdout(&hog).contains("PASS resource-hog:"),
+        "resource-hog pass report: {}",
+        stdout(&hog)
+    );
+
+    let net_none = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/worker-probe", "network-probe", "none"],
+    );
+    assert_ok(&net_none, "network-probe none");
+    assert!(
+        stdout(&net_none).contains("PASS network-probe: mode=none"),
+        "network-probe none pass report: {}",
+        stdout(&net_none)
+    );
+
+    // Default network — auto reports reachability either way.
+    let net_auto = run_container(
+        ws.path(),
+        out.path(),
+        None,
+        &["/usr/local/bin/worker-probe", "network-probe", "auto"],
+    );
+    assert_ok(&net_auto, "network-probe auto");
+    assert!(
+        stdout(&net_auto).contains("PASS network-probe: mode=auto"),
+        "network-probe auto pass report: {}",
+        stdout(&net_auto)
+    );
+
+    // Arbitrary --entrypoint argv replaces the image default command.
+    let entrypoint = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/sh",
+            IMAGE_TAG,
+            "-c",
+            "echo arbitrary-argv-ok",
+        ])
+        .output()
+        .expect("run arbitrary entrypoint");
+    assert_ok(&entrypoint, "arbitrary --entrypoint argv");
+    assert_eq!(stdout(&entrypoint).trim(), "arbitrary-argv-ok");
+
+    // Probes stay reachable at fixed paths without the dispatcher.
+    let direct = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/probes/sentinel-read.sh"],
+    );
+    assert_ok(&direct, "sentinel-read at its fixed path");
+
+    // Probe failure paths exit non-zero with a diagnostic.
+    std::fs::remove_file(ws.path().join("sentinel.txt")).expect("remove sentinel");
+    let sentinel_missing = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/worker-probe", "sentinel-read"],
+    );
+    assert_failed(&sentinel_missing, "sentinel-read with no sentinel");
+    assert!(
+        String::from_utf8_lossy(&sentinel_missing.stderr).contains("not found"),
+        "sentinel-read diagnostic: {}",
+        String::from_utf8_lossy(&sentinel_missing.stderr)
+    );
+
+    let net_unrestricted_under_none = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &[
+            "/usr/local/bin/worker-probe",
+            "network-probe",
+            "unrestricted",
+        ],
+    );
+    assert_failed(
+        &net_unrestricted_under_none,
+        "network-probe unrestricted under network none",
+    );
+
+    let hog_over_bound = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/worker-probe", "resource-hog", "999", "1"],
+    );
+    assert_failed(&hog_over_bound, "resource-hog beyond its cpu bound");
+    assert!(
+        String::from_utf8_lossy(&hog_over_bound.stderr).contains("bound"),
+        "resource-hog bound diagnostic: {}",
+        String::from_utf8_lossy(&hog_over_bound.stderr)
+    );
+
+    let unknown_probe = run_container(
+        ws.path(),
+        out.path(),
+        Some("none"),
+        &["/usr/local/bin/worker-probe", "frobnicate"],
+    );
+    assert_failed(&unknown_probe, "worker-probe with an unknown subcommand");
+}
+
+// ---------------------------------------------------------------------------
+// Container run helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum ReadOnlyOutput {
+    No,
+    Yes,
+}
+
+/// `-e NAME=VALUE` args for the canonical environment, with
+/// CADUCEUS_RESULT_PATH set to *result_path* (default the canonical
+/// `/output/worker-result.json`).
+fn canonical_env_args(result_path: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    for (name, value) in CANONICAL_ENV {
+        args.push("-e".to_string());
+        if *name == "CADUCEUS_RESULT_PATH" {
+            args.push(format!("{name}={result_path}"));
+        } else {
+            args.push(format!("{name}={value}"));
+        }
+    }
+    args
+}
+
+/// `-e NAME=VALUE` args for every canonical variable except
+/// CADUCEUS_RESULT_PATH (missing-variable and default-path scenarios).
+fn canonical_env_args_without_result_path() -> Vec<String> {
+    let mut args = Vec::new();
+    for (name, value) in CANONICAL_ENV {
+        if *name == "CADUCEUS_RESULT_PATH" {
+            continue;
+        }
+        args.push("-e".to_string());
+        args.push(format!("{name}={value}"));
+    }
+    args
+}
+
+/// `-e NAME=VALUE` args for every canonical variable, with
+/// CADUCEUS_ISSUE_BODY replaced by *body* (and CADUCEUS_RESULT_PATH
+/// set to *result_path*, default the canonical
+/// `/output/worker-result.json`).
+fn canonical_env_args_with_body(result_path: &str, body: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    for (name, value) in CANONICAL_ENV {
+        args.push("-e".to_string());
+        let value = if *name == "CADUCEUS_ISSUE_BODY" {
+            body
+        } else if *name == "CADUCEUS_RESULT_PATH" {
+            result_path
+        } else {
+            value
+        };
+        args.push(format!("{name}={value}"));
+    }
+    args
+}
+
+/// Run caduceus-env.sh (full mode) with a custom issue body.
+fn run_container_with_body(workspace: &Path, output: &Path, body: &str) -> Output {
+    let mut cmd = Command::new("docker");
+    cmd.args(run_args(workspace, output, None));
+    cmd.args(canonical_env_args_with_body(
+        "/output/worker-result.json",
+        body,
+    ));
+    cmd.arg(IMAGE_TAG).args(["/usr/local/bin/caduceus-env.sh"]);
+    cmd.output().expect("run multi-line-body caduceus-env")
+}
+
+fn run_container(workspace: &Path, output: &Path, network: Option<&str>, argv: &[&str]) -> Output {
+    run_container_inner(workspace, output, network, argv, None, ReadOnlyOutput::No)
+}
+
+fn run_container_default_path(workspace: &Path, output: &Path) -> Output {
+    // Same as run_container but with CADUCEUS_RESULT_PATH unset.
+    let mut cmd = Command::new("docker");
+    cmd.args(run_args(workspace, output, None));
+    cmd.args(canonical_env_args_without_result_path());
+    cmd.arg(IMAGE_TAG).args(["/usr/local/bin/write-result.sh"]);
+    cmd.output().expect("run default-path write-result")
+}
+
+fn run_container_missing_var(workspace: &Path, output: &Path) -> Output {
+    // Every canonical variable except CADUCEUS_RESULT_PATH.
+    let mut cmd = Command::new("docker");
+    cmd.args(run_args(workspace, output, None));
+    cmd.args(canonical_env_args_without_result_path());
+    cmd.arg(IMAGE_TAG).args(["/usr/local/bin/caduceus-env.sh"]);
+    cmd.output().expect("run missing-var caduceus-env")
+}
+
+fn run_container_with_result_path(
+    workspace: &Path,
+    output: &Path,
+    network: Option<&str>,
+    argv: &[&str],
+    result_path: &str,
+    read_only_output: ReadOnlyOutput,
+) -> Output {
+    run_container_inner(
+        workspace,
+        output,
+        network,
+        argv,
+        Some(result_path),
+        read_only_output,
+    )
+}
+
+fn run_container_inner(
+    workspace: &Path,
+    output: &Path,
+    network: Option<&str>,
+    argv: &[&str],
+    result_path: Option<&str>,
+    read_only_output: ReadOnlyOutput,
+) -> Output {
+    let mut args = run_args(workspace, output, network);
+    if matches!(read_only_output, ReadOnlyOutput::Yes) {
+        // Rebuild the /output mount as read-only for the unwritable
+        // target scenario; run_args used `:rw`.
+        let index = args
+            .iter()
+            .position(|arg| arg == &format!("{}:/output:rw", output.display()))
+            .expect("/output mount present");
+        args[index] = format!("{}:/output:ro", output.display());
+    }
+    args.extend(canonical_env_args(
+        result_path.unwrap_or("/output/worker-result.json"),
+    ));
+    let mut cmd = Command::new("docker");
+    cmd.args(&args);
+    cmd.arg(IMAGE_TAG);
+    cmd.args(argv);
+    cmd.output().expect("run container")
+}


### PR DESCRIPTION
markdown summarizing minimal caduceus-worker-reference image: plugin-assets/worker-reference-image/ with pinned busybox:1.36.1 digest, contract helper caduceus-env.sh (names-only + single-line collapse fix for multi-line issue_body), result writer write-result.sh honoring CADUCEUS_RESULT_PATH default /output/worker-result.json atomic, 4 probes sentinel-read/mount-probe/resource-hog/network-probe via worker-probe dispatcher, arbitrary --entrypoint argv, CI local-build-only oci-reference-image job with contract smoke, release-worker-image.yml tag-triggered GHCR publication digest-pinned with provenance, unrelated fixture image tests/fixtures/oci-fixture-image (debian-slim, no shared layers), fixture-parity/independence tests, README updates, all 1717 cargo tests pass, smoke handles multi-line bodies. Production executor has zero dependency. Be specific but no tool names leak.

Closes #250

Artifacts (4):

```json
{
  "ci_job": "oci-reference-image",
  "image": "plugin-assets/worker-reference-image",
  "release_workflow": ".github/workflows/release-worker-image.yml",
  "spec_change": "2026-08-30-build-oci-worker-reference-image"
}
```

<!-- caduceus-pr-body:run=01M1A0RKJ0472K4XVZDTEZ1JVK -->