### PR TITLE
feat(oci): add live readiness doctor checks (#251)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -644,6 +644,10 @@ name = "oci_independence_test"
 path = "tests/architecture/oci_independence_test.rs"
 
 [[test]]
+name = "readiness_test"
+path = "tests/readiness_test.rs"
+
+[[test]]
 name = "awaiting_review_test"
 path = "tests/daemon/awaiting_review_test.rs"
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,60 @@ never publicly released. The verbatim removal list lives
 on the
 [configuration wiki page](https://github.com/barkley-assistant/caduceus/wiki/Configuration).
 
+### OCI readiness and `caduceus doctor`
+
+OCI dispatch runs the readiness checks live at the dispatch boundary. A stored
+doctor report is never used to authorize a worker. The checks cover the Linux
+platform, engine reachability and mode, namespace mapping, cgroup `cpu`,
+`memory`, and `pids` controllers, configured storage and disk reserve, the
+digest-pinned operator image, network representability, and the engine's basic
+sandbox primitives.
+
+The image check performs the configured pull-policy action, inspects the
+result, and verifies both the requested repository digest and the host
+architecture. A successful dispatch reuses those verified image facts rather
+than pulling or inspecting the image a second time. The executor writes the
+facts and timing data to `<state_dir>/oci-runs/<run_id>/provenance.log`.
+
+The readiness filesystem policy is intentionally tiered: the repository
+storage root must be a daemon-owned, non-symlink directory with mode `0700`;
+the state and worktree roots must be daemon-owned, non-symlink directories
+with no group/other write permission. All three roots are checked before
+dispatch.
+
+Run the same checks manually:
+
+```sh
+caduceus doctor
+caduceus doctor --json
+```
+
+The mandatory verdict is `READY` only when every mandatory check passes. Any
+failure produces `UNAVAILABLE` with a remediation message, and OCI dispatch
+refuses with a typed infrastructure error. `caduceus doctor --json` keeps the
+mandatory `checks` and optional `diagnostic_canary` results in separate fields.
+
+The canary is opt-in and diagnostic only. It never changes the mandatory
+verdict and never runs the configured production `worker_command`. Supply a
+digest-pinned canary image and its benign contract command explicitly:
+
+```sh
+caduceus doctor \
+  --canary-image 'registry.example/reference@sha256:<64 lowercase hex>' \
+  --canary-command /path/to/contract-command
+```
+
+The image may also be supplied through `CADUCEUS_DOCTOR_CANARY_IMAGE` and the
+command through `CADUCEUS_DOCTOR_CANARY_COMMAND`. If either is absent, the
+canary is reported as `SKIP`; if it cannot be pulled, started, or produce a
+valid result artifact, it is reported as `FAILURE`. Neither case makes an
+otherwise-ready production sandbox unavailable. The last report is written to
+`<state_dir>/doctor.json` for informational status display only.
+
+This binary command is separate from the Hermes plugin's
+`hermes caduceus doctor`, which checks plugin installation and provider
+configuration.
+
 What the worker container sees is a closed, typed spec:
 
 - **An exactly-specified environment.** The container receives the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,8 +13,11 @@ use clap::{Parser, Subcommand};
 
 use caduceus::config::{Config, SetupAction};
 use caduceus::error::{CaduceusError, CaduceusResult};
+use caduceus::executor::oci::OciExecutor;
+use caduceus::executor::{Executor, ExecutorSpec};
 use caduceus::issue::IssueKey;
 use caduceus::queue::StateStore;
+use caduceus::readiness::{self, DiagnosticCanary, DiagnosticStatus, ReadinessVerdict};
 use caduceus::DaemonLock;
 
 static GIT_AUTHOR_WARNED: AtomicBool = AtomicBool::new(false);
@@ -47,6 +50,21 @@ pub enum Command {
         /// Print machine-readable JSON instead of the human summary.
         #[arg(long)]
         json: bool,
+    },
+    /// Check live OCI production readiness.
+    Doctor {
+        /// Print machine-readable JSON instead of the human summary.
+        #[arg(long)]
+        json: bool,
+        /// Do not run the optional diagnostic canary.
+        #[arg(long)]
+        skip_canary: bool,
+        /// Digest-pinned image to use for the optional diagnostic canary.
+        #[arg(long)]
+        canary_image: Option<String>,
+        /// Command argv to use for the optional diagnostic canary.
+        #[arg(long, num_args = 1..)]
+        canary_command: Vec<String>,
     },
     /// Garbage-collect stale worktrees.
     WorktreeGc {
@@ -206,6 +224,12 @@ pub fn run() -> CaduceusResult<()> {
             }
             Ok(())
         }
+        Some(Command::Doctor {
+            json,
+            skip_canary,
+            canary_image,
+            canary_command,
+        }) => run_doctor(json, skip_canary, canary_image, canary_command),
         Some(Command::MigrateState {
             from,
             dry_run,
@@ -249,6 +273,179 @@ pub fn run() -> CaduceusResult<()> {
         // is being built.
         _ => Ok(()),
     }
+}
+
+fn run_doctor(
+    json: bool,
+    skip_canary: bool,
+    canary_image: Option<String>,
+    canary_command: Vec<String>,
+) -> CaduceusResult<()> {
+    let config = match std::env::var_os("CADUCEUS_CONFIG") {
+        Some(path) => Config::load_from(std::path::Path::new(&path))?,
+        None => Config::load()?,
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| CaduceusError::Other(format!("build doctor runtime: {err}")))?;
+    let mut report = runtime.block_on(readiness::run_live(&config));
+    if !skip_canary {
+        let image = canary_image.or_else(|| std::env::var("CADUCEUS_DOCTOR_CANARY_IMAGE").ok());
+        let command = if canary_command.is_empty() {
+            std::env::var("CADUCEUS_DOCTOR_CANARY_COMMAND")
+                .ok()
+                .map(|value| value.split_whitespace().map(str::to_string).collect())
+                .unwrap_or_default()
+        } else {
+            canary_command
+        };
+        let canary = runtime.block_on(run_canary(&config, &report, image, command));
+        report.diagnostic_canary = Some(canary);
+    } else {
+        report.diagnostic_canary = Some(DiagnosticCanary {
+            status: DiagnosticStatus::Skip,
+            detail: "disabled by --skip-canary".to_string(),
+        });
+    }
+    if let Err(err) = readiness::write_informational_report(&config.state_dir, &report) {
+        eprintln!("caduceus doctor: could not write informational report: {err}");
+    }
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", readiness::render_human(&report));
+    }
+    if report.verdict == ReadinessVerdict::Unavailable {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn run_canary(
+    config: &Config,
+    report: &caduceus::readiness::ReadinessReport,
+    image: Option<String>,
+    command: Vec<String>,
+) -> DiagnosticCanary {
+    let Some(image) = image else {
+        return DiagnosticCanary {
+            status: DiagnosticStatus::Skip,
+            detail:
+                "no canary image configured (use --canary-image or CADUCEUS_DOCTOR_CANARY_IMAGE)"
+                    .to_string(),
+        };
+    };
+    if command.is_empty() {
+        return DiagnosticCanary {
+            status: DiagnosticStatus::Skip,
+            detail: "no canary command configured (use --canary-command or CADUCEUS_DOCTOR_CANARY_COMMAND)".to_string(),
+        };
+    }
+    if report.verdict != ReadinessVerdict::Ready {
+        return DiagnosticCanary {
+            status: DiagnosticStatus::Skip,
+            detail: "mandatory readiness is unavailable; canary was not attempted".to_string(),
+        };
+    }
+    let Some(sandbox) = config.sandbox.as_ref() else {
+        return DiagnosticCanary {
+            status: DiagnosticStatus::Skip,
+            detail: "OCI sandbox is not configured".to_string(),
+        };
+    };
+    let mut canary_config = config.clone();
+    let mut canary_sandbox = sandbox.clone();
+    canary_sandbox.image = image;
+    canary_sandbox.pull_policy = caduceus::config::OciPullPolicy::IfMissing;
+    canary_config.sandbox = Some(canary_sandbox);
+
+    let run_id = format!("doctor-canary-{}", uuid::Uuid::new_v4().simple());
+    let canary_root = std::env::temp_dir().join(&run_id);
+    canary_config.state_dir = canary_root.join("state");
+    canary_config.repo_storage_root = canary_root.join("repos");
+    canary_config.workdir_base = canary_root.join("workdirs");
+    canary_config.log_path = canary_root.join("doctor-canary.log");
+    let canary_paths = [
+        canary_config.state_dir.clone(),
+        canary_config.repo_storage_root.clone(),
+        canary_config.workdir_base.clone(),
+    ];
+    if let Err(err) = canary_paths.iter().try_for_each(std::fs::create_dir_all) {
+        return DiagnosticCanary {
+            status: DiagnosticStatus::Failure,
+            detail: format!("cannot create canary storage: {err}"),
+        };
+    }
+    #[cfg(unix)]
+    for path in &canary_paths {
+        if let Err(err) =
+            std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(0o700))
+        {
+            let _ = std::fs::remove_dir_all(&canary_root);
+            return DiagnosticCanary {
+                status: DiagnosticStatus::Failure,
+                detail: format!("cannot secure canary storage: {err}"),
+            };
+        }
+    }
+    let worktree = canary_config.workdir_base.join(&run_id);
+    if let Err(err) = std::fs::create_dir_all(&worktree) {
+        let _ = std::fs::remove_dir_all(&canary_root);
+        return DiagnosticCanary {
+            status: DiagnosticStatus::Failure,
+            detail: format!("cannot create canary worktree: {err}"),
+        };
+    }
+    let issue = match IssueKey::parse("caduceus/doctor#1") {
+        Ok(issue) => issue,
+        Err(err) => {
+            let _ = std::fs::remove_dir_all(&canary_root);
+            return DiagnosticCanary {
+                status: DiagnosticStatus::Failure,
+                detail: format!("cannot create canary issue key: {err}"),
+            };
+        }
+    };
+    let spec = ExecutorSpec {
+        self_exe: std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("caduceus")),
+        issue,
+        worktree: worktree.clone(),
+        run_id,
+        context_json: "{}".to_string(),
+        worker_command: command,
+        cancellation: tokio_util::sync::CancellationToken::new(),
+        issue_title: "OCI readiness canary".to_string(),
+        issue_body: "Diagnostic only".to_string(),
+        labels: Vec::new(),
+        branch_name: "doctor-canary".to_string(),
+    };
+    let executor = OciExecutor::new(
+        canary_config.clone(),
+        std::sync::Arc::new(caduceus::infra::disk::DiskPressureGuard::from_config(
+            &canary_config,
+        )),
+    );
+    let outcome = executor.run(&spec).await;
+    let result = match outcome {
+        Ok(outcome) => match caduceus::worker::parse_result_file(&outcome.result_path, &spec.issue)
+        {
+            Ok(result) => DiagnosticCanary {
+                status: DiagnosticStatus::Pass,
+                detail: format!("production path completed with {:?} result", result.status),
+            },
+            Err(err) => DiagnosticCanary {
+                status: DiagnosticStatus::Failure,
+                detail: format!("result artifact validation failed: {err}"),
+            },
+        },
+        Err(err) => DiagnosticCanary {
+            status: DiagnosticStatus::Failure,
+            detail: format!("production path failed: {err}"),
+        },
+    };
+    let _ = std::fs::remove_dir_all(canary_root);
+    result
 }
 
 /// `caduceus worktree-gc [--older-than-days N] [--dry-run]` —

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -211,6 +211,7 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         // after the reserve recovers; not worker-attributable
         // (issue #245).
         CaduceusError::OciDiskPressure { .. } => FailureClass::Infrastructure,
+        CaduceusError::OciReadinessUnavailable { .. } => FailureClass::Infrastructure,
         CaduceusError::OciUndeclaredMount { .. } => FailureClass::Worker,
         CaduceusError::OciMountConflict { .. } => FailureClass::Worker,
         CaduceusError::OciSecretLeakSuspected { .. } => FailureClass::Infrastructure,

--- a/src/daemon/status.rs
+++ b/src/daemon/status.rs
@@ -20,6 +20,7 @@ use serde::Serialize;
 
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::readiness::{ReadinessReport, ReadinessVerdict};
 use crate::state::meta::{MetaStore, StateMeta, TickOutcome};
 use crate::state::queue::{Phase, QueueEntry, QueueState, StateStore, TicketType};
 use crate::worker::supervisor::{read_heartbeat_record, Heartbeat};
@@ -75,6 +76,38 @@ pub struct StatusReport {
     pub readiness: Option<BTreeMap<String, String>>,
     /// Pool state: "idle", "active(n)", "saturated", or "draining".
     pub pool_state: Option<String>,
+    /// Last CLI doctor result. Informational only; dispatch never reads it.
+    pub doctor: Option<DoctorStatus>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DoctorStatus {
+    pub verdict: String,
+    pub generated_at: DateTime<Utc>,
+    pub informational: bool,
+    pub failed_checks: Vec<String>,
+}
+
+fn read_doctor_status(state_dir: &Path) -> Option<DoctorStatus> {
+    let bytes = fs::read(state_dir.join("doctor.json")).ok()?;
+    let report: ReadinessReport = serde_json::from_slice(&bytes).ok()?;
+    if report.schema_version != crate::readiness::REPORT_SCHEMA_VERSION {
+        return None;
+    }
+    Some(DoctorStatus {
+        verdict: match report.verdict {
+            ReadinessVerdict::Ready => "READY".to_string(),
+            ReadinessVerdict::Unavailable => "UNAVAILABLE".to_string(),
+        },
+        generated_at: report.generated_at,
+        informational: true,
+        failed_checks: report
+            .checks
+            .iter()
+            .filter(|check| check.status == crate::readiness::CheckStatus::Fail)
+            .map(|check| check.id.to_string())
+            .collect(),
+    })
 }
 
 /// One blocked (refuse-to-operate) entry surfaced by
@@ -118,6 +151,8 @@ pub struct LiveWorker {
 /// Schema version. Bumped when a new field is added so
 /// the `--json` consumer can detect the version.
 ///
+/// 7.7.0 — added the informational `doctor` field.
+///
 /// 7.6.0 — added `blocked_issues` field on
 /// `StatusReport` carrying dedicated `BlockedEntry`
 /// records for queue entries stuck in `NeedsAttention`
@@ -125,7 +160,7 @@ pub struct LiveWorker {
 /// is additive: the section is omitted from the human
 /// output when empty, and the JSON array is always
 /// present (empty array on a healthy state).
-pub const STATUS_SCHEMA_VERSION: &str = "7.6.0";
+pub const STATUS_SCHEMA_VERSION: &str = "7.7.0";
 
 /// Maximum number of recent errors surfaced by
 /// `StatusReport::recent_errors`.
@@ -284,6 +319,7 @@ pub fn build_report(state_dir: &Path) -> CaduceusResult<(StatusReport, Option<St
         state_corrupt,
         readiness: Some(readiness),
         pool_state: None,
+        doctor: read_doctor_status(state_dir),
     };
     Ok((report, None))
 }
@@ -336,6 +372,7 @@ fn empty_report(state_dir: &Path) -> StatusReport {
         state_corrupt: false,
         readiness: None,
         pool_state: None,
+        doctor: read_doctor_status(state_dir),
     }
 }
 
@@ -586,6 +623,13 @@ pub fn render_human(report: &StatusReport, diagnostic: Option<&StatusDiagnostic>
     if let Some(ref pool) = report.pool_state {
         out.push_str(&format!("  pool state: {pool}\n"));
     }
+    if let Some(doctor) = &report.doctor {
+        out.push_str(&format!(
+            "  doctor: {} (informational, generated {})\n",
+            doctor.verdict,
+            doctor.generated_at.to_rfc3339()
+        ));
+    }
     out.push_str("  phases:\n");
     for (label, count) in &report.phases {
         out.push_str(&format!("    {label}: {count}\n"));
@@ -734,6 +778,7 @@ pub fn build_report_from_state(
         state_corrupt: false,
         readiness: None,
         pool_state: None,
+        doctor: read_doctor_status(state_dir),
     }
 }
 

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -26,6 +26,7 @@ use crate::executor::{
 use crate::infra::config::Config;
 use crate::infra::disk::DiskPressureGuard;
 use crate::infra::error::CaduceusResult;
+use crate::readiness;
 use crate::state::meta::MetaStore;
 use crate::state::oci_run::OciRunDao;
 use crate::state::store;
@@ -38,12 +39,31 @@ pub struct OciExecutor {
     /// Host disk-pressure watchdog: refuses new dispatch and
     /// terminates in-flight work on breach (issue #245).
     disk: Arc<DiskPressureGuard>,
+    readiness_options: readiness::ProbeOptions,
 }
 
 impl OciExecutor {
     /// Wrap a config snapshot and the shared disk-pressure guard.
     pub fn new(cfg: Config, disk: Arc<DiskPressureGuard>) -> Self {
-        Self { cfg, disk }
+        Self {
+            cfg,
+            disk,
+            readiness_options: readiness::ProbeOptions::default(),
+        }
+    }
+
+    /// Construct an executor with an explicit readiness probe seam.
+    /// Production callers should use [`Self::new`].
+    pub fn new_with_readiness_options(
+        cfg: Config,
+        disk: Arc<DiskPressureGuard>,
+        readiness_options: readiness::ProbeOptions,
+    ) -> Self {
+        Self {
+            cfg,
+            disk,
+            readiness_options,
+        }
     }
 }
 
@@ -53,14 +73,16 @@ impl Executor for OciExecutor {
         spec: &'a ExecutorSpec,
     ) -> Pin<Box<dyn Future<Output = CaduceusResult<ExecutorOutcome>> + Send + 'a>> {
         Box::pin(async move {
-            // 0. Disk-pressure gate: refuse new OCI dispatch while the
-            //    host watchdog is breached — before the probe, before
-            //    any container can be created (issue #245). TrustedHost
-            //    work is structurally excluded: it never reaches this
-            //    executor.
+            // 0. Disk-pressure gate: refuse new OCI dispatch while the host
+            //    watchdog is breached before any readiness probe or other
+            //    per-run side effect (issue #245).
             self.disk.try_acquire_oci()?;
 
-            // 1. Load and durably establish the installation identity
+            // 1. Live readiness gate: no cached doctor result is consulted.
+            let image_acquisition =
+                readiness::assert_live_with_options(&self.cfg, &self.readiness_options).await?;
+
+            // 2. Load and durably establish the installation identity
             //    before any labels or create argv are rendered.
             let meta = if self.cfg.state_backend == "sqlite" {
                 MetaStore::open_sqlite(&self.cfg.state_dir)?
@@ -69,7 +91,7 @@ impl Executor for OciExecutor {
             };
             let daemon_id = meta.get_or_create_installation_uuid()?;
 
-            // 2. Pre-flight probe: collect the runtime facts (worktree
+            // 3. Pre-flight probe: collect the runtime facts (worktree
             //    owner uid/gid, host `.git` type, engine mode) and
             //    create the daemon-owned host artifacts. Every
             //    unsupported-configuration refusal (typed
@@ -80,17 +102,17 @@ impl Executor for OciExecutor {
                 engine_probe::probe_runtime_facts_with_daemon_id(&self.cfg, spec, &daemon_id)
                     .await?;
 
-            // 3. Resolve the closed typed spec. All host-path,
+            // 4. Resolve the closed typed spec. All host-path,
             //    identity, and mount decisions happen here; the
             //    renderer invents nothing.
             let resolved = sandbox_spec::resolve(self.cfg.sandbox(), &runtime, spec)?;
 
-            // 4. Open the state database.
+            // 5. Open the state database.
             let db_path = self.cfg.state_dir.join(store::DB_FILENAME);
             let conn = store::open(&db_path)?;
             let dao = OciRunDao::new(conn);
 
-            // 5. Write the assembled environment (canonical + compat +
+            // 6. Write the assembled environment (canonical + compat +
             //    resolved `pass_env` from `spec.environment`) to the
             //    daemon-private, randomly named, mode-0600 env file
             //    under `state_dir/oci-runs/<run_id>` (issue #249). Its
@@ -111,23 +133,22 @@ impl Executor for OciExecutor {
                 &[env_file.path().to_path_buf()],
             );
 
-            // 6. Acquire and verify the immutable worker image before the
-            //    lifecycle can insert its Created state or invoke create.
-            //    The run directory is already created by the probe (and
-            //    idempotently re-ensured by the env file), but is passed
-            //    explicitly so provenance remains scoped to this run.
+            // 7. Record the immutable worker image facts acquired by the
+            //    readiness gate before the lifecycle can insert its Created
+            //    state or invoke create. The run directory is already
+            //    created by the probe and keeps provenance scoped to this run.
             let host = oci_platform::host_platform();
-            let _image = oci_image::ensure_image(
+            oci_image::write_acquisition_provenance(
+                &run_dir,
                 engine,
                 resolved.image_ref(),
                 self.cfg.sandbox().pull_policy,
                 &host,
-                &run_dir,
                 &runtime.run_id,
-            )
-            .await?;
+                &image_acquisition,
+            );
 
-            // 6. Run the lifecycle with the rendered argv. The run's
+            // 8. Run the lifecycle with the rendered argv. The run's
             //    lifecycle token is linked with the watchdog token so
             //    a disk-pressure breach terminates in-flight work via
             //    the existing stop path (issue #245).

--- a/src/executor/oci_image.rs
+++ b/src/executor/oci_image.rs
@@ -125,19 +125,39 @@ pub struct ProvenanceError {
     pub detail: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct VerificationRecord {
     pub status: String,
     pub detail: String,
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct ProvenanceTimings {
     pub probe_ms: u64,
     pub pull_ms: u64,
     pub inspect_ms: u64,
     pub verify_ms: u64,
     pub total_ms: u64,
+}
+
+/// Facts collected while acquiring and verifying an image. Readiness passes
+/// these facts to dispatch so the image is not acquired twice.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImageAcquisition {
+    pub image: NormalizedImage,
+    pub pull_attempted: bool,
+    pub cache_hit: bool,
+    pub verification: Option<VerificationRecord>,
+    pub timings: ProvenanceTimings,
+}
+
+struct ImageAttempt {
+    result: CaduceusResult<ImageAcquisition>,
+    local_present: bool,
+    pull_attempted: bool,
+    stage: String,
+    verification: Option<VerificationRecord>,
+    timings: ProvenanceTimings,
 }
 
 /// Ensure the image is pulled, inspected, verified, and audited.
@@ -172,6 +192,67 @@ pub async fn ensure_image_with_adapter(
     run_dir: &Path,
     run_id: &str,
 ) -> CaduceusResult<NormalizedImage> {
+    let ImageAttempt {
+        result,
+        local_present,
+        pull_attempted,
+        stage,
+        verification,
+        timings,
+    } = acquire_image_attempt(&adapter, image_ref, policy, host).await;
+    let success = result.is_ok();
+    let resolved = result.as_ref().ok().map(|acquisition| &acquisition.image);
+    let record = ProvenanceRecord {
+        run_id: run_id.to_string(),
+        engine: engine.binary_name().to_string(),
+        reference: image_ref.to_string(),
+        resolved_id: resolved.map(|image| image.id.clone()),
+        repo_digests: resolved.map(|image| image.repo_digests.clone()),
+        architecture: resolved.map(|image| image.architecture.clone()),
+        variant: resolved.and_then(|image| image.variant.clone()),
+        host_arch: host.architecture.clone(),
+        host_variant: host.variant.clone(),
+        policy: policy_name(policy).to_string(),
+        pull_attempted,
+        cache_hit: local_present && policy != OciPullPolicy::Always,
+        mode: if pull_attempted { "pulled" } else { "local" }.to_string(),
+        stage: if success {
+            "acquired".to_string()
+        } else {
+            stage
+        },
+        outcome: if success { "ok" } else { "aborted" }.to_string(),
+        error: result.as_ref().err().map(|error| ProvenanceError {
+            variant: error_variant(error).to_string(),
+            detail: error.to_string(),
+        }),
+        verification,
+        timings,
+    };
+    write_provenance(run_dir, &record);
+    result.map(|acquisition| acquisition.image)
+}
+
+/// Acquire and verify an image without writing provenance. The readiness
+/// runner uses this once, then the executor records the returned facts after
+/// the per-run directory and run ID exist.
+pub async fn acquire_image_with_adapter(
+    adapter: &OciImageAdapter,
+    image_ref: &str,
+    policy: OciPullPolicy,
+    host: &HostPlatform,
+) -> CaduceusResult<ImageAcquisition> {
+    acquire_image_attempt(adapter, image_ref, policy, host)
+        .await
+        .result
+}
+
+async fn acquire_image_attempt(
+    adapter: &OciImageAdapter,
+    image_ref: &str,
+    policy: OciPullPolicy,
+    host: &HostPlatform,
+) -> ImageAttempt {
     let started = Instant::now();
     let mut stage = "presence_probe".to_string();
     let mut local_present = false;
@@ -232,42 +313,69 @@ pub async fn ensure_image_with_adapter(
             status: "passed".to_string(),
             detail: "digest+arch ok".to_string(),
         });
-        Ok(image)
+        Ok(ImageAcquisition {
+            image,
+            pull_attempted,
+            cache_hit: local_present && policy != OciPullPolicy::Always,
+            verification: verification.clone(),
+            timings: timings.clone(),
+        })
     }
     .await;
 
     timings.total_ms = elapsed_ms(started);
-    let success = result.is_ok();
-    let resolved = if success { result.as_ref().ok() } else { None };
-    let record = ProvenanceRecord {
-        run_id: run_id.to_string(),
-        engine: engine.binary_name().to_string(),
-        reference: image_ref.to_string(),
-        resolved_id: resolved.map(|image| image.id.clone()),
-        repo_digests: resolved.map(|image| image.repo_digests.clone()),
-        architecture: resolved.map(|image| image.architecture.clone()),
-        variant: resolved.and_then(|image| image.variant.clone()),
-        host_arch: host.architecture.clone(),
-        host_variant: host.variant.clone(),
-        policy: policy_name(policy).to_string(),
+    let result = result.map(|mut acquisition| {
+        acquisition.timings = timings.clone();
+        acquisition
+    });
+    ImageAttempt {
+        result,
+        local_present,
         pull_attempted,
-        cache_hit: local_present && policy != OciPullPolicy::Always,
-        mode: if pull_attempted { "pulled" } else { "local" }.to_string(),
-        stage: if success {
-            "acquired".to_string()
-        } else {
-            stage
-        },
-        outcome: if success { "ok" } else { "aborted" }.to_string(),
-        error: result.as_ref().err().map(|error| ProvenanceError {
-            variant: error_variant(error).to_string(),
-            detail: error.to_string(),
-        }),
+        stage,
         verification,
         timings,
-    };
-    write_provenance(run_dir, &record);
-    result
+    }
+}
+
+/// Record a successful acquisition performed by the live readiness gate.
+pub fn write_acquisition_provenance(
+    run_dir: &Path,
+    engine: SandboxEngine,
+    image_ref: &str,
+    policy: OciPullPolicy,
+    host: &HostPlatform,
+    run_id: &str,
+    acquisition: &ImageAcquisition,
+) {
+    let image = &acquisition.image;
+    write_provenance(
+        run_dir,
+        &ProvenanceRecord {
+            run_id: run_id.to_string(),
+            engine: engine.binary_name().to_string(),
+            reference: image_ref.to_string(),
+            resolved_id: Some(image.id.clone()),
+            repo_digests: Some(image.repo_digests.clone()),
+            architecture: Some(image.architecture.clone()),
+            variant: image.variant.clone(),
+            host_arch: host.architecture.clone(),
+            host_variant: host.variant.clone(),
+            policy: policy_name(policy).to_string(),
+            pull_attempted: acquisition.pull_attempted,
+            cache_hit: acquisition.cache_hit,
+            mode: if acquisition.pull_attempted {
+                "pulled".to_string()
+            } else {
+                "local".to_string()
+            },
+            stage: "acquired".to_string(),
+            outcome: "ok".to_string(),
+            error: None,
+            verification: acquisition.verification.clone(),
+            timings: acquisition.timings.clone(),
+        },
+    );
 }
 
 fn write_provenance(run_dir: &Path, record: &ProvenanceRecord) {

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -18,6 +18,14 @@
 use std::fmt;
 use std::path::PathBuf;
 
+/// One live readiness failure included in an OCI dispatch refusal.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReadinessFailure {
+    pub check: String,
+    pub detail: String,
+    pub remediation: String,
+}
+
 /// All Caduceus errors. The variant set is normative; new errors
 /// always go through a `CaduceusError` constructor, never a panic on
 /// external data.
@@ -382,6 +390,13 @@ pub enum CaduceusError {
         reserved_bytes: u64,
     },
 
+    /// OCI dispatch was refused because one or more live readiness checks
+    /// failed. This is always built from current observations.
+    #[error("OCI readiness unavailable: {failed_checks:?}")]
+    OciReadinessUnavailable {
+        failed_checks: Vec<ReadinessFailure>,
+    },
+
     #[error("{0}")]
     Other(String),
 }
@@ -647,6 +662,20 @@ impl fmt::Debug for CaduceusError {
                 free_bytes,
                 reserved_bytes
             ),
+            CaduceusError::OciReadinessUnavailable { failed_checks } => {
+                let failures = failed_checks
+                    .iter()
+                    .map(|failure| {
+                        format!(
+                            "{}: {}; remediation: {}",
+                            failure.check,
+                            scrub(&failure.detail),
+                            scrub(&failure.remediation)
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                format!("OciReadinessUnavailable {{ failed_checks: {failures:?} }}")
+            }
             CaduceusError::Other(s) => format!("Other({})", scrub(s)),
         };
         f.write_str(&rendered)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod executor;
 pub mod finalize;
 pub mod github;
 pub mod infra;
+pub mod readiness;
 pub mod repo;
 pub mod runtime;
 pub mod scheduler;

--- a/src/readiness/mod.rs
+++ b/src/readiness/mod.rs
@@ -1,0 +1,779 @@
+//! Live OCI production-readiness checks.
+//!
+//! Readiness is deliberately an invocation-time observation.  The executor
+//! uses the same check runner as the `doctor` command and never consults the
+//! informational report written by the CLI.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+use crate::executor::oci_engine::OciImageAdapter;
+use crate::executor::oci_image::{self, ImageAcquisition};
+use crate::executor::oci_platform::HostPlatform;
+use crate::executor::sandbox_spec::SandboxEngine;
+use crate::infra::config::{Config, OciPullPolicy, SandboxNetwork};
+use crate::infra::disk;
+use crate::infra::error::{CaduceusError, CaduceusResult, ReadinessFailure};
+
+const CHECK_TIMEOUT: Duration = Duration::from_secs(15);
+pub const REPORT_SCHEMA_VERSION: &str = "1.0.0";
+
+/// Stable identifiers for the mandatory readiness checks.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, Serialize, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckId {
+    Platform,
+    Engine,
+    Mode,
+    Namespace,
+    Resources,
+    Filesystem,
+    Image,
+    Network,
+    Primitives,
+}
+
+impl CheckId {
+    pub const ALL: [Self; 9] = [
+        Self::Platform,
+        Self::Engine,
+        Self::Mode,
+        Self::Namespace,
+        Self::Resources,
+        Self::Filesystem,
+        Self::Image,
+        Self::Network,
+        Self::Primitives,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Platform => "platform",
+            Self::Engine => "engine",
+            Self::Mode => "mode",
+            Self::Namespace => "namespace",
+            Self::Resources => "resources",
+            Self::Filesystem => "filesystem",
+            Self::Image => "image",
+            Self::Network => "network",
+            Self::Primitives => "primitives",
+        }
+    }
+}
+
+impl std::fmt::Display for CheckId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Result of one readiness observation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckStatus {
+    Pass,
+    Fail,
+}
+
+/// One machine-readable readiness finding.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CheckResult {
+    pub id: CheckId,
+    pub status: CheckStatus,
+    pub detail: String,
+    pub remediation: Option<String>,
+}
+
+impl CheckResult {
+    fn pass(id: CheckId, detail: impl Into<String>) -> Self {
+        Self {
+            id,
+            status: CheckStatus::Pass,
+            detail: detail.into(),
+            remediation: None,
+        }
+    }
+
+    fn fail(id: CheckId, detail: impl Into<String>, remediation: impl Into<String>) -> Self {
+        Self {
+            id,
+            status: CheckStatus::Fail,
+            detail: detail.into(),
+            remediation: Some(remediation.into()),
+        }
+    }
+}
+
+/// Overall mandatory readiness verdict.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ReadinessVerdict {
+    Ready,
+    Unavailable,
+}
+
+/// Optional diagnostic result.  It is intentionally not part of the verdict.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum DiagnosticStatus {
+    Pass,
+    Skip,
+    Failure,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DiagnosticCanary {
+    pub status: DiagnosticStatus,
+    pub detail: String,
+}
+
+/// Stable report consumed by people and tooling.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ReadinessReport {
+    pub schema_version: String,
+    pub generated_at: DateTime<Utc>,
+    pub verdict: ReadinessVerdict,
+    pub checks: Vec<CheckResult>,
+    pub diagnostic_canary: Option<DiagnosticCanary>,
+    #[serde(skip)]
+    pub verified_image: Option<ImageAcquisition>,
+}
+
+impl ReadinessReport {
+    pub fn mandatory_failures(&self) -> impl Iterator<Item = &CheckResult> {
+        self.checks
+            .iter()
+            .filter(|check| check.status == CheckStatus::Fail)
+    }
+}
+
+/// Pure verdict assembly.  The diagnostic canary is not an input by design.
+pub fn assemble_report(checks: Vec<CheckResult>) -> ReadinessReport {
+    let verdict = if checks.iter().all(|check| check.status == CheckStatus::Pass) {
+        ReadinessVerdict::Ready
+    } else {
+        ReadinessVerdict::Unavailable
+    };
+    ReadinessReport {
+        schema_version: REPORT_SCHEMA_VERSION.to_string(),
+        generated_at: Utc::now(),
+        verdict,
+        checks,
+        diagnostic_canary: None,
+        verified_image: None,
+    }
+}
+
+/// Test and production seams for host-derived paths.
+#[derive(Clone, Debug)]
+pub struct ProbeOptions {
+    pub cgroup_root: PathBuf,
+    /// Override the engine executable for deterministic tests.
+    pub engine_binary: Option<PathBuf>,
+}
+
+impl Default for ProbeOptions {
+    fn default() -> Self {
+        Self {
+            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
+            engine_binary: None,
+        }
+    }
+}
+
+/// Execute the mandatory checks live.  If the configuration has no sandbox,
+/// the report is still returned with an actionable failure rather than a
+/// panic, which makes `doctor` useful on TrustedHost-only installations.
+pub async fn run_live(cfg: &Config) -> ReadinessReport {
+    run_live_with_options(cfg, &ProbeOptions::default()).await
+}
+
+pub async fn run_live_with_options(cfg: &Config, options: &ProbeOptions) -> ReadinessReport {
+    let Some(sandbox) = cfg.sandbox.as_ref() else {
+        return assemble_report(vec![CheckResult::fail(
+            CheckId::Engine,
+            "no sandbox configuration is present",
+            "configure executor_mode: oci and a complete sandbox section, or keep trusted_host mode",
+        )]);
+    };
+
+    let mut checks = Vec::with_capacity(CheckId::ALL.len());
+    let engine_path = options
+        .engine_binary
+        .clone()
+        .map(Ok)
+        .unwrap_or_else(|| which::which(sandbox.engine.binary_name()));
+    checks.push(match engine_path {
+        Ok(ref path) => CheckResult::pass(
+            CheckId::Platform,
+            if cfg!(target_os = "linux") {
+                format!(
+                    "Linux host; {} resolves to {}",
+                    sandbox.engine.binary_name(),
+                    path.display()
+                )
+            } else {
+                format!(
+                    "unsupported host platform {}; {} resolves to {}",
+                    std::env::consts::OS,
+                    sandbox.engine.binary_name(),
+                    path.display()
+                )
+            },
+        ),
+        Err(_) => CheckResult::fail(
+            CheckId::Platform,
+            format!("{} is not executable on PATH", sandbox.engine.binary_name()),
+            format!(
+                "install {} and make it available on PATH",
+                sandbox.engine.binary_name()
+            ),
+        ),
+    });
+    if !cfg!(target_os = "linux") {
+        checks[0] = CheckResult::fail(
+            CheckId::Platform,
+            format!("unsupported host platform {}", std::env::consts::OS),
+            "run OCI workers on a supported Linux host",
+        );
+    }
+
+    let engine_binary = engine_path.as_ref().ok().cloned();
+    let info = EngineInfo::query(sandbox.engine, engine_binary.as_deref()).await;
+    match &info {
+        Ok(info) => {
+            checks.push(CheckResult::pass(
+                CheckId::Engine,
+                format!(
+                    "{} daemon is reachable{}",
+                    sandbox.engine.binary_name(),
+                    info.version_detail()
+                ),
+            ));
+            match info.mode(sandbox.engine) {
+                Ok((mode, userns_remap)) => {
+                    checks.push(CheckResult::pass(
+                        CheckId::Mode,
+                        format!("{} mode detected", mode_name(mode)),
+                    ));
+                    checks.push(if userns_remap {
+                        CheckResult::fail(
+                            CheckId::Namespace,
+                            "rootful engine reports userns-remap",
+                            "disable userns-remap or switch the engine to a supported rootless configuration",
+                        )
+                    } else {
+                        CheckResult::pass(CheckId::Namespace, "engine namespace mapping is supported")
+                    });
+                }
+                Err(detail) => {
+                    checks.push(CheckResult::fail(
+                        CheckId::Mode,
+                        detail.clone(),
+                        "run the configured engine's info command and repair the daemon configuration",
+                    ));
+                    checks.push(CheckResult::fail(
+                        CheckId::Namespace,
+                        "namespace safety could not be evaluated",
+                        "make the engine info probe succeed before dispatching OCI workers",
+                    ));
+                }
+            }
+            checks.push(check_resources(options, info));
+            checks.push(check_primitives(info));
+        }
+        Err(detail) => {
+            checks.push(CheckResult::fail(
+                CheckId::Engine,
+                detail.clone(),
+                format!(
+                    "start the {} daemon and confirm `{}` succeeds",
+                    sandbox.engine.binary_name(),
+                    sandbox.engine.binary_name()
+                ),
+            ));
+            for id in [
+                CheckId::Mode,
+                CheckId::Namespace,
+                CheckId::Resources,
+                CheckId::Primitives,
+            ] {
+                checks.push(CheckResult::fail(
+                    id,
+                    "engine-dependent check could not run",
+                    "repair engine reachability and rerun `caduceus doctor`",
+                ));
+            }
+        }
+    }
+
+    checks.push(check_filesystem(cfg));
+    checks.push(check_network(sandbox.engine, sandbox.network, engine_binary.as_deref()).await);
+    let (image_check, verified_image) = check_image(
+        sandbox.engine,
+        &sandbox.image,
+        sandbox.pull_policy,
+        engine_binary.as_deref(),
+    )
+    .await;
+    checks.push(image_check);
+    checks.sort_by_key(|check| check.id);
+    let mut report = assemble_report(checks);
+    report.verified_image = verified_image;
+    report
+}
+
+/// Refuse an OCI dispatch using only current live observations.
+pub async fn assert_live(cfg: &Config) -> CaduceusResult<ImageAcquisition> {
+    assert_live_with_options(cfg, &ProbeOptions::default()).await
+}
+
+/// Refuse an OCI dispatch using current observations and an optional test
+/// seam. The report cache is intentionally not part of this function.
+pub async fn assert_live_with_options(
+    cfg: &Config,
+    options: &ProbeOptions,
+) -> CaduceusResult<ImageAcquisition> {
+    let report = run_live_with_options(cfg, options).await;
+    if report.verdict == ReadinessVerdict::Ready {
+        return report.verified_image.ok_or_else(|| {
+            CaduceusError::Other("readiness passed without verified image facts".to_string())
+        });
+    }
+    let failures = report
+        .mandatory_failures()
+        .map(|check| ReadinessFailure {
+            check: check.id.to_string(),
+            detail: check.detail.clone(),
+            remediation: check
+                .remediation
+                .clone()
+                .unwrap_or_else(|| "repair the failing host or configuration check".to_string()),
+        })
+        .collect::<Vec<_>>();
+    Err(CaduceusError::OciReadinessUnavailable {
+        failed_checks: failures,
+    })
+}
+
+fn mode_name(mode: crate::executor::sandbox_spec::EngineMode) -> &'static str {
+    match mode {
+        crate::executor::sandbox_spec::EngineMode::Rootful => "rootful",
+        crate::executor::sandbox_spec::EngineMode::Rootless => "rootless",
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EngineInfo {
+    mode_output: String,
+    json: serde_json::Value,
+}
+
+impl EngineInfo {
+    async fn query(engine: SandboxEngine, binary: Option<&Path>) -> Result<Self, String> {
+        let mode_format = match engine {
+            SandboxEngine::Docker => "{{.SecurityOptions}}",
+            SandboxEngine::Podman => "{{.Host.Security.Rootless}}",
+        };
+        let json_format = match engine {
+            SandboxEngine::Docker => "{{json .}}",
+            SandboxEngine::Podman => "json",
+        };
+        let mode = run_engine(engine, binary, ["info", "--format", mode_format]).await?;
+        let json = run_engine(engine, binary, ["info", "--format", json_format]).await?;
+        let parsed = serde_json::from_str(&json)
+            .map_err(|err| format!("engine info JSON is invalid: {err}"))?;
+        Ok(Self {
+            mode_output: mode,
+            json: parsed,
+        })
+    }
+
+    fn mode(
+        &self,
+        engine: SandboxEngine,
+    ) -> Result<(crate::executor::sandbox_spec::EngineMode, bool), String> {
+        crate::executor::engine_probe::parse_engine_mode(engine, &self.mode_output)
+            .map_err(|err| err.to_string())
+    }
+
+    fn version_detail(&self) -> String {
+        find_string(&self.json, &["ServerVersion", "Version"])
+            .map(|version| format!(" (server {version})"))
+            .unwrap_or_default()
+    }
+}
+
+async fn run_engine<I, S>(
+    engine: SandboxEngine,
+    binary: Option<&Path>,
+    args: I,
+) -> Result<String, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let output = tokio::time::timeout(
+        CHECK_TIMEOUT,
+        tokio::process::Command::new(binary.unwrap_or_else(|| Path::new(engine.binary_name())))
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    .map_err(|_| "engine command timed out".to_string())?
+    .map_err(|err| format!("engine command could not start: {err}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("engine command exited with {}", output.status)
+        } else {
+            stderr
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn check_resources(options: &ProbeOptions, info: &EngineInfo) -> CheckResult {
+    let version = find_string(&info.json, &["CgroupVersion", "CgroupVersion"]);
+    let required = ["cpu", "memory", "pids"];
+    let controllers_path = options.cgroup_root.join("cgroup.controllers");
+    if let Some(version) = version {
+        if version == "2" {
+            match std::fs::read_to_string(&controllers_path) {
+                Ok(contents) => {
+                    let found: BTreeSet<&str> = contents.split_whitespace().collect();
+                    let missing: Vec<&str> = required
+                        .iter()
+                        .copied()
+                        .filter(|name| !found.contains(name))
+                        .collect();
+                    if missing.is_empty() {
+                        return CheckResult::pass(
+                            CheckId::Resources,
+                            "cgroup v2 exposes cpu, memory, and pids",
+                        );
+                    }
+                    return CheckResult::fail(
+                        CheckId::Resources,
+                        format!(
+                            "cgroup v2 is missing controller(s): {}",
+                            missing.to_vec().join(", ")
+                        ),
+                        "delegate cpu, memory, and pids controllers to the engine's cgroup scope",
+                    );
+                }
+                Err(err) => {
+                    return CheckResult::fail(
+                        CheckId::Resources,
+                        format!("cannot read {}: {err}", controllers_path.display()),
+                        "make the engine cgroup scope readable and delegate cpu, memory, and pids",
+                    )
+                }
+            }
+        }
+    }
+    let missing: Vec<&str> = required
+        .iter()
+        .copied()
+        .filter(|name| !options.cgroup_root.join(name).exists())
+        .collect();
+    if missing.is_empty() {
+        CheckResult::pass(CheckId::Resources, "cgroup controller paths are available")
+    } else {
+        CheckResult::fail(
+            CheckId::Resources,
+            format!(
+                "required cgroup controller(s) are unavailable: {}",
+                missing.to_vec().join(", ")
+            ),
+            "mount and delegate cpu, memory, and pids cgroup controllers to the engine",
+        )
+    }
+}
+
+fn check_primitives(info: &EngineInfo) -> CheckResult {
+    let driver = find_string(&info.json, &["CgroupDriver", "CgroupManager", "Driver"]);
+    match driver {
+        Some(driver) if !driver.eq_ignore_ascii_case("none") => CheckResult::pass(
+            CheckId::Primitives,
+            format!("engine reports cgroup driver {driver}"),
+        ),
+        Some(_) => CheckResult::fail(
+            CheckId::Primitives,
+            "engine reports no usable cgroup driver",
+            "configure the engine with cgroup resource-control support",
+        ),
+        None => CheckResult::fail(
+            CheckId::Primitives,
+            "engine did not report a cgroup driver",
+            "upgrade or configure the engine so its resource driver is exposed",
+        ),
+    }
+}
+
+fn check_filesystem(cfg: &Config) -> CheckResult {
+    let paths = [
+        ("state", cfg.state_dir.clone(), false),
+        ("repository-storage", cfg.repo_storage_root.clone(), true),
+        ("worktree", cfg.workdir_base.clone(), false),
+    ];
+    let watchdog_paths: Vec<PathBuf> = paths.iter().map(|(_, path, _)| path.clone()).collect();
+    for (role, path, strict_mode) in &paths {
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                return CheckResult::fail(
+                    CheckId::Filesystem,
+                    format!("required {role} directory is missing: {} ({err})", path.display()),
+                    "create the state, repository-storage, and worktree directories with daemon ownership",
+                )
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            return CheckResult::fail(
+                CheckId::Filesystem,
+                format!("required directory is a symlink: {}", path.display()),
+                "replace the symlink with a daemon-owned directory",
+            );
+        }
+        if !metadata.is_dir() {
+            return CheckResult::fail(
+                CheckId::Filesystem,
+                format!("required path is not a directory: {}", path.display()),
+                "replace the configured path with a daemon-owned directory",
+            );
+        }
+        #[cfg(unix)]
+        {
+            let mode = metadata.permissions().mode() & 0o777;
+            let mode_ok = if *strict_mode {
+                mode == 0o700
+            } else {
+                mode & 0o022 == 0
+            };
+            if !mode_ok {
+                return CheckResult::fail(
+                    CheckId::Filesystem,
+                    if *strict_mode {
+                        format!("{} has mode {mode:03o}; expected 700", path.display())
+                    } else {
+                        format!(
+                            "{} has mode {mode:03o}; group/other write access is not allowed",
+                            path.display()
+                        )
+                    },
+                    if *strict_mode {
+                        format!("chmod 700 {}", path.display())
+                    } else {
+                        format!("chmod u+rwX,go-w {}", path.display())
+                    },
+                );
+            }
+            let owner = nix::unistd::Uid::effective().as_raw();
+            if metadata.uid() != owner {
+                return CheckResult::fail(
+                    CheckId::Filesystem,
+                    format!(
+                        "{} is owned by uid {}, expected daemon uid {}",
+                        path.display(),
+                        metadata.uid(),
+                        owner
+                    ),
+                    format!("chown {} {}", owner, path.display()),
+                );
+            }
+        }
+    }
+    let samples = match disk::sample_free_bytes(&watchdog_paths) {
+        Ok(samples) => samples,
+        Err(err) => {
+            return CheckResult::fail(
+                CheckId::Filesystem,
+                format!("filesystem probe failed: {err}"),
+                "make all configured storage paths readable and writable, then rerun doctor",
+            )
+        }
+    };
+    let reserve = cfg
+        .sandbox()
+        .reserved_host_disk_mb
+        .saturating_mul(1024 * 1024);
+    if let Some(sample) = samples.iter().find(|sample| sample.free_bytes < reserve) {
+        return CheckResult::fail(
+            CheckId::Filesystem,
+            format!(
+                "{} has {} bytes free below the {} byte reserve",
+                sample.representative_path.display(),
+                sample.free_bytes,
+                reserve
+            ),
+            "free space on every filesystem hosting Caduceus state and worktrees",
+        );
+    }
+    CheckResult::pass(
+        CheckId::Filesystem,
+        "configured storage paths and disk reserve are healthy",
+    )
+}
+
+async fn check_network(
+    engine: SandboxEngine,
+    network: SandboxNetwork,
+    binary: Option<&Path>,
+) -> CheckResult {
+    if network == SandboxNetwork::None {
+        return CheckResult::pass(
+            CheckId::Network,
+            "network none is representable by the configured engine",
+        );
+    }
+    match run_engine(engine, binary, ["network", "inspect", "bridge"]).await {
+        Ok(_) => CheckResult::pass(CheckId::Network, "the default bridge network is available"),
+        Err(detail) => CheckResult::fail(
+            CheckId::Network,
+            format!("default bridge network is unavailable: {detail}"),
+            "create or repair the engine's default bridge network, or select network: none",
+        ),
+    }
+}
+
+async fn check_image(
+    engine: SandboxEngine,
+    image_ref: &str,
+    policy: OciPullPolicy,
+    binary: Option<&Path>,
+) -> (CheckResult, Option<ImageAcquisition>) {
+    if !is_digest_pinned(image_ref) {
+        return (
+            CheckResult::fail(
+                CheckId::Image,
+                "configured image is not digest-pinned",
+                "set sandbox.image to name@sha256:<64 hex characters>",
+            ),
+            None,
+        );
+    }
+    let adapter = binary
+        .map(|path| OciImageAdapter::with_binary(engine, path))
+        .unwrap_or_else(|| OciImageAdapter::new(engine));
+    let host = crate::executor::oci_platform::host_platform();
+    let acquisition =
+        match oci_image::acquire_image_with_adapter(&adapter, image_ref, policy, &host).await {
+            Ok(acquisition) => acquisition,
+            Err(err) => return (image_failure(err), None),
+        };
+    (
+        CheckResult::pass(
+            CheckId::Image,
+            format!(
+                "{} is present, digest-verified, and matches {}",
+                image_ref,
+                platform_name(&host)
+            ),
+        ),
+        Some(acquisition),
+    )
+}
+
+fn image_failure(err: CaduceusError) -> CheckResult {
+    CheckResult::fail(
+        CheckId::Image,
+        err.to_string(),
+        "make the configured immutable image present or pullable for this host architecture",
+    )
+}
+
+fn platform_name(platform: &HostPlatform) -> String {
+    platform
+        .variant
+        .as_deref()
+        .map(|variant| format!("{}/{}", platform.architecture, variant))
+        .unwrap_or_else(|| platform.architecture.clone())
+}
+
+fn is_digest_pinned(reference: &str) -> bool {
+    let Some((name, digest)) = reference.rsplit_once("@sha256:") else {
+        return false;
+    };
+    !name.is_empty() && digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn find_string(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            for key in keys {
+                if let Some(value) = map.get(*key).and_then(serde_json::Value::as_str) {
+                    return Some(value.to_string());
+                }
+            }
+            map.values().find_map(|value| find_string(value, keys))
+        }
+        serde_json::Value::Array(values) => {
+            values.iter().find_map(|value| find_string(value, keys))
+        }
+        _ => None,
+    }
+}
+
+/// Persist a report for display only.  The executor never calls this helper.
+pub fn write_informational_report(
+    state_dir: &Path,
+    report: &ReadinessReport,
+) -> CaduceusResult<()> {
+    std::fs::create_dir_all(state_dir)?;
+    let path = state_dir.join("doctor.json");
+    let bytes = serde_json::to_vec_pretty(report)?;
+    let temporary = state_dir.join("doctor.json.tmp");
+    std::fs::write(&temporary, bytes)?;
+    std::fs::set_permissions(
+        &temporary,
+        std::os::unix::fs::PermissionsExt::from_mode(0o600),
+    )?;
+    std::fs::rename(temporary, path)?;
+    Ok(())
+}
+
+/// Render the report for operators without conflating diagnostic output with
+/// the mandatory verdict.
+pub fn render_human(report: &ReadinessReport) -> String {
+    let mut output = String::from("caduceus doctor\n");
+    for check in &report.checks {
+        let label = match check.status {
+            CheckStatus::Pass => "PASS",
+            CheckStatus::Fail => "FAIL",
+        };
+        output.push_str(&format!("  [{label}] {}: {}\n", check.id, check.detail));
+        if let Some(remediation) = &check.remediation {
+            output.push_str(&format!("         remediation: {remediation}\n"));
+        }
+    }
+    output.push_str(&format!(
+        "  readiness: {}\n",
+        match report.verdict {
+            ReadinessVerdict::Ready => "READY",
+            ReadinessVerdict::Unavailable => "UNAVAILABLE",
+        }
+    ));
+    if let Some(canary) = &report.diagnostic_canary {
+        output.push_str(&format!(
+            "  diagnostic canary: {}: {}\n",
+            match canary.status {
+                DiagnosticStatus::Pass => "PASS",
+                DiagnosticStatus::Skip => "SKIP",
+                DiagnosticStatus::Failure => "FAILURE",
+            },
+            canary.detail,
+        ));
+    }
+    output
+}

--- a/tests/daemon/status_test.rs
+++ b/tests/daemon/status_test.rs
@@ -29,6 +29,7 @@ use caduceus::queue::{
     parse_queue_state, serialize_queue_state, ClaimToken, Phase, QueueEntry, QueueState,
     TicketType, QUEUE_FILE_VERSION,
 };
+use caduceus::readiness::{assemble_report, CheckId, CheckResult, CheckStatus};
 use caduceus::status::{
     build_report, build_report_from_state, live_worker_from_heartbeat, render_human, render_json,
     report, sample_heartbeat, StatusDiagnostic, STATUS_SCHEMA_VERSION,
@@ -54,9 +55,61 @@ fn empty_config(state_dir: &Path) -> Config {
 
 #[test]
 fn schema_version_is_pinned() {
-    // The 7.6.0 bump lands the `blocked_issues` field on
+    // The 7.7.0 bump lands the informational `doctor` field on
     // `StatusReport` — see `src/daemon/status.rs`.
-    assert_eq!(STATUS_SCHEMA_VERSION, "7.6.0");
+    assert_eq!(STATUS_SCHEMA_VERSION, "7.7.0");
+}
+
+#[test]
+fn status_surfaces_doctor_cache_as_informational() {
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    std::fs::create_dir_all(&cfg.state_dir).expect("state dir");
+    let checks = CheckId::ALL
+        .into_iter()
+        .map(|id| CheckResult {
+            id,
+            status: CheckStatus::Pass,
+            detail: "fixture".to_string(),
+            remediation: None,
+        })
+        .collect();
+    let doctor = assemble_report(checks);
+    caduceus::readiness::write_informational_report(&cfg.state_dir, &doctor)
+        .expect("write doctor report");
+    let (report, diagnostic) = build_report(&cfg.state_dir).expect("status report");
+    assert!(diagnostic.is_none());
+    let doctor = report.doctor.expect("doctor status");
+    assert_eq!(doctor.verdict, "READY");
+    assert!(doctor.informational);
+}
+
+#[test]
+fn status_ignores_doctor_cache_with_unknown_schema() {
+    let dir = tempdir().expect("tempdir");
+    let cfg = empty_config(dir.path());
+    std::fs::create_dir_all(&cfg.state_dir).expect("state dir");
+    let checks = CheckId::ALL
+        .into_iter()
+        .map(|id| CheckResult {
+            id,
+            status: CheckStatus::Pass,
+            detail: "fixture".to_string(),
+            remediation: None,
+        })
+        .collect();
+    let doctor = assemble_report(checks);
+    let mut value = serde_json::to_value(doctor).expect("serialize doctor report");
+    value["schema_version"] = serde_json::Value::String("0.0.0".to_string());
+    std::fs::write(
+        cfg.state_dir.join("doctor.json"),
+        serde_json::to_vec(&value).expect("serialize stale doctor report"),
+    )
+    .expect("write stale doctor report");
+
+    let (report, diagnostic) = build_report(&cfg.state_dir).expect("status report");
+    assert!(diagnostic.is_none());
+    assert!(report.doctor.is_none());
 }
 
 #[test]
@@ -550,7 +603,7 @@ fn human_omits_needs_attention_without_block_metadata_from_section() {
 
 #[test]
 fn json_carries_blocked_issues_array_with_entries() {
-    // The 7.6.0 schema adds a `blocked_issues` array on
+    // The 7.7.0 schema adds the informational doctor result on
     // the JSON contract. Each element carries
     // `issue_key`, `blocked_source`,
     // `blocked_recovery_hint`, and `last_error`.
@@ -602,7 +655,7 @@ fn json_carries_blocked_issues_array_with_entries() {
     assert_eq!(
         parsed["version"].as_str(),
         Some(STATUS_SCHEMA_VERSION),
-        "schema version must reflect the 7.6.0 bump"
+        "schema version must reflect the 7.7.0 bump"
     );
 }
 

--- a/tests/executor/executor_oci_test.rs
+++ b/tests/executor/executor_oci_test.rs
@@ -16,8 +16,9 @@ use caduceus::executor::oci::OciExecutor;
 use caduceus::executor::{Executor, ExecutorSpec};
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
-use caduceus::infra::disk::DiskPressureGuard;
+use caduceus::infra::disk::{DiskPressureGuard, DiskSample};
 use caduceus::infra::error::CaduceusError;
+use caduceus::readiness::{assemble_report, CheckId, CheckResult, CheckStatus};
 use tempfile::TempDir;
 
 fn issue_key() -> IssueKey {
@@ -93,6 +94,7 @@ async fn oci_executor_returns_typed_error() {
             | CaduceusError::OciCliNotFound { .. }
             | CaduceusError::OciPullFailed { .. }
             | CaduceusError::OciIdentityUnsupported { .. }
+            | CaduceusError::OciReadinessUnavailable { .. }
     );
     assert!(
         is_oci_error,
@@ -119,4 +121,63 @@ async fn oci_executor_does_not_spawn_process() {
         elapsed.as_secs() < 5,
         "OciExecutor::run returned in {elapsed:?} — should be fast even on error"
     );
+}
+
+/// Disk pressure is checked before live readiness, so a breached watchdog
+/// remains the authoritative refusal and the engine is not probed.
+#[tokio::test]
+async fn oci_executor_checks_disk_pressure_before_readiness() {
+    let (cfg, _tmp) = setup();
+    let guard = Arc::new(DiskPressureGuard::from_config(&cfg));
+    guard.refresh(&[DiskSample {
+        device_id: 1,
+        free_bytes: 0,
+        representative_path: cfg.state_dir.clone(),
+    }]);
+    let executor: Arc<dyn Executor> = Arc::new(OciExecutor::new(cfg.clone(), guard));
+
+    let err = executor
+        .run(&test_spec(&cfg))
+        .await
+        .expect_err("disk pressure must refuse before readiness");
+    assert!(matches!(err, CaduceusError::OciDiskPressure { .. }));
+}
+
+/// A cached READY doctor result must not authorize dispatch when a live check
+/// currently fails.
+#[tokio::test]
+async fn oci_executor_ignores_cached_doctor_verdict() {
+    let (cfg, _tmp) = setup();
+    let checks = CheckId::ALL
+        .into_iter()
+        .map(|id| CheckResult {
+            id,
+            status: CheckStatus::Pass,
+            detail: "stale fixture".to_string(),
+            remediation: None,
+        })
+        .collect();
+    let report = assemble_report(checks);
+    caduceus::readiness::write_informational_report(&cfg.state_dir, &report)
+        .expect("write cached doctor result");
+
+    let executor: Arc<dyn Executor> = Arc::new(OciExecutor::new(
+        cfg.clone(),
+        Arc::new(DiskPressureGuard::from_config(&cfg)),
+    ));
+    let err = executor
+        .run(&test_spec(&cfg))
+        .await
+        .expect_err("live readiness must refuse despite cached READY");
+    match err {
+        CaduceusError::OciReadinessUnavailable { failed_checks } => {
+            assert!(
+                failed_checks
+                    .iter()
+                    .any(|failure| failure.check == "filesystem"),
+                "live filesystem failure should be reported"
+            );
+        }
+        other => panic!("expected live readiness refusal, got {other:?}"),
+    }
 }

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -32,6 +32,7 @@ use caduceus::executor::engine_probe::{parse_engine_mode, GIT_SHADOW_FILE_CONTEN
 use caduceus::executor::sandbox_renderer::render;
 use caduceus::executor::sandbox_spec::{resolve, EngineMode, GitShadowKind, SandboxEngine};
 use caduceus::infra::config::Config;
+use caduceus::readiness::{run_live_with_options, ProbeOptions, ReadinessVerdict};
 use tempfile::TempDir;
 
 /// Build the live fixture: a real worktree (with a `.git` artifact of
@@ -253,6 +254,37 @@ fn wait_for(predicate: impl Fn() -> bool, budget: Duration, what: &str) -> bool 
 // ---------------------------------------------------------------------------
 // Named mount-enumeration test (consumed by task I12)
 // ---------------------------------------------------------------------------
+
+/// Exercise the same live readiness gate used by dispatch against a real
+/// engine and the configured digest-pinned image.
+#[tokio::test]
+#[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
+async fn oci_readiness_gate_accepts_live_engine_and_image() {
+    if std::env::var("CADUCEUS_LIVE_TEST_IMAGE").is_err() {
+        println!("skipped: set CADUCEUS_LIVE_TEST_IMAGE to a digest-pinned image");
+        return;
+    }
+    let fx = live_fixture(GitShadowKind::Absent, "true");
+    for path in [
+        &fx.cfg.state_dir,
+        &fx.cfg.repo_storage_root,
+        &fx.cfg.workdir_base,
+    ] {
+        std::fs::create_dir_all(path).expect("create readiness root");
+    }
+    let mut cfg = fx.cfg.clone();
+    cfg.sandbox.as_mut().expect("sandbox").reserved_host_disk_mb = 0;
+    let report = run_live_with_options(
+        &cfg,
+        &ProbeOptions {
+            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
+            engine_binary: Some(PathBuf::from(engine_binary(fx.engine))),
+        },
+    )
+    .await;
+    assert_eq!(report.verdict, ReadinessVerdict::Ready, "{report:?}");
+    assert!(report.verified_image.is_some());
+}
 
 /// I12 consumption point: run a real container whose command dumps
 /// `/proc/mounts`; assert the writable host-backed set ==

--- a/tests/readiness_test.rs
+++ b/tests/readiness_test.rs
@@ -1,0 +1,269 @@
+use caduceus::config::Config;
+use caduceus::executor::oci_platform::host_platform;
+use caduceus::readiness::{
+    assemble_report, render_human, run_live_with_options, CheckId, CheckResult, CheckStatus,
+    DiagnosticCanary, DiagnosticStatus, ProbeOptions, ReadinessVerdict,
+};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn checks(status: CheckStatus) -> Vec<CheckResult> {
+    CheckId::ALL
+        .into_iter()
+        .map(|id| CheckResult {
+            id,
+            status,
+            detail: "fixture".to_string(),
+            remediation: None,
+        })
+        .collect()
+}
+
+#[test]
+fn mandatory_verdict_matrix_is_fail_closed() {
+    assert_eq!(
+        assemble_report(checks(CheckStatus::Pass)).verdict,
+        ReadinessVerdict::Ready
+    );
+    for failed_index in 0..CheckId::ALL.len() {
+        let mut failed = checks(CheckStatus::Pass);
+        failed[failed_index].status = CheckStatus::Fail;
+        assert_eq!(
+            assemble_report(failed).verdict,
+            ReadinessVerdict::Unavailable,
+            "check index {failed_index} must be mandatory"
+        );
+    }
+}
+
+#[test]
+fn diagnostic_canary_cannot_change_mandatory_verdict() {
+    let baseline = assemble_report(checks(CheckStatus::Pass));
+    for status in [
+        DiagnosticStatus::Pass,
+        DiagnosticStatus::Skip,
+        DiagnosticStatus::Failure,
+    ] {
+        let mut report = baseline.clone();
+        report.diagnostic_canary = Some(DiagnosticCanary {
+            status,
+            detail: "fixture".to_string(),
+        });
+        assert_eq!(report.verdict, baseline.verdict);
+        assert_eq!(report.checks, baseline.checks);
+    }
+}
+
+#[test]
+fn json_shape_keeps_readiness_and_diagnostic_sections_distinct() {
+    let mut report = assemble_report(checks(CheckStatus::Pass));
+    report.diagnostic_canary = Some(DiagnosticCanary {
+        status: DiagnosticStatus::Skip,
+        detail: "not configured".to_string(),
+    });
+    let value = serde_json::to_value(report).expect("serialize report");
+    assert_eq!(value["verdict"], "READY");
+    assert!(value["checks"].is_array());
+    assert_eq!(value["diagnostic_canary"]["status"], "SKIP");
+    assert!(value.get("verified_image").is_none());
+}
+
+#[test]
+fn human_render_keeps_mandatory_and_diagnostic_results_distinct() {
+    let mut report = assemble_report(checks(CheckStatus::Pass));
+    report.diagnostic_canary = Some(DiagnosticCanary {
+        status: DiagnosticStatus::Failure,
+        detail: "fixture failure".to_string(),
+    });
+    let rendered = render_human(&report);
+    assert!(rendered.contains("readiness: READY"));
+    assert!(rendered.contains("diagnostic canary: FAILURE: fixture failure"));
+}
+
+#[cfg(unix)]
+fn fake_engine(dir: &Path, image_present: bool, userns_remap: bool) -> PathBuf {
+    let image_id = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    let host = host_platform();
+    let security_options = if userns_remap {
+        "[name=userns-remap]"
+    } else {
+        "[]"
+    };
+    let image = if image_present {
+        format!(
+            "{{\"Id\":\"{image_id}\",\"RepoDigests\":[\"placeholder/worker@{image_id}\"],\"Architecture\":\"{}\"}}",
+            host.architecture
+        )
+    } else {
+        String::new()
+    };
+    let script = format!(
+        "#!/bin/sh\ncase \"$1:$2:$3\" in\n  info:--format:*)\n    case \"$3\" in\n      *SecurityOptions*) printf '%s\\n' '{security_options}' ;;\n      *) printf '%s\\n' '{{\"ServerVersion\":\"test\",\"CgroupVersion\":\"2\",\"CgroupDriver\":\"systemd\"}}' ;;\n    esac\n    ;;\n  network:inspect:bridge) exit 0 ;;\n  image:inspect:*)\n    if [ \"$2\" = inspect ] && [ \"$3\" != --format ]; then\n      __PRESENT__\n    else\n      printf '%s\\n' '__IMAGE__'\n    fi\n    ;;\n  pull:*) exit 0 ;;\n  *) exit 1 ;;\nesac\n"
+    )
+    .replace(
+        "__PRESENT__",
+        if image_present { "exit 0" } else { "exit 1" },
+    )
+    .replace("__IMAGE__", &image);
+    let path = dir.join("fake-engine");
+    std::fs::write(&path, script).expect("write fake engine");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+        .expect("make fake engine executable");
+    path
+}
+
+#[cfg(unix)]
+fn ready_fixture(image_present: bool, userns_remap: bool) -> (TempDir, Config, ProbeOptions) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = Config::test_defaults(dir.path());
+    for path in [
+        &config.state_dir,
+        &config.repo_storage_root,
+        &config.workdir_base,
+    ] {
+        std::fs::create_dir_all(path).expect("create config path");
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .expect("secure config path");
+    }
+    let cgroup_root = dir.path().join("cgroup");
+    std::fs::create_dir_all(&cgroup_root).expect("create cgroup root");
+    std::fs::write(cgroup_root.join("cgroup.controllers"), "cpu memory pids\n")
+        .expect("write controllers");
+    let engine = fake_engine(dir.path(), image_present, userns_remap);
+    let options = ProbeOptions {
+        cgroup_root,
+        engine_binary: Some(engine),
+    };
+    config.sandbox.as_mut().expect("test sandbox").network = caduceus::config::SandboxNetwork::None;
+    (dir, config, options)
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_probe_reports_namespace_failure_without_running_dispatch() {
+    let (_dir, config, options) = ready_fixture(true, true);
+    let report = run_live_with_options(&config, &options).await;
+    assert_eq!(report.verdict, ReadinessVerdict::Unavailable);
+    let namespace = report
+        .checks
+        .iter()
+        .find(|check| check.id == CheckId::Namespace)
+        .expect("namespace check");
+    assert_eq!(namespace.status, CheckStatus::Fail);
+    assert!(namespace.remediation.is_some());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_probe_reports_missing_image_as_mandatory_failure() {
+    let (_dir, config, options) = ready_fixture(false, false);
+    let report = run_live_with_options(&config, &options).await;
+    assert_eq!(report.verdict, ReadinessVerdict::Unavailable);
+    assert_eq!(
+        report
+            .checks
+            .iter()
+            .find(|check| check.id == CheckId::Image)
+            .expect("image check")
+            .status,
+        CheckStatus::Fail
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_probe_accepts_a_compliant_fake_engine() {
+    let (_dir, config, options) = ready_fixture(true, false);
+    let report = run_live_with_options(&config, &options).await;
+    assert_eq!(
+        report.verdict,
+        ReadinessVerdict::Ready,
+        "checks: {:?}",
+        report.checks
+    );
+    assert!(report.verified_image.is_some());
+    assert!(report
+        .checks
+        .iter()
+        .all(|check| check.status == CheckStatus::Pass));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_probe_allows_nonwritable_group_access_on_state_and_worktree() {
+    let (_dir, config, options) = ready_fixture(true, false);
+    for path in [&config.state_dir, &config.workdir_base] {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o750))
+            .expect("relax non-repository directory mode");
+    }
+    let report = run_live_with_options(&config, &options).await;
+    assert_eq!(
+        report.verdict,
+        ReadinessVerdict::Ready,
+        "checks: {:?}",
+        report.checks
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_probe_requires_private_repository_storage_root() {
+    let (_dir, config, options) = ready_fixture(true, false);
+    std::fs::set_permissions(
+        &config.repo_storage_root,
+        std::fs::Permissions::from_mode(0o750),
+    )
+    .expect("relax repository storage mode");
+    let report = run_live_with_options(&config, &options).await;
+    let filesystem = report
+        .checks
+        .iter()
+        .find(|check| check.id == CheckId::Filesystem)
+        .expect("filesystem check");
+    assert_eq!(filesystem.status, CheckStatus::Fail);
+    assert!(filesystem.detail.contains("expected 700"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_probe_reports_reserve_breach_as_filesystem_failure() {
+    let (_dir, mut config, options) = ready_fixture(true, false);
+    config
+        .sandbox
+        .as_mut()
+        .expect("test sandbox")
+        .reserved_host_disk_mb = u64::MAX;
+    let report = run_live_with_options(&config, &options).await;
+    assert_eq!(report.verdict, ReadinessVerdict::Unavailable);
+    let filesystem = report
+        .checks
+        .iter()
+        .find(|check| check.id == CheckId::Filesystem)
+        .expect("filesystem check");
+    assert_eq!(filesystem.status, CheckStatus::Fail);
+    assert!(filesystem
+        .remediation
+        .as_deref()
+        .is_some_and(|hint| !hint.is_empty()));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_probe_reports_missing_cgroup_controller() {
+    let (dir, config, options) = ready_fixture(true, false);
+    std::fs::write(
+        dir.path().join("cgroup").join("cgroup.controllers"),
+        "cpu memory\n",
+    )
+    .expect("remove pids controller");
+    let report = run_live_with_options(&config, &options).await;
+    assert_eq!(report.verdict, ReadinessVerdict::Unavailable);
+    let resources = report
+        .checks
+        .iter()
+        .find(|check| check.id == CheckId::Resources)
+        .expect("resources check");
+    assert_eq!(resources.status, CheckStatus::Fail);
+    assert!(resources.detail.contains("pids"));
+}

--- a/tests/state/config_bootstrap_test.rs
+++ b/tests/state/config_bootstrap_test.rs
@@ -543,12 +543,12 @@ fn raw_env_from_process_env_handles_unset_vars() {
 
 #[test]
 fn status_schema_version_bumped_to_7_6_0() {
-    // 7.6.0 lands the `blocked_issues` field on
+    // 7.7.0 lands the informational doctor result on
     // `StatusReport` for the AC5 dedicated surface; the
     // previous bump (7.5.0) added `pool_state`.
     assert_eq!(
         caduceus::status::STATUS_SCHEMA_VERSION,
-        "7.6.0",
-        "schema version should be 7.6.0 for the blocked_issues field"
+        "7.7.0",
+        "schema version should be 7.7.0 for the doctor field"
     );
 }


### PR DESCRIPTION
Closes #251

## Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add shared live OCI readiness checks for `caduceus doctor` and the dispatch boundary.
- Add typed fail-closed refusals, optional diagnostic canary execution, informational status surfacing, and provenance reuse.
- Add readiness, filesystem, cache, gate-order, and gated live coverage with operator documentation.

## Changes
| File | Change |
|------|--------|
| `src/readiness/mod.rs` | Shared live readiness checks, verdict assembly, rendering, and image acquisition facts |
| `src/executor/oci.rs` | Disk/readiness dispatch gates and provenance handoff |
| `src/executor/oci_image.rs` | Reusable verified image acquisition and provenance recording |
| `src/cli/mod.rs` | `caduceus doctor` and isolated diagnostic canary |
| `src/daemon/status.rs` | Informational doctor cache/status surfacing with schema validation |
| `tests/` | Unit, integration, filesystem, gate-order, cache, and gated live coverage |
| `README.md` | Readiness, canary, provenance, and filesystem policy documentation |

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] Focused Rust readiness, executor, provenance, and status suites
- [x] `cargo test --locked --all-targets -- --skip release_binary_canary`
- [x] `git diff --check`
- [ ] Gated live OCI tests require an engine and `CADUCEUS_LIVE_TEST_IMAGE`

## Verification Notes
- The full unfiltered Rust suite reaches the long release-canary test and requires a longer environment-specific timeout.
- Python verification remains subject to 8 known bridge environment/pre-existing failures; 158 tests pass.
- No Hermes plugin files were changed.

## Contributor Checklist
- [x] Linked issue
- [x] Conventional commit format
- [x] Docs updated for behavior changes
- [x] No generated files or secrets added
- [ ] Repository `status:approved` label is unavailable; maintainer approval requested on this PR