### PR TITLE
ci(ci): port macos test job to cargo nextest

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,6 +60,10 @@ jobs:
             | sh -s -- -y --default-toolchain 1.97 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           rustup component add rustfmt clippy
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: cache cargo registry and target
         uses: Swatinem/rust-cache@v2
       - name: configure git identity for tests
@@ -77,7 +81,7 @@ jobs:
         # compile the release binary; allow 15 min for the test
         # step on macOS just like ci.yml.
         timeout-minutes: 15
-        run: env -u GITHUB_TOKEN cargo test --locked --all-targets
+        run: env -u GITHUB_TOKEN cargo nextest run --locked --all-targets --retries 2
 
 
 

--- a/tests/readiness_test.rs
+++ b/tests/readiness_test.rs
@@ -171,7 +171,11 @@ async fn live_probe_reports_missing_image_as_mandatory_failure() {
     );
 }
 
-#[cfg(unix)]
+// The live probe's Platform check deliberately fails on non-Linux hosts
+// (OCI workers require Linux), so the compliant-engine happy path can
+// only reach ReadinessVerdict::Ready on Linux. Gate to target_os to keep
+// the macOS CI gate green.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn live_probe_accepts_a_compliant_fake_engine() {
     let (_dir, config, options) = ready_fixture(true, false);
@@ -189,7 +193,7 @@ async fn live_probe_accepts_a_compliant_fake_engine() {
         .all(|check| check.status == CheckStatus::Pass));
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn live_probe_allows_nonwritable_group_access_on_state_and_worktree() {
     let (_dir, config, options) = ready_fixture(true, false);


### PR DESCRIPTION
Closes #268. Also closes #274.

## What

Ports the `macos / test` job from bare `cargo test --locked --all-targets`
to `cargo nextest run --locked --all-targets --retries 2`, matching the
Linux gate in `ci.yml`.

## Changes

- `.github/workflows/macos.yml`:
  - new `install cargo-nextest` step via `taiki-e/install-action@v2`
    with `tool: cargo-nextest` (mirrors ci.yml)
  - test step now runs `env -u GITHUB_TOKEN cargo nextest run --locked
    --all-targets --retries 2`
- `timeout-minutes: 15` and the `env -u GITHUB_TOKEN` hermeticity guard
  are preserved
- required-check name (`macos / test`) unchanged — no branch-protection
  coordination needed
- `.config/nextest.toml` untouched; the platform-override filter stays
  linux-only, so the default profile (120s slow-timeout, canary
  exclusion) now applies on macOS

## Follow-up commit: 9cae12a (closes #274)

The first CI run on this PR failed `macos / test`. Investigation: the
failure is **not** caused by the nextest port — PR #272 (merged as
`8409499`) added two `#[cfg(unix)]` readiness tests that assert
`ReadinessVerdict::Ready`, but the production Platform check
deliberately fails on non-Linux hosts (OCI workers require Linux), so
those tests cannot pass on macOS. Deterministic, retry-immune, and
already failing on main since #272 merged.

Fix (second commit): gate both tests to `#[cfg(target_os = "linux")]`,
matching the hermes_lifecycle overrides in `.config/nextest.toml`. The
Linux suite is unaffected (11/11 `readiness_test` pass locally, fmt +
clippy clean).

## Acceptance criteria

- [x] macos.yml test step runs nextest with `--retries 2`
- [x] `.config/nextest.toml` profile applies on macOS (platform-override
      filter still linux-only)
- [x] macOS check green on a clean main push — verified by CI on this PR
      (was impossible before the #274 fix included here)