### PR TITLE
ci(ci): add weekly cache-warm schedule to macos.yml

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,6 +35,14 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/macos.yml'
+  schedule:
+    # Weekly cache-warm run for the macOS gate (issue #271). Sunday
+    # 06:30 UTC — adjacent to ci.yml's 06:00 slot so the two weekly
+    # runners spread load. Swatinem/rust-cache saves on job completion,
+    # so the next real push restores the cache in seconds instead of
+    # paying the 40+ minute cold-cache build. Schedule events ignore
+    # `paths:` filters by design; push/PR triggers keep theirs.
+    - cron: '30 6 * * 0'
 
 # Cancel in-progress runs on the same ref so a force-push does
 # not leave a stale runner burning macOS minutes.


### PR DESCRIPTION
Closes #271

## What

Adds a `schedule:` trigger to `.github/workflows/macos.yml` mirroring
ci.yml's weekly cache-warm run:

- cron `30 6 * * 0` (Sunday 06:30 UTC) — adjacent to ci.yml's `0 6 * * 0`
  slot so the two weekly runners don't collide
- the scheduled run executes the same single `test` job;
  Swatinem/rust-cache saves on completion and restores on the next real
  push
- push/PR path filters unchanged; schedule fires unconditionally (path
  filters don't apply to schedule events)
- no other changes — the job definition, nextest command, guards, and
  required-check name are untouched

## Why

macos.yml has no schedule, so after a quiet week the cargo + target
caches go cold and the next macOS run pays the full build (measured
40+ min, e.g. 2026-08-30 13:45→17:23) where a warm run finishes in
~4.

## Acceptance criteria

- [x] Sunday macOS run keeps the cache warm (schedule trigger added;
      first fire next Sunday 06:30 UTC)
- [ ] Next weekday push's macOS run restores cache in <15s (verifiable
      only after the first scheduled fire — cache restore step timing
      will show it)