### PR TITLE
fix(plugin): inject default HERMES_HOME into daemon subprocess env (closes #263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   This is a host-level mitigation — `/workspace` remains a host bind mount
   with no per-container byte quota.
 
+### Fixed
+
+- **Status commands in non-Hermes shells.** `hermes caduceus status` (and
+  every adapter subcommand shelling out to the daemon binary) no longer
+  fails with `no configuration source found` in shells that do not export
+  `HERMES_HOME`. The adapter now injects its computed default into the
+  child environment only when the variable is unset; explicit overrides
+  (multi-profile hosts) are preserved and a deliberately-empty value
+  still reaches the binary's guard. Closes #263.
+
 ## [1.0.0] - 2026-08-08
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -208,11 +208,22 @@ def _run(
     The adapter never uses ``shell=True``. Errors are caught and re-raised
     as ``RuntimeError`` with a redacted message so the caller can present
     a chat-friendly diagnostic without leaking secrets.
+
+    The child env is a copy of ``os.environ`` with ``HERMES_HOME`` defaulted
+    to the adapter's ``_hermes_home()`` resolution when unset, so daemon
+    config resolution works in shells that do not export it (issue #263).
     """
+    # Inject the adapter's HERMES_HOME default when the shell does not
+    # export one (issue #263). setdefault semantics: an explicit operator
+    # override (multi-profile hosts) wins, and a deliberately-empty value
+    # still reaches the binary so the Rust guard reports it (mod.rs:1033).
+    env = dict(os.environ)
+    env.setdefault("HERMES_HOME", str(_hermes_home()))
     try:
         return subprocess.run(
             argv,
             cwd=str(cwd) if cwd else None,
+            env=env,
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/tests/plugin/subprocess_env_test.py
+++ b/tests/plugin/subprocess_env_test.py
@@ -1,0 +1,92 @@
+"""Regression tests for the HERMES_HOME injection into daemon subprocesses.
+
+Issue #263: `hermes caduceus status` failed in shells that do not export
+HERMES_HOME because the adapter inherited the caller env verbatim. The
+adapter must inject its computed default only when the variable is unset.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _completed(argv: list) -> "subprocess.CompletedProcess[str]":
+    return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+
+class TestHermesHomeInjection:
+    def test_run_passes_env_kwarg_to_subprocess(
+        self, adapter, monkeypatch, isolated_hermes_home: Path
+    ) -> None:
+        """_run passes an explicit env (the seam this fix adds)."""
+        monkeypatch.setenv("HERMES_HOME", str(isolated_hermes_home))
+        captured: list[dict] = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(kwargs)
+            return _completed(argv)
+
+        monkeypatch.setattr(adapter.subprocess, "run", fake_run)
+
+        adapter._run(["/bin/true"])
+
+        assert captured, "subprocess.run was not invoked"
+        assert "env" in captured[0], captured[0]
+        assert isinstance(captured[0]["env"], dict)
+
+    def test_run_injects_default_hermes_home_when_unset_strict(
+        self, adapter, monkeypatch, isolated_hermes_home: Path
+    ) -> None:
+        """The child env carries _hermes_home()'s value when the parent
+        env does not export HERMES_HOME (the #263 regression)."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        captured: list[dict] = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(kwargs)
+            return _completed(argv)
+
+        monkeypatch.setattr(adapter.subprocess, "run", fake_run)
+
+        adapter._run(["/bin/true"])
+
+        expected = str(adapter._hermes_home())
+        assert captured[0]["env"]["HERMES_HOME"] == expected
+
+    def test_run_preserves_explicit_hermes_home_override(
+        self, adapter, monkeypatch, isolated_hermes_home: Path
+    ) -> None:
+        """An operator-exported HERMES_HOME reaches the child untouched."""
+        override = str(isolated_hermes_home / "custom-profile")
+        monkeypatch.setenv("HERMES_HOME", override)
+        captured: list[dict] = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(kwargs)
+            return _completed(argv)
+
+        monkeypatch.setattr(adapter.subprocess, "run", fake_run)
+
+        adapter._run(["/bin/true"])
+
+        assert captured[0]["env"]["HERMES_HOME"] == override
+
+    def test_run_leaves_empty_hermes_home_verbatim(
+        self, adapter, monkeypatch, isolated_hermes_home: Path
+    ) -> None:
+        """A deliberately-empty HERMES_HOME still reaches the binary (the
+        Rust guard "HERMES_HOME must not be empty" is correct operator
+        feedback and must not be masked)."""
+        monkeypatch.setenv("HERMES_HOME", "")
+        captured: list[dict] = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(kwargs)
+            return _completed(argv)
+
+        monkeypatch.setattr(adapter.subprocess, "run", fake_run)
+
+        adapter._run(["/bin/true"])
+
+        assert captured[0]["env"]["HERMES_HOME"] == ""


### PR DESCRIPTION
## What

`hermes caduceus status` (and every adapter subcommand that shells out to the
Rust daemon binary) now works in interactive shells that do not export
`HERMES_HOME`. The adapter's `_run()` builds the child env as a copy of
`os.environ` and injects its computed `_hermes_home()` default only when the
variable is unset (`setdefault` semantics).

Closes #263

## Root cause (live-probed against main @ c9c745a)

1. The Rust binary reads config strictly from the environment —
   `src/infra/config/mod.rs` `Config::load_with_context` maps an absent
   `HERMES_HOME` to `None` (there is deliberately no `~/.hermes` fallback),
   and `src/infra/config/load.rs` emits `no configuration source found
   (set $CADUCEUS_CONFIG, $HERMES_HOME, ...)`.
2. The adapter's `_run()` (`__init__.py:200`) called `subprocess.run(...)`
   with no `env=`, inheriting the caller's environment verbatim.
3. `_hermes_home()` (`__init__.py:997`) already defaults to `~/.hermes` but
   never injected it into the child env.

Gateway/cron worked because the gateway process carries `HERMES_HOME`;
interactive shells broke.

## Fix (single seam, three behaviours preserved)

```python
env = dict(os.environ)
env.setdefault("HERMES_HOME", str(_hermes_home()))
```

- **Explicit override wins** — an operator-exported `HERMES_HOME`
  (multi-profile hosts) is already in `os.environ`; `setdefault` leaves it
  untouched.
- **Deliberately-empty still errors** — `setdefault` fires only when the key
  is absent, so `HERMES_HOME=""` reaches the binary verbatim and the Rust
  guard (`HERMES_HOME must not be empty`) gives correct operator feedback.
- **Default shells get `~/.hermes`** — `_hermes_home()` resolves via
  `expanduser`, so the injected value is absolute (the loader rejects
  relative paths).

All four daemon-spawning call sites (`_handle_caduceus_status`,
`_check_setup_prerequisites`, `_build_daemon_binary`, `_cli_status`) route
through `_run()`, so one seam covers every invocation that needs config
resolution.

## Tests

New `tests/plugin/subprocess_env_test.py` (4 tests): env kwarg is passed,
default injected when unset (strict — compares against `_hermes_home()`),
explicit override preserved, empty value preserved verbatim. Verified RED
against pre-fix code (all 4 failed with `KeyError: 'env'`), GREEN after.

## Verification

- `cargo fmt --check` — OK
- `cargo clippy --locked --all-targets -- -D warnings` — OK
- `cargo test --locked --all-targets` (with documented hermetic skips) —
  green except `signal_test`, a documented load-dependent host race: failing
  names shuffled 4 → 3 → 1 across three runs of unmodified Rust code
  (`idle_sigint_exits_zero`, `idle_sigterm_exits_zero`,
  `daemon_surfaces_cancelled_outcome_on_idle_signal`,
  `idle_cancellation_does_not_mutate_state`). This PR touches no Rust code.
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` —
  164 passed; 6 failures, all the documented hermetic
  `TestSubprocessEndToEnd` bridge names (`harness executable not found:
  bash`, exit 127 — synthetic PATH without `bash`, pre-existing on clean
  main, unaffected by this Python-only fix).
- Manual repro (throwaway plugin layout, freshly built
  `target/release/caduceus`, `_cli_status()`/`_cli_doctor()`):
  - `env -u HERMES_HOME -u CADUCEUS_CONFIG` → live daemon status, rc 0
    (was `no configuration source found` pre-fix)
  - explicit `HERMES_HOME=/home/agent/.hermes` → live daemon status, rc 0
  - `HERMES_HOME=` → `HERMES_HOME must not be empty`, rc 1
  - `env -u HERMES_HOME -u CADUCEUS_CONFIG` doctor → binary/config checks
    pass (only the provider-secret credential check fails — no token in the
    sandbox env)