### PR TITLE
test(fixtures): converge all tempdir helpers on shared helper (closes #269)

### DIFF
--- a/tests/architecture/fixtures_self_test.rs
+++ b/tests/architecture/fixtures_self_test.rs
@@ -16,16 +16,6 @@
 
 #![allow(clippy::needless_return)]
 
-#[path = "../fixtures/mod.rs"]
-mod fixtures;
-
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
-#[cfg_attr(not(target_os = "linux"), allow(unused_imports))]
-use std::time::{Duration, Instant};
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use serde_json::json;
 
 #[cfg(target_os = "linux")]
@@ -649,38 +639,36 @@ fn ac04_release_binary_runs_with_no_user_secrets() {
 // Helpers
 // -----------------------------------------------------------------------
 
-fn tempdir(label: &str) -> PathBuf {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let mut dir = std::env::temp_dir();
-    dir.push(format!("caduceus-fixture-self-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
-
 // -----------------------------------------------------------------------
 // Regression: shared tempdir uniqueness (issue #269)
 // -----------------------------------------------------------------------
 
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::collections::HashSet;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::sync::Arc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 #[test]
 fn shared_tempdir_paths_are_distinct_under_parallel_same_label() {
     // Regression for issue #269: the pre-fix helpers derived
-    // uniqueness from SystemTime::as_nanos(), which collides on the
-    // coarse-clock macOS runner (~1 us) under parallel threads.
+    // uniqueness from the wall clock (SystemTime nanoseconds), which
+    // collides on the coarse-clock macOS runner (~1 us) under
+    // parallel threads.
     // The shared helper uses pid + AtomicU64 counter, so N threads
     // x M calls with the SAME label must produce N*M distinct paths,
     // and every path must contain the pid and a counter (never a
     // bare nanosecond nonce).
     const THREADS: usize = 8;
     const PER_THREAD: usize = 100;
-    let collected: Arc<std::sync::Mutex<Vec<std::path::PathBuf>>> =
-        Arc::new(std::sync::Mutex::new(Vec::with_capacity(THREADS * PER_THREAD)));
+    let collected: Arc<std::sync::Mutex<Vec<std::path::PathBuf>>> = Arc::new(
+        std::sync::Mutex::new(Vec::with_capacity(THREADS * PER_THREAD)),
+    );
     let handles: Vec<_> = (0..THREADS)
         .map(|_| {
             let collected = Arc::clone(&collected);

--- a/tests/architecture/fixtures_self_test.rs
+++ b/tests/architecture/fixtures_self_test.rs
@@ -659,3 +659,75 @@ fn tempdir(label: &str) -> PathBuf {
     std::fs::create_dir_all(&dir).expect("create tempdir");
     dir
 }
+
+// -----------------------------------------------------------------------
+// Regression: shared tempdir uniqueness (issue #269)
+// -----------------------------------------------------------------------
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::thread;
+
+#[test]
+fn shared_tempdir_paths_are_distinct_under_parallel_same_label() {
+    // Regression for issue #269: the pre-fix helpers derived
+    // uniqueness from SystemTime::as_nanos(), which collides on the
+    // coarse-clock macOS runner (~1 us) under parallel threads.
+    // The shared helper uses pid + AtomicU64 counter, so N threads
+    // x M calls with the SAME label must produce N*M distinct paths,
+    // and every path must contain the pid and a counter (never a
+    // bare nanosecond nonce).
+    const THREADS: usize = 8;
+    const PER_THREAD: usize = 100;
+    let collected: Arc<std::sync::Mutex<Vec<std::path::PathBuf>>> =
+        Arc::new(std::sync::Mutex::new(Vec::with_capacity(THREADS * PER_THREAD)));
+    let handles: Vec<_> = (0..THREADS)
+        .map(|_| {
+            let collected = Arc::clone(&collected);
+            thread::spawn(move || {
+                let mut local = Vec::with_capacity(PER_THREAD);
+                for _ in 0..PER_THREAD {
+                    // same label on every thread — the pre-fix code
+                    // would collide here on a coarse clock.
+                    let p = fixtures::tempdir("dup");
+                    local.push(p);
+                }
+                collected.lock().unwrap().extend(local);
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+    let all = collected.lock().unwrap();
+    assert_eq!(all.len(), THREADS * PER_THREAD);
+    let set: HashSet<&std::path::Path> = all.iter().map(|p| p.as_path()).collect();
+    assert_eq!(
+        set.len(),
+        THREADS * PER_THREAD,
+        "tempdir paths collided under parallel same-label calls"
+    );
+    // Every path must contain the pid and the monotonic counter,
+    // never a bare nanosecond nonce. The format is
+    // caduceus-test-<label>-<pid>-<counter>.
+    let pid = std::process::id().to_string();
+    for p in all.iter() {
+        let s = p.to_string_lossy();
+        assert!(s.contains(&pid), "path missing pid: {s}");
+        // The counter is the last path component's tail after the
+        // pid. We don't pin the exact number, but we assert the
+        // component after the pid is a non-empty decimal (the
+        // counter), which rules out a bare nanosecond nonce
+        // (19 digits, no separator) and a missing counter.
+        let file = p.file_name().unwrap().to_string_lossy().into_owned();
+        let parts: Vec<&str> = file.split('-').collect();
+        // caduceus-test-<label>-<pid>-<counter>: label may itself
+        // contain '-', so check the last two are pid + counter.
+        assert_eq!(parts[parts.len() - 2], pid, "path pid slot wrong: {file}");
+        let counter_str = parts[parts.len() - 1];
+        assert!(
+            !counter_str.is_empty() && counter_str.chars().all(|c| c.is_ascii_digit()),
+            "path counter slot not a decimal: {file}"
+        );
+    }
+}

--- a/tests/daemon/awaiting_review_test.rs
+++ b/tests/daemon/awaiting_review_test.rs
@@ -4,19 +4,6 @@
 //! causes `enqueue_summaries` to propagate that error rather than
 //! silently swallowing it.
 
-use std::path::PathBuf;
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-awaiting-review-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
-
 #[tokio::test]
 async fn enqueue_summaries_propagates_state_error() {
     let state_dir = tempdir("enqueue-error");
@@ -67,12 +54,14 @@ use caduceus::state::meta::TickOutcome;
 use caduceus::state::queue::{FinalizationCheckpoint, FinalizationStage};
 use caduceus::{queue::TicketType, CaduceusError};
 use serde_json::json;
-use std::sync::Arc;
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 #[test]
 fn exit_code_for_outcome_table() {

--- a/tests/daemon/daemon_lock_test.rs
+++ b/tests/daemon/daemon_lock_test.rs
@@ -14,25 +14,16 @@
 
 #![allow(unused_variables, unused_imports)]
 
+use caduceus::DaemonLock;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::fs;
-use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
-
-use caduceus::DaemonLock;
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-daemon-lock-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 // Single-process behaviour
 

--- a/tests/daemon/idle304_integration_test.rs
+++ b/tests/daemon/idle304_integration_test.rs
@@ -6,33 +6,21 @@
 //! decision logic, and this test verifies the poll layer produces
 //! the correct signal.
 
-use std::path::PathBuf;
-
 use caduceus::config::Config;
 use caduceus::github::{Client, HttpCache};
 use caduceus::poll::{merge_outcomes, poll_code, poll_investigation};
 use wiremock::matchers::{method, path, query_param_is_missing};
 use wiremock::{Match, Mock, Request, ResponseTemplate};
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
 const CODE_LABEL: &str = "🤖 auto-fix";
 const INVESTIGATION_LABEL: &str = "🤖 auto-fix-investigate";
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-idle304-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn issue_list_json(entries: &[serde_json::Value]) -> serde_json::Value {
     serde_json::Value::Array(entries.to_vec())

--- a/tests/daemon/orchestration_active_run_inline_test.rs
+++ b/tests/daemon/orchestration_active_run_inline_test.rs
@@ -12,10 +12,14 @@ use caduceus::queue::{
 use caduceus::worktree::{create as create_worktree, GitRunner, RepositoryInfo};
 use caduceus::{CaduceusError, IssueKey};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use tempfile::TempDir;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
-use tempfile::TempDir;
 
 fn cfg() -> Config {
     Config::test_defaults(std::path::Path::new("/tmp"))
@@ -729,14 +733,7 @@ fn finish_needs_attention_emits_stable_terminal_block_event() {
     // `caduceus.terminal_block` callsite is cached as never-enabled and
     // this test's event is silently dropped before reaching its capture
     // subscriber (empty capture under `--test-threads>=2`).
-    let root = std::env::temp_dir().join(format!(
-        "caduceus-167-capture-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).expect("create tempdir");
+    let root = tempdir("167-capture");
     let log_path = root.join("capture.json");
     let file = std::fs::OpenOptions::new()
         .create(true)

--- a/tests/daemon/signal_test.rs
+++ b/tests/daemon/signal_test.rs
@@ -23,14 +23,6 @@
 
 #![allow(unused_imports)]
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::io::{Read, Write};
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
-
 use chrono::{DateTime, Utc};
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
@@ -40,6 +32,17 @@ use caduceus::queue::{
     serialize_queue_state, Phase, QueueEntry, QueueState, TicketType, QUEUE_FILE_VERSION,
 };
 use caduceus::IssueKey;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 /// Find the `caduceus` binary as a sibling of the test
 /// binary. The test binary is the test executable, not the
@@ -56,17 +59,6 @@ fn find_self_exe() -> PathBuf {
             panic!("could not find caduceus binary in target/debug");
         }
     }
-}
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-signal-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
 }
 
 fn write_script(path: &PathBuf, body: &str) {

--- a/tests/daemon/startup_test.rs
+++ b/tests/daemon/startup_test.rs
@@ -1,21 +1,12 @@
 //! Integration tests for daemon startup — storage tree init, idempotent restart.
 
-use std::path::Path;
-
 use caduceus::config::Config;
 use caduceus::repo::Storage;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-startup-test-{label}-{nonce}"));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::path::Path;
 
 #[test]
 fn startup_creates_storage_tree_when_missing() {

--- a/tests/fixtures/crash_point.rs
+++ b/tests/fixtures/crash_point.rs
@@ -154,6 +154,10 @@ impl SignalAction {
     }
 }
 
+/// NOTE: as_nanos() here is a process-id nonce for script
+/// filenames, NOT a tempdir path uniqueness source — see the
+/// issue #269 plan (.hermes/plans/tempdir-uniqueness.md).
+/// Do not "fix" this as part of a tempdir-uniqueness sweep.
 fn rand_id() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -29,6 +29,8 @@ mod github;
 mod process_tree;
 #[cfg(test)]
 mod release_binary;
+#[cfg(test)]
+mod tempdir;
 
 #[cfg(test)]
 #[allow(unused_imports)]
@@ -54,3 +56,6 @@ pub use process_tree::{assert_no_survivors, snapshot_subtree, ProcessTree};
 #[cfg(test)]
 #[allow(unused_imports)]
 pub use release_binary::{ReleaseBinary, RunSupervisorArgs};
+#[cfg(test)]
+#[allow(unused_imports)]
+pub use tempdir::{tempdir, tempdir_owned};

--- a/tests/fixtures/process_tree.rs
+++ b/tests/fixtures/process_tree.rs
@@ -264,6 +264,11 @@ pub fn assert_no_survivors(pids: &[i32]) {
 }
 
 /// Tiny nonce for script filenames.
+///
+/// NOTE: as_nanos() here is a process-id nonce for script
+/// filenames, NOT a tempdir path uniqueness source — see the
+/// issue #269 plan (.hermes/plans/tempdir-uniqueness.md).
+/// Do not "fix" this as part of a tempdir-uniqueness sweep.
 fn rand_id() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()

--- a/tests/fixtures/tempdir.rs
+++ b/tests/fixtures/tempdir.rs
@@ -7,6 +7,7 @@
 //! collides on the coarse-clock macOS runner (~1 us resolution): two
 //! parallel tests observe the same nanosecond, produce the same path,
 //! and race on the same directory (proven torn git trees in PR #254).
+#![allow(dead_code)] // not every test binary that includes fixtures uses both fns
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/tests/fixtures/tempdir.rs
+++ b/tests/fixtures/tempdir.rs
@@ -1,0 +1,51 @@
+//! Shared tempdir helper for the test suite (issue #269).
+//!
+//! Every test that needs a scratch directory under `std::env::temp_dir()`
+//! must use one of these helpers instead of rolling its own. The old
+//! per-file helpers derived uniqueness from
+//! `SystemTime::now().duration_since(UNIX_EPOCH).as_nanos()`, which
+//! collides on the coarse-clock macOS runner (~1 us resolution): two
+//! parallel tests observe the same nanosecond, produce the same path,
+//! and race on the same directory (proven torn git trees in PR #254).
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Unique scratch directory under `std::env::temp_dir()`.
+///
+/// Uniqueness derives from `std::process::id()` + a process-wide
+/// monotonic `AtomicU64` counter — NEVER from the wall clock. The
+/// macOS runner clock is coarse (~1 us) so two parallel tests can
+/// observe the same nanosecond and collide; the pid + counter pair
+/// is collision-free within a process and across parallel test
+/// binaries (different pids).
+///
+/// No auto-cleanup. Matches the shape of the 50 local
+/// `fn tempdir(label) -> PathBuf` helpers it replaces.
+pub fn tempdir(label: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!(
+        "caduceus-test-{label}-{}-{}",
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+/// `tempfile::TempDir` with auto-cleanup, for the one site that
+/// previously returned `TempDir` (tests/state/migration_test.rs).
+/// Uniqueness same as `tempdir(label)`; the `TempDir` owns the
+/// directory and removes it on drop.
+///
+/// Mirrors the old migration_test.rs helper exactly: create a unique
+/// parent, then `TempDir::new_in(parent)` (tempfile 3.x has no
+/// `from_path`; the pre-fix helper used `new_in` on an `as_nanos`
+/// parent, so this keeps the same shape with collision-free
+/// uniqueness).
+pub fn tempdir_owned(label: &str) -> tempfile::TempDir {
+    let parent = tempdir(label);
+    tempfile::TempDir::new_in(parent).expect("TempDir new_in")
+}

--- a/tests/github/discovery_pagination_test.rs
+++ b/tests/github/discovery_pagination_test.rs
@@ -11,27 +11,19 @@
 //! * `Config::from_raw` rejects `discovery_max_pages = 0`.
 //! * `Config::test_defaults` sets `discovery_max_pages = 20`.
 
-use std::path::{Path, PathBuf};
-
 use caduceus::config::{
     Config, LoadContext, RawConfig, DEFAULT_DISCOVERY_MAX_PAGES, DEFAULT_TICKET_LABEL_CODE,
 };
 use caduceus::github::{Client, HttpCache};
 use wiremock::matchers::{method, path};
 use wiremock::{Match, Mock, Request, ResponseTemplate};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::path::Path;
 
 // Helpers
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-pagination-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn test_config(state_dir: &Path, api_base: &str, max_pages: u32) -> Config {
     let mut cfg = Config::test_defaults(state_dir);

--- a/tests/github/github_client_test.rs
+++ b/tests/github/github_client_test.rs
@@ -19,9 +19,6 @@
 
 #![allow(unused_imports)]
 
-use std::path::{Path, PathBuf};
-use std::time::Duration;
-
 use caduceus::config::Config;
 use caduceus::error::CaduceusError;
 use caduceus::github::{
@@ -31,10 +28,13 @@ use caduceus::github::{
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Match, Mock, Request, ResponseTemplate};
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// Custom matcher that requires the request to NOT carry the named
 /// header. Used to build stateful mocks that branch on header
@@ -50,17 +50,6 @@ impl Match for NoHeader {
 // Fixtures
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-http-client-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn test_config(state_dir: &Path, api_base: &str, token: Option<&str>) -> Config {
     let mut cfg = Config::test_defaults(state_dir);

--- a/tests/github/issue_detail_test.rs
+++ b/tests/github/issue_detail_test.rs
@@ -9,27 +9,18 @@
 //!   three concurrent requests trips the rate-limit).
 //! - `Serialize` round-trip for context construction.
 
-use std::path::PathBuf;
-
 use caduceus::config::Config;
 use caduceus::github::{Client, HttpCache, ACCEPT_VALUE};
 use caduceus::issue::{fetch_issue_detail, IssueComment, IssueDetail, IssueEvent, IssueKey};
 use chrono::{TimeZone, Utc};
 use wiremock::matchers::{method, path, query_param_is_missing};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-issue-detail-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn mock_client(server: &MockServer) -> (Client, Config) {
     let state_dir = tempdir("mock");

--- a/tests/github/issue_poll_test.rs
+++ b/tests/github/issue_poll_test.rs
@@ -15,8 +15,6 @@
 //! `NoHeader` inversion, so they drop down to the underlying
 //! wiremock `MockServer` via [`fixtures::MockGitHub::server`].
 
-use std::path::PathBuf;
-
 use caduceus::config::Config;
 use caduceus::github::{Client, HttpCache};
 use caduceus::issue::IssueKey;
@@ -28,25 +26,15 @@ use caduceus::queue::TicketType;
 use wiremock::matchers::{method, path, query_param_is_missing};
 use wiremock::{Match, Mock, Request, ResponseTemplate};
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
 const CODE_LABEL: &str = "🤖 auto-fix";
 const INVESTIGATION_LABEL: &str = "🤖 auto-fix-investigate";
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-issue-poll-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn mock_client(gh: &MockGitHub) -> (Client, Config) {
     let state_dir = tempdir("mock");

--- a/tests/github/rate_limit_test.rs
+++ b/tests/github/rate_limit_test.rs
@@ -13,8 +13,6 @@
 //! remaining on 200). The header-parsing and `CadenceGate`
 //! state-machine tests are pure unit tests and need no mock.
 
-use std::path::{Path, PathBuf};
-
 use caduceus::config::Config;
 use caduceus::github::{
     poll_interval_from_headers, rate_limit_from_headers, Client, HttpCache, RateLimitInfo,
@@ -25,23 +23,14 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
+use std::path::Path;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-rate-limit-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn mock_client(gh: &MockGitHub, state_dir: &Path) -> Client {
     let mut cfg = Config::test_defaults(state_dir);

--- a/tests/github/verify_test.rs
+++ b/tests/github/verify_test.rs
@@ -16,21 +16,14 @@ use caduceus::queue::TicketType;
 use caduceus::verify::{SkipReason, VerifyOutcome};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
 const CODE_LABEL: &str = "🤖 auto-fix";
 const INVESTIGATION_LABEL: &str = "🤖 auto-fix-investigate";
-
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-verify-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn mock_client_with_repos(server: &MockServer) -> (Client, Config) {
     let state_dir = tempdir("mock");

--- a/tests/integration/code_pre_pr_checkpoint_recovery_test.rs
+++ b/tests/integration/code_pre_pr_checkpoint_recovery_test.rs
@@ -13,12 +13,6 @@
 //! would — asserting exactly one commit, one branch, one PR, one
 //! comment.
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::Path;
-use std::process::Command;
-use std::sync::Arc;
-
 use caduceus::config::{Config, LoadContext, RawConfig};
 use caduceus::daemon::tick::resume::{resume_from_checkpoint, ResumeAction};
 use caduceus::finalize::voice::generate_operation_id;
@@ -40,24 +34,19 @@ use serde_json::json;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
 const EXPECTED_PR_NUMBER: u64 = 4242;
-
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-code-pre-pr-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn empty_config(state_dir: &Path) -> Config {
     let raw = RawConfig {

--- a/tests/integration/failure_matrix_test.rs
+++ b/tests/integration/failure_matrix_test.rs
@@ -34,19 +34,10 @@
 
 #![allow(unused_imports, unused_variables)]
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
-
 use chrono::Utc;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-#[path = "../fixtures/mod.rs"]
-mod fixtures;
 use fixtures::{LocalOrigin, MockGitHub};
 
 #[path = "../fixtures/failure-matrix-stubs/mod.rs"]
@@ -64,6 +55,16 @@ use caduceus::queue::{
     QUEUE_FILE_VERSION,
 };
 use caduceus::{CaduceusError, CircuitStore, FakeClock, IssueKey, Pool, StateStore};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 // ---------------------------------------------------------------------------
 // AC-10 — Re-export the canonical isolation escape tests.
@@ -94,17 +95,6 @@ fn require_daemon_binary() -> PathBuf {
 // ---------------------------------------------------------------------------
 // Fixture: tempdir helper.
 // ---------------------------------------------------------------------------
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-fm-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 // ---------------------------------------------------------------------------
 // Fixture: WorkerScript.

--- a/tests/integration/finalize_pr_number_test.rs
+++ b/tests/integration/finalize_pr_number_test.rs
@@ -6,10 +6,6 @@
 //! `StateStore::save_finalization` exactly as the daemon's resume path
 //! does, and asserts the queue entry carries the PR number.
 
-use std::collections::BTreeMap;
-use std::path::Path;
-use std::sync::Arc;
-
 use caduceus::config::{Config, LoadContext, RawConfig};
 use caduceus::finalize::{find_or_create_pr_and_finalize, FinalizeContext, FinalizeRequest};
 use caduceus::github::Client;
@@ -24,24 +20,17 @@ use serde_json::json;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
 const EXPECTED_PR_NUMBER: u64 = 4242;
-
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-finalize-pr-number-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn empty_config(state_dir: &Path) -> Config {
     let raw = RawConfig {

--- a/tests/integration/integration_scenarios.rs
+++ b/tests/integration/integration_scenarios.rs
@@ -47,14 +47,6 @@
 
 #![allow(unused_imports, unused_variables)]
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::io::Read;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
-
 use chrono::Utc;
 use serde_json::Value;
 use wiremock::matchers::{method, path, query_param};
@@ -65,6 +57,17 @@ use caduceus::queue::{
     parse_queue_state, serialize_queue_state, Phase, QueueEntry, QueueState, TicketType,
     QUEUE_FILE_VERSION,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 // ---------------------------------------------------------------------------
 // Binary precondition.
@@ -94,17 +97,6 @@ fn require_daemon_binary() -> PathBuf {
 // ---------------------------------------------------------------------------
 // Fixture: tempdir helper.
 // ---------------------------------------------------------------------------
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-scenario-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 // ---------------------------------------------------------------------------
 // Fixture: WorkerScript.

--- a/tests/integration/integration_test.rs
+++ b/tests/integration/integration_test.rs
@@ -38,14 +38,6 @@
 
 #![allow(unused_imports, unused_variables)]
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::io::Read;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
-
 use chrono::Utc;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -55,21 +47,21 @@ use caduceus::queue::{
     parse_queue_state, serialize_queue_state, Phase, QueueEntry, QueueState, TicketType,
     QUEUE_FILE_VERSION,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 // ---------------------------------------------------------------------------
 // Fixture: tempdir helper.
 // ---------------------------------------------------------------------------
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-integration-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 // ---------------------------------------------------------------------------
 // Fixture: WiremockServer.

--- a/tests/integration/investigation_finalize_checkpoint_test.rs
+++ b/tests/integration/investigation_finalize_checkpoint_test.rs
@@ -8,10 +8,6 @@
 //! that a crash after the comment does not duplicate it on recovery
 //! (the idempotent `run_id` marker suppresses the re-post).
 
-use std::collections::BTreeMap;
-use std::path::Path;
-use std::sync::Arc;
-
 use caduceus::config::{Config, LoadContext, RawConfig};
 use caduceus::finalize::{
     post_investigation_comment_and_finalize, FinalizeContext, FinalizeRequest,
@@ -29,23 +25,16 @@ use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
+use fixtures::MockGitHub;
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-investigation-finalize-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn empty_config(state_dir: &Path) -> Config {
     let raw = RawConfig {

--- a/tests/migrate_to_sqlite_backend_test.rs
+++ b/tests/migrate_to_sqlite_backend_test.rs
@@ -2,25 +2,16 @@
 //! and metadata, preserves the originals as backups, and writes the
 //! `state_backend` config flag.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-
 use caduceus::config::Config;
 use caduceus::meta::{MetaStore, TickOutcome};
 use caduceus::migrate_to_sqlite::{migrate_to_sqlite, LockPolicy, SqliteMigrationOutcome};
 use caduceus::queue::StateStore;
+#[path = "fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-migrate-integration-{label}-{nonce}"));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::fs;
+use std::path::Path;
 
 fn write_json_state(state_dir: &Path) {
     fs::write(

--- a/tests/migrate_to_sqlite_lock_race_test.rs
+++ b/tests/migrate_to_sqlite_lock_race_test.rs
@@ -6,26 +6,17 @@
 //! lock guard covers the migration I/O, then kills the child and
 //! verifies the exit signal semantics.
 
+use caduceus::queue::DaemonLock;
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::fs;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
-
-use caduceus::queue::DaemonLock;
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-migrate-race-{label}-{nonce}"));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn caduceus_binary() -> PathBuf {
     let mut exe = std::env::current_exe().expect("current exe");

--- a/tests/repo/mirror_test.rs
+++ b/tests/repo/mirror_test.rs
@@ -2,23 +2,15 @@
 //!
 //! Tests cover: creation, fetch, idempotency, mode 0700.
 
-use std::path::Path;
-use std::process::Command;
-
 use caduceus::config::Config;
 use caduceus::repo::BareMirror;
 use caduceus::worktree::GitRunner;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-mirror-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::path::Path;
+use std::process::Command;
 
 fn run_command(cmd: &mut Command) {
     let output = cmd.output().expect("spawn command");

--- a/tests/repo/repository_discovery_test.rs
+++ b/tests/repo/repository_discovery_test.rs
@@ -23,33 +23,25 @@
 
 #![allow(unused_variables, unused_imports)]
 
-use std::ffi::OsStr;
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::time::Duration;
-
 use caduceus::config::Config;
 use caduceus::error::CaduceusError;
 use caduceus::issue::IssueKey;
 use caduceus::worktree::{
     find_main_clone, parse_origin, validate_origin_host, GitOutput, GitRunner, RepositoryInfo,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::ffi::OsStr;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
 
 /// Build a temporary directory with a unique name so parallel
 /// test invocations don't collide.
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-repo-discovery-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
-
 /// Default config rooted at *root*; the daemon's pre-flight
 /// checks aren't exercised here so we skip the worker command.
 fn config_for(root: &Path, api_base: &str) -> Config {

--- a/tests/repo/repository_poll_test.rs
+++ b/tests/repo/repository_poll_test.rs
@@ -7,27 +7,19 @@
 //! - Page-cap error (>20 pages)
 //! - Rate-limit on page two
 
-use std::path::{Path, PathBuf};
-
 use caduceus::config::Config;
 use caduceus::error::CaduceusError;
 use caduceus::github::{Client, HttpCache};
 use caduceus::poll::{discover_watched_repos, next_url_from_link_header, MAX_PAGES_PER_ENDPOINT};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::path::Path;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-repo-poll-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn configured_client(state_dir: &Path, watched: &[&str]) -> (Client, Config) {
     let cfg = {

--- a/tests/repo/storage_root_test.rs
+++ b/tests/repo/storage_root_test.rs
@@ -1,16 +1,14 @@
 //! Integration tests for `repo::Storage` — symlink rejection, mode validation.
 
 use caduceus::repo::Storage;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 
 #[test]
 fn symlink_storage_root_rejected() {
-    let tmp = std::env::temp_dir().join(format!(
-        "caduceus-storage-test-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let tmp = tempdir("storage");
     let _ = std::fs::remove_dir_all(&tmp);
     std::fs::create_dir_all(&tmp).unwrap();
     let real_dir = tmp.join("real");
@@ -33,13 +31,7 @@ fn symlink_storage_root_rejected() {
 
 #[test]
 fn valid_directory_accepted() {
-    let tmp = std::env::temp_dir().join(format!(
-        "caduceus-storage-accept-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let tmp = tempdir("storage-accept");
     let _ = std::fs::remove_dir_all(&tmp);
     std::fs::create_dir_all(&tmp).unwrap();
 
@@ -55,13 +47,7 @@ fn valid_directory_accepted() {
 fn ensure_dirs_creates_subdirectories() {
     use std::os::unix::fs::PermissionsExt;
 
-    let tmp = std::env::temp_dir().join(format!(
-        "caduceus-ensure-dirs-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let tmp = tempdir("ensure-dirs");
     let _ = std::fs::remove_dir_all(&tmp);
 
     let storage = Storage::new(tmp.clone());
@@ -97,13 +83,7 @@ fn ensure_dirs_creates_subdirectories() {
 
 #[test]
 fn ensure_dirs_is_idempotent() {
-    let tmp = std::env::temp_dir().join(format!(
-        "caduceus-idempotent-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let tmp = tempdir("idempotent");
     let _ = std::fs::remove_dir_all(&tmp);
 
     let storage = Storage::new(tmp.clone());

--- a/tests/repo/worktree_create_test.rs
+++ b/tests/repo/worktree_create_test.rs
@@ -23,16 +23,19 @@
 
 #![allow(unused_variables)]
 
-use std::fs;
-use std::panic::AssertUnwindSafe;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
 use tokio::runtime::Runtime;
 
 use caduceus::config::Config;
 use caduceus::issue::IssueKey;
 use caduceus::worktree::{create as create_worktree, GitRunner, RepositoryInfo, Worktree};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::fs;
+use std::panic::AssertUnwindSafe;
+use std::path::Path;
+use std::process::Command;
 
 /// Serialises the two .lock-env-var tests so the global
 /// `_CADUCEUS_TEST_PANIC_IN_CREATE_LOCKED` flag cannot leak between them.
@@ -40,17 +43,6 @@ static LOCK_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Unique tempdir per call so parallel test invocations don't
 /// trample each other.
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-worktree-create-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
-
 /// Build a config rooted at *root*.
 fn config_for(root: &Path, api_base: &str) -> Config {
     let mut cfg = Config::test_defaults(root);

--- a/tests/repo/worktree_remove_test.rs
+++ b/tests/repo/worktree_remove_test.rs
@@ -22,32 +22,22 @@
 
 #![allow(unused_variables)]
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
-#[cfg(unix)]
-use std::os::unix::fs::symlink;
-
 use caduceus::config::Config;
 use caduceus::issue::IssueKey;
 use caduceus::worktree::{
     create as create_worktree, remove as remove_worktree, GitRunner, RepositoryInfo, Worktree,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use std::process::Command;
 
 /// Unique tempdir per call so parallel test invocations don't
 /// trample each other.
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-worktree-remove-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
-
 fn config_for(root: &Path, api_base: &str) -> Config {
     let mut cfg = Config::test_defaults(root);
     cfg.api_base = api_base.to_string();

--- a/tests/repo/worktree_retry_test.rs
+++ b/tests/repo/worktree_retry_test.rs
@@ -10,27 +10,19 @@
 
 #![allow(unused_variables)]
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
 use caduceus::config::Config;
 use caduceus::issue::IssueKey;
 use caduceus::worktree::{create as create_worktree, GitRunner, RepositoryInfo, Worktree};
 use filetime::{set_file_mtime, FileTime};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 const HAPPY_RUN_ID: &str = "01H9Z3Y4G8W2J7N5K1QXV0F8P3";
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-worktree-retry-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn config_for(root: &Path, api_base: &str) -> Config {
     let mut cfg = Config::test_defaults(root);

--- a/tests/repo/worktree_test.rs
+++ b/tests/repo/worktree_test.rs
@@ -2,24 +2,16 @@
 //!
 //! Tests cover: lifecycle, failure reuse refused, cleanup.
 
-use std::path::Path;
-use std::process::Command;
-
 use caduceus::config::Config;
 use caduceus::repo::BareMirror;
 use caduceus::worktree::GitRunner;
 use caduceus::RepoWorktree;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-worktree-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::path::Path;
+use std::process::Command;
 
 fn run_command(cmd: &mut Command) {
     let output = cmd.output().expect("spawn command");

--- a/tests/state/cadence_test.rs
+++ b/tests/state/cadence_test.rs
@@ -8,22 +8,13 @@
 //!   early second tick is recorded as a `Cadence` outcome and
 //!   writes no HTTP traffic on the second invocation.
 
-use std::path::PathBuf;
-
 use caduceus::config::Config;
 use caduceus::meta::{CadenceDecision, CadenceGate, TickOutcome};
 use chrono::{Duration, Utc};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-cadence-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
 
 // Cadence across two process-equivalent clients
 

--- a/tests/state/claim_test.rs
+++ b/tests/state/claim_test.rs
@@ -11,13 +11,6 @@
 
 #![allow(unused_variables, unused_imports, clippy::unnecessary_min_or_max)]
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::PathBuf;
-use std::sync::{Arc, Barrier};
-use std::thread;
-use std::time::Duration;
-
 use chrono::Utc;
 
 use caduceus::queue::{
@@ -25,17 +18,16 @@ use caduceus::queue::{
     CLAIM_FILE_VERSION, QUEUE_FILE_VERSION,
 };
 use caduceus::IssueKey;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-claim-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
 
 fn key(owner: &str, repo: &str, number: u64) -> IssueKey {
     IssueKey {

--- a/tests/state/config_bootstrap_test.rs
+++ b/tests/state/config_bootstrap_test.rs
@@ -3,23 +3,14 @@
 //! the real `Config::load()` path.
 //!
 
-use std::path::PathBuf;
+use caduceus::config::{Config, RawEnv, SetupAction};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::sync::Mutex;
 
-use caduceus::config::{Config, RawEnv, SetupAction};
-
 static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-bootstrap-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn write(path: &std::path::Path, body: &str) {
     if let Some(parent) = path.parent() {

--- a/tests/state/config_resolution_test.rs
+++ b/tests/state/config_resolution_test.rs
@@ -3,23 +3,14 @@
 //! without mutating the host process environment beyond the
 //! ``CADUCEUS_DRY_RUN`` variable (serialised under ``ENV_LOCK``).
 
-use std::path::PathBuf;
+use caduceus::config::Config;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::sync::Mutex;
 
-use caduceus::config::Config;
-
 static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-resolution-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn write(path: &std::path::Path, body: &str) {
     if let Some(parent) = path.parent() {

--- a/tests/state/config_test.rs
+++ b/tests/state/config_test.rs
@@ -4,12 +4,15 @@
 //! env-aware resolution chain is the responsibility of Task 1.3 —
 //! end of the loader.
 
-use std::path::Path;
-
 use caduceus::config::{
     expand_leading_tilde, is_valid_repo_slug, Config, LoadContext, RawConfig, RawEnv,
     DEFAULT_API_BASE, DEFAULT_TICKET_LABEL_CODE, DEFAULT_TICKET_LABEL_INVESTIGATION,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::path::Path;
 
 fn ctx(root: &Path) -> LoadContext {
     LoadContext {
@@ -806,14 +809,3 @@ fn discovery_max_pages_zero_rejected() {
 }
 
 // Test helpers
-
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-config-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}

--- a/tests/state/config_token_resolution_test.rs
+++ b/tests/state/config_token_resolution_test.rs
@@ -3,11 +3,13 @@
 //! a stub `TokenEnv` (so tests do not mutate the process environment)
 //! and a stub `GhRunner` where needed.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
-
 use caduceus::config::{Config, GhRunner, GhRunnerOutput, TokenEnv};
 use serial_test::serial;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::HashMap;
 
 #[derive(Default)]
 struct MapEnv {
@@ -46,17 +48,6 @@ impl GhRunner for StubGh {
             )),
         }
     }
-}
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-load-token-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
 }
 
 fn write(path: &std::path::Path, body: &str) {

--- a/tests/state/lifecycle_matrix_test.rs
+++ b/tests/state/lifecycle_matrix_test.rs
@@ -13,11 +13,6 @@
 //! AwaitingReview → NeedsAttention with a diagnostic reason;
 //! closed-without-merge and merged-PR states are mutually exclusive.
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use caduceus::state::queue::{
     serialize_queue_state, Phase, QueueEntry, QueueState, StateStore, TicketType,
     QUEUE_FILE_VERSION,
@@ -26,22 +21,15 @@ use chrono::{TimeZone, Utc};
 
 use caduceus::github::issue::IssueKey;
 use caduceus::runtime::audit::refuse_auto_merge;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
 
 // Helpers
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn scratch_dir(label: &str) -> PathBuf {
-    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-    let dir = std::env::temp_dir().join(format!(
-        "lifecycle-matrix-{label}-{}-{}",
-        std::process::id(),
-        n
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).expect("create scratch dir");
-    dir
-}
 
 fn sample_key() -> IssueKey {
     IssueKey {
@@ -90,7 +78,7 @@ fn seed_entry(store: &StateStore, phase: Phase) {
 
 #[test]
 fn resolve_awaiting_review_as_done_transitions_to_done() {
-    let dir = scratch_dir("ac02-merge");
+    let dir = tempdir("ac02-merge");
     let store = make_store(&dir);
     seed_entry(&store, Phase::AwaitingReview);
 
@@ -112,7 +100,7 @@ fn resolve_awaiting_review_as_done_transitions_to_done() {
 
 #[test]
 fn route_to_needs_attention_transitions_to_needs_attention() {
-    let dir = scratch_dir("ac02-needs-attn");
+    let dir = tempdir("ac02-needs-attn");
     let store = make_store(&dir);
     seed_entry(&store, Phase::AwaitingReview);
 
@@ -146,7 +134,7 @@ fn route_to_needs_attention_transitions_to_needs_attention() {
 
 #[test]
 fn reopen_then_merge_flow() {
-    let dir = scratch_dir("ac02-reopen");
+    let dir = tempdir("ac02-reopen");
     let store = make_store(&dir);
     seed_entry(&store, Phase::NeedsAttention);
 
@@ -193,7 +181,7 @@ fn reopen_then_merge_flow() {
 
 #[test]
 fn reprocess_entry_refuses_awaiting_review() {
-    let dir = scratch_dir("ac02-reprocess");
+    let dir = tempdir("ac02-reprocess");
     let store = make_store(&dir);
     seed_entry(&store, Phase::AwaitingReview);
 

--- a/tests/state/logging_test.rs
+++ b/tests/state/logging_test.rs
@@ -13,23 +13,15 @@
 //!   `tracing::subscriber::with_default` and never touches the
 //!   global default.
 
+use caduceus::logging::{build_test_subscriber, init, init_for_test, is_initialised, redact};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use caduceus::logging::{build_test_subscriber, init, init_for_test, is_initialised, redact};
-
 static INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-logging-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn read_file(path: &PathBuf) -> String {
     std::fs::read_to_string(path).expect("read log file")

--- a/tests/state/meta_test.rs
+++ b/tests/state/meta_test.rs
@@ -3,12 +3,6 @@
 //! quarantine path, the rate-limit observer merge semantics, and
 //! diagnostic coalescing.
 
-use std::fs::{self, OpenOptions};
-use std::io::Write;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::thread;
-
 use chrono::{Duration, TimeZone, Utc};
 
 use caduceus::error::CaduceusError;
@@ -17,17 +11,15 @@ use caduceus::meta::{
     append_diagnostic, load, save, MetaStore, RateLimitObservation, RateLimitObserver, StateMeta,
     TickOutcome, META_VERSION,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-meta-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
 
 fn sample_key() -> IssueKey {
     IssueKey {

--- a/tests/state/migrate_to_sqlite_test.rs
+++ b/tests/state/migrate_to_sqlite_test.rs
@@ -1,26 +1,17 @@
 //! Unit-level tests for the `migrate-state --to-sqlite` path.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::thread;
-
 use caduceus::migrate_to_sqlite::{migrate_to_sqlite, LockPolicy, SqliteMigrationOutcome};
 use caduceus::queue::DaemonLock;
 use caduceus::queue::STATE_FILENAME;
 use caduceus::store;
 use rusqlite::params;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-migrate-test-{label}-{nonce}"));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::fs;
+use std::path::Path;
+use std::thread;
 
 #[test]
 fn migrate_with_acquire_rejects_concurrent_daemon_lock() {

--- a/tests/state/migration_test.rs
+++ b/tests/state/migration_test.rs
@@ -30,9 +30,6 @@
 //! exist solely to exercise the import path and never talk to
 //! GitHub.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-
 use caduceus::error::CaduceusError;
 use caduceus::issue::IssueKey;
 use caduceus::migrate::{run as migrate_run, MigrationOutcome};
@@ -41,6 +38,12 @@ use caduceus::queue::{
 };
 use chrono::{TimeZone, Utc};
 use tempfile::TempDir;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir_owned;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 /// Legacy v0 state entry. The migration path accepts this shape
 /// and produces a current-schema [`caduceus::queue::QueueEntry`]
@@ -61,19 +64,6 @@ struct LegacyEntryV0 {
 #[derive(serde::Serialize, serde::Deserialize)]
 struct LegacyStateV0 {
     entries: Vec<LegacyEntryV0>,
-}
-
-fn tempdir(label: &str) -> TempDir {
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let path = std::env::temp_dir().join(format!(
-        "caduceus-migration-test-{label}-{nonce}-{}",
-        std::process::id()
-    ));
-    fs::create_dir_all(&path).expect("create tempdir");
-    TempDir::new_in(path).expect("TempDir new_in")
 }
 
 fn open_state(path: &Path) -> QueueState {
@@ -104,7 +94,7 @@ fn backup_path(state_dir: &Path) -> PathBuf {
 
 #[test]
 fn empty_legacy_state_imports_empty_current_state_and_is_idempotent() {
-    let dir = tempdir("empty");
+    let dir = tempdir_owned("empty");
     let state_dir = state_dir_setup(&dir);
     let from = dir.path().join("legacy.json");
     fs::write(
@@ -134,7 +124,7 @@ fn empty_legacy_state_imports_empty_current_state_and_is_idempotent() {
 
 #[test]
 fn legacy_state_with_queued_and_failed_entries_imports_to_current_schema() {
-    let dir = tempdir("queued-failed");
+    let dir = tempdir_owned("queued-failed");
     let state_dir = state_dir_setup(&dir);
     let from = dir.path().join("legacy.json");
     let legacy = LegacyStateV0 {
@@ -182,7 +172,7 @@ fn legacy_state_with_queued_and_failed_entries_imports_to_current_schema() {
 
 #[test]
 fn dry_run_does_not_touch_state_file() {
-    let dir = tempdir("dry-run");
+    let dir = tempdir_owned("dry-run");
     let state_dir = state_dir_setup(&dir);
     let from = dir.path().join("legacy.json");
     let legacy = LegacyStateV0 {
@@ -206,7 +196,7 @@ fn dry_run_does_not_touch_state_file() {
 
 #[test]
 fn malformed_legacy_input_does_not_overwrite_existing_state() {
-    let dir = tempdir("malformed");
+    let dir = tempdir_owned("malformed");
     let state_dir = state_dir_setup(&dir);
     // Pre-seed a valid v1 state under the daemon's path.
     let store = StateStore::open(&state_dir).expect("open store");
@@ -229,7 +219,7 @@ fn malformed_legacy_input_does_not_overwrite_existing_state() {
 
 #[test]
 fn duplicate_legacy_entries_are_reported_and_skipped() {
-    let dir = tempdir("duplicates");
+    let dir = tempdir_owned("duplicates");
     let state_dir = state_dir_setup(&dir);
     let from = dir.path().join("legacy.json");
     // Two legacy entries with the same repo/number.
@@ -264,7 +254,7 @@ fn duplicate_legacy_entries_are_reported_and_skipped() {
 
 #[test]
 fn already_current_state_is_idempotent_no_op() {
-    let dir = tempdir("already-current");
+    let dir = tempdir_owned("already-current");
     let state_dir = state_dir_setup(&dir);
     // Pre-seed a v1 state file.
     let mut state = QueueState::empty();
@@ -304,7 +294,7 @@ fn already_current_state_is_idempotent_no_op() {
 
 #[test]
 fn migration_is_atomic_and_leaves_a_backup() {
-    let dir = tempdir("atomic-backup");
+    let dir = tempdir_owned("atomic-backup");
     let state_dir = state_dir_setup(&dir);
     let from = dir.path().join("legacy.json");
     let legacy = LegacyStateV0 {
@@ -335,7 +325,7 @@ fn migration_is_atomic_and_leaves_a_backup() {
 
 #[test]
 fn recovery_validates_supplied_file_under_daemon_lock_and_clears_marker() {
-    let dir = tempdir("recovery");
+    let dir = tempdir_owned("recovery");
     let state_dir = state_dir_setup(&dir);
 
     // Pretend a corrupt state.json + marker file are present.
@@ -396,7 +386,7 @@ fn recovery_validates_supplied_file_under_daemon_lock_and_clears_marker() {
 
 #[test]
 fn recovery_refuses_to_install_malformed_repaired_file() {
-    let dir = tempdir("recovery-malformed");
+    let dir = tempdir_owned("recovery-malformed");
     let state_dir = state_dir_setup(&dir);
     let active = state_dir.join("state.json");
     fs::write(&active, b"original corrupt").unwrap();
@@ -424,7 +414,7 @@ fn recovery_refuses_when_corrupt_original_cannot_be_archived() {
     // writable. We make the state dir read-only after planting
     // the corrupt file; recovery should refuse before any rename
     // touches the active file.
-    let dir = tempdir("recovery-no-archive");
+    let dir = tempdir_owned("recovery-no-archive");
     let state_dir = state_dir_setup(&dir);
     let active = state_dir.join("state.json");
     fs::write(&active, b"original corrupt").unwrap();

--- a/tests/state/queue_model_test.rs
+++ b/tests/state/queue_model_test.rs
@@ -10,17 +10,10 @@ use caduceus::queue::{
     QUEUE_FILE_VERSION,
 };
 use chrono::{TimeZone, Utc};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-queue-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
 
 fn sample_key() -> IssueKey {
     IssueKey {

--- a/tests/state/queue_reset_cli_test.rs
+++ b/tests/state/queue_reset_cli_test.rs
@@ -18,11 +18,6 @@
 
 #![allow(unused_variables, unused_imports)]
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-
 use chrono::Utc;
 
 use caduceus::queue::{
@@ -30,17 +25,14 @@ use caduceus::queue::{
     TicketType, QUEUE_FILE_VERSION,
 };
 use caduceus::{IssueKey, StateStore as _};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-queue-reset-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
 
 fn key(owner: &str, repo: &str, number: u64) -> IssueKey {
     IssueKey {

--- a/tests/state/retry_test.rs
+++ b/tests/state/retry_test.rs
@@ -14,27 +14,18 @@
 
 #![allow(unused_variables, unused_imports, clippy::unnecessary_min_or_max)]
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::PathBuf;
-
 use chrono::{TimeZone, Utc};
 
 use caduceus::queue::{
     ClaimToken, Phase, QueueEntry, QueueState, StateStore, TicketType, QUEUE_FILE_VERSION,
 };
 use caduceus::IssueKey;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-retry-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
 
 fn key(owner: &str, repo: &str, number: u64) -> IssueKey {
     IssueKey {

--- a/tests/state/review_lifecycle_test.rs
+++ b/tests/state/review_lifecycle_test.rs
@@ -11,11 +11,6 @@
 //! - **4.3-AC-05** — `AwaitingReview` phase round-trips through
 //!   serialization correctly.
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use caduceus::state::queue::{
     parse_queue_state, serialize_queue_state, Phase, QueueEntry, QueueState, StateStore,
     TicketType, QUEUE_FILE_VERSION,
@@ -24,22 +19,15 @@ use chrono::{TimeZone, Utc};
 
 use caduceus::github::issue::IssueKey;
 use caduceus::runtime::audit::refuse_auto_merge;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
 
 // Helpers
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn scratch_dir(label: &str) -> PathBuf {
-    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-    let dir = std::env::temp_dir().join(format!(
-        "review-lifecycle-{label}-{}-{}",
-        std::process::id(),
-        n
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).expect("create scratch dir");
-    dir
-}
 
 fn sample_key() -> IssueKey {
     IssueKey {
@@ -88,7 +76,7 @@ fn seed_entry(store: &StateStore, phase: Phase) {
 
 #[test]
 fn complete_awaiting_review_sets_awaiting_review_phase() {
-    let dir = scratch_dir("ac01");
+    let dir = tempdir("ac01");
     let store = make_store(&dir);
     seed_entry(&store, Phase::InProgress);
 
@@ -128,7 +116,7 @@ fn refuse_auto_merge_returns_error() {
 
 #[test]
 fn route_to_needs_attention_from_awaiting_review() {
-    let dir = scratch_dir("ac03");
+    let dir = tempdir("ac03");
     let store = make_store(&dir);
     seed_entry(&store, Phase::AwaitingReview);
 
@@ -158,7 +146,7 @@ fn route_to_needs_attention_from_awaiting_review() {
 
 #[test]
 fn reprocess_entry_refuses_awaiting_review() {
-    let dir = scratch_dir("ac04");
+    let dir = tempdir("ac04");
     let store = make_store(&dir);
     seed_entry(&store, Phase::AwaitingReview);
 

--- a/tests/state/state_store_test.rs
+++ b/tests/state/state_store_test.rs
@@ -16,13 +16,6 @@
 // green without weakening any assertion.
 #![allow(unused_variables, unused_imports, clippy::unnecessary_min_or_max)]
 
-use std::collections::BTreeMap;
-use std::fs::{self, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Barrier};
-use std::thread;
-
 use chrono::Utc;
 
 use caduceus::error::CaduceusError;
@@ -31,17 +24,16 @@ use caduceus::queue::{
     parse_queue_state, serialize_queue_state, ClaimToken, EnqueueOutcome, FinalizationCheckpoint,
     FinalizationStage, Phase, QueueEntry, QueueState, StateStore, TicketType, QUEUE_FILE_VERSION,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-state-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 fn key(owner: &str, repo: &str, number: u64) -> IssueKey {
     IssueKey {

--- a/tests/state/token_test.rs
+++ b/tests/state/token_test.rs
@@ -11,14 +11,17 @@
 //! process environment is never touched except by the env-scoping
 //! helper (which restores every variable it touched).
 
-use std::collections::HashMap;
-use std::sync::Mutex;
-
 use caduceus::config::{
     Config, GhRunner, GhRunnerOutput, OsEnv, ResolvedToken, TokenEnv, TokenSource,
 };
 use caduceus::error::CaduceusError;
 use serial_test::serial;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 // Global env-scoping guard. Only one scoped-env test runs at a time,
 // and each scoped block records every variable it touched so they can
@@ -106,7 +109,7 @@ where
 fn explicit_config_field_wins_over_env_vars_and_gh() {
     let cfg = Config {
         github_token: Some("explicit-token".to_string()),
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::with(&[
         ("CADUCEUS_GITHUB_TOKEN", "env-cad"),
@@ -129,7 +132,7 @@ fn explicit_config_field_wins_over_env_vars_and_gh() {
 fn caduceus_env_wins_over_github_env_and_gh() {
     let cfg = Config {
         github_token: None,
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::with(&[
         ("CADUCEUS_GITHUB_TOKEN", "env-cad"),
@@ -152,7 +155,7 @@ fn caduceus_env_wins_over_github_env_and_gh() {
 fn github_env_wins_over_gh_when_caduceus_env_unset() {
     let cfg = Config {
         github_token: None,
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::with(&[("GITHUB_TOKEN", "env-gh")]);
     let runner = StubGh {
@@ -172,7 +175,7 @@ fn github_env_wins_over_gh_when_caduceus_env_unset() {
 fn gh_cli_used_when_no_config_or_env_set() {
     let cfg = Config {
         github_token: None,
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::default();
     let runner = StubGh {
@@ -194,7 +197,7 @@ fn fallback_chain_skips_blank_levels() {
     // confirm that empty env vars do not block the chain.
     let cfg = Config {
         github_token: Some(String::new()),
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::with(&[("CADUCEUS_GITHUB_TOKEN", "   "), ("GITHUB_TOKEN", "")]);
     let runner = StubGh {
@@ -214,7 +217,7 @@ fn fallback_chain_skips_blank_levels() {
 fn whitespace_only_explicit_field_is_treated_as_unset() {
     let cfg = Config {
         github_token: Some("   ".to_string()),
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::default();
     let runner = StubGh { output: Err(()) };
@@ -233,7 +236,7 @@ fn whitespace_only_explicit_field_is_treated_as_unset() {
 fn missing_gh_is_a_token_resolution_error() {
     let cfg = Config {
         github_token: None,
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::default();
     let runner = StubGh { output: Err(()) };
@@ -247,7 +250,7 @@ fn missing_gh_is_a_token_resolution_error() {
 fn gh_exit_nonzero_surfaces_exit_code_but_not_stderr() {
     let cfg = Config {
         github_token: None,
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::default();
     let runner = StubGh {
@@ -270,7 +273,7 @@ fn gh_exit_nonzero_surfaces_exit_code_but_not_stderr() {
 fn gh_empty_output_is_failure() {
     let cfg = Config {
         github_token: None,
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::default();
     let runner = StubGh {
@@ -294,7 +297,7 @@ fn error_text_never_includes_token_value() {
     // error message must surface only the exit code, not the value.
     let cfg = Config {
         github_token: Some(String::new()),
-        ..Config::test_defaults(&tempdir())
+        ..Config::test_defaults(&tempdir("token"))
     };
     let env = MapEnv::with(&[("CADUCEUS_GITHUB_TOKEN", ""), ("GITHUB_TOKEN", "")]);
     let runner = StubGh {
@@ -374,7 +377,7 @@ fn os_env_trims_surrounding_whitespace() {
 fn real_runner_surfaces_spawn_errors_without_leaking_command_args() {
     // Point PATH at an empty directory so ``which::which("gh")`` fails.
     scoped_env(|| {
-        let empty = tempdir().join("empty-bin");
+        let empty = tempdir("token").join("empty-bin");
         std::fs::create_dir_all(&empty).unwrap();
         std::env::set_var("PATH", &empty);
         let runner = caduceus::config::RealGhRunner;
@@ -395,15 +398,4 @@ fn resolve_or_err(cfg: Config, env: &dyn TokenEnv, runner: &dyn GhRunner) -> Cad
         Ok(token) => panic!("expected error, got token {token:?}"),
         Err(err) => err,
     }
-}
-
-fn tempdir() -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-token-test-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
 }

--- a/tests/state/validate_test.rs
+++ b/tests/state/validate_test.rs
@@ -2,27 +2,19 @@
 //! `PATH` (built explicitly so the host's real `/usr/bin` cannot
 //! accidentally satisfy a check).
 
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-
 use caduceus::config::Config;
 use caduceus::validate::{
     check_bridge_readable, first_unwritable_parent, is_executable_file, preflight,
     process_groups_supported, resolve_executable, which_in, CheckOutcome,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-validate-test-{label}-{nonce}"));
-    std::fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn write_executable(path: &Path, body: &str) {
     std::fs::write(path, body).expect("write executable body");

--- a/tests/worker/supervisor_ack_gate_test.rs
+++ b/tests/worker/supervisor_ack_gate_test.rs
@@ -8,28 +8,17 @@
 
 #![cfg(target_os = "linux")]
 
+use caduceus::worker_supervisor::{collect_descendants, decode_frame, encode_frame, ControlFrame};
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
+use fixtures::tempdir;
 use std::fs;
 use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
-
-use caduceus::worker_supervisor::{collect_descendants, decode_frame, encode_frame, ControlFrame};
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-ack-gate-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn write_script(path: &PathBuf, body: &str) {
     fs::write(path, body).expect("write script");

--- a/tests/worker/supervisor_cancel_vs_done_test.rs
+++ b/tests/worker/supervisor_cancel_vs_done_test.rs
@@ -15,28 +15,17 @@
 
 #![cfg(target_os = "linux")]
 
-#[path = "../fixtures/mod.rs"]
-mod fixtures;
-
-use std::fs;
-use std::path::PathBuf;
-use std::time::Duration;
-
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
 use caduceus::worker_supervisor::supervise;
 use tokio_util::sync::CancellationToken;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-cancel-vs-done-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
 
 fn find_self_exe() -> PathBuf {
     fixtures::ReleaseBinary::locate()

--- a/tests/worker/supervisor_env_test.rs
+++ b/tests/worker/supervisor_env_test.rs
@@ -7,14 +7,17 @@
 //! the daemon into the supervisor CLI and then into the worker
 //! subprocess.
 
-use std::collections::BTreeMap;
-use std::ffi::{OsStr, OsString};
-use std::fs;
-use std::path::{Path, PathBuf};
-
 use caduceus::issue::IssueKey;
 use caduceus::worker::sanitized_env;
 use caduceus::worker::SanitizedEnvInputs;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::Path;
 
 fn empty_env() -> BTreeMap<OsString, OsString> {
     BTreeMap::new()
@@ -25,17 +28,6 @@ fn env_with(pairs: &[(&str, &str)]) -> BTreeMap<OsString, OsString> {
         .iter()
         .map(|(k, v)| (OsString::from(*k), OsString::from(*v)))
         .collect()
-}
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-supervisor-env-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
 }
 
 fn sample_inputs(worktree: &Path) -> SanitizedEnvInputs {

--- a/tests/worker/supervisor_transcript_ownership_test.rs
+++ b/tests/worker/supervisor_transcript_ownership_test.rs
@@ -15,27 +15,16 @@
 
 #![cfg(target_os = "linux")]
 
-#[path = "../fixtures/mod.rs"]
-mod fixtures;
-
-use std::fs;
-use std::path::PathBuf;
-
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
 use caduceus::worker_supervisor::supervise;
 use tokio_util::sync::CancellationToken;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
 
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-transcript-owner-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
+use fixtures::tempdir;
+use std::fs;
+use std::path::PathBuf;
 
 fn find_self_exe() -> PathBuf {
     fixtures::ReleaseBinary::locate()

--- a/tests/worker/worker_archive_test.rs
+++ b/tests/worker/worker_archive_test.rs
@@ -9,14 +9,16 @@
 //! * Worker exit 0 + no result file → file-not-found error
 //! * Signaled exit bypasses the nonzero check
 
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
-
 use caduceus::error::CaduceusError;
 use caduceus::finalize::archive_worker_result;
 use caduceus::issue::IssueKey;
 use caduceus::worker::parse_result_file;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 
 fn sample_issue() -> IssueKey {
     IssueKey {
@@ -24,17 +26,6 @@ fn sample_issue() -> IssueKey {
         repo: "repo".to_string(),
         number: 1,
     }
-}
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-archive-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
 }
 
 fn minimal_result_json() -> &'static str {

--- a/tests/worker/worker_env_test.rs
+++ b/tests/worker/worker_env_test.rs
@@ -28,17 +28,20 @@
 //!   (the no-allowlist, single-credential case is end-to-end
 //!   exercised by spawning a helper that prints its own env).
 
+use caduceus::issue::IssueKey;
+use caduceus::worker::sanitized_env;
+use caduceus::worker::spawn;
+use caduceus::worker::SanitizedEnvInputs;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-
-use caduceus::issue::IssueKey;
-use caduceus::worker::sanitized_env;
-use caduceus::worker::spawn;
-use caduceus::worker::SanitizedEnvInputs;
 
 fn sample_inputs(worktree: &Path) -> SanitizedEnvInputs {
     SanitizedEnvInputs {
@@ -67,17 +70,6 @@ fn env_with(pairs: &[(&str, &str)]) -> BTreeMap<OsString, OsString> {
         .iter()
         .map(|(k, v)| (OsString::from(*k), OsString::from(*v)))
         .collect()
-}
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-worker-env-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
 }
 
 // Sanitized-env contract: every CADUCEUS_* variable is set

--- a/tests/worker/worker_parent_death_test.rs
+++ b/tests/worker/worker_parent_death_test.rs
@@ -13,28 +13,17 @@
 //! from Rust and exercise the EOF / TERM / KILL paths with
 //! deterministic POSIX shell helpers as the worker.
 
+use caduceus::worker_supervisor::{encode_frame, ControlFrame};
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
+use fixtures::tempdir;
 use std::fs;
 use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
-
-use caduceus::worker_supervisor::{encode_frame, ControlFrame};
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-supervisor-parent-death-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn write_script(path: &PathBuf, body: &str) {
     fs::write(path, body).expect("write script");

--- a/tests/worker/worker_process_test.rs
+++ b/tests/worker/worker_process_test.rs
@@ -12,9 +12,16 @@
 //! * The supervisor protocol is versioned and length-bounded.
 //! * The hidden command never appears in `--help`.
 
+use caduceus::config::Config;
+use caduceus::issue::IssueKey;
+use caduceus::worker_supervisor::{
+    clear_heartbeat, encode_frame, open_transcript, read_heartbeat, write_heartbeat, ControlFrame,
+    WorkerRunPaths, PROTOCOL_VERSION,
+};
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
+use fixtures::tempdir;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
@@ -23,24 +30,6 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
-
-use caduceus::config::Config;
-use caduceus::issue::IssueKey;
-use caduceus::worker_supervisor::{
-    clear_heartbeat, encode_frame, open_transcript, read_heartbeat, write_heartbeat, ControlFrame,
-    WorkerRunPaths, PROTOCOL_VERSION,
-};
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-supervisor-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
-}
 
 fn write_script(path: &PathBuf, body: &str) {
     fs::write(path, body).expect("write script");

--- a/tests/worker/worker_result_test.rs
+++ b/tests/worker/worker_result_test.rs
@@ -4,12 +4,6 @@
 //! construct bytes in memory so the schema assertions stay
 //! fast and deterministic.
 
-use std::collections::BTreeMap;
-use std::fs::{self, OpenOptions};
-use std::io::Write;
-use std::os::unix::fs::OpenOptionsExt;
-use std::path::PathBuf;
-
 use caduceus::error::CaduceusError;
 use caduceus::issue::IssueKey;
 use caduceus::worker::{
@@ -17,6 +11,15 @@ use caduceus::worker::{
     WorkerStatus, MAX_ARTIFACTS, MAX_ARTIFACT_KEY_LEN, MAX_PULL_REQUEST_TITLE_CHARS,
     MAX_RESULT_FILE_BYTES, MAX_SUMMARY_BYTES,
 };
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
 
 fn sample_issue() -> IssueKey {
     IssueKey {
@@ -24,17 +27,6 @@ fn sample_issue() -> IssueKey {
         repo: "repo".to_string(),
         number: 1,
     }
-}
-
-fn tempdir(label: &str) -> PathBuf {
-    let mut dir = std::env::temp_dir();
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    dir.push(format!("caduceus-worker-test-{label}-{nonce}"));
-    fs::create_dir_all(&dir).expect("create tempdir");
-    dir
 }
 
 fn write_file(path: &PathBuf, body: &[u8]) {


### PR DESCRIPTION
## What

Replace the 52 per-file `fn tempdir(label) -> PathBuf` helpers under
`tests/` (plus 2 `fn scratch_dir` and 2 inline `as_nanos` temp-path
sites) with one shared helper in `tests/fixtures/tempdir.rs`.
Uniqueness now derives from `std::process::id()` + a process-wide
`AtomicU64` counter — NEVER from `SystemTime::now().as_nanos()`, which
collides on the coarse-clock (~1 us) macOS runner and caused parallel
tests to race on the same seed-clone directory (torn git trees, PR
#254, path `caduceus-code-pre-pr-state-1787857016180384000`).

## Changes

- New shared helper `fixtures::tempdir(label) -> PathBuf` and
  `fixtures::tempdir_owned(label) -> tempfile::TempDir` in
  `tests/fixtures/tempdir.rs`, re-exported from
  `tests/fixtures/mod.rs`.
- All 52 local `fn tempdir` definitions removed; call sites converge on
  the shared helper. `token_test`'s no-arg variant moves to
  `tempdir("token")`; `migration_test`'s `TempDir` variant moves to
  `tempdir_owned`.
- 2 `scratch_dir` helpers (`lifecycle_matrix_test`,
  `review_lifecycle_test`) and 2 inline `as_nanos` temp paths
  (`storage_root_test`, `orchestration_active_run_inline_test`) converge
  on the shared helper too.
- Retained and documented: the two `as_nanos()` process-id nonces in
  `tests/fixtures/crash_point.rs` and `tests/fixtures/process_tree.rs`
  (script filenames, not temp paths).
- Regression test in `tests/architecture/fixtures_self_test.rs`: 8
  threads x 100 calls with the SAME label must produce distinct paths,
  and every path must carry pid + monotonic counter (format assertion —
  the host-independent discriminator that catches the disease even on a
  fine-clock Linux box). Verified RED against a temporary `as_nanos`
  helper, GREEN with the shared helper.

## Verification

- `cargo fmt --check` — OK
- `cargo clippy --locked --all-targets -- -D warnings` — OK
- `cargo test --locked --all-targets` with the documented hermetic
  skips — OK (signal_test flakes once under full-suite load; re-run
  green, and pristine main flakes on the same tests in this sandbox)
- `fixtures_self_test` 33/33 — OK, including the new regression test
- Python gate (`uv run pytest -q tests/plugin/ tests/integration/bridge_test.py`):
  161 passed / 9 failed — the 9 failures are pre-existing on pristine
  main in this sandbox ("harness executable not found: bash", PATH
  sandbox), verified byte-identical failure set on `main`.

Closes #269