### PR TITLE
fix(daemon): close idle-SIGTERM startup race (closes #270)

### DIFF
--- a/src/daemon/signals.rs
+++ b/src/daemon/signals.rs
@@ -10,11 +10,32 @@
 //! immediate self-`SIGKILL`, which the operating system delivers
 //! to every descendant the daemon owns.
 //!
-//! The crate's `#![forbid(unsafe_code)]` policy forbids unsafe
+//! The crate's `#![deny(unsafe_code)]` policy forbids unsafe
 //! blocks, so all signal syscalls are routed through the safe
 //! `tokio::signal::unix` and `nix::sys::signal` wrappers. The
 //! listener is `Send + 'static` so the orchestrator can spawn
 //! it as a side task alongside the tick.
+//!
+//! # Startup mask discipline (issue #270)
+//!
+//! A SIGINT/SIGTERM delivered between process start and handler
+//! installation hits the default disposition and kills the daemon
+//! (`ExitStatus(unix_wait_status(15))`). `run_blocking` therefore
+//! blocks both signals on the orchestrator thread before the tokio
+//! runtime exists ([`block_idle_signals`]), so the signal pends
+//! instead of terminating the process. Runtime worker threads inherit
+//! the blocked mask; each restores its own mask via a
+//! `tokio::runtime::Builder::on_thread_start` hook gated on the
+//! handlers-installed flag ([`unblock_worker_after_handlers_installed`]),
+//! so worker subprocesses never inherit a blocked `SIGTERM`.
+//! Inside `block_on`, [`install_idle_handlers`] eagerly registers both
+//! tokio streams before the tick arm is polled — handler installation
+//! therefore always precedes the tick, and the readiness marker
+//! (`repos/mirrors`) is a valid "runtime is live" signal again.
+//! The orchestrator thread restores its mask immediately after
+//! registration ([`unblock_idle_signals`]); a signal that was pending
+//! is then delivered to the now-installed handler, producing the
+//! usual graceful cancel / exit 0.
 //!
 //! # Idle cancellation contract
 //!
@@ -25,14 +46,99 @@
 //! state files are not mutated by the
 //! listener itself.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use nix::sys::signal::{pthread_sigmask, SigSet, SigmaskHow, Signal as NixSignal};
+use tokio::signal::unix::{signal, Signal as TokioSignal, SignalKind as TokioSignalKind};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::scheduler::Pool;
+
+/// Set once [`install_idle_handlers`] has registered the tokio signal
+/// streams. Runtime worker threads are spawned with SIGINT/SIGTERM
+/// blocked (they inherit the orchestrator thread's pre-runtime mask)
+/// and spin on this flag in
+/// [`unblock_worker_after_handlers_installed`] before restoring their
+/// own mask, so the whole process stays protected until the handlers
+/// exist and worker subprocesses never inherit a blocked SIGTERM.
+static IDLE_HANDLERS_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+/// Drop guard that releases runtime worker threads blocked in
+/// [`unblock_worker_after_handlers_installed`] even when the `block_on`
+/// closure bails out before [`install_idle_handlers`] ran (registration
+/// error or panic), so `Runtime::drop` never deadlocks on the workers.
+pub(crate) struct WakeWorkersGuard;
+
+impl Drop for WakeWorkersGuard {
+    fn drop(&mut self) {
+        IDLE_HANDLERS_INSTALLED.store(true, Ordering::Release);
+    }
+}
+
+/// Block `SIGINT` and `SIGTERM` on the calling thread. Called before
+/// the tokio runtime is built so every worker thread the runtime
+/// spawns inherits the blocked mask; a signal delivered before the
+/// handlers are installed then pends at the process level instead of
+/// hitting the default disposition and killing the daemon (issue
+/// #270). Idempotent — repeated calls are no-ops. The caller restores
+/// the mask after registration via [`unblock_idle_signals`] (orchestrator
+/// thread) / [`unblock_worker_after_handlers_installed`] (worker
+/// threads).
+pub fn block_idle_signals() -> std::io::Result<()> {
+    let mut set = SigSet::empty();
+    set.add(NixSignal::SIGINT);
+    set.add(NixSignal::SIGTERM);
+    pthread_sigmask(SigmaskHow::SIG_BLOCK, Some(&set), None)?;
+    Ok(())
+}
+
+/// Unblock `SIGINT` and `SIGTERM` on the calling thread. Called by the
+/// orchestrator thread immediately after [`install_idle_handlers`]
+/// registers the tokio streams, so a signal that was pending during
+/// the blocked startup window is delivered to the now-installed
+/// handler (graceful cancel / exit 0), never to the default
+/// disposition. Only the two idle signals are touched; any other
+/// blocked signals are preserved.
+pub fn unblock_idle_signals() -> std::io::Result<()> {
+    let mut set = SigSet::empty();
+    set.add(NixSignal::SIGINT);
+    set.add(NixSignal::SIGTERM);
+    pthread_sigmask(SigmaskHow::SIG_UNBLOCK, Some(&set), None)?;
+    Ok(())
+}
+
+/// Callback installed via `tokio::runtime::Builder::on_thread_start`.
+/// Runtime worker threads are spawned with SIGINT/SIGTERM blocked
+/// (inherited from the orchestrator thread). They wait until
+/// [`install_idle_handlers`] has installed the tokio handlers, then
+/// restore their own mask so the worker subprocesses they later spawn
+/// never inherit a blocked SIGTERM (supervisor TERM-to-KILL contract).
+pub(crate) fn unblock_worker_after_handlers_installed() {
+    while !IDLE_HANDLERS_INSTALLED.load(Ordering::Acquire) {
+        std::thread::yield_now();
+    }
+    let mut set = SigSet::empty();
+    set.add(NixSignal::SIGINT);
+    set.add(NixSignal::SIGTERM);
+    let _ = pthread_sigmask(SigmaskHow::SIG_UNBLOCK, Some(&set), None);
+}
+
+/// Eagerly register the SIGINT/SIGTERM tokio streams. Must be called
+/// from inside the runtime (`signal` requires the signal driver);
+/// handler installation is synchronous, so once this returns the
+/// OS-level handlers exist and any signal that was pending because of
+/// the pre-runtime mask is delivered to them. Sets the worker-wake
+/// flag so the runtime worker threads can restore their own masks.
+pub fn install_idle_handlers() -> std::io::Result<(TokioSignal, TokioSignal)> {
+    let int_stream = signal(TokioSignalKind::interrupt())?;
+    let term_stream = signal(TokioSignalKind::terminate())?;
+    IDLE_HANDLERS_INSTALLED.store(true, Ordering::Release);
+    Ok((int_stream, term_stream))
+}
 
 /// Kind of signal the listener received. Used for diagnostic
 /// logging; the operator-shutdown semantics are identical for
@@ -85,9 +191,28 @@ pub const ESCALATE_GRACE: Duration = Duration::from_secs(2);
 pub async fn wait_for_signal() -> std::io::Result<SignalKind> {
     #[cfg(unix)]
     {
-        use tokio::signal::unix::{signal, SignalKind as TokioSignalKind};
         let mut int_stream = signal(TokioSignalKind::interrupt())?;
         let mut term_stream = signal(TokioSignalKind::terminate())?;
+        wait_for_signal_on(&mut int_stream, &mut term_stream).await
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = sleep(Duration::from_secs(3600)).await;
+        Ok(SignalKind::Terminate)
+    }
+}
+
+/// Wait for a single SIGINT or SIGTERM on already-registered streams.
+/// [`run_blocking`](crate::daemon::tick::run_blocking) registers the
+/// streams eagerly via [`install_idle_handlers`] and passes them to
+/// [`listen_on`]; the no-arg [`wait_for_signal`] constructs fresh
+/// streams for the acceptance-test seam.
+pub async fn wait_for_signal_on(
+    int_stream: &mut TokioSignal,
+    term_stream: &mut TokioSignal,
+) -> std::io::Result<SignalKind> {
+    #[cfg(unix)]
+    {
         tokio::select! {
             _ = int_stream.recv() => Ok(SignalKind::Interrupt),
             _ = term_stream.recv() => Ok(SignalKind::Terminate),
@@ -111,11 +236,35 @@ pub async fn wait_for_signal() -> std::io::Result<SignalKind> {
 /// worker pool drain so in-flight workers have a chance to
 /// complete within the configured drain timeout.
 pub async fn listen(pool: Arc<Pool>, cancellation: CancellationToken) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let int_stream = signal(TokioSignalKind::interrupt())?;
+        let term_stream = signal(TokioSignalKind::terminate())?;
+        listen_on(pool, cancellation, int_stream, term_stream).await
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = sleep(Duration::from_secs(3600)).await;
+        Ok(())
+    }
+}
+
+/// Like [`listen`] but drives the already-registered streams returned
+/// by [`install_idle_handlers`]. The daemon's `run_blocking` uses this
+/// path so handler installation is guaranteed to precede the tick arm;
+/// the public [`listen`] delegates here after constructing its own
+/// streams.
+pub async fn listen_on(
+    pool: Arc<Pool>,
+    cancellation: CancellationToken,
+    mut int_stream: TokioSignal,
+    mut term_stream: TokioSignal,
+) -> std::io::Result<()> {
     // First signal: start drain, then cancel and wait briefly for
     // cooperative shutdown. If a second signal arrives inside the
     // grace window, escalate to self-`SIGKILL` so the operating
     // system reaps every descendant immediately.
-    let first = wait_for_signal().await?;
+    let first = wait_for_signal_on(&mut int_stream, &mut term_stream).await?;
     info!(
         signal = first.label(),
         "operator signal received; draining worker pool"
@@ -140,7 +289,7 @@ pub async fn listen(pool: Arc<Pool>, cancellation: CancellationToken) -> std::io
     let deadline = Instant::now() + ESCALATE_GRACE;
     match tokio::time::timeout(
         deadline.saturating_duration_since(Instant::now()),
-        wait_for_signal(),
+        wait_for_signal_on(&mut int_stream, &mut term_stream),
     )
     .await
     {

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -65,6 +65,13 @@ use tokio::task::JoinSet;
 /// rate-limited / cancelled outcomes; 1 for configuration,
 /// corruption, invariant, or unrecovered pipeline failures.
 pub fn run() -> CaduceusResult<u8> {
+    // Block SIGINT/SIGTERM before any config / logging work so a
+    // signal delivered during startup pends instead of hitting the
+    // default disposition and killing the process (issue #270).
+    // Idempotent; `run_blocking` blocks again and installs the
+    // handlers / restores the mask.
+    signals::block_idle_signals()
+        .map_err(|err| CaduceusError::Other(format!("block idle signals: {err}")))?;
     let cfg = Config::load()?;
     let log_path = cfg.log_path.clone();
     let _log_guard = logging::init(&log_path)?;
@@ -80,6 +87,19 @@ pub fn run() -> CaduceusResult<u8> {
 /// cancels the in-flight work and the orchestrator returns
 /// `TickOutcome::Cancelled` / exit 0.
 pub fn run_blocking(cfg: Config) -> CaduceusResult<TickOutcome> {
+    // Block SIGINT/SIGTERM before the runtime spawns its worker
+    // threads (issue #270). Every worker thread inherits the blocked
+    // mask and restores its own mask via the `on_thread_start` hook
+    // below once `install_idle_handlers` has installed the tokio
+    // handlers; the orchestrator thread restores its mask right after
+    // the eager registration inside `block_on`. This closes the
+    // pre-registration default-disposition window (a blocked signal
+    // pends and is delivered to the installed handler on unblock,
+    // never to the default disposition) and guarantees handler
+    // installation precedes the tick arm. Idempotent with the block in
+    // [`run`] / `main`.
+    signals::block_idle_signals()
+        .map_err(|err| CaduceusError::Other(format!("block idle signals: {err}")))?;
     // A multi-threaded runtime is required so the sync finalize
     // helpers (commit / push / status) can drive their async git
     // operations via `tokio::task::block_in_place` + `Handle::block_on`.
@@ -89,6 +109,14 @@ pub fn run_blocking(cfg: Config) -> CaduceusResult<TickOutcome> {
     // `block_in_place`, not to per-tick concurrency.
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
+        .on_thread_start(|| {
+            // Workers inherit the blocked SIGINT/SIGTERM mask from the
+            // orchestrator thread. Wait for the tokio handlers, then
+            // restore this worker's mask so worker subprocesses never
+            // inherit a blocked SIGTERM (supervisor TERM-to-KILL
+            // contract).
+            crate::daemon::signals::unblock_worker_after_handlers_installed();
+        })
         .build()
         .map_err(|err| CaduceusError::Other(format!("build tokio runtime: {err}")))?;
     let cancellation = CancellationToken::new();
@@ -112,6 +140,22 @@ pub fn run_blocking(cfg: Config) -> CaduceusResult<TickOutcome> {
         ),
     );
     rt.block_on(async move {
+        // Wake the runtime workers even if registration fails or the
+        // closure panics, so `Runtime::drop` never deadlocks on them.
+        let _wake_workers = signals::WakeWorkersGuard;
+        // Eagerly register both signal streams BEFORE the select! arms
+        // are polled, so the tick arm is never polled with handlers
+        // uninstalled. Registration is synchronous (tokio
+        // `signal_enable` → `signal_hook_registry::register`), so once
+        // this returns the OS-level handlers exist.
+        let (int_stream, term_stream) = signals::install_idle_handlers()
+            .map_err(|err| CaduceusError::Other(format!("install idle signal handlers: {err}")))?;
+        // Restore this thread's mask immediately after registration —
+        // a signal that was pending during the blocked window is now
+        // delivered to the installed handler (graceful cancel), and
+        // the second-signal escalation path stays fully unblocked.
+        signals::unblock_idle_signals()
+            .map_err(|err| CaduceusError::Other(format!("unblock idle signals: {err}")))?;
         tokio::select! {
         outcome = run_with_config(cfg, Arc::clone(&pool), cancellation.clone()) => outcome,
         // The signal listener's first signal drains the worker
@@ -120,7 +164,7 @@ pub fn run_blocking(cfg: Config) -> CaduceusResult<TickOutcome> {
         // The listener itself continues to await a possible
         // second signal so the orchestrator can escalate to
         // immediate kill.
-        res = signals::listen(pool, cancellation.clone()) => {
+        res = signals::listen_on(pool, cancellation.clone(), int_stream, term_stream) => {
         match res {
         Ok(()) => Ok(TickOutcome::Cancelled),
         Err(err) => Err(CaduceusError::Other(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,23 @@ fn main() -> ExitCode {
     // the contractually documented behaviour (the CLI contract in
     // `src/cli/mod.rs`: "Implement no-argument behavior by inspecting
     // `args_os`...").
+    //
+    // Block SIGINT/SIGTERM before any CLI work when this process is a
+    // daemon tick (`caduceus` / `caduceus run`), so a signal delivered
+    // during startup pends instead of hitting the default disposition
+    // and killing the process (issue #270). `run_blocking` installs
+    // the tokio handlers and restores the mask after registration.
+    // Other subcommands (`status`, `queue reset`, `doctor`, ...) keep
+    // their default signal behaviour, and the supervisor mode above is
+    // exempted so the worker TERM-to-KILL contract is unaffected.
+    let is_tick_invocation = std::env::args_os().nth(1).is_none_or(|arg| arg == "run");
+    if is_tick_invocation {
+        if let Err(err) = caduceus::signals::block_idle_signals() {
+            eprintln!("caduceus: {err}");
+            return ExitCode::from(1);
+        }
+    }
+
     match cli::run() {
         Ok(()) => ExitCode::from(0),
         Err(err) => {

--- a/tests/architecture/fixtures_self_test.rs
+++ b/tests/architecture/fixtures_self_test.rs
@@ -652,6 +652,10 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::Arc;
 use std::thread;
+// The only Duration/Instant consumers are linux-only tests
+// (cfg(target_os = "linux")), so macOS clippy sees this import
+// as unused. Narrow allow, matching a85021e's pattern.
+#[cfg_attr(not(target_os = "linux"), allow(unused_imports))]
 use std::time::{Duration, Instant};
 
 #[test]

--- a/tests/daemon/signal_test.rs
+++ b/tests/daemon/signal_test.rs
@@ -161,24 +161,25 @@ fn spawn_daemon(config: &Path, args: &[&str]) -> std::process::Child {
         .expect("spawn caduceus")
 }
 
-/// Block until the daemon has installed its signal handlers.
+/// Block until the daemon's runtime is live.
 ///
 /// `logging::init` creates `state_dir/processor.log` before the
 /// tokio runtime starts, and the first tracing event is emitted
-/// from inside the runtime — by which point the signal listener
-/// task has been spawned and its SIGINT/SIGTERM streams are
-/// registered. Polling for non-empty log content is therefore a
-/// reliable readiness signal, unlike a fixed sleep (macOS CI
-/// runners can exceed 200 ms of cold-start before `main` even
-/// begins, which sent SIGTERM to a daemon that had not yet
+/// from inside the runtime. Polling for the tick's repo-storage
+/// marker (`repos/mirrors`, created by `tick() ->
+/// storage.ensure_dirs()` as its first action inside `block_on`) is
+/// therefore a reliable readiness signal — unlike a fixed sleep
+/// (macOS CI runners can exceed 200 ms of cold-start before `main`
+/// even begins, which sent SIGTERM to a daemon that had not yet
 /// registered handlers — the default disposition killed it).
+///
+/// Since issue #270, handler installation is guaranteed to precede
+/// the tick arm: `run_blocking` blocks SIGINT/SIGTERM before the
+/// runtime exists and eagerly registers both tokio signal streams
+/// inside `block_on` before the `select!` arms are polled. The
+/// marker therefore indicates a fully-started daemon whose signal
+/// handlers are installed.
 fn wait_for_daemon_ready(state_dir: &Path) {
-    // The tick creates its repo-storage directories as its first
-    // action inside the tokio runtime (tick() -> storage.ensure_dirs()),
-    // which runs concurrently with the signal listener registration in
-    // the same block_on. Once those dirs exist, the runtime is live and
-    // the SIGINT/SIGTERM handler streams are registered - unlike a fixed
-    // sleep, which loses the race on cold-started macOS CI runners.
     let marker = state_dir.join("repos").join("mirrors");
     let deadline = Instant::now() + Duration::from_secs(10);
     while !marker.is_dir() {
@@ -463,4 +464,47 @@ fn escalate_grace_matches_supervisor_window() {
     // under a single operator press.
     use std::time::Duration;
     assert_eq!(caduceus::signals::ESCALATE_GRACE, Duration::from_secs(2));
+}
+
+// Startup-race regression (issue #270). The daemon must exit 0 when
+// SIGTERM lands at ANY point during startup, including before the
+// readiness marker exists. The pre-fix daemon installs its signal
+// handlers as a `select!` arm racing the tick arm, so a SIGTERM in
+// the gap hits the default disposition and kills the process
+// (`ExitStatus(unix_wait_status(15))`); this was the macOS CI flake
+// root cause on PR #254.
+
+#[test]
+fn idle_sigterm_exits_zero_under_startup_stress() {
+    // Deterministic delay schedule covering the startup window, wrapped
+    // over 50 iterations so every iteration is reproducible. No
+    // `wait_for_daemon_ready` before the send — the point is to hit
+    // arbitrary startup points, including the pre-registration window
+    // the marker cannot observe.
+    //
+    // Delays below 7ms are deliberately excluded: a SIGTERM sent
+    // 0-5ms after spawn lands during exec/dynamic linking, before the
+    // daemon's `main()` executes, so the default disposition applies
+    // and no in-process handler can intercept it. That window is
+    // unfixable in-process and fails CI identically; the 7-20ms range
+    // covers the actual handler-registration race this test guards.
+    let delays_ms = [7u64, 10, 13, 16, 20];
+    for i in 0..50 {
+        let delay = delays_ms[i % delays_ms.len()];
+        let dir = tempdir("idle-sigterm-stress");
+        let worker = dir.join("noop.sh");
+        write_script(&worker, "#!/bin/sh\nexit 0\n");
+        let cfg = write_config(&dir, &worker, 3600);
+        seed_recent_tick(&dir);
+        let mut child = spawn_daemon(&cfg, &["run"]);
+        if delay > 0 {
+            std::thread::sleep(Duration::from_millis(delay));
+        }
+        send(child.id(), Signal::SIGTERM);
+        let status = wait_with_timeout(&mut child, Duration::from_secs(10));
+        assert!(
+            status.success(),
+            "iteration {i} (delay {delay}ms): expected exit 0 on idle SIGTERM during startup; got {status:?}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #270

Fix the idle-SIGTERM startup race: SIGTERM arriving between process
spawn and tokio signal-handler registration hit the default disposition
and killed the daemon (`ExitStatus(unix_wait_status(15))`) instead of a
graceful idle cancel + exit 0. This was macOS CI flake root cause #2 on
PR #254.

## Approach

- Block SIGINT/SIGTERM on the orchestrator thread before the runtime
  starts (safe nix `pthread_sigmask`, no `unsafe`), closing the
  pre-registration default-disposition window.
- Eagerly register both tokio signal streams inside `block_on` before
  the select! arms are polled, then unblock immediately.
- tokio worker threads restore their own mask on start
  (`Builder::on_thread_start` gate) so worker subprocesses never
  inherit a blocked SIGTERM (supervisor TERM-to-KILL contract intact).
- `main()` blocks SIGINT/SIGTERM for tick invocations before any
  config/git-identity work; `run()`/`run_blocking` block idempotently.
  Supervisor mode exempt.

## Verification

- RED: pre-fix code fails 13/20 at 7-20ms delays (`unix_wait_status(15)`).
- GREEN: new stress test `idle_sigterm_exits_zero_under_startup_stress`
  (50 iterations, 7-20ms schedule) passes 50/50; all existing signal,
  worker, tick, daemon-lock tests pass.
- `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`,
  `cargo test --locked --all-targets` clean. pytest: 164 passed, 6
  pre-existing PATH-sandbox failures (`harness executable not found:
  bash`) unrelated to this diff (Rust-only change).

Note: the stress-test delay floor is 7ms — a SIGTERM sent 0-5ms after
spawn lands during exec/dynamic linking before `main()` executes
(unfixable in-process, fails CI identically); documented in the test.