### PR TITLE
fix(executor): scope neutrality override and repair live exit-code readback

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -37,3 +37,15 @@ platform = "x86_64-unknown-linux-gnu"
 [profile.nightly]
 inherits = "default"
 default-filter = "all()"
+
+# CI profile used by the oci-live-certification job (ci.yml, issue
+# #252). Inherits `default` (120s slow-timeout + canary filter) and
+# emits a JUnit report so the upload-diagnostics-on-failure artifact
+# step has a real file to upload (the report lands at
+# target/nextest/ci/junit.xml). This nextest version has no
+# `--junit-xml` CLI flag; JUnit output is config-driven only.
+[profile.ci]
+inherits = "default"
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
           CADUCEUS_RUN_ISOLATION_TESTS: "1"
         run: |
           set -euo pipefail
-          cargo nextest run --locked --all-targets --run-ignored all \
+          cargo nextest run --locked --all-targets --run-ignored all --profile ci \
             -E 'binary(oci_isolation_live_test) or binary(oci_env_live_test) or binary(certification_mapping_test)'
       - name: upload diagnostics on failure
         if: failure() && steps.filter.outputs.security == 'true'
@@ -471,7 +471,7 @@ jobs:
         with:
           name: oci-live-diagnostics
           path: |
-            target/nextest/ci-junit.xml
+            target/nextest/ci/junit.xml
             **/engine.log
             **/oci-runs/**/*.log
           if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **Live OCI certification suite: image precedence and exit-code
+  readback (issue #252).** The shared live-test fixture now applies
+  `CADUCEUS_LIVE_TEST_IMAGE` (the reference image) to every test;
+  only `image_neutrality_custom_unrelated_image_live` reads
+  `CADUCEUS_LIVE_NEUTRALITY_IMAGE` and scopes it to its own sandbox,
+  so CI legs no longer run the bulk of the adversarial suite against
+  alpine. `run_container` parses the first space-separated field of
+  `docker inspect` (not the whole three-field string), restoring the
+  authoritative exit-code readback for OOM/cancellation/timeout
+  assertions. The `oci-live-certification` job also runs under a new
+  `ci` nextest profile with a JUnit emitter, so the failure-diagnostics
+  artifact is real.
 - **Status commands in non-Hermes shells.** `hermes caduceus status` (and
   every adapter subcommand shelling out to the daemon binary) no longer
   fails with `no configuration source found` in shells that do not export

--- a/docs/certification/oci-certification.md
+++ b/docs/certification/oci-certification.md
@@ -83,7 +83,12 @@ skip-not-fail when the host engine does not match their mode.
   digest-pinned reference image (local registry push of the built
   reference image) plus a non-reference neutrality image (alpine),
   and runs `cargo nextest run --run-ignored all` over the two live
-  binaries and the mapping self-check.
+  binaries and the mapping self-check. Every live test runs against
+  the reference image (`CADUCEUS_LIVE_TEST_IMAGE` is the shared
+  default); only
+  `image_neutrality_custom_unrelated_image_live` reads
+  `CADUCEUS_LIVE_NEUTRALITY_IMAGE` and overrides its own sandbox
+  image with it.
 - **Nightly (not merge-gating):** `oci-live-nightly.yml` — rootless
   Docker and Podman Tier-2, 07:30 UTC daily.
 - **Release:** `release.yml` runs all three modes in the

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -187,16 +187,12 @@ fn live_fixture_with(
     // Digest-pinned image override for hosts with a pre-pulled image;
     // defaults to the test_defaults placeholder (fine for pure argv
     // assertions, but a live `create` needs a resolvable digest).
-    // `CADUCEUS_LIVE_NEUTRALITY_IMAGE` wins when both are set: the
-    // image-neutrality certification test runs a deliberately
-    // unrelated image while every other test uses the reference.
-    if let Ok(image) = std::env::var("CADUCEUS_LIVE_NEUTRALITY_IMAGE") {
-        assert!(
-            image.contains("@sha256:"),
-            "CADUCEUS_LIVE_NEUTRALITY_IMAGE must be digest-pinned, got: {image}"
-        );
-        cfg.sandbox.as_mut().expect("sandbox").image = image;
-    } else if let Ok(image) = std::env::var("CADUCEUS_LIVE_TEST_IMAGE") {
+    // `CADUCEUS_LIVE_TEST_IMAGE` is the global reference every live
+    // test runs against. Only the image-neutrality certification test
+    // (`image_neutrality_custom_unrelated_image_live`) overrides its
+    // own sandbox image with `CADUCEUS_LIVE_NEUTRALITY_IMAGE` via the
+    // `adjust` hook below.
+    if let Ok(image) = std::env::var("CADUCEUS_LIVE_TEST_IMAGE") {
         assert!(
             image.contains("@sha256:"),
             "CADUCEUS_LIVE_TEST_IMAGE must be digest-pinned, got: {image}"
@@ -316,9 +312,17 @@ fn run_container(fx: &LiveFixture) -> (i64, String) {
         ])
         .output();
     if let Ok(out) = inspected {
-        if let Ok(recorded) = String::from_utf8_lossy(&out.stdout).trim().parse::<i64>() {
-            if recorded != 0 || code == 0 {
-                code = recorded;
+        // The format string emits three space-separated fields
+        // (`ExitCode OOMKilled Status`); only the first is the exit
+        // code, so split before parsing.
+        if let Some(first) = String::from_utf8_lossy(&out.stdout)
+            .split_whitespace()
+            .next()
+        {
+            if let Ok(recorded) = first.parse::<i64>() {
+                if recorded != 0 || code == 0 {
+                    code = recorded;
+                }
             }
         }
     }
@@ -1719,10 +1723,23 @@ fn wrong_digest_rejected_before_execution_live() {
 #[test]
 #[cfg_attr(not(env = "CADUCEUS_RUN_ISOLATION_TESTS"), ignore)]
 fn image_neutrality_custom_unrelated_image_live() {
+    // This test is the ONLY consumer of the neutrality override: it
+    // reads `CADUCEUS_LIVE_NEUTRALITY_IMAGE` explicitly and scopes it
+    // to its own sandbox config, while the shared `live_fixture_with`
+    // helper uses `CADUCEUS_LIVE_TEST_IMAGE` for every other test.
+    let neutrality = std::env::var("CADUCEUS_LIVE_NEUTRALITY_IMAGE")
+        .expect("CADUCEUS_LIVE_NEUTRALITY_IMAGE required for the image-neutrality certification");
+    assert!(
+        neutrality.contains("@sha256:"),
+        "CADUCEUS_LIVE_NEUTRALITY_IMAGE must be digest-pinned, got: {neutrality}"
+    );
     let reference = std::env::var("CADUCEUS_LIVE_TEST_IMAGE").unwrap_or_default();
-    let fx = live_fixture(
+    let fx = live_fixture_with(
         GitShadowKind::File,
         "echo neutrality-ok; id -u > /workspace/neutrality-canary; exit 0",
+        |cfg| {
+            cfg.sandbox.as_mut().expect("sandbox").image = neutrality.clone();
+        },
     );
     let used = fx.cfg.sandbox().image.clone();
     if !reference.is_empty() {


### PR DESCRIPTION
Review rework for the issue #252 live OCI certification suite (PR #279).

Blocking fixes from the review:

1. **Image-neutrality override defeated the reference-image leg on CI.**
   The shared live-test fixture read `CADUCEUS_LIVE_NEUTRALITY_IMAGE`
   first and applied it to every test's sandbox config, while the CI
   jobs export both image vars — so on GitHub's runner ~10 of the 16
   adversarial bullets ran against alpine:3.20 instead of the built
   reference image. The helper now applies `CADUCEUS_LIVE_TEST_IMAGE`
   (the reference) to every test, and only
   `image_neutrality_custom_unrelated_image_live` reads
   `CADUCEUS_LIVE_NEUTRALITY_IMAGE` explicitly and scopes it to its own
   sandbox via the `adjust` hook.

2. **Dead exit-code readback in `run_container`.**
   `docker inspect --format "{{.State.ExitCode}} ..."` emits three
   space-separated fields but the code parsed the whole string as one
   `i64`, which can never succeed — OOM/cancellation/timeout assertions
   fell back to the racy `docker wait` path. The inspect output is now
   `split_whitespace()`'d and only the first field is parsed.

Non-blocking item addressed:

- Wired a real JUnit emitter for `upload-diagnostics-on-failure`.
  This nextest version has no `--junit-xml` CLI flag; JUnit output is
  config-driven. Added a `[profile.ci.junit]` entry in
  `.config/nextest.toml`, switched the `oci-live-certification` job to
  `--profile ci`, and pointed the artifact glob at
  `target/nextest/ci/junit.xml`. Verified locally: report is written
  and contains all 30 tests.

Docs: `docs/certification/oci-certification.md` now documents the
precedence explicitly; CHANGELOG updated.

Verification (local, Docker 29.7.2):

- `cargo fmt --check` — PASS
- `cargo clippy --locked --all-targets -- -D warnings` — PASS
- `cargo test --locked --all-targets` — 2188 passed / 0 failed
  (158 test binaries)
- Live suite via nextest with `CADUCEUS_RUN_ISOLATION_TESTS=1` and
  both digest-pinned image vars — 30/30 PASS (twice); sampled
  containers confirmed every non-neutrality test uses the reference
  image (127.0.0.1:5000/caduceus-worker-reference@sha256:021f7fa4...)