### PR TITLE
fix(tests): make bridge subprocess env hermetic against real harness

### DIFF
--- a/tests/integration/bridge_test.py
+++ b/tests/integration/bridge_test.py
@@ -59,6 +59,7 @@ def fake_env(tmp_path: Path) -> dict:
     prompt = worktree / "worker-prompt.md"
     prompt.write_text("# Caduceus prompt\n\nRun the workflow per the spec.", encoding="utf-8")
     return {
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
         "CADUCEUS_ISSUE_NUMBER": "42",
         "CADUCEUS_ISSUE_TITLE": "Test issue with spaces and unicode ✨",
         "CADUCEUS_ISSUE_BODY": "Body with newline\nand quote \" marks.",
@@ -476,6 +477,8 @@ def _make_worktree_with_prompt(tmp_path: Path) -> Path:
 
 def _build_env(tmp_path: Path, **overrides: str) -> dict:
     env = {
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+        "PATH": os.environ.get("PATH") or os.defpath,
         "CADUCEUS_ISSUE_NUMBER": "42",
         "CADUCEUS_ISSUE_TITLE": "issue with spaces ✨",
         "CADUCEUS_ISSUE_BODY": "line one\nline two 🚀",


### PR DESCRIPTION
Closes #284

Root cause (reproduced on this host): the tests were not hermetic against the operator's real environment.

- `_build_env()`/`fake_env` never set `HERMES_HOME`, so `_hook_path()` fell back to `~/.hermes/caduceus/harness.py` — and when that file exists (it does on any host running the daemon), the bridge silently switches to the new-contract hook path and spawns the REAL harness instead of the fake test wrapper. The failing tests then executed the real `opencode run --auto ...` argv and returned nondeterministic results (6 failures on this host, plus multi-minute hangs while real agent runs started).
- The constructed subprocess env also had no `PATH` (or a trimmed `bin_dir:`-only PATH), so the child could not resolve `bash`/`python3` via `env` shebangs on hosts with a trimmed runner PATH.

Fix:
- Pin `HERMES_HOME` to a per-test temp dir in both `fake_env` and `_build_env` so the real user hook can never leak in (the new-contract tests already override it deliberately).
- Give `_build_env` a sane `PATH` default (`os.environ` PATH, falling back to `os.defpath`).

Verified locally:
- `uv run pytest -q tests/integration/bridge_test.py` — 55 passed / 0 failed in ~1.4s (was 5 failures + a hang)
- `uv run pytest -q tests/plugin/` — 115 passed / 0 failed