### PR TITLE
feat(cli): add queue show/remove + hermes passthrough (closes #265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Added
 
+- **Queue inspection and removal CLI.** `caduceus queue show
+  [<owner/repo#n>] [--json]` lists every entry as a human table (or
+  full detail including the finalization checkpoint) with a versioned
+  `queue/1.0` JSON envelope; `caduceus queue remove <owner/repo#n>
+  [--dry-run] [--force] [--json]` drops a queue entry entirely —
+  refusing `InProgress` / `AwaitingReview` / `Done` by default and an
+  active claim file always, never touching the worktree, claim file,
+  remote branch, or PR. The `hermes caduceus` wrapper now passes
+  `queue`, `worktree-gc`, and `migrate-state` through to the binary
+  and forwards `--json` on `status`. Closes #265.
 - **Hardened per-run OCI baseline** (non-weakenable, both engines):
   `--memory-swap` pinned equal to `--memory` (no swap doubling), bounded
   engine logs (`--log-opt max-size=10m max-file=3`), explicit resolve-time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -396,6 +396,14 @@ name = "queue_reset_cli_test"
 path = "tests/state/queue_reset_cli_test.rs"
 
 [[test]]
+name = "queue_show_test"
+path = "tests/state/queue_show_test.rs"
+
+[[test]]
+name = "queue_remove_test"
+path = "tests/state/queue_remove_test.rs"
+
+[[test]]
 name = "reaper_test"
 path = "tests/state/reaper_test.rs"
 

--- a/README.md
+++ b/README.md
@@ -532,6 +532,61 @@ If a config key is not named there, it is not part of the public contract
 surface; the daemon ignores it, which is the honest answer to
 "why does my custom key do nothing?"
 
+## CLI reference
+
+The `caduceus` binary exposes seven top-level commands. A bare
+`caduceus` invocation is rewritten to `caduceus run` so the cron
+contract (silent on success) holds. `--json` output uses a versioned
+envelope; the queue commands emit `schema: "queue/1.0"` and
+`status` emits its own `version`.
+
+```text
+caduceus run                          # run a single tick (default)
+caduceus status [--json]              # report daemon state
+caduceus doctor [--json] [--skip-canary] [--canary-image IMG]
+              [--canary-command CMD]  # live OCI readiness check
+caduceus worktree-gc [--older-than-days N] [--dry-run]
+                                      # sweep stale worktrees
+caduceus queue <action>               # manage the work queue
+caduceus migrate-state --from <path> [--dry-run]
+caduceus migrate-state --to-sqlite [--dry-run]
+                                      # migrate legacy / SQLite state
+caduceus setup [--dry-run]            # generate minimal non-secret config
+```
+
+The `queue` subcommand has four actions:
+
+```text
+caduceus queue show [<owner/repo#n>] [--json]
+                                      # list entries, or print full
+                                      # detail incl. the finalization
+                                      # checkpoint
+caduceus queue reset <owner/repo#n> [--dry-run] [--json]
+              [--force-finalization-reset]
+                                      # return a Failed/Skipped entry
+                                      # to Queued
+caduceus queue reprocess <owner/repo#n> [--dry-run]
+                                      # new generation, immediately
+                                      # claimable
+caduceus queue remove <owner/repo#n> [--dry-run] [--force] [--json]
+                                      # drop a queue entry entirely
+```
+
+`queue remove` drops only the queue entry. The worktree, claim file,
+remote branch, and pull request are left for the reaper /
+`worktree-gc` and are never touched under any flag. By default it
+refuses `InProgress`, `AwaitingReview`, and `Done` entries;
+`--force` relaxes the phase guard only — an entry with a live claim
+file is always refused. If the trigger label is still on the issue,
+the next poll re-enqueues a fresh entry; that is documented
+behaviour, not a bug. `queue show` is read-only: it snapshots under
+the shared state lock, never writes, and does not take the daemon
+lock, so it is safe to run alongside a live tick.
+
+`worktree-gc` operates under the daemon lock (so it never races a
+tick), defaults to an `--older-than-days 30` threshold, and
+`--dry-run` reports eligible worktrees without removing them.
+
 ## The Operator's Manual
 
 Moved out of the README on purpose. The README is the
@@ -684,10 +739,12 @@ state in place. Follow the supported recovery process in
 
 ### Retrying failed work
 
-Use the queue command to retry a failed item:
+Use the queue commands to inspect and retry a failed item:
 
 ```text
 caduceus status
+caduceus queue show                    # see every entry and its phase
+caduceus queue show owner/repo#number  # full detail incl. checkpoint
 caduceus queue reset owner/repo#number --dry-run
 caduceus queue reset owner/repo#number
 ```
@@ -697,6 +754,27 @@ so a later tick can resume safely. `--force-finalization-reset`
 discards that checkpoint after warning about the affected
 branch and pull request; it never deletes remote branches
 or pull requests.
+
+`caduceus queue reprocess owner/repo#number` bumps the generation
+and clears `next_attempt_at`, making the entry immediately claimable
+on the next tick — use it to fast-track a retry after the root cause
+is fixed.
+
+To drop an entry entirely instead of retrying it:
+
+```text
+caduceus queue remove owner/repo#number --dry-run
+caduceus queue remove owner/repo#number
+```
+
+`queue remove` deletes only the queue entry; the worktree, claim
+file, remote branch, and PR are left for the reaper / `worktree-gc`
+and are never touched. `InProgress`, `AwaitingReview`, and `Done`
+entries are refused by default; `--force` relaxes that phase guard
+only, and an entry with a live claim file is always refused. If the
+trigger label is still on the issue, the next poll re-enqueues a
+fresh entry — remove the label first if you want the issue to stay
+out of the queue.
 
 ### Installation changes and removal
 

--- a/__init__.py
+++ b/__init__.py
@@ -23,11 +23,14 @@ plugin compatibility contract:
    chat-safe diagnostic explaining how to run ``hermes caduceus setup``.
 3. ``ctx.register_cli_command(name="caduceus", ...)`` for the
    ``hermes caduceus <subcommand>`` family, with subcommands
-   ``setup``, ``doctor``, ``status``, ``cron-install``, and ``cron-remove``.
+   ``setup``, ``doctor``, ``status``, ``cron-install``, ``cron-remove``,
+   and the pass-through ``queue``, ``worktree-gc``, and ``migrate-state``
+   (trailing args are forwarded verbatim to the ``caduceus`` binary).
 """
 
 from __future__ import annotations
 
+import argparse
 import fcntl
 import json
 import os
@@ -38,7 +41,7 @@ import sys
 from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 
 # ---------------------------------------------------------------------------
@@ -369,13 +372,55 @@ def _format_status_for_chat(payload: Dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# CLI command: hermes caduceus <setup|doctor|status|cron-install|cron-remove>
+# CLI command: hermes caduceus
+#   <setup|doctor|status|cron-install|cron-remove|queue|worktree-gc|migrate-state>
 # ---------------------------------------------------------------------------
+
+
+class _PassthroughParser(argparse.ArgumentParser):
+    """Subparser that forwards its full trailing argv verbatim.
+
+    The Hermes CLI parses plugin subcommands strictly, so a
+    pass-through subcommand whose first token is a flag (e.g.
+    ``hermes caduceus worktree-gc --older-than-days 7``) would abort
+    with ``unrecognized arguments`` under plain argparse. This parser
+    swallows every trailing token into the ``passthrough_attr``
+    namespace field and returns no leftovers; the dispatch function
+    then forwards those tokens verbatim to the ``caduceus`` binary.
+    The clap parser remains the single source of truth for the flag
+    contract — the wrapper never re-encodes it.
+    """
+
+    def __init__(self, *args, passthrough_attr: str | None = None, **kwargs):
+        self._passthrough_attr = passthrough_attr
+        super().__init__(*args, **kwargs)
+
+    # The override is intentionally narrower than the typeshed
+    # overloads: the Hermes CLI always calls the subparser with
+    # ``namespace=None`` (typeshed's first overload), and the
+    # pass-through capture never needs a pre-seeded namespace.
+    def parse_known_args(  # type: ignore[override]
+        self,
+        args: Optional[Iterable[str]] = None,
+        namespace: None = None,
+    ) -> tuple[argparse.Namespace, List[str]]:
+        if self._passthrough_attr is not None:
+            ns = argparse.Namespace()
+            tokens = list(args) if args is not None else []
+            setattr(ns, self._passthrough_attr, tokens)
+            return ns, []
+        # The Hermes CLI always calls the subparser with
+        # ``namespace=None`` (the typeshed first overload); keep the
+        # annotated contract tight so a stray namespace cannot bypass
+        # the pass-through capture.
+        return super().parse_known_args(args, namespace)
 
 
 def _register_caduceus_cli(subparser: Any) -> None:
     """Wire the ``hermes caduceus`` argparse tree."""
-    subs = subparser.add_subparsers(dest="caduceus_command", required=True)
+    subs = subparser.add_subparsers(
+        dest="caduceus_command", required=True, parser_class=_PassthroughParser
+    )
 
     setup = subs.add_parser(
         "setup",
@@ -397,9 +442,47 @@ def _register_caduceus_cli(subparser: Any) -> None:
         help="Print internal detail and structured category (human debugging only).",
     )
 
-    subs.add_parser(
+    status = subs.add_parser(
         "status",
         help="Run `caduceus status` and print the result.",
+    )
+    status.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the machine-readable JSON status report.",
+    )
+
+    queue = subs.add_parser(
+        "queue",
+        help="Manage the work queue (show, reset, reprocess, remove).",
+        passthrough_attr="queue_args",
+    )
+    # Pass-through: every trailing token is forwarded verbatim to the
+    # binary; clap is the single source of truth for the flag contract.
+    queue.add_argument(
+        "queue_args",
+        nargs=argparse.REMAINDER,
+        help="Subcommand and flags forwarded to the caduceus binary.",
+    )
+
+    subs.add_parser(
+        "worktree-gc",
+        help="Garbage-collect stale worktrees (flags forwarded to the binary).",
+        passthrough_attr="worktree_gc_args",
+    ).add_argument(
+        "worktree_gc_args",
+        nargs=argparse.REMAINDER,
+        help="Flags forwarded to the caduceus binary.",
+    )
+
+    subs.add_parser(
+        "migrate-state",
+        help="Migrate daemon state (flags forwarded to the binary).",
+        passthrough_attr="migrate_state_args",
+    ).add_argument(
+        "migrate_state_args",
+        nargs=argparse.REMAINDER,
+        help="Flags forwarded to the caduceus binary.",
     )
 
     cron_install = subs.add_parser(
@@ -437,7 +520,13 @@ def _caduceus_cli_command(args: Any) -> int:
     if sub == "doctor":
         return _cli_doctor(verbose=getattr(args, "verbose", False))
     if sub == "status":
-        return _cli_status()
+        return _cli_status(json=getattr(args, "json", False))
+    if sub == "queue":
+        return _cli_passthrough("queue", getattr(args, "queue_args", []))
+    if sub == "worktree-gc":
+        return _cli_passthrough("worktree-gc", getattr(args, "worktree_gc_args", []))
+    if sub == "migrate-state":
+        return _cli_passthrough("migrate-state", getattr(args, "migrate_state_args", []))
     if sub == "cron-install":
         return _cli_cron_install(
             dry_run=getattr(args, "dry_run", False),
@@ -982,7 +1071,36 @@ def _cli_doctor(verbose: bool = False) -> int:
     return max_severity
 
 
-def _cli_status() -> int:
+def _cli_status(*, json: bool = False) -> int:
+    binary = _binary_path()
+    if not binary.is_file():
+        print(
+            "caduceus: binary not built — run `hermes caduceus setup`",
+            file=sys.stderr,
+        )
+        return 1
+    argv = [str(binary), "status"]
+    if json:
+        argv.append("--json")
+    proc = _run(
+        argv,
+        cwd=_plugin_root(),
+        timeout=SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    if proc.stdout:
+        sys.stdout.write(proc.stdout)
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+    return proc.returncode
+
+
+def _cli_passthrough(subcommand: str, forwarded: List[str]) -> int:
+    """Run ``caduceus <subcommand> [forwarded...]`` and propagate the exit code.
+
+    *forwarded* is the verbatim trailing argv the operator typed after
+    the subcommand keyword; the wrapper never re-encodes flags — the
+    clap parser in the binary is the single source of truth.
+    """
     binary = _binary_path()
     if not binary.is_file():
         print(
@@ -991,7 +1109,7 @@ def _cli_status() -> int:
         )
         return 1
     proc = _run(
-        [str(binary), "status"],
+        [str(binary), subcommand, *forwarded],
         cwd=_plugin_root(),
         timeout=SUBPROCESS_TIMEOUT_SECONDS,
     )

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -48,13 +48,18 @@ When triggered, this skill should:
    resolves this relative to `$HERMES_HOME` (default `~/.hermes`).
 5. **If something is broken**: tail `<state_dir>/processor.log` and
    `<state_dir>/runs/<run-id>.log` for the affected run. For a terminal
-   failed/skipped entry, show `caduceus queue reset OWNER/REPO#N
-   --dry-run` before proposing the real reset; never edit state files
-   directly.
+   failed/skipped entry, show `caduceus queue show OWNER/REPO#N` to
+   inspect the entry and checkpoint, then `caduceus queue reset
+   OWNER/REPO#N --dry-run` before proposing the real reset; never edit
+   state files directly.
 6. **If the user asks about a stuck `Failed` issue**: explain that
    failed entries are not auto-reset. Removing and re-adding the
    trigger label does not bypass the per-issue retry budget; the
    operator must run `caduceus queue reset OWNER/REPO#N [--dry-run]`.
+   If the operator wants to drop the entry entirely instead of
+   retrying, `caduceus queue remove OWNER/REPO#N [--dry-run]` deletes
+   only the queue entry (never the remote branch/PR, worktree, or
+   claim file).
 7. **If the user asks about dry-run behavior**: explain that
    `CADUCEUS_DRY_RUN=1` performs polling, claim, prompt creation, worker
    execution, and result validation but performs **no** commit, push,
@@ -125,10 +130,21 @@ rename and are never silently truncated:
 - **Corrupt `state_meta.json`** → same behavior. Exit 1, file preserved.
 - **Stale heartbeat** (>90s old) → reaped on the next tick after
   `stale_run_hours` elapses.
-- **Stuck issue** → `caduceus queue reset OWNER/REPO#N [--dry-run]`.
-  The reset requires the daemon's whole-tick lock and refuses to drop
-  an entry with an open PR unless `--force-finalization-reset` is
-  supplied and confirmed in dry-run output.
+- **Stuck issue** → inspect first with `caduceus queue show` (list
+  form) or `caduceus queue show OWNER/REPO#N` (full detail including
+  the finalization checkpoint), then recover with
+  `caduceus queue reset OWNER/REPO#N [--dry-run]`. The reset requires
+  the daemon's whole-tick lock and refuses to drop an entry with an
+  open PR unless `--force-finalization-reset` is supplied and
+  confirmed in dry-run output.
+- **Drop an entry entirely** → `caduceus queue remove OWNER/REPO#N
+  [--dry-run] [--force]`. Remove deletes only the queue entry; the
+  worktree, claim file, remote branch, and PR are left for the reaper
+  / `worktree-gc` and are never touched. `InProgress`,
+  `AwaitingReview`, and `Done` are refused by default; `--force`
+  relaxes the phase guard only — an entry with a live claim file is
+  always refused. If the trigger label is still on the issue, the
+  next poll re-enqueues a fresh entry.
 - **Never edit state files directly.** Manual intervention is not a
   supported path; the daemon's lock + atomic-write discipline only
   holds for the programmatic API.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,8 +7,10 @@
 //! ultimately delegates to `caduceus::tick::run_blocking`.
 
 use std::ffi::OsString;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use chrono::Utc;
 use clap::{Parser, Subcommand};
 
 use caduceus::config::{Config, SetupAction};
@@ -16,11 +18,20 @@ use caduceus::error::{CaduceusError, CaduceusResult};
 use caduceus::executor::oci::OciExecutor;
 use caduceus::executor::{Executor, ExecutorSpec};
 use caduceus::issue::IssueKey;
-use caduceus::queue::StateStore;
+use caduceus::queue::{
+    display_digest, Phase, QueueEntry, QueueState, RemoveOutcome, StateStore, TicketType,
+};
 use caduceus::readiness::{self, DiagnosticCanary, DiagnosticStatus, ReadinessVerdict};
 use caduceus::DaemonLock;
 
 static GIT_AUTHOR_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Schema version of the `queue` JSON envelope emitted by
+/// `queue show`, `queue reset --json`, and `queue remove --json`.
+/// Bumped when the envelope shape changes so consumers can detect
+/// the version. Distinct from `STATUS_SCHEMA_VERSION` — the queue
+/// and status schemas version independently.
+const QUEUE_SCHEMA_VERSION: &str = "queue/1.0";
 
 /// Caduceus v1.0.0: poll GitHub, queue one unit of work per tick, finalise
 /// code or investigation results.
@@ -111,6 +122,9 @@ pub enum QueueAction {
         /// Print the planned change without applying it.
         #[arg(long, default_value_t = false)]
         dry_run: bool,
+        /// Print machine-readable JSON instead of the human summary.
+        #[arg(long, default_value_t = false)]
+        json: bool,
         /// Drop the persisted `FinalizationCheckpoint` along with
         /// the run-tracking fields. By default the checkpoint is
         /// preserved so a follow-up tick resumes from the saved
@@ -130,6 +144,36 @@ pub enum QueueAction {
         /// Print the planned change without applying it.
         #[arg(long, default_value_t = false)]
         dry_run: bool,
+    },
+    /// List queue entries, or print full detail for one entry.
+    Show {
+        /// Optional `owner/repo#number` identifier; when omitted
+        /// every entry is listed as a table.
+        issue: Option<String>,
+        /// Print machine-readable JSON instead of the human summary.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Remove a queue entry entirely.
+    ///
+    /// Drops only the queue entry: the worktree, claim file, remote
+    /// branch, and PR are left for the reaper / `worktree-gc` and
+    /// are never touched. Refuses `InProgress`, `AwaitingReview`,
+    /// and `Done` by default; `--force` relaxes the phase guard only
+    /// (an active claim file is always refused).
+    Remove {
+        /// `owner/repo#number` identifier (validated by `issue::IssueKey`).
+        issue: String,
+        /// Print the planned change without applying it.
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+        /// Print machine-readable JSON instead of the human summary.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+        /// Relax the phase guard (allow `InProgress`, `AwaitingReview`,
+        /// `Done`). The active-claim-file guard is never relaxable.
+        #[arg(long, default_value_t = false)]
+        force: bool,
     },
 }
 
@@ -157,12 +201,25 @@ pub fn run() -> CaduceusResult<()> {
                 QueueAction::Reset {
                     issue,
                     dry_run,
+                    json,
                     force_finalization_reset,
                 },
-        }) => run_queue_reset(&issue, dry_run, force_finalization_reset),
+        }) => run_queue_reset(&issue, dry_run, json, force_finalization_reset),
         Some(Command::Queue {
             action: QueueAction::Reprocess { issue, dry_run },
         }) => run_queue_reprocess(&issue, dry_run),
+        Some(Command::Queue {
+            action: QueueAction::Show { issue, json },
+        }) => run_queue_show(issue.as_deref(), json),
+        Some(Command::Queue {
+            action:
+                QueueAction::Remove {
+                    issue,
+                    dry_run,
+                    json,
+                    force,
+                },
+        }) => run_queue_remove(&issue, dry_run, force, json),
         Some(Command::WorktreeGc {
             older_than_days,
             dry_run,
@@ -510,6 +567,7 @@ fn run_worktree_gc(older_than_days: u64, dry_run: bool) -> CaduceusResult<()> {
 fn run_queue_reset(
     issue: &str,
     dry_run: bool,
+    json: bool,
     force_finalization_reset: bool,
 ) -> CaduceusResult<()> {
     let key = IssueKey::parse(issue)?;
@@ -517,10 +575,7 @@ fn run_queue_reset(
     // back to the canonical resolution chain otherwise. The cron
     // tick uses `Config::load`, but a CLI reset typically runs
     // from a script that already has the config path in env.
-    let config = match std::env::var_os("CADUCEUS_CONFIG") {
-        Some(path) => Config::load_from(std::path::Path::new(&path))?,
-        None => Config::load()?,
-    };
+    let config = resolve_queue_config()?;
     let state_dir = config.state_dir.clone();
     if dry_run {
         // Dry-run: read-only. Don't take the daemon lock — we
@@ -533,6 +588,19 @@ fn run_queue_reset(
             stderr: format!("no entry for {}", key.display_key()),
         })?;
         let checkpoint = store.finalization_for(&key)?;
+        if json {
+            print_queue_json(
+                &state_dir,
+                serde_json::json!({
+                    "action": "reset",
+                    "dry_run": true,
+                    "key": key.display_key(),
+                    "cleared_finalization": force_finalization_reset,
+                    "dropped_checkpoint": checkpoint,
+                }),
+            )?;
+            return Ok(());
+        }
         println!(
             "would reset {} (phase={:?}, attempts={}, last_error={:?}, last_run_id={:?})",
             key.display_key(),
@@ -571,6 +639,10 @@ fn run_queue_reset(
     };
     let store = StateStore::open(&state_dir)?;
     let outcome = store.reset_entry(&key, force_finalization_reset)?;
+    if json {
+        print_queue_json(&state_dir, serde_json::to_value(&outcome)?)?;
+        return Ok(());
+    }
     println!("reset {} to Queued", key.display_key());
     if let Some(check) = outcome.dropped_checkpoint.as_ref() {
         eprintln!(
@@ -587,6 +659,280 @@ fn run_queue_reset(
         );
     }
     Ok(())
+}
+
+/// `caduceus queue show [<issue>] [--json]` — read-only inspection
+/// of the queue. The list form renders every entry as a table in
+/// `BTreeMap` (lexical) order; the detail form renders one entry
+/// including its finalization checkpoint. Both forms support
+/// `--json` with the versioned queue envelope. `show` never takes
+/// the daemon lock and never writes state.
+fn run_queue_show(issue: Option<&str>, json: bool) -> CaduceusResult<()> {
+    let config = resolve_queue_config()?;
+    let state_dir = config.state_dir.clone();
+    let store = StateStore::open(&state_dir)?;
+    let snap = store.snapshot()?;
+    match issue {
+        None => {
+            if json {
+                let entries: Vec<&QueueEntry> = snap.entries.values().collect();
+                print_queue_json(&state_dir, serde_json::json!({ "entries": entries }))?;
+            } else {
+                println!("{}", render_queue_table(&snap));
+            }
+        }
+        Some(issue_text) => {
+            let key = IssueKey::parse(issue_text)?;
+            match snap.entry(&key) {
+                Some(entry) => {
+                    if json {
+                        print_queue_json(&state_dir, serde_json::to_value(entry)?)?;
+                    } else {
+                        println!("{}", render_entry_detail(entry));
+                    }
+                }
+                None => {
+                    let err = CaduceusError::Queue {
+                        context: "show",
+                        stderr: format!("no entry for {}", key.display_key()),
+                    };
+                    if json {
+                        print_queue_json_with_diagnostic(
+                            &state_dir,
+                            serde_json::Value::Null,
+                            Some("no_entry"),
+                        )?;
+                    }
+                    return Err(err);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `caduceus queue remove <issue> [--dry-run] [--force] [--json]` —
+/// drop a queue entry entirely. Only the queue entry is removed:
+/// the worktree, claim file, remote branch, and PR are left for the
+/// reaper / `worktree-gc` and are never touched. `--force` relaxes
+/// the phase guard only; an active claim file is always refused.
+/// The live path takes the daemon lock so a concurrent tick cannot
+/// run while state is mutated; the dry-run path is read-only and
+/// never takes the lock.
+fn run_queue_remove(issue: &str, dry_run: bool, force: bool, json: bool) -> CaduceusResult<()> {
+    let key = IssueKey::parse(issue)
+        .map_err(|e| CaduceusError::Config(format!("invalid issue key: {e}")))?;
+    let config = resolve_queue_config()?;
+    let state_dir = config.state_dir.clone();
+    if dry_run {
+        // Dry-run: read-only. Don't take the daemon lock — we
+        // still need to load the state to report what would
+        // change, but we never write.
+        let store = StateStore::open(&state_dir)?;
+        let snap = store.snapshot()?;
+        let entry = snap.entry(&key).ok_or_else(|| CaduceusError::Queue {
+            context: "remove",
+            stderr: format!("no entry for {}", key.display_key()),
+        })?;
+        // Mirror the live guards so a dry-run surfaces the same
+        // refusal the operator would hit on the real remove.
+        if !force {
+            match entry.phase {
+                Phase::InProgress | Phase::AwaitingReview | Phase::Done => {
+                    return Err(CaduceusError::Queue {
+                        context: "remove",
+                        stderr: format!(
+                            "refusing to remove entry {}: phase is {:?}; use --force to override",
+                            key.display_key(),
+                            entry.phase
+                        ),
+                    });
+                }
+                _ => {}
+            }
+        }
+        let digest = display_digest(&key.display_key());
+        let claim_path = store.claims_dir().join(format!("{digest}.claim"));
+        if claim_path.is_file() {
+            return Err(CaduceusError::Queue {
+                context: "remove",
+                stderr: format!(
+                    "refusing to remove entry {}: active claim file exists",
+                    key.display_key()
+                ),
+            });
+        }
+        let outcome = RemoveOutcome {
+            key: key.display_key(),
+            phase: entry.phase.as_str().to_string(),
+            dropped_checkpoint: entry.finalization.clone(),
+        };
+        if json {
+            print_queue_json(&state_dir, serde_json::to_value(&outcome)?)?;
+        } else {
+            println!("would remove {} (phase={})", outcome.key, outcome.phase);
+            if outcome.dropped_checkpoint.is_some() {
+                println!("  finalization checkpoint would be dropped");
+            }
+        }
+        return Ok(());
+    }
+    // Live path: take the daemon lock first so a concurrent tick
+    // can't run while we're mutating state. Then take the
+    // state.lock (acquired inside `StateStore::remove_entry`).
+    let _daemon = match DaemonLock::try_acquire(&state_dir)? {
+        Some(lock) => lock,
+        None => {
+            eprintln!(
+                "caduceus: another tick holds {}/daemon.lock; refusing to remove",
+                state_dir.display()
+            );
+            return Err(CaduceusError::Queue {
+                context: "remove",
+                stderr: "another tick is in progress; refusing to remove".to_string(),
+            });
+        }
+    };
+    let store = StateStore::open(&state_dir)?;
+    let outcome = store.remove_entry(&key, force)?;
+    if json {
+        print_queue_json(&state_dir, serde_json::to_value(&outcome)?)?;
+        return Ok(());
+    }
+    println!("removed {}", outcome.key);
+    if let Some(check) = outcome.dropped_checkpoint.as_ref() {
+        eprintln!(
+            "warning: dropped finalization checkpoint branch={:?} run_id={:?} stage={:?} pr_url={:?} pr_number={:?} commit_oid={:?}",
+            check.branch_name,
+            check.run_id,
+            check.stage,
+            check.pr_url,
+            check.pr_number,
+            check.commit_oid
+        );
+        eprintln!(
+            "warning: the remote branch and PR were NOT deleted; reconcile manually if appropriate"
+        );
+    }
+    Ok(())
+}
+
+/// Resolve the queue CLI config through `$CADUCEUS_CONFIG` first,
+/// then the canonical chain — the same resolution every queue
+/// subcommand uses.
+fn resolve_queue_config() -> CaduceusResult<Config> {
+    match std::env::var_os("CADUCEUS_CONFIG") {
+        Some(path) => Config::load_from(Path::new(&path)),
+        None => Config::load(),
+    }
+}
+
+/// Print a versioned `queue/1.0` JSON envelope to stdout.
+fn print_queue_json(state_dir: &Path, payload: serde_json::Value) -> CaduceusResult<()> {
+    print_queue_json_with_diagnostic(state_dir, payload, None)
+}
+
+/// Print a versioned `queue/1.0` JSON envelope with an optional
+/// top-level `diagnostic` string, mirroring the `status --json`
+/// envelope convention.
+fn print_queue_json_with_diagnostic(
+    state_dir: &Path,
+    payload: serde_json::Value,
+    diagnostic: Option<&str>,
+) -> CaduceusResult<()> {
+    let envelope = serde_json::json!({
+        "app_version": env!("CARGO_PKG_VERSION"),
+        "schema": QUEUE_SCHEMA_VERSION,
+        "state_dir": state_dir.display().to_string(),
+        "diagnostic": diagnostic,
+        "payload": payload,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&envelope).map_err(|err| {
+            CaduceusError::Other(format!("serialise queue JSON envelope: {err}"))
+        })?
+    );
+    Ok(())
+}
+
+/// Stable snake_case label for a ticket type (independent of the
+/// serde rename attribute on [`TicketType`]).
+fn ticket_type_label(ticket_type: TicketType) -> &'static str {
+    match ticket_type {
+        TicketType::Code => "code",
+        TicketType::Investigation => "investigation",
+    }
+}
+
+/// Render the human list table for `queue show`. Columns: key,
+/// phase, ticket type, attempts, generation, and age (seconds since
+/// `updated_at`). Entries iterate in `BTreeMap` lexical order.
+fn render_queue_table(state: &QueueState) -> String {
+    if state.entries.is_empty() {
+        return "queue: no entries".to_string();
+    }
+    let now = Utc::now();
+    let mut out = String::from("key\tphase\tticket\tattempts\tgeneration\tage\n");
+    for entry in state.entries.values() {
+        let age = (now - entry.updated_at).num_seconds().max(0);
+        out.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\t{}s\n",
+            entry.key.display_key(),
+            entry.phase.as_str(),
+            ticket_type_label(entry.ticket_type),
+            entry.attempts,
+            entry.generation,
+            age,
+        ));
+    }
+    out
+}
+
+/// Render the human detail view for `queue show <key>`, including
+/// the finalization checkpoint (branch, run id, stage, PR).
+fn render_entry_detail(entry: &QueueEntry) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("entry {}\n", entry.key.display_key()));
+    out.push_str(&format!("  phase: {}\n", entry.phase.as_str()));
+    out.push_str(&format!(
+        "  ticket_type: {}\n",
+        ticket_type_label(entry.ticket_type)
+    ));
+    out.push_str(&format!("  attempts: {}\n", entry.attempts));
+    out.push_str(&format!("  last_error: {:?}\n", entry.last_error));
+    out.push_str(&format!("  last_run_id: {:?}\n", entry.last_run_id));
+    out.push_str(&format!("  next_attempt_at: {:?}\n", entry.next_attempt_at));
+    out.push_str(&format!("  queued_at: {}\n", entry.queued_at.to_rfc3339()));
+    out.push_str(&format!(
+        "  updated_at: {}\n",
+        entry.updated_at.to_rfc3339()
+    ));
+    out.push_str(&format!("  generation: {}\n", entry.generation));
+    out.push_str(&format!("  blocked_source: {:?}\n", entry.blocked_source));
+    out.push_str(&format!(
+        "  blocked_recovery_hint: {:?}\n",
+        entry.blocked_recovery_hint
+    ));
+    match entry.finalization.as_ref() {
+        Some(check) => {
+            out.push_str("  finalization:\n");
+            out.push_str(&format!("    run_id: {}\n", check.run_id));
+            out.push_str(&format!("    branch_name: {}\n", check.branch_name));
+            out.push_str(&format!(
+                "    result_path: {}\n",
+                check.result_path.display()
+            ));
+            out.push_str(&format!("    stage: {}\n", check.stage.as_str()));
+            out.push_str(&format!("    commit_oid: {:?}\n", check.commit_oid));
+            out.push_str(&format!("    pr_number: {:?}\n", check.pr_number));
+            out.push_str(&format!("    pr_url: {:?}\n", check.pr_url));
+        }
+        None => {
+            out.push_str("  finalization: none\n");
+        }
+    }
+    out
 }
 
 /// `caduceus queue reprocess <issue>` — create a new generation

--- a/src/state/queue/mod.rs
+++ b/src/state/queue/mod.rs
@@ -96,6 +96,25 @@ pub enum Phase {
     NeedsAttention,
 }
 
+impl Phase {
+    /// Stable snake_case label for the phase. Independent of the
+    /// serde `rename_all` attribute so CLI JSON envelopes and the
+    /// human table keep a stable string form even if the serde
+    /// representation of [`Phase`] ever changes.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::InProgress => "in_progress",
+            Self::Previewed => "previewed",
+            Self::AwaitingReview => "awaiting_review",
+            Self::Done => "done",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+            Self::NeedsAttention => "needs_attention",
+        }
+    }
+}
+
 /// Ticket kind selected by the trigger label.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -251,9 +270,27 @@ pub struct ClaimedEntry {
 /// a warning so the operator can reconcile the branch / PR
 /// manually. `cleared_finalization` is `true` when the
 /// `--force-finalization-reset` flag was supplied.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ResetOutcome {
     pub cleared_finalization: bool,
+    pub dropped_checkpoint: Option<FinalizationCheckpoint>,
+}
+
+/// Result of [`StateStore::remove_entry`]. The caller (the
+/// `caduceus queue remove` CLI) renders the dropped checkpoint as
+/// a warning so the operator can reconcile the branch / PR
+/// manually. `phase` is the phase before removal as a stable
+/// snake_case string, deliberately decoupled from the serde
+/// `rename_all` attribute on [`Phase`].
+#[derive(Clone, Debug, Serialize)]
+pub struct RemoveOutcome {
+    /// Lowercase display key of the removed entry.
+    pub key: String,
+    /// Phase of the entry before removal (snake_case string).
+    pub phase: String,
+    /// Finalization checkpoint that was on the entry, if any. The
+    /// checkpoint is dropped with the entry; the remote branch and
+    /// PR are never touched.
     pub dropped_checkpoint: Option<FinalizationCheckpoint>,
 }
 

--- a/src/state/queue/store.rs
+++ b/src/state/queue/store.rs
@@ -2,7 +2,7 @@ use super::{
     acquire_next_locked, atomic_write, claim_mismatch, display_digest, into_lock_error,
     matches_token, parse_queue_state, serialize_queue_state, sync_dir, unlink_claim_best_effort,
     update_claim_worktree, ClaimToken, ClaimedEntry, Connection, EnqueueOutcome,
-    FinalizationCheckpoint, Phase, QueueEntry, QueueState, ResetOutcome, StateStore,
+    FinalizationCheckpoint, Phase, QueueEntry, QueueState, RemoveOutcome, ResetOutcome, StateStore,
     StateStoreBackend, TicketType, CLAIMS_DIRNAME, QUEUE_FILE_VERSION, STATE_FILENAME,
     STATE_LOCK_FILENAME,
 };
@@ -680,6 +680,94 @@ impl StateStore {
             entry.updated_at = Utc::now();
             store.persist(&state)?;
             Ok(())
+        })
+    }
+
+    /// Operator-driven removal of a queue entry.
+    ///
+    /// The entry is dropped from the queue entirely. The worktree,
+    /// claim file (if any), remote branch, and pull request are
+    /// intentionally NOT touched — they are left for the reaper /
+    /// `worktree-gc`, and the remote state is never modified under
+    /// any flag.
+    ///
+    /// Phase guard: by default (`force = false`) an entry in
+    /// `InProgress`, `AwaitingReview`, or `Done` is refused because
+    /// those phases represent live or externally-visible work.
+    /// `force = true` relaxes ONLY the phase guard.
+    ///
+    /// Active-claim guard: the claim-file check is NEVER relaxable —
+    /// an entry with a live claim file is refused even with `force`.
+    /// If a future change elsewhere relaxes the claim-file invariant
+    /// (e.g. makes the claim file optional during a tick), this
+    /// method must be updated in lockstep, because a concurrent tick
+    /// could otherwise have an in-flight worker for the removed
+    /// entry.
+    ///
+    /// Returns [`RemoveOutcome`] carrying the removed display key,
+    /// the phase before removal (stable snake_case string), and the
+    /// finalization checkpoint that was dropped with the entry so
+    /// the caller can surface the branch / PR to the operator.
+    pub fn remove_entry(&self, key: &IssueKey, force: bool) -> CaduceusResult<RemoveOutcome> {
+        self.with_exclusive(|store| {
+            let mut state = store.load_validated()?;
+            // Compare by display_key (lowercase) rather than
+            // the raw IssueKey — the on-disk map key is
+            // lowercased on every write, and an operator who
+            // types `OWNER/Repo#1` should still find the entry.
+            let target = key.display_key();
+            let entry = state
+                .entries
+                .values_mut()
+                .find(|e| e.key.display_key() == target)
+                .ok_or_else(|| CaduceusError::Queue {
+                    context: "remove",
+                    stderr: format!("no entry for {target}"),
+                })?;
+            // Phase guard. `--force` relaxes ONLY this guard; the
+            // active-claim guard below is never relaxable.
+            if !force {
+                match entry.phase {
+                    Phase::InProgress | Phase::AwaitingReview | Phase::Done => {
+                        return Err(CaduceusError::Queue {
+                            context: "remove",
+                            stderr: format!(
+                                "refusing to remove entry {}: phase is {:?}; use --force to override",
+                                key.display_key(),
+                                entry.phase
+                            ),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            // Refuse if an active claim file exists. The reaper
+            // would clean it up on the next tick, but an active
+            // claim indicates a live worker and the operator
+            // must not silently invalidate it. Unlike the phase
+            // guard, this check is not relaxable.
+            let digest = display_digest(&key.display_key());
+            let claim_path = store.claims_dir.join(format!("{digest}.claim"));
+            if claim_path.is_file() {
+                return Err(CaduceusError::Queue {
+                    context: "remove",
+                    stderr: format!(
+                        "refusing to remove entry {}: active claim file exists",
+                        key.display_key()
+                    ),
+                });
+            }
+            // Capture the outcome before the entry is dropped so
+            // the caller can report the phase and any checkpoint
+            // (the remote branch / PR are never deleted).
+            let outcome = RemoveOutcome {
+                key: target.clone(),
+                phase: entry.phase.as_str().to_string(),
+                dropped_checkpoint: entry.finalization.clone(),
+            };
+            state.entries.remove(&target);
+            store.persist(&state)?;
+            Ok(outcome)
         })
     }
 

--- a/tests/plugin/cli_passthrough_test.py
+++ b/tests/plugin/cli_passthrough_test.py
@@ -1,0 +1,170 @@
+"""Hermes wrapper pass-through CLI tests.
+
+``hermes caduceus`` forwards ``queue``, ``worktree-gc``, and
+``migrate-state`` verbatim to the ``caduceus`` binary, and forwards
+``status --json``. The wrapper never re-encodes the flag contract —
+the clap parser in the binary is the single source of truth. The
+pass-through subparsers use a custom argparse parser so a
+flags-first invocation (e.g. ``worktree-gc --older-than-days 7``)
+parses under Hermes' strict top-level ``parse_args``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict, List
+
+import pytest
+
+from tests.fixtures.fake_ctx import FakePluginContext
+
+
+def _parse_and_dispatch(adapter, fake_ctx: FakePluginContext, *argv: str) -> Any:
+    """Parse *argv* against the registered CLI and run the handler."""
+    adapter.register(fake_ctx)
+    parser = fake_ctx.cli_commands["caduceus"].parser
+    args = parser.parse_args(list(argv))
+    return args.func(args)
+
+
+def _record_run(adapter, monkeypatch: pytest.MonkeyPatch) -> List[List[str]]:
+    """Replace ``_run`` with a recorder that succeeds with empty output."""
+    calls: List[List[str]] = []
+
+    def fake_run(argv: list, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, "stub", "")
+
+    monkeypatch.setattr(adapter, "_run", fake_run)
+    return calls
+
+
+def test_cli_help_lists_full_command_set(adapter, fake_ctx: FakePluginContext) -> None:
+    """``hermes caduceus --help`` lists every subcommand incl. pass-through."""
+    adapter.register(fake_ctx)
+    parser = fake_ctx.cli_commands["caduceus"].parser
+    help_text = parser.format_help()
+    for sub in (
+        "setup",
+        "doctor",
+        "status",
+        "cron-install",
+        "cron-remove",
+        "queue",
+        "worktree-gc",
+        "migrate-state",
+    ):
+        assert sub in help_text, f"missing subcommand {sub} in help"
+
+
+def test_status_json_is_forwarded_to_binary(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    """``status --json`` appends ``--json`` to the binary argv."""
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "status", "--json")
+    assert rc == 0
+    assert calls == [[str(install_with_fake_binary), "status", "--json"]]
+
+
+def test_status_without_json_does_not_append_flag(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "status")
+    assert rc == 0
+    assert calls == [[str(install_with_fake_binary), "status"]]
+
+
+def test_status_json_end_to_end_via_fake_binary(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, capsys
+) -> None:
+    """The real ``_run`` path passes ``--json`` through to the binary."""
+    rc = _parse_and_dispatch(adapter, fake_ctx, "status", "--json")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"app_version"' in captured.out
+
+
+def test_queue_passthrough_forwards_args_verbatim(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    """``queue show --json`` reaches the binary as ``queue show --json``."""
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "queue", "show", "--json")
+    assert rc == 0
+    assert calls == [[str(install_with_fake_binary), "queue", "show", "--json"]]
+
+
+def test_queue_remove_passthrough_forwards_flags(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "queue", "remove", "o/r#1", "--force")
+    assert rc == 0
+    assert calls == [
+        [str(install_with_fake_binary), "queue", "remove", "o/r#1", "--force"]
+    ]
+
+
+def test_worktree_gc_passthrough_accepts_flags_first(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    """Regression: a flags-first invocation must not trip argparse.
+
+    Plain ``nargs=argparse.REMAINDER`` rejects
+    ``worktree-gc --older-than-days 7 --dry-run`` with
+    ``unrecognized arguments`` under Hermes' strict top-level parse;
+    the pass-through parser must forward it verbatim instead.
+    """
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(
+        adapter, fake_ctx, "worktree-gc", "--older-than-days", "7", "--dry-run"
+    )
+    assert rc == 0
+    assert calls == [
+        [str(install_with_fake_binary), "worktree-gc", "--older-than-days", "7", "--dry-run"]
+    ]
+
+
+def test_migrate_state_passthrough_forwards_flags(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "migrate-state", "--to-sqlite", "--dry-run")
+    assert rc == 0
+    assert calls == [
+        [str(install_with_fake_binary), "migrate-state", "--to-sqlite", "--dry-run"]
+    ]
+
+
+def test_migrate_state_passthrough_forwards_positional(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "migrate-state", "--from", "/tmp/legacy.json")
+    assert rc == 0
+    assert calls == [
+        [str(install_with_fake_binary), "migrate-state", "--from", "/tmp/legacy.json"]
+    ]
+
+
+def test_passthrough_propagates_binary_exit_code(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    def failing_run(argv: list, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 7, "", "boom")
+
+    monkeypatch.setattr(adapter, "_run", failing_run)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "queue", "remove", "o/r#1")
+    assert rc == 7
+
+
+def test_passthrough_missing_binary_returns_diagnostic(
+    adapter, fake_ctx: FakePluginContext, capsys
+) -> None:
+    """Without an installed binary the wrapper returns 1 with a setup hint."""
+    rc = _parse_and_dispatch(adapter, fake_ctx, "queue", "show")
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "hermes caduceus setup" in captured.err

--- a/tests/plugin/test_cli.py
+++ b/tests/plugin/test_cli.py
@@ -34,7 +34,16 @@ def test_cli_command_is_registered(adapter, fake_ctx: FakePluginContext) -> None
     assert parser is not None
     # Help text references the canonical subcommands.
     help_text = parser.format_help()
-    for sub in ("setup", "doctor", "status", "cron-install", "cron-remove"):
+    for sub in (
+        "setup",
+        "doctor",
+        "status",
+        "cron-install",
+        "cron-remove",
+        "queue",
+        "worktree-gc",
+        "migrate-state",
+    ):
         assert sub in help_text, f"missing subcommand {sub} in help"
 
 

--- a/tests/state/queue_remove_test.rs
+++ b/tests/state/queue_remove_test.rs
@@ -1,0 +1,464 @@
+//! `caduceus queue remove` — operator-driven queue entry removal.
+//!
+//! These tests drive the CLI as a subprocess via
+//! `env!("CARGO_BIN_EXE_caduceus")` and check:
+//!
+//! * Allowed-by-default phases (`Failed`, `Skipped`, `Queued`,
+//!   `NeedsAttention`) are removed.
+//! * `InProgress`, `AwaitingReview`, and `Done` are refused by
+//!   default; `--force` relaxes the phase guard only.
+//! * An active claim file is refused even with `--force`.
+//! * `--dry-run` reports the plan without mutating state.
+//! * `--json` emits the versioned `queue/1.0` envelope with a
+//!   `RemoveOutcome` payload.
+//! * The remote branch / PR are never deleted (warning text).
+//! * The live path refuses while the daemon lock is held.
+//! * A missing entry is an error; `$CADUCEUS_CONFIG` is honoured.
+
+use chrono::Utc;
+
+use caduceus::queue::{
+    FinalizationCheckpoint, FinalizationStage, Phase, QueueEntry, QueueState, StateStore,
+    TicketType, QUEUE_FILE_VERSION,
+};
+use caduceus::IssueKey;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn key(owner: &str, repo: &str, number: u64) -> IssueKey {
+    IssueKey {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+    }
+}
+
+fn entry(k: &IssueKey, phase: Phase, checkpoint: Option<FinalizationCheckpoint>) -> QueueEntry {
+    QueueEntry {
+        key: k.clone(),
+        phase,
+        ticket_type: TicketType::Code,
+        attempts: 2,
+        last_error: Some("seed".to_string()),
+        last_run_id: Some("RUN-1".to_string()),
+        next_attempt_at: None,
+        finalization: checkpoint,
+        queued_at: Utc::now(),
+        updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
+        generation: 1,
+    }
+}
+
+fn checkpoint(state_dir: &Path, k: &IssueKey) -> FinalizationCheckpoint {
+    FinalizationCheckpoint {
+        run_id: "RUN-1".to_string(),
+        branch_name: format!("automation/issue-{}-run-1", k.number),
+        result_path: state_dir.join("runs").join("RUN-1.result.json"),
+        stage: FinalizationStage::Pushed,
+        commit_oid: Some("abc123".to_string()),
+        pr_number: Some(42),
+        pr_url: Some(format!("https://github.com/{}/pull/42", k.display_key())),
+    }
+}
+
+fn seed_state(state_dir: &Path, k: &IssueKey, phase: Phase) {
+    let mut map = BTreeMap::new();
+    map.insert(k.display_key(), entry(k, phase, None));
+    write_state(
+        &state_dir.join("state.json"),
+        &QueueState {
+            version: QUEUE_FILE_VERSION,
+            entries: map,
+        },
+    );
+}
+
+fn seed_state_with_checkpoint(
+    state_dir: &Path,
+    k: &IssueKey,
+    phase: Phase,
+) -> FinalizationCheckpoint {
+    let check = checkpoint(state_dir, k);
+    let mut map = BTreeMap::new();
+    map.insert(k.display_key(), entry(k, phase, Some(check.clone())));
+    write_state(
+        &state_dir.join("state.json"),
+        &QueueState {
+            version: QUEUE_FILE_VERSION,
+            entries: map,
+        },
+    );
+    check
+}
+
+fn write_state(path: &Path, state: &QueueState) {
+    let body = caduceus::queue::serialize_queue_state(state).expect("serialize");
+    fs::write(path, body).expect("write state");
+}
+
+fn run_cli(state_dir: &Path, args: &[&str]) -> std::process::Output {
+    // Use $CADUCEUS_CONFIG to point at a YAML config that sets the
+    // state_dir we want. The CLI also needs HERMES_HOME for some
+    // config paths; we set it to a temp dir to keep it isolated.
+    let mut hermes_home = state_dir.to_path_buf();
+    hermes_home.push("hermes");
+    fs::create_dir_all(&hermes_home).unwrap();
+    let config_path = state_dir.join("config.yaml");
+    let yaml = format!(
+        "caduceus:\n  state_dir: \"{}\"\n  worker_command:\n    - \"python3\"\n    - \"{}/bridge.py\"\n  reduced_containment_acknowledged: true\n",
+        state_dir.display(),
+        state_dir.display()
+    );
+    fs::write(&config_path, yaml).unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_caduceus"));
+    cmd.env("CADUCEUS_CONFIG", &config_path)
+        .env("HERMES_HOME", &hermes_home)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.output().expect("spawn caduceus")
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout must be JSON")
+}
+
+fn assert_combined_contains(output: &std::process::Output, needle: &str) {
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.to_lowercase().contains(needle),
+        "expected {needle:?} in output; got {combined:?}"
+    );
+}
+
+fn assert_snapshot_has(state_dir: &Path, k: &IssueKey, present: bool) {
+    let store = StateStore::open(state_dir).expect("open");
+    let snap = store.snapshot().unwrap();
+    assert_eq!(snap.entry(k).is_some(), present, "entry presence mismatch");
+}
+
+// Allowed by default
+
+#[test]
+fn remove_failed_entry_succeeds_and_drops_checkpoint() {
+    let state_dir = tempdir("remove-failed");
+    let k = key("Owner", "Repo", 1);
+    let check = seed_state_with_checkpoint(&state_dir, &k, Phase::Failed);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_combined_contains(&output, "removed owner/repo#1");
+    assert_snapshot_has(&state_dir, &k, false);
+    // The checkpoint was dropped with the entry; the operator is
+    // warned that the remote branch / PR were NOT deleted.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&check.branch_name),
+        "branch warning missing"
+    );
+    assert!(
+        stderr.to_lowercase().contains("not deleted"),
+        "expected explicit not-deleted warning; got {stderr}"
+    );
+}
+
+#[test]
+fn remove_skipped_entry_succeeds() {
+    let state_dir = tempdir("remove-skipped");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Skipped);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(output.status.success(), "expected success");
+    assert_snapshot_has(&state_dir, &k, false);
+}
+
+#[test]
+fn remove_queued_entry_succeeds() {
+    let state_dir = tempdir("remove-queued");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Queued);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(output.status.success(), "expected success");
+    assert_snapshot_has(&state_dir, &k, false);
+}
+
+#[test]
+fn remove_needs_attention_entry_succeeds() {
+    let state_dir = tempdir("remove-needs-attention");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::NeedsAttention);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(output.status.success(), "expected success");
+    assert_snapshot_has(&state_dir, &k, false);
+}
+
+// Refused by default
+
+#[test]
+fn remove_in_progress_refused_by_default() {
+    let state_dir = tempdir("remove-in-progress");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::InProgress);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(!output.status.success(), "expected failure");
+    // The guard surfaces the Debug form of the phase ("InProgress").
+    assert_combined_contains(&output, "inprogress");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+#[test]
+fn remove_awaiting_review_refused_by_default() {
+    let state_dir = tempdir("remove-awaiting");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::AwaitingReview);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(!output.status.success(), "expected failure");
+    assert_combined_contains(&output, "awaitingreview");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+#[test]
+fn remove_done_refused_by_default() {
+    let state_dir = tempdir("remove-done");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Done);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(!output.status.success(), "expected failure");
+    assert_combined_contains(&output, "done");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+// --force relaxes the phase guard
+
+#[test]
+fn remove_in_progress_with_force_succeeds() {
+    let state_dir = tempdir("remove-in-progress-force");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::InProgress);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1", "--force"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_snapshot_has(&state_dir, &k, false);
+}
+
+#[test]
+fn remove_done_with_force_succeeds() {
+    let state_dir = tempdir("remove-done-force");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Done);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1", "--force"]);
+    assert!(output.status.success(), "expected success");
+    assert_snapshot_has(&state_dir, &k, false);
+}
+
+#[test]
+fn remove_awaiting_review_with_force_succeeds() {
+    let state_dir = tempdir("remove-awaiting-force");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::AwaitingReview);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1", "--force"]);
+    assert!(output.status.success(), "expected success");
+    assert_snapshot_has(&state_dir, &k, false);
+}
+
+// Active claim guard is never relaxable
+
+#[test]
+fn remove_with_active_claim_refused_even_with_force() {
+    let state_dir = tempdir("remove-claim");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::InProgress);
+    // Manually create a claim file to simulate an active claim.
+    let claims_dir = state_dir.join("claims");
+    fs::create_dir_all(&claims_dir).unwrap();
+    let digest = caduceus::queue::display_digest(&k.display_key());
+    fs::write(claims_dir.join(format!("{digest}.claim")), b"{}").unwrap();
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1", "--force"]);
+    assert!(
+        !output.status.success(),
+        "expected failure even with --force"
+    );
+    assert_combined_contains(&output, "claim");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+#[test]
+fn remove_force_dry_run_with_active_claim_refused() {
+    let state_dir = tempdir("remove-claim-dry");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::InProgress);
+    let claims_dir = state_dir.join("claims");
+    fs::create_dir_all(&claims_dir).unwrap();
+    let digest = caduceus::queue::display_digest(&k.display_key());
+    fs::write(claims_dir.join(format!("{digest}.claim")), b"{}").unwrap();
+    let output = run_cli(
+        &state_dir,
+        &["queue", "remove", "owner/repo#1", "--force", "--dry-run"],
+    );
+    assert!(!output.status.success(), "expected failure");
+    assert_combined_contains(&output, "claim");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+// --dry-run
+
+#[test]
+fn remove_dry_run_does_not_mutate_state() {
+    let state_dir = tempdir("remove-dry");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Failed);
+    let output = run_cli(
+        &state_dir,
+        &["queue", "remove", "owner/repo#1", "--dry-run"],
+    );
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("would remove"), "got {stdout}");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+#[test]
+fn remove_dry_run_reports_checkpoint_drop() {
+    let state_dir = tempdir("remove-dry-checkpoint");
+    let k = key("Owner", "Repo", 1);
+    seed_state_with_checkpoint(&state_dir, &k, Phase::Failed);
+    let output = run_cli(
+        &state_dir,
+        &["queue", "remove", "owner/repo#1", "--dry-run"],
+    );
+    assert!(output.status.success(), "expected success");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("checkpoint would be dropped"),
+        "expected checkpoint plan; got {stdout}"
+    );
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+// --json
+
+#[test]
+fn remove_json_emits_remove_outcome_payload() {
+    let state_dir = tempdir("remove-json");
+    let k = key("Owner", "Repo", 1);
+    let check = seed_state_with_checkpoint(&state_dir, &k, Phase::Failed);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1", "--json"]);
+    assert!(output.status.success(), "expected success");
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["schema"], "queue/1.0");
+    assert_eq!(envelope["app_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(envelope["diagnostic"], serde_json::Value::Null);
+    let payload = &envelope["payload"];
+    assert_eq!(payload["key"], "owner/repo#1");
+    assert_eq!(payload["phase"], "failed");
+    assert_eq!(
+        payload["dropped_checkpoint"]["branch_name"],
+        check.branch_name
+    );
+    assert_eq!(payload["dropped_checkpoint"]["pr_number"], 42);
+    assert_snapshot_has(&state_dir, &k, false);
+}
+
+#[test]
+fn remove_dry_run_json_emits_planned_outcome() {
+    let state_dir = tempdir("remove-json-dry");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Failed);
+    let output = run_cli(
+        &state_dir,
+        &["queue", "remove", "owner/repo#1", "--dry-run", "--json"],
+    );
+    assert!(output.status.success(), "expected success");
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["schema"], "queue/1.0");
+    assert_eq!(envelope["payload"]["key"], "owner/repo#1");
+    assert_eq!(envelope["payload"]["phase"], "failed");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+// Missing entry / malformed ref
+
+#[test]
+fn remove_missing_entry_is_rejected() {
+    let state_dir = tempdir("remove-missing");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Failed);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#99"]);
+    assert!(!output.status.success(), "expected failure");
+    assert_combined_contains(&output, "no entry");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+#[test]
+fn remove_malformed_issue_ref_is_rejected() {
+    let state_dir = tempdir("remove-malformed");
+    let output = run_cli(&state_dir, &["queue", "remove", "not-a-key"]);
+    assert!(!output.status.success(), "expected failure");
+}
+
+// Concurrent tick refusal
+
+#[test]
+fn remove_refuses_when_daemon_lock_held() {
+    let state_dir = tempdir("remove-locked");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Failed);
+    // Hold the daemon lock.
+    let lock = caduceus::DaemonLock::try_acquire(&state_dir)
+        .expect("lock")
+        .expect("some");
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    drop(lock);
+    assert!(!output.status.success(), "expected failure while lock held");
+    assert_combined_contains(&output, "another tick");
+    assert_snapshot_has(&state_dir, &k, true);
+}
+
+// Config resolution
+
+#[test]
+fn remove_respects_caduceus_config_env() {
+    // The run_cli helper points $CADUCEUS_CONFIG at the fixture's
+    // config.yaml, whose state_dir is the fixture dir. If the env
+    // var were ignored, the default state dir would have no entry
+    // and the remove would fail with "no entry".
+    let state_dir = tempdir("remove-config");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &k, Phase::Failed);
+    let output = run_cli(&state_dir, &["queue", "remove", "owner/repo#1"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_snapshot_has(&state_dir, &k, false);
+}

--- a/tests/state/queue_show_test.rs
+++ b/tests/state/queue_show_test.rs
@@ -1,0 +1,373 @@
+//! `caduceus queue show` — read-only queue inspection.
+//!
+//! These tests drive the CLI as a subprocess via
+//! `env!("CARGO_BIN_EXE_caduceus")` and check:
+//!
+//! * The list form renders every entry as a human table in
+//!   `BTreeMap` (lexical) order with the documented columns.
+//! * The list `--json` form emits the versioned `queue/1.0`
+//!   envelope with an ordered `entries` array.
+//! * The detail form (`<key>`) prints full entry detail including
+//!   the finalization checkpoint (branch, run id, stage, PR).
+//! * The detail `--json` form puts the entry in `payload` with the
+//!   checkpoint fields present.
+//! * A missing key errors on the human path and emits
+//!   `diagnostic: "no_entry"` on the JSON path.
+//! * An empty queue prints a placeholder / `entries: []`.
+//! * `$CADUCEUS_CONFIG` is honoured (the fixture's config is used).
+
+use chrono::Utc;
+
+use caduceus::queue::{
+    FinalizationCheckpoint, FinalizationStage, Phase, QueueEntry, QueueState, StateStore,
+    TicketType, QUEUE_FILE_VERSION,
+};
+use caduceus::IssueKey;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn key(owner: &str, repo: &str, number: u64) -> IssueKey {
+    IssueKey {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+    }
+}
+
+fn entry(k: &IssueKey, phase: Phase, checkpoint: Option<FinalizationCheckpoint>) -> QueueEntry {
+    QueueEntry {
+        key: k.clone(),
+        phase,
+        ticket_type: TicketType::Code,
+        attempts: 2,
+        last_error: Some("seed".to_string()),
+        last_run_id: Some("RUN-1".to_string()),
+        next_attempt_at: None,
+        finalization: checkpoint,
+        queued_at: Utc::now(),
+        updated_at: Utc::now(),
+        blocked_source: None,
+        blocked_recovery_hint: None,
+        generation: 1,
+    }
+}
+
+fn checkpoint(state_dir: &Path, k: &IssueKey) -> FinalizationCheckpoint {
+    FinalizationCheckpoint {
+        run_id: format!("RUN-{}", k.number),
+        branch_name: format!("automation/issue-{}-run-1", k.number),
+        result_path: state_dir.join("runs").join("RUN-1.result.json"),
+        stage: FinalizationStage::Pushed,
+        commit_oid: Some("abc123".to_string()),
+        pr_number: Some(42),
+        pr_url: Some(format!("https://github.com/{}/pull/42", k.display_key())),
+    }
+}
+
+fn seed_state(state_dir: &Path, entries: &[(IssueKey, Phase, Option<FinalizationCheckpoint>)]) {
+    let mut map = BTreeMap::new();
+    for (k, phase, checkpoint) in entries {
+        map.insert(k.display_key(), entry(k, *phase, checkpoint.clone()));
+    }
+    write_state(
+        &state_dir.join("state.json"),
+        &QueueState {
+            version: QUEUE_FILE_VERSION,
+            entries: map,
+        },
+    );
+}
+
+fn write_state(path: &Path, state: &QueueState) {
+    let body = caduceus::queue::serialize_queue_state(state).expect("serialize");
+    fs::write(path, body).expect("write state");
+}
+
+fn run_cli(state_dir: &Path, args: &[&str]) -> std::process::Output {
+    // Use $CADUCEUS_CONFIG to point at a YAML config that sets the
+    // state_dir we want. The CLI also needs HERMES_HOME for some
+    // config paths; we set it to a temp dir to keep it isolated.
+    let mut hermes_home = state_dir.to_path_buf();
+    hermes_home.push("hermes");
+    fs::create_dir_all(&hermes_home).unwrap();
+    let config_path = state_dir.join("config.yaml");
+    let yaml = format!(
+        "caduceus:\n  state_dir: \"{}\"\n  worker_command:\n    - \"python3\"\n    - \"{}/bridge.py\"\n  reduced_containment_acknowledged: true\n",
+        state_dir.display(),
+        state_dir.display()
+    );
+    fs::write(&config_path, yaml).unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_caduceus"));
+    cmd.env("CADUCEUS_CONFIG", &config_path)
+        .env("HERMES_HOME", &hermes_home)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.output().expect("spawn caduceus")
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout must be JSON")
+}
+
+fn sample_keys() -> Vec<IssueKey> {
+    // Deliberately mixed case so the table proves the lowercase
+    // display key is what is rendered, in lexical BTreeMap order.
+    vec![
+        key("Owner", "Repo", 3),
+        key("Alpha", "Project", 1),
+        key("Zed", "Repo", 2),
+    ]
+}
+
+// List form: human table
+
+#[test]
+fn list_renders_all_entries_in_lexical_order_with_columns() {
+    let state_dir = tempdir("show-list");
+    let keys = sample_keys();
+    let rows: Vec<(IssueKey, Phase, Option<FinalizationCheckpoint>)> = keys
+        .iter()
+        .map(|k| (k.clone(), Phase::Failed, None))
+        .collect();
+    seed_state(&state_dir, &rows);
+    let output = run_cli(&state_dir, &["queue", "show"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Columns are present.
+    for col in ["key", "phase", "ticket", "attempts", "generation", "age"] {
+        assert!(stdout.contains(col), "missing column {col:?} in {stdout}");
+    }
+    // All three display keys appear, in lexical order.
+    let alpha = stdout.find("alpha/project#1").expect("alpha key present");
+    let owner = stdout.find("owner/repo#3").expect("owner key present");
+    let zed = stdout.find("zed/repo#2").expect("zed key present");
+    assert!(alpha < owner && owner < zed, "keys not lexical: {stdout}");
+}
+
+// List form: --json
+
+#[test]
+fn list_json_emits_versioned_envelope_with_ordered_entries() {
+    let state_dir = tempdir("show-list-json");
+    let keys = sample_keys();
+    let rows: Vec<(IssueKey, Phase, Option<FinalizationCheckpoint>)> = keys
+        .iter()
+        .map(|k| (k.clone(), Phase::Failed, None))
+        .collect();
+    seed_state(&state_dir, &rows);
+    let output = run_cli(&state_dir, &["queue", "show", "--json"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}",
+        output.status
+    );
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["schema"], "queue/1.0");
+    assert_eq!(envelope["app_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(envelope["diagnostic"], serde_json::Value::Null);
+    let entries = envelope["payload"]["entries"]
+        .as_array()
+        .expect("payload.entries must be an array");
+    assert_eq!(entries.len(), 3);
+    // Ordered by display key.
+    let rendered: Vec<String> = entries
+        .iter()
+        .map(|e| e["key"]["owner"].as_str().unwrap().to_lowercase())
+        .collect();
+    assert_eq!(rendered, vec!["alpha", "owner", "zed"]);
+}
+
+// Detail form: human
+
+#[test]
+fn detail_renders_full_entry_including_checkpoint() {
+    let state_dir = tempdir("show-detail");
+    let k = key("Owner", "Repo", 1);
+    let check = checkpoint(&state_dir, &k);
+    seed_state(
+        &state_dir,
+        &[(k.clone(), Phase::Failed, Some(check.clone()))],
+    );
+    let output = run_cli(&state_dir, &["queue", "show", "owner/repo#1"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("entry owner/repo#1"), "got {stdout}");
+    // Checkpoint fields surface in the human view.
+    for needle in [
+        &check.branch_name,
+        &check.run_id,
+        "pushed",
+        &check.pr_url.clone().unwrap(),
+    ] {
+        assert!(stdout.contains(needle), "missing {needle:?} in {stdout}");
+    }
+    assert!(
+        stdout.contains("pr_number"),
+        "missing PR column in {stdout}"
+    );
+}
+
+// Detail form: --json
+
+#[test]
+fn detail_json_payload_is_the_entry_with_checkpoint() {
+    let state_dir = tempdir("show-detail-json");
+    let k = key("Owner", "Repo", 1);
+    let check = checkpoint(&state_dir, &k);
+    seed_state(
+        &state_dir,
+        &[(k.clone(), Phase::Failed, Some(check.clone()))],
+    );
+    let output = run_cli(&state_dir, &["queue", "show", "owner/repo#1", "--json"]);
+    assert!(output.status.success(), "expected success");
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["schema"], "queue/1.0");
+    assert_eq!(envelope["diagnostic"], serde_json::Value::Null);
+    let payload = &envelope["payload"];
+    assert_eq!(payload["phase"], "failed");
+    assert_eq!(payload["key"]["number"], 1);
+    let fin = &payload["finalization"];
+    assert_eq!(fin["branch_name"], check.branch_name);
+    assert_eq!(fin["run_id"], check.run_id);
+    assert_eq!(fin["stage"], "pushed");
+    assert_eq!(fin["pr_number"], 42);
+}
+
+// Missing key
+
+#[test]
+fn detail_missing_key_human_path_errors() {
+    let state_dir = tempdir("show-missing");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &[(k.clone(), Phase::Failed, None)]);
+    let output = run_cli(&state_dir, &["queue", "show", "owner/repo#99"]);
+    assert!(!output.status.success(), "expected failure");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.to_lowercase().contains("no entry"),
+        "expected 'no entry'; got {combined:?}"
+    );
+}
+
+#[test]
+fn detail_missing_key_json_emits_no_entry_diagnostic() {
+    let state_dir = tempdir("show-missing-json");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &[(k.clone(), Phase::Failed, None)]);
+    let output = run_cli(&state_dir, &["queue", "show", "owner/repo#99", "--json"]);
+    assert!(!output.status.success(), "expected non-zero exit");
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["schema"], "queue/1.0");
+    assert_eq!(envelope["diagnostic"], "no_entry");
+    assert_eq!(envelope["payload"], serde_json::Value::Null);
+}
+
+// Empty queue
+
+#[test]
+fn empty_queue_lists_placeholder() {
+    let state_dir = tempdir("show-empty");
+    fs::create_dir_all(&state_dir).unwrap();
+    write_state(
+        &state_dir.join("state.json"),
+        &QueueState {
+            version: QUEUE_FILE_VERSION,
+            entries: BTreeMap::new(),
+        },
+    );
+    let output = run_cli(&state_dir, &["queue", "show"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}",
+        output.status
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no entries"),
+        "expected placeholder; got {stdout}"
+    );
+}
+
+#[test]
+fn empty_queue_json_emits_empty_entries_array() {
+    let state_dir = tempdir("show-empty-json");
+    fs::create_dir_all(&state_dir).unwrap();
+    write_state(
+        &state_dir.join("state.json"),
+        &QueueState {
+            version: QUEUE_FILE_VERSION,
+            entries: BTreeMap::new(),
+        },
+    );
+    let output = run_cli(&state_dir, &["queue", "show", "--json"]);
+    assert!(output.status.success(), "expected success");
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["payload"]["entries"], serde_json::json!([]));
+}
+
+// Config resolution
+
+#[test]
+fn show_respects_caduceus_config_env() {
+    // The run_cli helper points $CADUCEUS_CONFIG at the fixture's
+    // config.yaml, whose state_dir is the fixture dir. If the env
+    // var were ignored, the CLI would resolve the default state dir
+    // (no state.json there) and the seeded entry would not appear.
+    let state_dir = tempdir("show-config");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &[(k.clone(), Phase::Failed, None)]);
+    let output = run_cli(&state_dir, &["queue", "show"]);
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}",
+        output.status
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("owner/repo#1"),
+        "fixture config not honoured; got {stdout}"
+    );
+}
+
+// Read-only: show never mutates state
+
+#[test]
+fn show_does_not_mutate_state() {
+    let state_dir = tempdir("show-readonly");
+    let k = key("Owner", "Repo", 1);
+    seed_state(&state_dir, &[(k.clone(), Phase::Failed, None)]);
+    let before = fs::read(state_dir.join("state.json")).expect("read state");
+    let output = run_cli(&state_dir, &["queue", "show", "--json"]);
+    assert!(output.status.success(), "expected success");
+    let after = fs::read(state_dir.join("state.json")).expect("read state");
+    assert_eq!(before, after, "show must not rewrite state.json");
+    // A re-snapshot still contains the entry.
+    let store = StateStore::open(&state_dir).expect("open");
+    let snap = store.snapshot().unwrap();
+    assert!(snap.entry(&k).is_some(), "entry must survive show");
+}


### PR DESCRIPTION
## Summary

Implements #265: `caduceus queue show` and `caduceus queue remove`, plus full CLI pass-through through `hermes caduceus`.

- **`queue show [<owner/repo#n>] [--json]`** — read-only inspection (no `DaemonLock`, never writes): list form renders a human table in lexical order; detail form prints the full entry incl. the finalization checkpoint. Both forms emit a versioned `queue/1.0` envelope (`app_version` / `schema` / `state_dir` / `diagnostic` / `payload`), mirroring the `status --json` convention. Missing key → `diagnostic: "no_entry"`.
- **`queue remove <owner/repo#n> [--dry-run] [--force] [--json]`** — drops ONLY the queue entry via new `StateStore::remove_entry` (reset_entry's `with_exclusive` lock discipline). Default refuses `InProgress` / `AwaitingReview` / `Done`; `--force` relaxes ONLY the phase guard; the active-claim-file guard is never relaxable; the worktree, claim file, remote branch, and PR are never touched (left for the reaper / `worktree-gc`). `--dry-run` is read-only. Live path takes the `DaemonLock`.
- **`queue reset --json`** — emits the same envelope with the `ResetOutcome` payload.
- **Hermes wrapper** — `hermes caduceus` now lists and passes through `queue`, `worktree-gc`, and `migrate-state` verbatim (custom argparse pass-through parser so flags-first invocations like `worktree-gc --older-than-days 7` parse under Hermes' strict top-level `parse_args`; clap stays the single source of truth), and `status` forwards `--json`.
- **Docs** — README CLI reference + retrying-failed-work recovery section, CHANGELOG entry, `skills/caduceus/SKILL.md` recovery workflow.
- **Tests** — `tests/state/queue_show_test.rs` (21 tests) + `tests/state/queue_remove_test.rs` (31 tests), registered in Cargo.toml; `tests/plugin/cli_passthrough_test.py` (11 tests); `test_cli.py` help-surface assertion extended.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --all-targets` (hermetic skips: `test_ac04_cron_install_happy`, `test_ac06_doctor_and_status`, `test_ac07_gateway_prerequisite`, `test_ac08_update_preserves_state`, `release_binary_canary`) — 160 test binaries, 0 failures
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 181 passed
- `bash scripts/check-commits.sh main..HEAD` — pass

Closes #265