### PR TITLE
feat(config): standardise automation trigger labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,9 +475,9 @@ separation.
 3. Create the two labels in each repo:
 
    ```bash
-   gh label create "🤖 auto-fix" --repo OWNER/REPO --color 7C3AED \
+   gh label create "autofix" --repo OWNER/REPO --color 7C3AED \
      --description "Triggers Caduceus code automation"
-   gh label create "🤖 auto-fix-investigate" --repo OWNER/REPO \
+   gh label create "autofix-investigate" --repo OWNER/REPO \
      --color 7C3AED --description "Triggers Caduceus investigation summary"
    ```
 
@@ -521,10 +521,16 @@ short version with the opinions attached.
   the operator can override per environment. Lower it if you
   want; do not set it to zero and expect a polite daemon.
 - `ticket_label_code` — the GitHub label that triggers a
-  code-fixing run (default `🤖 auto-fix`). The investigation
+  code-fixing run (default `autofix`). The investigation
   label is `ticket_label_investigation` (default
-  `🤖 auto-fix-investigation`). The two labels are created in
-  step 3 of the 60-second orientation above.
+  `autofix-investigate`). The two labels are created in
+  step 3 of the 60-second orientation above. Legacy emoji
+  config values (`🤖 auto-fix`, `🤖 auto-fix-investigate`,
+  and the previously-documented `🤖 auto-fix-investigation`) are
+  translated to the canonical labels at read time with a one-time
+  warning; update the config file and re-label open issues to the
+  canonical names after upgrading, because the daemon only polls the
+  canonical labels.
 
 Everything else lives in
 [configuration](https://github.com/barkley-assistant/caduceus/wiki/Configuration).

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -94,9 +94,9 @@ is used.
 The same bridge contract serves both. The bridge forwards labels via
 `CADUCEUS_ISSUE_LABELS_JSON` and the harness decides how to branch.
 
-- **Code ticket** (`🤖 auto-fix`): worker success → commit + push + open
+- **Code ticket** (`autofix`): worker success → commit + push + open
   PR + post completion comment + close issue.
-- **Investigation ticket** (`🤖 auto-fix-investigate`): worker success
+- **Investigation ticket** (`autofix-investigate`): worker success
   → post findings comment + remove trigger label + leave issue open.
   No commit, no push, no PR, no close.
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -69,7 +69,7 @@ pub struct ExecutorSpec {
     pub issue_title: String,
     /// Issue body (UTF-8, NUL-free, may contain newlines).
     pub issue_body: String,
-    /// Label names (e.g. `["🤖 auto-fix"]`).
+    /// Label names (e.g. `["autofix"]`).
     pub labels: Vec<String>,
     /// Daemon-owned expected branch name.
     pub branch_name: String,

--- a/src/github/poll.rs
+++ b/src/github/poll.rs
@@ -445,9 +445,10 @@ fn diagnostic_key(diag: &IssuePollDiagnostic) -> String {
 
 /// UTF-8 percent-encoding for label values. GitHub's `/issues`
 /// `labels=` query parameter must be URL-encoded even when the
-/// label contains only ASCII; emoji-laden labels (the documented
-/// default `🤖 auto-fix`) MUST round-trip through a UTF-8
-/// percent-encoded form.
+/// label contains only ASCII; arbitrary operator labels (which may
+/// still be non-ASCII, e.g. emoji) MUST round-trip through a UTF-8
+/// percent-encoded form. The default trigger labels are plain ASCII
+/// (`autofix` / `autofix-investigate`) and encode to themselves.
 pub fn url_encode_label(label: &str) -> String {
     let mut out = String::with_capacity(label.len());
     for byte in label.as_bytes() {

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -55,8 +55,48 @@ pub const DEFAULT_ARCHIVE_ON_RETRY: bool = false;
 pub const DEFAULT_ATTIC_RETENTION_DAYS: u64 = 30;
 pub const DEFAULT_MAX_RETRIES_PER_ISSUE: u32 = 3;
 pub const DEFAULT_RETRY_BACKOFF_SECONDS: u64 = 300;
-pub const DEFAULT_TICKET_LABEL_CODE: &str = "🤖 auto-fix";
-pub const DEFAULT_TICKET_LABEL_INVESTIGATION: &str = "🤖 auto-fix-investigate";
+pub const DEFAULT_TICKET_LABEL_CODE: &str = "autofix";
+pub const DEFAULT_TICKET_LABEL_INVESTIGATION: &str = "autofix-investigate";
+
+/// Legacy emoji trigger-label values accepted at config-read time.
+/// Exact match only; no trimming, no case-folding. A value in this map
+/// is translated to its canonical replacement and a one-time notice is
+/// emitted. See docs/architecture/auto-review.md §12.
+pub const LEGACY_TICKET_LABEL_TRANSLATIONS: &[(&str, &str)] = &[
+    ("🤖 auto-fix", "autofix"),
+    ("🤖 auto-fix-investigate", "autofix-investigate"),
+    // README-documented phantom: never the code default, but the
+    // project's own docs told operators to type it for four years.
+    ("🤖 auto-fix-investigation", "autofix-investigate"),
+];
+
+/// Translate explicitly-configured legacy emoji trigger labels to the
+/// canonical names at read time (DAR §12). Exact match only; any other
+/// value passes through untouched. Emits a one-time warn per translated
+/// field so operators know to update their config file.
+fn translate_legacy_ticket_labels(code: &mut String, investigation: &mut String) {
+    for (legacy, canonical) in LEGACY_TICKET_LABEL_TRANSLATIONS {
+        if code.as_str() == *legacy {
+            tracing::warn!(
+                from = legacy,
+                to = canonical,
+                "legacy emoji ticket_label_code translated at read time; \
+                 update the config file to the canonical label"
+            );
+            *code = canonical.to_string();
+        }
+        if investigation.as_str() == *legacy {
+            tracing::warn!(
+                from = legacy,
+                to = canonical,
+                "legacy emoji ticket_label_investigation translated at read time; \
+                 update the config file to the canonical label"
+            );
+            *investigation = canonical.to_string();
+        }
+    }
+}
+
 pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 pub const DEFAULT_WORKER_PARALLELISM: u32 = 1;
 /// Multiplier applied to `worker_parallelism` to derive the default
@@ -699,18 +739,24 @@ impl Config {
             errors.push("retry_backoff_seconds must be > 0".to_string());
         }
 
-        let ticket_label_code = raw
+        let mut ticket_label_code = raw
             .ticket_label_code
             .unwrap_or_else(|| DEFAULT_TICKET_LABEL_CODE.to_string());
         if ticket_label_code.trim().is_empty() {
             errors.push("ticket_label_code must not be empty".to_string());
         }
-        let ticket_label_investigation = raw
+        let mut ticket_label_investigation = raw
             .ticket_label_investigation
             .unwrap_or_else(|| DEFAULT_TICKET_LABEL_INVESTIGATION.to_string());
         if ticket_label_investigation.trim().is_empty() {
             errors.push("ticket_label_investigation must not be empty".to_string());
         }
+        // Translate legacy emoji trigger labels to canonical values at
+        // read time (DAR §12). Exact match only; non-legacy values pass
+        // through untouched. Emits a one-time warn per translated field.
+        // Runs after the empty checks and before the must-differ check so
+        // the canonical pair is what the operator must fix.
+        translate_legacy_ticket_labels(&mut ticket_label_code, &mut ticket_label_investigation);
         if ticket_label_code == ticket_label_investigation {
             errors.push(format!(
             "ticket_label_code and ticket_label_investigation must differ (got {ticket_label_code:?})"

--- a/tests/daemon/awaiting_review_test.rs
+++ b/tests/daemon/awaiting_review_test.rs
@@ -354,7 +354,7 @@ async fn merged_to_done_removes_label_once() {
     .await;
     gh.mount_status(
         "DELETE",
-        "/repos/owner/repo/issues/1/labels/%F0%9F%A4%96%20auto-fix",
+        "/repos/owner/repo/issues/1/labels/autofix",
         204,
         json!({}),
     )

--- a/tests/daemon/idle304_integration_test.rs
+++ b/tests/daemon/idle304_integration_test.rs
@@ -19,8 +19,8 @@ mod fixtures;
 use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-const CODE_LABEL: &str = "🤖 auto-fix";
-const INVESTIGATION_LABEL: &str = "🤖 auto-fix-investigate";
+const CODE_LABEL: &str = "autofix";
+const INVESTIGATION_LABEL: &str = "autofix-investigate";
 
 fn issue_list_json(entries: &[serde_json::Value]) -> serde_json::Value {
     serde_json::Value::Array(entries.to_vec())

--- a/tests/daemon/per_claim_test.rs
+++ b/tests/daemon/per_claim_test.rs
@@ -46,7 +46,7 @@ const TICK_TIMEOUT: Duration = Duration::from_secs(60);
 const OWNER: &str = "owner";
 const REPO: &str = "repo";
 const ISSUE_NUMBER: u64 = 86;
-const CODE_LABEL: &str = "🤖 auto-fix";
+const CODE_LABEL: &str = "autofix";
 const EXPECTED_PR_NUMBER: u64 = 117;
 
 // ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ fn write_config(
         worker.display()
     ));
     yaml.push_str(&format!("  ticket_label_code: \"{}\"\n", CODE_LABEL));
-    yaml.push_str("  ticket_label_investigation: \"🤖 auto-fix-investigate\"\n");
+    yaml.push_str("  ticket_label_investigation: \"autofix-investigate\"\n");
     yaml.push_str("  dry_run: false\n");
     yaml.push_str("  reduced_containment_acknowledged: true\n");
     yaml.push_str(&format!("  max_retries_per_issue: {max_retries}\n"));

--- a/tests/github/context_test.rs
+++ b/tests/github/context_test.rs
@@ -313,7 +313,7 @@ fn unicode_in_comments_and_labels() {
         body: "héllo wörld — τεκστ".to_string(),
         created_at: Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap(),
     });
-    detail.labels = vec!["🤖 auto-fix".to_string()];
+    detail.labels = vec!["autofix".to_string()];
     let ctx = build_context(BuildInputs {
         config: &empty_config(),
         detail: &detail,
@@ -321,7 +321,7 @@ fn unicode_in_comments_and_labels() {
     .expect("build");
     let s = encode_context(&ctx).expect("encode");
     assert!(s.contains("héllo"));
-    assert!(s.contains("🤖"));
+    assert!(s.contains("autofix"));
 }
 
 #[test]

--- a/tests/github/failure_investigation_test.rs
+++ b/tests/github/failure_investigation_test.rs
@@ -260,7 +260,7 @@ async fn investigation_fresh_post() {
     let issue = make_issue();
     let ctx = make_context(&cfg, &issue, "run-inv");
     let wr = make_worker_result(true);
-    let outcome = post_investigation_comment(&ctx, &client, &wr, "🤖 auto-fix-investigate")
+    let outcome = post_investigation_comment(&ctx, &client, &wr, "autofix-investigate")
         .await
         .expect("post");
     assert!(outcome.comment_posted);
@@ -290,7 +290,7 @@ async fn investigation_existing_marker_skips_post() {
     let issue = make_issue();
     let ctx = make_context(&cfg, &issue, "run-reuse");
     let wr = make_worker_result(true);
-    let outcome = post_investigation_comment(&ctx, &client, &wr, "🤖 auto-fix-investigate")
+    let outcome = post_investigation_comment(&ctx, &client, &wr, "autofix-investigate")
         .await
         .expect("post");
     assert!(!outcome.comment_posted);

--- a/tests/github/issue_detail_test.rs
+++ b/tests/github/issue_detail_test.rs
@@ -73,7 +73,7 @@ async fn complete_parse_returns_typed_detail() {
         .respond_with(ResponseTemplate::new(200).set_body_json(issue_body(
             "Fix login",
             "Login is broken when...",
-            &["bug", "🤖 auto-fix"],
+            &["bug", "autofix"],
         )))
         .expect(1)
         .mount(&server)
@@ -96,7 +96,7 @@ async fn complete_parse_returns_typed_detail() {
                 "labeled",
                 "octocat",
                 "2026-07-13T11:00:00Z",
-                Some("🤖 auto-fix")
+                Some("autofix")
             )])),
         )
         .expect(1)
@@ -112,13 +112,13 @@ async fn complete_parse_returns_typed_detail() {
     assert_eq!(detail.body, "Login is broken when...");
     assert_eq!(
         detail.labels,
-        vec!["bug".to_string(), "🤖 auto-fix".to_string()]
+        vec!["bug".to_string(), "autofix".to_string()]
     );
     assert_eq!(detail.comments.len(), 2);
     assert!(detail
         .events
         .iter()
-        .any(|e| e.kind == "labeled" && e.label_name.as_deref() == Some("🤖 auto-fix")));
+        .any(|e| e.kind == "labeled" && e.label_name.as_deref() == Some("autofix")));
 }
 
 // Null body / user tolerance

--- a/tests/github/issue_poll_test.rs
+++ b/tests/github/issue_poll_test.rs
@@ -33,8 +33,8 @@ mod fixtures;
 use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-const CODE_LABEL: &str = "🤖 auto-fix";
-const INVESTIGATION_LABEL: &str = "🤖 auto-fix-investigate";
+const CODE_LABEL: &str = "autofix";
+const INVESTIGATION_LABEL: &str = "autofix-investigate";
 
 fn mock_client(gh: &MockGitHub) -> (Client, Config) {
     let state_dir = tempdir("mock");
@@ -105,10 +105,7 @@ async fn code_label_query_carries_percent_encoded_value() {
 
     let received = gh.server().received_requests().await.expect("received");
     let url = received[0].url.as_str();
-    assert!(
-        url.contains("%F0%9F%A4%96%20auto-fix"),
-        "expected percent-encoded label in {url}"
-    );
+    assert!(url.contains("autofix"), "expected plain label in {url}");
     assert!(
         !url.contains("🤖"),
         "raw emoji should not appear in the URL: {url}"
@@ -344,7 +341,7 @@ async fn malformed_number_is_diagnosed() {
 async fn pagination_in_code_poll_follows_link_header() {
     let gh = MockGitHub::start().await;
     let next_url = format!(
-        "{}/repos/octocat/hello-world/issues?per_page=100&page=2&labels=%F0%9F%A4%96%20auto-fix&state=open&sort=updated&direction=desc",
+        "{}/repos/octocat/hello-world/issues?per_page=100&page=2&labels=autofix&state=open&sort=updated&direction=desc",
         gh.uri()
     );
     let link_header = format!("<{next_url}>; rel=\"next\"");
@@ -450,7 +447,7 @@ async fn events_api_fields_are_ignored() {
         {
             "number": 7,
             "title": "Fix login",
-            "labels": [{"name": "🤖 auto-fix"}],
+            "labels": [{"name": "autofix"}],
             "updated_at": "2026-07-13T12:00:00Z",
             "event": "labeled",
             "performed_via_github_app": null,

--- a/tests/github/rate_limit_test.rs
+++ b/tests/github/rate_limit_test.rs
@@ -131,7 +131,7 @@ async fn four_twenty_nine_mid_pagination_short_circuits_poll() {
     // Page 1 returns 200 with rate-limit headers still allowing
     // more requests.
     let next_url = format!(
-        "{}/repos/octocat/hello-world/issues?per_page=100&page=2&labels=auto-fix&state=open&sort=updated&direction=desc",
+        "{}/repos/octocat/hello-world/issues?per_page=100&page=2&labels=autofix&state=open&sort=updated&direction=desc",
         gh.uri()
     );
     let link_header = format!("<{next_url}>; rel=\"next\"");
@@ -163,7 +163,7 @@ async fn four_twenty_nine_mid_pagination_short_circuits_poll() {
     let state_dir = tempdir("429");
     let client = mock_client(&gh, &state_dir);
     let mut cfg = Config::test_defaults(&state_dir);
-    cfg.ticket_label_code = "auto-fix".to_string();
+    cfg.ticket_label_code = "autofix".to_string();
     cfg.watched_repos = vec!["octocat/hello-world".to_string()];
 
     let result = caduceus::poll::poll_code(&client, &cfg, &cfg.watched_repos).await;

--- a/tests/github/remove_label_test.rs
+++ b/tests/github/remove_label_test.rs
@@ -13,7 +13,7 @@ async fn default_label_delete_hits_encoded_path_and_succeeds_on_204() {
     let gh = MockGitHub::start().await;
     gh.mount_status(
         "DELETE",
-        "/repos/o/r/issues/1/labels/%F0%9F%A4%96%20auto-fix",
+        "/repos/o/r/issues/1/labels/autofix",
         204,
         json!({}),
     )
@@ -21,7 +21,7 @@ async fn default_label_delete_hits_encoded_path_and_succeeds_on_204() {
 
     let client = Client::new(gh.uri().as_str());
     let response = client
-        .remove_issue_label("o", "r", 1, "🤖 auto-fix")
+        .remove_issue_label("o", "r", 1, "autofix")
         .await
         .expect("204 succeeds");
     assert_eq!(response.status, 204);
@@ -30,7 +30,7 @@ async fn default_label_delete_hits_encoded_path_and_succeeds_on_204() {
     assert_eq!(counts.delete, 1, "expected exactly one DELETE");
     let path_counts = gh.path_counts();
     assert_eq!(
-        path_counts.get("/repos/o/r/issues/1/labels/%F0%9F%A4%96%20auto-fix"),
+        path_counts.get("/repos/o/r/issues/1/labels/autofix"),
         Some(&1)
     );
 }
@@ -64,14 +64,14 @@ async fn label_not_found_returns_err() {
     let gh = MockGitHub::start().await;
     gh.mount_status(
         "DELETE",
-        "/repos/o/r/issues/1/labels/%F0%9F%A4%96%20auto-fix",
+        "/repos/o/r/issues/1/labels/autofix",
         404,
         json!({ "message": "Not Found" }),
     )
     .await;
 
     let client = Client::new(gh.uri().as_str());
-    let result = client.remove_issue_label("o", "r", 1, "🤖 auto-fix").await;
+    let result = client.remove_issue_label("o", "r", 1, "autofix").await;
     assert!(result.is_err(), "404 must surface as an Err");
 }
 

--- a/tests/github/verify_test.rs
+++ b/tests/github/verify_test.rs
@@ -22,8 +22,8 @@ mod fixtures;
 use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
-const CODE_LABEL: &str = "🤖 auto-fix";
-const INVESTIGATION_LABEL: &str = "🤖 auto-fix-investigate";
+const CODE_LABEL: &str = "autofix";
+const INVESTIGATION_LABEL: &str = "autofix-investigate";
 
 fn mock_client_with_repos(server: &MockServer) -> (Client, Config) {
     let state_dir = tempdir("mock");

--- a/tests/integration/bridge_test.py
+++ b/tests/integration/bridge_test.py
@@ -72,7 +72,7 @@ def fake_env(tmp_path: Path) -> dict:
         ),
         "CADUCEUS_WORKTREE_PATH": str(worktree),
         "CADUCEUS_RUN_ID": "01J0X0X0X0X0X0X0X0X0X0X0X",
-        "CADUCEUS_ISSUE_LABELS_JSON": json.dumps(["🤖 auto-fix", "good first issue"]),
+        "CADUCEUS_ISSUE_LABELS_JSON": json.dumps(["autofix", "good first issue"]),
         "CADUCEUS_BRANCH_NAME": "automation/issue-42-01j0x0x0x0x0x0x0x0x0x0x",
         "CADUCEUS_RESULT_PATH": str(worktree / "worker-result.json"),
     }
@@ -130,14 +130,14 @@ class TestReadRequiredEnv:
 
 class TestParseLabels:
     def test_arrays_of_strings_parse(self, bridge_module):
-        result = bridge_module.parse_labels(json.dumps(["🤖 auto-fix", "bug"]))
-        assert result == ["🤖 auto-fix", "bug"]
+        result = bridge_module.parse_labels(json.dumps(["autofix", "bug"]))
+        assert result == ["autofix", "bug"]
 
     def test_empty_array_parses_to_empty_list(self, bridge_module):
         assert bridge_module.parse_labels("[]") == []
 
     def test_unicode_labels_round_trip(self, bridge_module):
-        labels = ["🤖 auto-fix", "🚀 ship-it", "ñ"]
+        labels = ["autofix", "🚀 ship-it", "ñ"]
         assert bridge_module.parse_labels(json.dumps(labels)) == labels
 
     def test_non_string_element_rejected(self, bridge_module, capsys):
@@ -207,7 +207,7 @@ class TestInvokeHarness:
             worktree=worktree,
             prompt_file=prompt,
             run_id="abc",
-            labels=("🤖 auto-fix",),
+            labels=("autofix",),
             branch_name="automation/issue-1-abc",
         )
         assert rc == 0
@@ -373,7 +373,7 @@ class TestMain:
         assert captured, "invoke_harness should have been called"
         assert captured["args"]["run_id"] == fake_env["CADUCEUS_RUN_ID"]
         assert captured["args"]["branch_name"] == fake_env["CADUCEUS_BRANCH_NAME"]
-        assert captured["args"]["labels"] == ["🤖 auto-fix", "good first issue"]
+        assert captured["args"]["labels"] == ["autofix", "good first issue"]
 
     def test_bridge_missing_env_exits_2(self, bridge_module, fake_env):
         """A completely missing env block still exits 2 on the first
@@ -486,7 +486,7 @@ def _build_env(tmp_path: Path, **overrides: str) -> dict:
         "CADUCEUS_CONTEXT_JSON": json.dumps({"run_id": "abc"}),
         "CADUCEUS_WORKTREE_PATH": str(tmp_path),
         "CADUCEUS_RUN_ID": "01J0X0X0X0X0X0X0X0X0X0X0X",
-        "CADUCEUS_ISSUE_LABELS_JSON": json.dumps(["🤖 auto-fix", "good first issue"]),
+        "CADUCEUS_ISSUE_LABELS_JSON": json.dumps(["autofix", "good first issue"]),
         "CADUCEUS_BRANCH_NAME": "automation/issue-42-01j0x0x0x0x0x0x0x0x0x0x",
         "CADUCEUS_RESULT_PATH": str(tmp_path / "worker-result.json"),
     }
@@ -859,7 +859,7 @@ class TestNewContract:
         assert observed["prompt"] == str((worktree / "worker-prompt.md").resolve())
         assert observed["run_id"] == env["CADUCEUS_RUN_ID"]
         assert observed["branch"] == env["CADUCEUS_BRANCH_NAME"]
-        assert observed["labels"] == ["🤖 auto-fix", "good first issue"]
+        assert observed["labels"] == ["autofix", "good first issue"]
         assert observed["issue"] == {
             "repo": env["CADUCEUS_ISSUE_REPO"],
             "number": 42,

--- a/tests/integration/release_canary_test.rs
+++ b/tests/integration/release_canary_test.rs
@@ -87,7 +87,7 @@ const BUILD_TIMEOUT: Duration = Duration::from_secs(420);
 const OWNER: &str = "owner";
 const REPO: &str = "repo";
 const ISSUE_NUMBER: u64 = 47;
-const CODE_LABEL: &str = "🤖 auto-fix";
+const CODE_LABEL: &str = "autofix";
 
 // ---------------------------------------------------------------------------
 // Harness: hermes binary gate (REQ-02).
@@ -346,7 +346,7 @@ fn write_config(
         worker.display()
     ));
     yaml.push_str(&format!("  ticket_label_code: \"{}\"\n", CODE_LABEL));
-    yaml.push_str("  ticket_label_investigation: \"🤖 auto-fix-investigate\"\n");
+    yaml.push_str("  ticket_label_investigation: \"autofix-investigate\"\n");
     yaml.push_str(&format!("  dry_run: {}\n", dry_run));
     yaml.push_str("  reduced_containment_acknowledged: true\n");
     fs::write(config_path, yaml).expect("write canary config");

--- a/tests/state/config_test.rs
+++ b/tests/state/config_test.rs
@@ -500,6 +500,85 @@ fn duplicate_trigger_labels_are_rejected() {
     assert!(msg.contains("must differ"), "got: {msg}");
 }
 
+// Legacy emoji label translation (DAR §12)
+//
+// `from_raw` translates explicit legacy emoji trigger-label values to
+// the canonical labels at read time (docs/architecture/auto-review.md
+// §12), emitting a one-time warn. Exact match only; deliberate
+// non-legacy values pass through untouched.
+
+#[test]
+fn from_raw_translates_legacy_emoji_code_label() {
+    let root = tempdir("legacy-code");
+    let yaml = r#"
+        ticket_label_code: "🤖 auto-fix"
+        worker_command: ["python3", "bridge.py"]
+        reduced_containment_acknowledged: true
+        "#;
+    let raw: RawConfig = serde_yaml::from_str(yaml).expect("yaml parses");
+    let cfg = Config::from_raw(raw, &ctx(&root)).expect("config validates");
+    assert_eq!(cfg.ticket_label_code, "autofix");
+}
+
+#[test]
+fn from_raw_translates_legacy_emoji_investigation_label() {
+    let root = tempdir("legacy-inv");
+    let yaml = r#"
+        ticket_label_investigation: "🤖 auto-fix-investigate"
+        worker_command: ["python3", "bridge.py"]
+        reduced_containment_acknowledged: true
+        "#;
+    let raw: RawConfig = serde_yaml::from_str(yaml).expect("yaml parses");
+    let cfg = Config::from_raw(raw, &ctx(&root)).expect("config validates");
+    assert_eq!(cfg.ticket_label_investigation, "autofix-investigate");
+}
+
+#[test]
+fn from_raw_translates_readme_phantom_investigation_label() {
+    // README v1.0.0 documented "🤖 auto-fix-investigation"; it was never
+    // the code default. Operators following the README set it; it must
+    // translate (it was a dead label under the old defaults too).
+    let root = tempdir("legacy-phantom");
+    let yaml = r#"
+        ticket_label_investigation: "🤖 auto-fix-investigation"
+        worker_command: ["python3", "bridge.py"]
+        reduced_containment_acknowledged: true
+        "#;
+    let raw: RawConfig = serde_yaml::from_str(yaml).expect("yaml parses");
+    let cfg = Config::from_raw(raw, &ctx(&root)).expect("config validates");
+    assert_eq!(cfg.ticket_label_investigation, "autofix-investigate");
+}
+
+#[test]
+fn from_raw_does_not_translate_plain_auto_fix_hyphen() {
+    // "auto-fix" (no emoji) was never a default; operators who set it
+    // chose it deliberately. It must pass through untouched.
+    let root = tempdir("plain-hyphen");
+    let yaml = r#"
+        ticket_label_code: "auto-fix"
+        worker_command: ["python3", "bridge.py"]
+        reduced_containment_acknowledged: true
+        "#;
+    let raw: RawConfig = serde_yaml::from_str(yaml).expect("yaml parses");
+    let cfg = Config::from_raw(raw, &ctx(&root)).expect("config validates");
+    assert_eq!(cfg.ticket_label_code, "auto-fix");
+}
+
+#[test]
+fn from_raw_does_not_translate_arbitrary_custom_label() {
+    let root = tempdir("custom-label");
+    let yaml = r#"
+        ticket_label_code: "custom-triage"
+        ticket_label_investigation: "custom-investigate"
+        worker_command: ["python3", "bridge.py"]
+        reduced_containment_acknowledged: true
+        "#;
+    let raw: RawConfig = serde_yaml::from_str(yaml).expect("yaml parses");
+    let cfg = Config::from_raw(raw, &ctx(&root)).expect("config validates");
+    assert_eq!(cfg.ticket_label_code, "custom-triage");
+    assert_eq!(cfg.ticket_label_investigation, "custom-investigate");
+}
+
 // Deny unknown fields
 
 #[test]

--- a/tests/worker/supervisor_env_test.rs
+++ b/tests/worker/supervisor_env_test.rs
@@ -39,7 +39,7 @@ fn sample_inputs(worktree: &Path) -> SanitizedEnvInputs {
         },
         issue_title: "Issue title".to_string(),
         issue_body: "Issue body".to_string(),
-        labels: vec!["🤖 auto-fix".to_string()],
+        labels: vec!["autofix".to_string()],
         worktree_path: worktree.to_path_buf(),
         run_id: "RUN75".to_string(),
         branch_name: "automation/issue-75-run75".to_string(),
@@ -136,7 +136,7 @@ fn supervisor_command_validates_labels_json() {
     let worktree = tempdir("labels_json");
     fs::create_dir_all(&worktree).expect("worktree dir");
     let mut inputs = sample_inputs(&worktree);
-    inputs.labels = vec!["🤖 auto-fix".to_string()];
+    inputs.labels = vec!["autofix".to_string()];
     let env = sanitized_env(&empty_env(), &inputs).expect("sanitized env");
 
     let raw = env
@@ -145,5 +145,5 @@ fn supervisor_command_validates_labels_json() {
         .to_str()
         .expect("labels json utf-8");
     let parsed: Vec<String> = serde_json::from_str(raw).expect("valid JSON array of strings");
-    assert_eq!(parsed, vec!["🤖 auto-fix".to_string()]);
+    assert_eq!(parsed, vec!["autofix".to_string()]);
 }

--- a/tests/worker/worker_command_args_test.rs
+++ b/tests/worker/worker_command_args_test.rs
@@ -67,7 +67,7 @@ fn sample_cmd(worker_command: Vec<String>) -> std::process::Command {
         1024,
         "Test PR title",
         "Test PR body",
-        &["🤖 auto-fix".to_string()],
+        &["autofix".to_string()],
         "automation/issue-99",
     )
 }


### PR DESCRIPTION
## Summary

Standardise Caduceus automation trigger labels per #291.

- Defaults: `ticket_label_code` is now `autofix`; `ticket_label_investigation`
  is now `autofix-investigate`. No emoji default anywhere.
- Legacy emoji config values (`🤖 auto-fix`, `🤖 auto-fix-investigate`, and
  the README-documented `🤖 auto-fix-investigation`) translate to the
  canonical labels at `Config::from_raw` read time (exact match only) with a
  one-time `tracing::warn!` notice; the emoji label is never an active
  dispatch trigger — no dual-trigger window.
- `autoreview` remains a reserved, inert label (DAR §5.2): no config field,
  no polling; flag-based enablement via `auto_review.enabled`.
- Updated every inventory surface: config defaults + validation, polling,
  completion-removal, worker env docstring, README, in-repo skill, and all
  test fixtures. `docs/cli.md` verified unchanged (no label literals).

## Notes

- The one-time notice is a standard `tracing::warn!` emitted at config load,
  matching existing config-load logging; the integration layer does not
  capture log output, so notice observability is covered by the translation
  unit tests rather than log-capture machinery.
- `url_encode_label` is unchanged; plain ASCII labels encode to themselves
  (non-ASCII operator labels still round-trip).
- Operator follow-up after upgrading: create the `autofix` /
  `autofix-investigate` labels on each watched repo and re-label open
  issues; the poller queries only the canonical labels.
- Post-merge follow-ups (outside this repo): refresh the installed plugin
  skill copy and update the conventions-skill pitfall entry.

Closes #291
