### PR TITLE
feat(review): add Auto Review domain types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   `OciDiskPressure` error until the reserve recovers (256 MiB hysteresis).
   This is a host-level mitigation — `/workspace` remains a host bind mount
   with no per-container byte quota.
+- **Auto Review domain types.** `caduceus::review` now defines the
+  Phase-1 review domain model — `ReviewTarget` (immutable
+  `(repository, PR, head SHA)` identity with persisted merge-base
+  context), `ReviewState` (per-PR current pointer with the monotonic
+  `review_generation` publication guard), and the
+  `ReviewResult`/`Review`/`Finding` worker contract with strict serde,
+  snake_case enums, and parse-time field caps. Foundation for the Auto
+  Review epic (#290); no behaviour change yet. Closes #292.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,6 +428,10 @@ name = "review_lifecycle_test"
 path = "tests/state/review_lifecycle_test.rs"
 
 [[test]]
+name = "review_domain_test"
+path = "tests/review/review_domain_test.rs"
+
+[[test]]
 name = "state_store_test"
 path = "tests/state/state_store_test.rs"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod github;
 pub mod infra;
 pub mod readiness;
 pub mod repo;
+pub mod review;
 pub mod runtime;
 pub mod scheduler;
 pub mod state;

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -143,6 +143,89 @@ pub struct ReviewTarget {
 }
 
 // ---------------------------------------------------------------------------
+// Per-run result contract
+// ---------------------------------------------------------------------------
+
+/// Review severity — drives verdict consistency (#305) and deterministic
+/// renderer consumption order (blocking → warnings → suggestions,
+/// DAR §9.2).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum Severity {
+    Blocking,
+    Warning,
+    Suggestion,
+}
+
+/// Did the code pass the review? Drives **publication only** — never
+/// retry (DAR §8).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum Verdict {
+    Pass,
+    Fail,
+}
+
+/// Did the review *execute*? Drives **retry** — never publication
+/// (DAR §8). A failed code review is never `Failure`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum ExecutionStatus {
+    Success,
+    Failure,
+}
+
+/// One review finding. Ordering inside `Review.findings` is the
+/// persisted order and is load-bearing: byte-identical re-publication
+/// depends on it (DAR §3, §9.2). Nothing in this module sorts findings.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct Finding {
+    pub severity: Severity,
+    pub title: String,
+    pub body: String,
+    /// Repo-relative file path, when the finding is positional.
+    pub path: Option<String>,
+    /// 1-based line number within `path`, when positional.
+    pub line: Option<u32>,
+    pub remediation: Option<String>,
+}
+
+/// The review payload of a successful run.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct Review {
+    pub verdict: Verdict,
+    pub summary: String,
+    /// Ordered findings; order is preserved verbatim through
+    /// serialization (determinism requirement, DAR §3).
+    pub findings: Vec<Finding>,
+}
+
+/// Per-run structured review result — the canonical,
+/// presentation-independent document the worker harness produces and
+/// the daemon persists as an opaque version-tagged history blob
+/// (DAR §4.3). The PR comment is presentation derived from this; never
+/// the reverse.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct ReviewResult {
+    /// Document schema version; must equal [`REVIEW_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Did the review execute? Drives retry (DAR §8).
+    pub status: ExecutionStatus,
+    /// Present iff `status == Success` (the iff-rule itself is #305's
+    /// validator; here it is shape + caps only).
+    pub review: Option<Review>,
+}
+
+// ---------------------------------------------------------------------------
 // Parse-time contracts (caps + schema version + non-empty)
 // ---------------------------------------------------------------------------
 
@@ -158,6 +241,73 @@ fn required_string(scope: &str, field: &str, value: &str, max: usize) -> Caduceu
             "{scope}: {field} exceeds limit of {max} bytes (got {})",
             value.len()
         )));
+    }
+    Ok(())
+}
+
+/// Optional string: absent is fine; present must be non-empty and
+/// within `max` bytes.
+fn optional_string(
+    scope: &str,
+    field: &str,
+    value: &Option<String>,
+    max: usize,
+) -> CaduceusResult<()> {
+    match value {
+        Some(value) => required_string(scope, field, value, max),
+        None => Ok(()),
+    }
+}
+
+/// Parse and validate a `ReviewResult` document (the v1 parser).
+///
+/// Strict at every layer: unknown fields rejected by serde, schema
+/// version must equal [`REVIEW_SCHEMA_VERSION`], and all worker-facing
+/// caps below are enforced. Verdict/severity consistency and the
+/// status↔review presence rule are #305's validator, not this parse.
+pub fn parse_review_result(json: &str) -> CaduceusResult<ReviewResult> {
+    let result: ReviewResult = serde_json::from_str(json).map_err(|err| {
+        CaduceusError::Config(format!("review result: malformed document: {err}"))
+    })?;
+    if result.schema_version != REVIEW_SCHEMA_VERSION {
+        return Err(CaduceusError::Config(format!(
+            "review result: schema_version {} is not supported (this daemon accepts \
+             {REVIEW_SCHEMA_VERSION})",
+            result.schema_version
+        )));
+    }
+    validate_review_result(&result)?;
+    Ok(result)
+}
+
+/// Cap validation for a [`ReviewResult`] (exposed so #305's full
+/// validator can compose it).
+pub fn validate_review_result(result: &ReviewResult) -> CaduceusResult<()> {
+    if let Some(review) = &result.review {
+        required_string(
+            "review result",
+            "summary",
+            &review.summary,
+            MAX_REVIEW_SUMMARY_BYTES,
+        )?;
+        if review.findings.len() > MAX_FINDINGS {
+            return Err(CaduceusError::Config(format!(
+                "review result: findings exceed limit of {MAX_FINDINGS} entries (got {})",
+                review.findings.len()
+            )));
+        }
+        for (idx, finding) in review.findings.iter().enumerate() {
+            let scope = format!("review result: finding[{idx}]");
+            required_string(&scope, "title", &finding.title, MAX_FINDING_TITLE_BYTES)?;
+            required_string(&scope, "body", &finding.body, MAX_FINDING_BODY_BYTES)?;
+            optional_string(&scope, "path", &finding.path, MAX_FINDING_PATH_BYTES)?;
+            optional_string(
+                &scope,
+                "remediation",
+                &finding.remediation,
+                MAX_FINDING_REMEDIATION_BYTES,
+            )?;
+        }
     }
     Ok(())
 }

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -28,6 +28,7 @@
 //! status/review presence, line/path semantics (#305) — executor
 //! targets (#346), CLI (#318).
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
@@ -140,6 +141,80 @@ pub struct ReviewTarget {
     /// admission and persisted here (DAR §2.1). Frozen context: all
     /// later diff computation and CLI display reuse this value.
     pub merge_base: String,
+}
+
+// ---------------------------------------------------------------------------
+// Per-PR current state
+// ---------------------------------------------------------------------------
+
+/// Publication FSM stage for the sticky PR comment (DAR §9.1):
+/// `Pending → Publishing → Published | FailedRetryable`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum PublicationState {
+    Pending,
+    Publishing,
+    Published,
+    FailedRetryable,
+}
+
+/// Per-`(repo, pr)` durable current-state pointer (DAR §3).
+///
+/// This is a *current pointer*, not history: per-run history is the
+/// append-only, per-`review_run_id` store (#295, DAR §4.3).
+///
+/// **No execution `attempt_count` here** — the queue entry owns
+/// execution attempts; `publication_attempt_count` owns publication
+/// retries; a third counter has no consumer (DAR §3).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct ReviewState {
+    pub repository: RepositoryId,
+    pub pull_request: u64,
+    /// Head SHA of the last completed (published or suppressed) review.
+    pub last_reviewed_head_sha: Option<String>,
+    pub last_verdict: Option<Verdict>,
+    pub last_reviewed_at: Option<DateTime<Utc>>,
+    /// Authoritative id of the sticky PR comment; marker search is the
+    /// fallback (DAR §9.2).
+    pub sticky_comment_id: Option<u64>,
+    /// Run id of the most recent review run (opaque daemon string;
+    /// 64-byte cap mirrors `validate_run_id`).
+    pub last_run_id: Option<String>,
+    /// Monotonic per-`(repo, pr)` generation, assigned at admission —
+    /// the stale-publication guard (DAR §9.4): an older generation may
+    /// persist its historical result but must never update the PR's
+    /// current presentation.
+    pub review_generation: u64,
+    pub publication_state: PublicationState,
+    /// Publication retries — NEVER the worker attempt counter.
+    pub publication_attempt_count: u32,
+    pub next_publish_at: Option<DateTime<Utc>>,
+    pub last_publish_error: Option<String>,
+}
+
+impl ReviewState {
+    /// Fresh state for a PR entering the review pipeline: `Pending`
+    /// publication, zero counters, no observations yet. `#295`'s store
+    /// calls this at admission.
+    pub fn new(repository: RepositoryId, pull_request: u64, review_generation: u64) -> Self {
+        Self {
+            repository,
+            pull_request,
+            last_reviewed_head_sha: None,
+            last_verdict: None,
+            last_reviewed_at: None,
+            sticky_comment_id: None,
+            last_run_id: None,
+            review_generation,
+            publication_state: PublicationState::Pending,
+            publication_attempt_count: 0,
+            next_publish_at: None,
+            last_publish_error: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -335,6 +410,42 @@ pub fn validate_review_target(target: &ReviewTarget) -> CaduceusResult<()> {
         "merge_base",
         &target.merge_base,
         MAX_SHA_BYTES,
+    )?;
+    Ok(())
+}
+
+/// Cap validation for a [`ReviewState`] (the store calls this on
+/// load, #295).
+pub fn validate_review_state(state: &ReviewState) -> CaduceusResult<()> {
+    required_string(
+        "review state",
+        "repository.owner",
+        &state.repository.owner,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    required_string(
+        "review state",
+        "repository.repo",
+        &state.repository.repo,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    optional_string(
+        "review state",
+        "last_reviewed_head_sha",
+        &state.last_reviewed_head_sha,
+        MAX_SHA_BYTES,
+    )?;
+    optional_string(
+        "review state",
+        "last_run_id",
+        &state.last_run_id,
+        MAX_RUN_ID_BYTES,
+    )?;
+    optional_string(
+        "review state",
+        "last_publish_error",
+        &state.last_publish_error,
+        MAX_PUBLISH_ERROR_BYTES,
     )?;
     Ok(())
 }

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -1,0 +1,190 @@
+//! Auto Review domain model — the typed foundation for the review
+//! pipeline (epic #290, spec `docs/architecture/auto-review.md`).
+//!
+//! This module owns the review domain's data shapes and their
+//! parse-time contracts only. It deliberately contains no I/O, no
+//! store, and no execution logic:
+//!
+//! - [`ReviewTarget`] — immutable review identity
+//!   `(repository, PR number, head SHA)` frozen at discovery, plus the
+//!   diff context (`base_sha`, `base_ref`, `merge_base`) computed and
+//!   persisted at admission (DAR §2.1).
+//! - [`ReviewState`] — per-`(repo, pr)` durable current-state pointer,
+//!   including the monotonic `review_generation` publication guard
+//!   (DAR §9.4).
+//! - [`ReviewResult`] / [`Review`] / [`Finding`] — the per-run worker
+//!   result contract (DAR §3). `ReviewResult` is the only review type
+//!   carrying `schema_version`: it crosses a process boundary and is
+//!   persisted as an opaque version-tagged history blob (DAR §4.3).
+//!
+//! Diff semantics (DAR §2.2): the review scope is always
+//! `git diff <merge_base> <head_sha>` — merge-base (three-dot)
+//! semantics. Endpoint-to-endpoint `base..head` ranges are prohibited;
+//! no helper in this module may format a `..`/`...` range string, and
+//! `base_sha` is context, never a diff endpoint.
+//!
+//! Out of scope here (later issues): persistence (#295), migrations
+//! (#293), the full result validator — verdict/severity consistency,
+//! status/review presence, line/path semantics (#305) — executor
+//! targets (#346), CLI (#318).
+
+use serde::{Deserialize, Serialize};
+
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Schema version of the [`ReviewResult`] document. Bumped on any
+/// breaking change to the wire shape. The v1 parser
+/// ([`parse_review_result`]) rejects documents carrying any other
+/// value; version-aware reading of old history blobs arrives with the
+/// store (#295).
+pub const REVIEW_SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Field caps (DAR §3, §10.3)
+//
+// Caps are byte budgets (UTF-8), matching the byte-budget world of the
+// sticky-comment renderer (DAR §9.2). Tight where the field is
+// worker-produced (adversarial surface; rejections burn retry budget
+// per DAR §8, so limits are generous enough to never reject a sane
+// result), loose where the field is daemon-authored (storage bounds
+// only). Content-shape rules beyond length (hex form, ref syntax,
+// GitHub naming) belong to the #305 validator.
+// ---------------------------------------------------------------------------
+
+/// `Review.summary` — mirrors `MAX_SUMMARY_BYTES`
+/// (`src/worker/worker_contract.rs`).
+pub const MAX_REVIEW_SUMMARY_BYTES: usize = 64 * 1024;
+/// Maximum number of findings in one review — mirrors `MAX_ARTIFACTS`.
+pub const MAX_FINDINGS: usize = 100;
+/// `Finding.title` — mirrors `MAX_PULL_REQUEST_TITLE_CHARS`.
+pub const MAX_FINDING_TITLE_BYTES: usize = 256;
+/// `Finding.body` — a single finding must not approach the 64 KiB
+/// comment budget on its own.
+pub const MAX_FINDING_BODY_BYTES: usize = 16 * 1024;
+/// `Finding.remediation` — guidance text, shorter than the body.
+pub const MAX_FINDING_REMEDIATION_BYTES: usize = 8 * 1024;
+/// `Finding.path` — PATH_MAX.
+pub const MAX_FINDING_PATH_BYTES: usize = 4096;
+/// SHA fields (`head_sha`, `base_sha`, `merge_base`) — fits SHA-1 (40)
+/// and SHA-256 (64) hex forms.
+pub const MAX_SHA_BYTES: usize = 64;
+/// `base_ref` — storage bound; ref-syntax validation is #297/#305.
+pub const MAX_REF_BYTES: usize = 1024;
+/// `RepositoryId.owner` / `.repo` — coarse storage bound; GitHub
+/// naming rules are #305's validator.
+pub const MAX_REPO_COMPONENT_BYTES: usize = 256;
+/// `ReviewState.last_run_id` — mirrors `validate_run_id`
+/// (`src/worktree/worktree.rs`).
+pub const MAX_RUN_ID_BYTES: usize = 64;
+/// `ReviewState.last_publish_error` — bounded logging surface;
+/// generous to never reject daemon-authored state.
+pub const MAX_PUBLISH_ERROR_BYTES: usize = 4096;
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/// GitHub repository identity for the review domain: `(owner, repo)`.
+///
+/// Deliberately NOT [`crate::github::issue::IssueKey`]: review identity
+/// never enters `IssueKey` (DAR §4.1) — a PR review is not an issue,
+/// and this type cannot be used as one without the caller explicitly
+/// constructing a separate key. Cheap by design: no registry, no I/O,
+/// no case normalisation (canonical comparison is a store-layer
+/// concern, #295).
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct RepositoryId {
+    /// Repository owner (user or organisation login).
+    pub owner: String,
+    /// Repository name.
+    pub repo: String,
+}
+
+impl RepositoryId {
+    /// `owner/repo` display form. No case normalisation — callers that
+    /// need canonical comparison normalise at their own layer.
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+}
+
+/// Immutable review revision identity, frozen at discovery (DAR §2.1).
+///
+/// Identity = `(repository, pull_request, head_sha)`. The head SHA is
+/// captured at discovery and never re-resolved; if the PR moves on
+/// while a review runs, the next poll admits the new SHA as a new
+/// target. `base_sha`, `base_ref`, and `merge_base` are **context**,
+/// not identity: base movement with an unchanged head SHA is not a new
+/// review.
+///
+/// Diff rule (DAR §2.2): review scope is always
+/// `git diff <merge_base> <head_sha>`. Never `base..head`.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct ReviewTarget {
+    /// Repository the PR lives in.
+    pub repository: RepositoryId,
+    /// PR number.
+    pub pull_request: u64,
+    /// Head SHA at discovery — the identity component.
+    pub head_sha: String,
+    /// Base SHA — context for merge-base computation; never a diff
+    /// endpoint.
+    pub base_sha: String,
+    /// Base ref name — context.
+    pub base_ref: String,
+    /// Merge base of `base_sha` and `head_sha`, computed once at
+    /// admission and persisted here (DAR §2.1). Frozen context: all
+    /// later diff computation and CLI display reuse this value.
+    pub merge_base: String,
+}
+
+// ---------------------------------------------------------------------------
+// Parse-time contracts (caps + schema version + non-empty)
+// ---------------------------------------------------------------------------
+
+/// Required string: non-empty and at most `max` bytes.
+fn required_string(scope: &str, field: &str, value: &str, max: usize) -> CaduceusResult<()> {
+    if value.is_empty() {
+        return Err(CaduceusError::Config(format!(
+            "{scope}: {field} must not be empty"
+        )));
+    }
+    if value.len() > max {
+        return Err(CaduceusError::Config(format!(
+            "{scope}: {field} exceeds limit of {max} bytes (got {})",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Cap validation for a [`ReviewTarget`] (the store calls this on
+/// load, #295).
+pub fn validate_review_target(target: &ReviewTarget) -> CaduceusResult<()> {
+    required_string(
+        "review target",
+        "repository.owner",
+        &target.repository.owner,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    required_string(
+        "review target",
+        "repository.repo",
+        &target.repository.repo,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    required_string("review target", "head_sha", &target.head_sha, MAX_SHA_BYTES)?;
+    required_string("review target", "base_sha", &target.base_sha, MAX_SHA_BYTES)?;
+    required_string("review target", "base_ref", &target.base_ref, MAX_REF_BYTES)?;
+    required_string(
+        "review target",
+        "merge_base",
+        &target.merge_base,
+        MAX_SHA_BYTES,
+    )?;
+    Ok(())
+}

--- a/tests/review/review_domain_test.rs
+++ b/tests/review/review_domain_test.rs
@@ -1,0 +1,121 @@
+//! Auto Review domain types (issue #292).
+//!
+//! Acceptance coverage:
+//!
+//! - AC1 — round-trips with `deny_unknown_fields` on every type.
+//! - AC2 — `schema_version` present, daemon const = 1, enforced.
+//! - AC3 — `merge_base` on target; generation/publication fields on
+//!   state; `attempt_count` is an unknown field.
+//! - AC4 — findings ordering preserved verbatim.
+//! - AC5 — enums serialize snake_case, reject unknown values.
+//! - AC6 — caps declared and enforced at parse time.
+
+use caduceus::review::{
+    validate_review_target, RepositoryId, ReviewTarget, MAX_REF_BYTES, MAX_REPO_COMPONENT_BYTES,
+    MAX_SHA_BYTES,
+};
+use serde_json::json;
+
+// -----------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------
+
+fn sample_repository() -> RepositoryId {
+    RepositoryId {
+        owner: "barkley-assistant".to_string(),
+        repo: "caduceus".to_string(),
+    }
+}
+
+fn sample_target() -> ReviewTarget {
+    ReviewTarget {
+        repository: sample_repository(),
+        pull_request: 42,
+        head_sha: "a".repeat(40),
+        base_sha: "b".repeat(40),
+        base_ref: "main".to_string(),
+        merge_base: "c".repeat(40),
+    }
+}
+
+// -----------------------------------------------------------------------
+// AC1 — round-trips + deny_unknown_fields
+// -----------------------------------------------------------------------
+
+#[test]
+fn repository_id_round_trip_and_full_name() {
+    let repo = sample_repository();
+    let json = serde_json::to_string(&repo).unwrap();
+    assert_eq!(json, r#"{"owner":"barkley-assistant","repo":"caduceus"}"#);
+    let back: RepositoryId = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, repo);
+    assert_eq!(repo.full_name(), "barkley-assistant/caduceus");
+}
+
+#[test]
+fn repository_id_rejects_unknown_fields() {
+    let doc = json!({"owner": "o", "repo": "r", "number": 1});
+    assert!(serde_json::from_str::<RepositoryId>(&doc.to_string()).is_err());
+}
+
+#[test]
+fn review_target_round_trip_pins_wire_shape() {
+    let target = sample_target();
+    let json = serde_json::to_string(&target).unwrap();
+    // Golden: field order + snake_case + merge_base present (AC3).
+    assert_eq!(
+        json,
+        concat!(
+            r#"{"repository":{"owner":"barkley-assistant","repo":"caduceus"},"#,
+            r#""pull_request":42,"head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","#,
+            r#""base_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","#,
+            r#""base_ref":"main","#,
+            r#""merge_base":"cccccccccccccccccccccccccccccccccccccccc"}"#
+        )
+    );
+    let back: ReviewTarget = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, target);
+}
+
+#[test]
+fn review_target_rejects_unknown_fields() {
+    let mut doc = serde_json::to_value(sample_target()).unwrap();
+    doc["diff_range"] = json!("base..head");
+    assert!(serde_json::from_str::<ReviewTarget>(&doc.to_string()).is_err());
+}
+
+// -----------------------------------------------------------------------
+// AC6 — caps at parse time
+// -----------------------------------------------------------------------
+
+#[test]
+fn review_target_caps_enforced() {
+    // At limit passes.
+    validate_review_target(&sample_target()).unwrap();
+
+    let cases: [(&str, usize); 4] = [
+        ("head_sha", MAX_SHA_BYTES + 1),
+        ("base_ref", MAX_REF_BYTES + 1),
+        ("owner", MAX_REPO_COMPONENT_BYTES + 1),
+        ("repo", MAX_REPO_COMPONENT_BYTES + 1),
+    ];
+    for (field, over_len) in cases {
+        let mut target = sample_target();
+        match field {
+            "head_sha" => target.head_sha = "a".repeat(over_len),
+            "base_ref" => target.base_ref = "b".repeat(over_len),
+            "owner" => target.repository.owner = "o".repeat(over_len),
+            "repo" => target.repository.repo = "r".repeat(over_len),
+            _ => unreachable!(),
+        }
+        assert!(
+            validate_review_target(&target).is_err(),
+            "{field} over limit accepted"
+        );
+    }
+
+    // Empty identity strings are malformed.
+    let mut empty = sample_target();
+    empty.head_sha = String::new();
+    assert!(validate_review_target(&empty).is_err());
+}

--- a/tests/review/review_domain_test.rs
+++ b/tests/review/review_domain_test.rs
@@ -11,8 +11,10 @@
 //! - AC6 — caps declared and enforced at parse time.
 
 use caduceus::review::{
-    validate_review_target, RepositoryId, ReviewTarget, MAX_REF_BYTES, MAX_REPO_COMPONENT_BYTES,
-    MAX_SHA_BYTES,
+    parse_review_result, validate_review_target, ExecutionStatus, Finding, RepositoryId, Review,
+    ReviewResult, ReviewTarget, Severity, Verdict, MAX_FINDINGS, MAX_FINDING_BODY_BYTES,
+    MAX_FINDING_PATH_BYTES, MAX_FINDING_REMEDIATION_BYTES, MAX_FINDING_TITLE_BYTES, MAX_REF_BYTES,
+    MAX_REPO_COMPONENT_BYTES, MAX_REVIEW_SUMMARY_BYTES, MAX_SHA_BYTES, REVIEW_SCHEMA_VERSION,
 };
 use serde_json::json;
 
@@ -35,6 +37,29 @@ fn sample_target() -> ReviewTarget {
         base_sha: "b".repeat(40),
         base_ref: "main".to_string(),
         merge_base: "c".repeat(40),
+    }
+}
+
+fn finding(severity: Severity, title: &str) -> Finding {
+    Finding {
+        severity,
+        title: title.to_string(),
+        body: "body".to_string(),
+        path: Some("src/lib.rs".to_string()),
+        line: Some(7),
+        remediation: Some("fix it".to_string()),
+    }
+}
+
+fn result_with_findings(findings: Vec<Finding>) -> ReviewResult {
+    ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status: ExecutionStatus::Success,
+        review: Some(Review {
+            verdict: Verdict::Pass,
+            summary: "ok".to_string(),
+            findings,
+        }),
     }
 }
 
@@ -118,4 +143,285 @@ fn review_target_caps_enforced() {
     let mut empty = sample_target();
     empty.head_sha = String::new();
     assert!(validate_review_target(&empty).is_err());
+}
+
+// -----------------------------------------------------------------------
+// AC1 — round-trips + deny_unknown_fields (result contract)
+// -----------------------------------------------------------------------
+
+#[test]
+fn review_result_round_trip_pins_wire_shape() {
+    let result = ReviewResult {
+        schema_version: 1,
+        status: ExecutionStatus::Failure,
+        review: None,
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    assert_eq!(
+        json,
+        r#"{"schema_version":1,"status":"failure","review":null}"#
+    );
+    let back: ReviewResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, result);
+}
+
+#[test]
+fn review_result_rejects_unknown_fields() {
+    let doc = json!({
+        "schema_version": 1,
+        "status": "success",
+        "review": null,
+        "attempt_count": 3
+    });
+    assert!(serde_json::from_str::<ReviewResult>(&doc.to_string()).is_err());
+}
+
+#[test]
+fn finding_and_review_reject_unknown_fields() {
+    let mut finding_doc = serde_json::to_value(finding(Severity::Warning, "t")).unwrap();
+    finding_doc["column"] = json!(3);
+    assert!(serde_json::from_str::<Finding>(&finding_doc.to_string()).is_err());
+
+    let mut review_doc = json!({
+        "verdict": "pass",
+        "summary": "s",
+        "findings": []
+    });
+    review_doc["score"] = json!(0.9);
+    assert!(serde_json::from_str::<Review>(&review_doc.to_string()).is_err());
+}
+
+// -----------------------------------------------------------------------
+// AC2 — schema_version
+// -----------------------------------------------------------------------
+
+#[test]
+fn parse_review_result_accepts_v1() {
+    let doc = json!({
+        "schema_version": 1,
+        "status": "success",
+        "review": {
+            "verdict": "fail",
+            "summary": "two blocking findings",
+            "findings": [
+                {"severity": "blocking", "title": "t1", "body": "b",
+                 "path": "src/a.rs", "line": 1, "remediation": "r"},
+                {"severity": "suggestion", "title": "t2", "body": "b"}
+            ]
+        }
+    });
+    let result = parse_review_result(&doc.to_string()).unwrap();
+    assert_eq!(result.schema_version, REVIEW_SCHEMA_VERSION);
+    assert_eq!(result.review.as_ref().unwrap().findings.len(), 2);
+    assert!(result.review.as_ref().unwrap().findings[1].path.is_none());
+    assert_eq!(REVIEW_SCHEMA_VERSION, 1);
+}
+
+#[test]
+fn parse_review_result_rejects_wrong_schema_version() {
+    for bad in [0u32, 2, 999] {
+        let doc = json!({"schema_version": bad, "status": "success", "review": null});
+        let err = parse_review_result(&doc.to_string()).unwrap_err();
+        assert!(err.to_string().contains("schema_version"), "v{bad}: {err}");
+    }
+}
+
+#[test]
+fn parse_review_result_rejects_missing_schema_version() {
+    let doc = json!({"status": "success", "review": null});
+    assert!(parse_review_result(&doc.to_string()).is_err());
+}
+
+#[test]
+fn parse_review_result_rejects_malformed_documents() {
+    assert!(parse_review_result("not json").is_err());
+    assert!(parse_review_result("{}").is_err());
+}
+
+// -----------------------------------------------------------------------
+// AC4 — findings ordering
+// -----------------------------------------------------------------------
+
+#[test]
+fn findings_order_preserved_verbatim_through_round_trip() {
+    // Deliberately NOT severity-grouped and NOT alphabetical: any
+    // future "helpful" sort at parse time breaks this test.
+    let result = result_with_findings(vec![
+        finding(Severity::Warning, "b-warning"),
+        finding(Severity::Blocking, "a-blocking"),
+        finding(Severity::Suggestion, "c-suggestion"),
+        finding(Severity::Blocking, "d-blocking"),
+    ]);
+    let json = serde_json::to_string(&result).unwrap();
+    let back: ReviewResult = serde_json::from_str(&json).unwrap();
+    let review = back.review.unwrap();
+    let titles: Vec<&str> = review.findings.iter().map(|f| f.title.as_str()).collect();
+    assert_eq!(
+        titles,
+        vec!["b-warning", "a-blocking", "c-suggestion", "d-blocking"]
+    );
+}
+
+#[test]
+fn review_result_serialization_is_deterministic() {
+    // Byte-identical re-publish (DAR §9.2) starts here: serialize →
+    // parse → serialize must be a fixed point.
+    let result = result_with_findings(vec![
+        finding(Severity::Blocking, "x"),
+        finding(Severity::Warning, "y"),
+    ]);
+    let first = serde_json::to_string(&result).unwrap();
+    let reparsed: ReviewResult = serde_json::from_str(&first).unwrap();
+    let second = serde_json::to_string(&reparsed).unwrap();
+    assert_eq!(first, second);
+}
+
+// -----------------------------------------------------------------------
+// AC5 — enums
+// -----------------------------------------------------------------------
+
+#[test]
+fn severity_serializes_snake_case_and_rejects_unknown() {
+    assert_eq!(
+        serde_json::to_string(&Severity::Blocking).unwrap(),
+        "\"blocking\""
+    );
+    assert_eq!(
+        serde_json::to_string(&Severity::Warning).unwrap(),
+        "\"warning\""
+    );
+    assert_eq!(
+        serde_json::to_string(&Severity::Suggestion).unwrap(),
+        "\"suggestion\""
+    );
+    for bad in ["BLOCKING", "block", "critical", ""] {
+        assert!(
+            serde_json::from_str::<Severity>(&format!("\"{bad}\"")).is_err(),
+            "accepted {bad:?}"
+        );
+    }
+}
+
+#[test]
+fn verdict_serializes_snake_case_and_rejects_unknown() {
+    assert_eq!(serde_json::to_string(&Verdict::Pass).unwrap(), "\"pass\"");
+    assert_eq!(serde_json::to_string(&Verdict::Fail).unwrap(), "\"fail\"");
+    for bad in ["passed", "failed", "PASS", ""] {
+        assert!(
+            serde_json::from_str::<Verdict>(&format!("\"{bad}\"")).is_err(),
+            "accepted {bad:?}"
+        );
+    }
+}
+
+#[test]
+fn execution_status_serializes_snake_case_and_rejects_unknown() {
+    assert_eq!(
+        serde_json::to_string(&ExecutionStatus::Success).unwrap(),
+        "\"success\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ExecutionStatus::Failure).unwrap(),
+        "\"failure\""
+    );
+    for bad in ["failed", "ok", "Success", ""] {
+        assert!(
+            serde_json::from_str::<ExecutionStatus>(&format!("\"{bad}\"")).is_err(),
+            "accepted {bad:?}"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------
+// AC6 — caps at parse time (result contract)
+// -----------------------------------------------------------------------
+
+#[test]
+fn review_summary_cap_enforced() {
+    let mut at = result_with_findings(vec![]);
+    at.review.as_mut().unwrap().summary = "x".repeat(MAX_REVIEW_SUMMARY_BYTES);
+    parse_review_result(&serde_json::to_string(&at).unwrap()).unwrap();
+
+    let mut over = at;
+    over.review.as_mut().unwrap().summary = "x".repeat(MAX_REVIEW_SUMMARY_BYTES + 1);
+    assert!(parse_review_result(&serde_json::to_string(&over).unwrap()).is_err());
+}
+
+#[test]
+fn findings_count_cap_enforced() {
+    let at = result_with_findings(
+        (0..MAX_FINDINGS)
+            .map(|i| finding(Severity::Suggestion, &format!("f{i}")))
+            .collect(),
+    );
+    parse_review_result(&serde_json::to_string(&at).unwrap()).unwrap();
+
+    let over = result_with_findings(
+        (0..MAX_FINDINGS + 1)
+            .map(|i| finding(Severity::Suggestion, &format!("f{i}")))
+            .collect(),
+    );
+    assert!(parse_review_result(&serde_json::to_string(&over).unwrap()).is_err());
+}
+
+#[test]
+fn finding_field_caps_enforced() {
+    let cases: [(&str, usize); 4] = [
+        ("title", MAX_FINDING_TITLE_BYTES),
+        ("body", MAX_FINDING_BODY_BYTES),
+        ("remediation", MAX_FINDING_REMEDIATION_BYTES),
+        ("path", MAX_FINDING_PATH_BYTES),
+    ];
+    for (field, max) in cases {
+        // Exactly at the limit passes.
+        let mut f = finding(Severity::Warning, "t");
+        match field {
+            "title" => f.title = "x".repeat(max),
+            "body" => f.body = "x".repeat(max),
+            "remediation" => f.remediation = Some("x".repeat(max)),
+            "path" => f.path = Some("x".repeat(max)),
+            _ => unreachable!(),
+        }
+        let at = result_with_findings(vec![f]);
+        parse_review_result(&serde_json::to_string(&at).unwrap())
+            .unwrap_or_else(|e| panic!("{field} at limit rejected: {e}"));
+
+        // One over fails.
+        let mut f = finding(Severity::Warning, "t");
+        match field {
+            "title" => f.title = "x".repeat(max + 1),
+            "body" => f.body = "x".repeat(max + 1),
+            "remediation" => f.remediation = Some("x".repeat(max + 1)),
+            "path" => f.path = Some("x".repeat(max + 1)),
+            _ => unreachable!(),
+        }
+        let over = result_with_findings(vec![f]);
+        assert!(
+            parse_review_result(&serde_json::to_string(&over).unwrap()).is_err(),
+            "{field} over limit accepted"
+        );
+    }
+}
+
+#[test]
+fn caps_count_bytes_not_chars() {
+    // 'é' is two UTF-8 bytes: 128 chars = 256 bytes (at the title
+    // limit), 129 chars = 258 bytes (over it). Pins byte semantics.
+    let at = result_with_findings(vec![finding(Severity::Warning, &"é".repeat(128))]);
+    parse_review_result(&serde_json::to_string(&at).unwrap()).unwrap();
+
+    let over = result_with_findings(vec![finding(Severity::Warning, &"é".repeat(129))]);
+    assert!(parse_review_result(&serde_json::to_string(&over).unwrap()).is_err());
+}
+
+#[test]
+fn parse_rejects_empty_required_strings() {
+    let mut f = finding(Severity::Warning, "");
+    f.body = "".to_string();
+    let bad = result_with_findings(vec![f]);
+    assert!(parse_review_result(&serde_json::to_string(&bad).unwrap()).is_err());
+
+    let mut empty_summary = result_with_findings(vec![]);
+    empty_summary.review.as_mut().unwrap().summary = String::new();
+    assert!(parse_review_result(&serde_json::to_string(&empty_summary).unwrap()).is_err());
 }

--- a/tests/review/review_domain_test.rs
+++ b/tests/review/review_domain_test.rs
@@ -11,10 +11,12 @@
 //! - AC6 — caps declared and enforced at parse time.
 
 use caduceus::review::{
-    parse_review_result, validate_review_target, ExecutionStatus, Finding, RepositoryId, Review,
-    ReviewResult, ReviewTarget, Severity, Verdict, MAX_FINDINGS, MAX_FINDING_BODY_BYTES,
-    MAX_FINDING_PATH_BYTES, MAX_FINDING_REMEDIATION_BYTES, MAX_FINDING_TITLE_BYTES, MAX_REF_BYTES,
-    MAX_REPO_COMPONENT_BYTES, MAX_REVIEW_SUMMARY_BYTES, MAX_SHA_BYTES, REVIEW_SCHEMA_VERSION,
+    parse_review_result, validate_review_state, validate_review_target, ExecutionStatus, Finding,
+    PublicationState, RepositoryId, Review, ReviewResult, ReviewState, ReviewTarget, Severity,
+    Verdict, MAX_FINDINGS, MAX_FINDING_BODY_BYTES, MAX_FINDING_PATH_BYTES,
+    MAX_FINDING_REMEDIATION_BYTES, MAX_FINDING_TITLE_BYTES, MAX_PUBLISH_ERROR_BYTES, MAX_REF_BYTES,
+    MAX_REPO_COMPONENT_BYTES, MAX_REVIEW_SUMMARY_BYTES, MAX_RUN_ID_BYTES, MAX_SHA_BYTES,
+    REVIEW_SCHEMA_VERSION,
 };
 use serde_json::json;
 
@@ -63,6 +65,23 @@ fn result_with_findings(findings: Vec<Finding>) -> ReviewResult {
     }
 }
 
+fn sample_state_json() -> serde_json::Value {
+    json!({
+        "repository": {"owner": "barkley-assistant", "repo": "caduceus"},
+        "pull_request": 42,
+        "last_reviewed_head_sha": null,
+        "last_verdict": null,
+        "last_reviewed_at": null,
+        "sticky_comment_id": null,
+        "last_run_id": null,
+        "review_generation": 7,
+        "publication_state": "pending",
+        "publication_attempt_count": 0,
+        "next_publish_at": null,
+        "last_publish_error": null
+    })
+}
+
 // -----------------------------------------------------------------------
 // AC1 — round-trips + deny_unknown_fields
 // -----------------------------------------------------------------------
@@ -109,46 +128,6 @@ fn review_target_rejects_unknown_fields() {
     assert!(serde_json::from_str::<ReviewTarget>(&doc.to_string()).is_err());
 }
 
-// -----------------------------------------------------------------------
-// AC6 — caps at parse time
-// -----------------------------------------------------------------------
-
-#[test]
-fn review_target_caps_enforced() {
-    // At limit passes.
-    validate_review_target(&sample_target()).unwrap();
-
-    let cases: [(&str, usize); 4] = [
-        ("head_sha", MAX_SHA_BYTES + 1),
-        ("base_ref", MAX_REF_BYTES + 1),
-        ("owner", MAX_REPO_COMPONENT_BYTES + 1),
-        ("repo", MAX_REPO_COMPONENT_BYTES + 1),
-    ];
-    for (field, over_len) in cases {
-        let mut target = sample_target();
-        match field {
-            "head_sha" => target.head_sha = "a".repeat(over_len),
-            "base_ref" => target.base_ref = "b".repeat(over_len),
-            "owner" => target.repository.owner = "o".repeat(over_len),
-            "repo" => target.repository.repo = "r".repeat(over_len),
-            _ => unreachable!(),
-        }
-        assert!(
-            validate_review_target(&target).is_err(),
-            "{field} over limit accepted"
-        );
-    }
-
-    // Empty identity strings are malformed.
-    let mut empty = sample_target();
-    empty.head_sha = String::new();
-    assert!(validate_review_target(&empty).is_err());
-}
-
-// -----------------------------------------------------------------------
-// AC1 — round-trips + deny_unknown_fields (result contract)
-// -----------------------------------------------------------------------
-
 #[test]
 fn review_result_round_trip_pins_wire_shape() {
     let result = ReviewResult {
@@ -189,6 +168,59 @@ fn finding_and_review_reject_unknown_fields() {
     });
     review_doc["score"] = json!(0.9);
     assert!(serde_json::from_str::<Review>(&review_doc.to_string()).is_err());
+}
+
+#[test]
+fn review_state_round_trip_and_rejects_unknown_fields() {
+    let state: ReviewState = serde_json::from_str(&sample_state_json().to_string()).unwrap();
+    assert_eq!(state.review_generation, 7);
+    assert_eq!(state.publication_state, PublicationState::Pending);
+    let json = serde_json::to_string(&state).unwrap();
+    // snake_case on the wire (AC5 surface for PublicationState).
+    assert!(json.contains(r#""publication_state":"pending""#));
+    let back: ReviewState = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, state);
+
+    let mut bad = sample_state_json();
+    bad["unexpected"] = json!(true);
+    assert!(serde_json::from_str::<ReviewState>(&bad.to_string()).is_err());
+}
+
+// -----------------------------------------------------------------------
+// AC3 — no attempt_count; field set
+// -----------------------------------------------------------------------
+
+#[test]
+fn review_state_rejects_attempt_count_field() {
+    // The queue owns execution attempts; a serialized `attempt_count`
+    // on ReviewState must be an UNKNOWN field, not a tolerated one.
+    let mut doc = sample_state_json();
+    doc["attempt_count"] = json!(3);
+    assert!(serde_json::from_str::<ReviewState>(&doc.to_string()).is_err());
+}
+
+#[test]
+fn review_state_option_fields_default_to_none_when_missing() {
+    // Pin serde's Option-missing semantics so a future required-Option
+    // regression is caught.
+    let mut doc = sample_state_json();
+    doc.as_object_mut().unwrap().remove("last_publish_error");
+    doc.as_object_mut().unwrap().remove("next_publish_at");
+    let state: ReviewState = serde_json::from_str(&doc.to_string()).unwrap();
+    assert!(state.last_publish_error.is_none());
+    assert!(state.next_publish_at.is_none());
+}
+
+#[test]
+fn review_state_new_starts_pending_with_zero_counters() {
+    let state = ReviewState::new(sample_repository(), 42, 3);
+    assert_eq!(state.publication_state, PublicationState::Pending);
+    assert_eq!(state.publication_attempt_count, 0);
+    assert_eq!(state.review_generation, 3);
+    assert!(state.last_run_id.is_none());
+    assert!(state.sticky_comment_id.is_none());
+    assert!(state.last_reviewed_head_sha.is_none());
+    assert!(state.last_publish_error.is_none());
 }
 
 // -----------------------------------------------------------------------
@@ -332,8 +364,34 @@ fn execution_status_serializes_snake_case_and_rejects_unknown() {
     }
 }
 
+#[test]
+fn publication_state_serializes_snake_case_and_rejects_unknown() {
+    assert_eq!(
+        serde_json::to_string(&PublicationState::Pending).unwrap(),
+        "\"pending\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PublicationState::Publishing).unwrap(),
+        "\"publishing\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PublicationState::Published).unwrap(),
+        "\"published\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PublicationState::FailedRetryable).unwrap(),
+        "\"failed_retryable\""
+    );
+    for bad in ["failed", "FailedRetryable", "failed-retryable", "retryable"] {
+        assert!(
+            serde_json::from_str::<PublicationState>(&format!("\"{bad}\"")).is_err(),
+            "accepted {bad:?}"
+        );
+    }
+}
+
 // -----------------------------------------------------------------------
-// AC6 — caps at parse time (result contract)
+// AC6 — caps at parse time
 // -----------------------------------------------------------------------
 
 #[test]
@@ -424,4 +482,55 @@ fn parse_rejects_empty_required_strings() {
     let mut empty_summary = result_with_findings(vec![]);
     empty_summary.review.as_mut().unwrap().summary = String::new();
     assert!(parse_review_result(&serde_json::to_string(&empty_summary).unwrap()).is_err());
+}
+
+#[test]
+fn review_target_caps_enforced() {
+    // At limit passes.
+    validate_review_target(&sample_target()).unwrap();
+
+    let cases: [(&str, usize); 4] = [
+        ("head_sha", MAX_SHA_BYTES + 1),
+        ("base_ref", MAX_REF_BYTES + 1),
+        ("owner", MAX_REPO_COMPONENT_BYTES + 1),
+        ("repo", MAX_REPO_COMPONENT_BYTES + 1),
+    ];
+    for (field, over_len) in cases {
+        let mut target = sample_target();
+        match field {
+            "head_sha" => target.head_sha = "a".repeat(over_len),
+            "base_ref" => target.base_ref = "b".repeat(over_len),
+            "owner" => target.repository.owner = "o".repeat(over_len),
+            "repo" => target.repository.repo = "r".repeat(over_len),
+            _ => unreachable!(),
+        }
+        assert!(
+            validate_review_target(&target).is_err(),
+            "{field} over limit accepted"
+        );
+    }
+
+    // Empty identity strings are malformed.
+    let mut empty = sample_target();
+    empty.head_sha = String::new();
+    assert!(validate_review_target(&empty).is_err());
+}
+
+#[test]
+fn review_state_caps_enforced() {
+    let mut base: ReviewState = serde_json::from_str(&sample_state_json().to_string()).unwrap();
+
+    base.last_run_id = Some("r".repeat(MAX_RUN_ID_BYTES));
+    base.last_publish_error = Some("e".repeat(MAX_PUBLISH_ERROR_BYTES));
+    validate_review_state(&base).unwrap();
+
+    base.last_run_id = Some("r".repeat(MAX_RUN_ID_BYTES + 1));
+    assert!(validate_review_state(&base).is_err());
+
+    base.last_run_id = Some("r".repeat(MAX_RUN_ID_BYTES));
+    base.last_publish_error = Some("e".repeat(MAX_PUBLISH_ERROR_BYTES + 1));
+    assert!(validate_review_state(&base).is_err());
+
+    base.last_publish_error = Some(String::new());
+    assert!(validate_review_state(&base).is_err());
 }


### PR DESCRIPTION
## Summary

Add the Auto Review domain model per #292, the typed foundation for
every later issue in epic #290.

- `caduceus::review` module: `ReviewTarget` (immutable
  `(repository, PR, head SHA)` identity plus persisted merge-base
  context), `ReviewState` (per-PR current-state pointer with the
  monotonic `review_generation` publication guard, publication FSM,
  and `publication_attempt_count` — deliberately no execution
  `attempt_count`), and the `ReviewResult` / `Review` / `Finding`
  worker result contract.
- Strict serde everywhere: `deny_unknown_fields` + `snake_case`
  `Severity` / `Verdict` / `ExecutionStatus` / `PublicationState`
  enums that reject unknown values.
- `REVIEW_SCHEMA_VERSION = 1` daemon const; the v1
  `parse_review_result` parser rejects any other `schema_version`.
- Parse-time field caps declared as constants and enforced by
  `parse_review_result` / `validate_review_result` /
  `validate_review_target` / `validate_review_state` (CAP table in the
  plan; content-shape rules such as SHA hex form and status/review
  presence stay with the #305 validator).
- 28 unit tests in `tests/review/review_domain_test.rs` covering all
  six acceptance criteria: round-trips, unknown-field rejection,
  schema-version enforcement, findings ordering preservation,
  snake_case enum serialization, and cap enforcement. No store, no
  execution, no CLI — no behaviour change.

## Notes

- Plan: `docs/architecture/auto-review.md` sections 2-3 plus the
  architect's plan (D1-D5). `RepositoryId { owner, repo }` keeps
  review identity out of `IssueKey` at the type level (DAR §4.1).
- One deviation from the plan's verbatim test sketch: the ordering
  test binds `back.review.unwrap()` to a local before collecting
  `&str` titles — the plan's chained form does not borrow-check
  (E0716). Assertions unchanged.
- `schema_version` lives on `ReviewResult` only (the plan's flagged D3
  interpretation of AC2, matching the DAR §3 sketch and the
  envelope-versioning precedent).

## Verification

Full gate output (see PR checks):

- `cargo fmt --check` — OK
- `cargo clippy --locked --all-targets -- -D warnings` — OK
- `cargo test --locked --all-targets` — OK (hermetic failures skipped
  by name per repo conventions)
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — OK

Closes #292