### PR TITLE
feat(repo): add SHA-anchored mirror fetch with unavailable reject

### DIFF
--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -146,6 +146,12 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         CaduceusError::Http(_) => FailureClass::Infrastructure,
         CaduceusError::GitHubApi { .. } => FailureClass::Infrastructure,
         CaduceusError::Git { .. } => FailureClass::Infrastructure,
+        // Unavailable head SHA: a remote-side condition that resolves
+        // itself (the successor SHA is admitted by the next poll,
+        // DAR §8.1) — classified as infrastructure so it does not
+        // count against the worker retry budget. #339 owns the actual
+        // skip routing and matches on the variant before this default.
+        CaduceusError::HeadShaUnavailable { .. } => FailureClass::Infrastructure,
         CaduceusError::Push { .. } => FailureClass::Infrastructure,
         CaduceusError::PushCollision { .. } => FailureClass::Infrastructure,
         CaduceusError::Worktree { context, .. }

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -61,6 +61,13 @@ pub enum CaduceusError {
         stderr: String,
     },
 
+    /// A PR head SHA is unavailable in both the remote and the local
+    /// mirror (force-push + GC between discovery and execution). The
+    /// review is self-resolving — the successor SHA is admitted by the
+    /// next poll (DAR §8.1). Distinct skip route, not NeedsAttention.
+    #[error("head SHA unavailable: {sha}")]
+    HeadShaUnavailable { sha: String },
+
     /// GitHub API returned a non-success status.
     #[error("GitHub API status {status}: {message}")]
     GitHubApi { status: u16, message: String },
@@ -421,6 +428,9 @@ impl fmt::Debug for CaduceusError {
                     operation,
                     scrub(stderr)
                 )
+            }
+            CaduceusError::HeadShaUnavailable { sha } => {
+                format!("HeadShaUnavailable {{ sha: {} }}", scrub(sha))
             }
             CaduceusError::GitHubApi { status, message } => format!(
                 "GitHubApi {{ status: {status}, message: {} }}",

--- a/src/repo/mirror.rs
+++ b/src/repo/mirror.rs
@@ -180,6 +180,71 @@ impl BareMirror {
         Ok(output.stdout.trim().to_string())
     }
 
+    /// Fetch a specific commit SHA into the mirror (SHA-anchored).
+    ///
+    /// This is the `#297` primitive: a same-repo PR head SHA is fetched
+    /// via `git fetch origin <sha>`, which makes the commit object
+    /// available in the mirror's object store without creating any branch
+    /// or remote-tracking ref. The SHA is then checkout-able by
+    /// `Worktree::create` via `git worktree add --detach <sha>`.
+    ///
+    /// **Idempotent:** re-fetching an already-present SHA is a safe no-op
+    /// (git fetch of a present SHA succeeds without contacting the
+    /// remote's ref availability). Safe to call before worktree
+    /// materialisation (#299).
+    ///
+    /// **Reject-on-unavailable-SHA:** if the SHA is absent from both the
+    /// remote and the local mirror (force-push + GC between discovery and
+    /// execution), returns `CaduceusError::HeadShaUnavailable`. This is
+    /// the structured error the skip route (#339) matches on.
+    pub async fn fetch_sha(&self, runner: &GitRunner, sha: &str) -> CaduceusResult<()> {
+        let output = runner
+            .run_args(
+                "mirror-fetch-sha",
+                ["-C", &self.path.to_string_lossy(), "fetch", "origin", sha],
+            )
+            .await?;
+
+        if output.cancelled {
+            return Err(CaduceusError::Cancelled);
+        }
+        if output.timed_out || output.status != Some(0) {
+            // Fetch failed. Distinguish "SHA genuinely unavailable" from
+            // a transient fetch error on an already-present SHA. A local
+            // cat-file presence check is deterministic and avoids
+            // transport-dependent stderr string parsing.
+            if self.sha_present(runner, sha).await? {
+                // SHA is already in the mirror's object store — the
+                // fetch failure is transient (e.g. remote flaked). The
+                // SHA is usable for checkout.
+                return Ok(());
+            }
+            return Err(CaduceusError::HeadShaUnavailable {
+                sha: sha.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Check whether a commit SHA is present in the mirror's object
+    /// store. Uses `git cat-file -e <sha>^{commit}` (local, no network).
+    async fn sha_present(&self, runner: &GitRunner, sha: &str) -> CaduceusResult<bool> {
+        let output = runner
+            .run_args(
+                "mirror-cat-file",
+                [
+                    "-C",
+                    &self.path.to_string_lossy(),
+                    "cat-file",
+                    "-e",
+                    &format!("{sha}^{{commit}}"),
+                ],
+            )
+            .await?;
+        // cat-file -e exits 0 if the object exists, 1 if not.
+        Ok(output.status == Some(0))
+    }
+
     /// Expose the mirror path.
     pub fn path(&self) -> &Path {
         &self.path

--- a/tests/repo/mirror_test.rs
+++ b/tests/repo/mirror_test.rs
@@ -3,6 +3,7 @@
 //! Tests cover: creation, fetch, idempotency, mode 0700.
 
 use caduceus::config::Config;
+use caduceus::error::CaduceusError;
 use caduceus::repo::BareMirror;
 use caduceus::worktree::GitRunner;
 #[path = "../fixtures/mod.rs"]
@@ -51,6 +52,72 @@ fn init_bare_remote(path: &Path) -> String {
         &commit,
     ]));
     commit
+}
+
+/// Initialise a bare repository at *path* with `main` (commit A) and a
+/// `feature` branch (commit B whose parent is A). Returns `(A, B)`.
+///
+/// B is a **non-ancestor** of main: deleting the `feature` ref makes B
+/// unreachable, so `git gc --prune=now` on the remote actually prunes
+/// it. (If B were an ancestor of main, gc would keep it and a later
+/// SHA-anchored fetch would succeed instead of rejecting.)
+fn init_bare_remote_with_feature(path: &Path) -> (String, String) {
+    run_command(Command::new("git").arg("init").arg("--bare").arg(path));
+    run_command(Command::new("git").current_dir(path).args([
+        "symbolic-ref",
+        "HEAD",
+        "refs/heads/main",
+    ]));
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
+        .output()
+        .expect("hash-object");
+    let tree = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["commit-tree", &tree, "-m", "initial"])
+        .output()
+        .expect("commit-tree");
+    let commit_a = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/main",
+        &commit_a,
+    ]));
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["commit-tree", &tree, "-p", &commit_a, "-m", "feature"])
+        .output()
+        .expect("commit-tree feature");
+    let commit_b = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/feature",
+        &commit_b,
+    ]));
+    (commit_a, commit_b)
+}
+
+/// Sorted `git show-ref` output for deterministic before/after
+/// comparison (ref order across ls-refs walks is not guaranteed).
+fn sorted_show_refs(git_dir: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .current_dir(git_dir)
+        .args(["show-ref"])
+        .output()
+        .expect("show-ref");
+    assert!(
+        output.status.success(),
+        "show-ref failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut refs: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+    refs.sort();
+    refs
 }
 
 #[tokio::test]
@@ -158,4 +225,120 @@ async fn mirror_mode_0700() {
     let meta = std::fs::metadata(&mirror.path).expect("metadata");
     let mode = meta.permissions().mode() & 0o777;
     assert_eq!(mode, 0o700, "mirror dir should be 0700, got {:03o}", mode);
+}
+
+#[tokio::test]
+async fn mirror_fetches_pr_head_sha() {
+    let root = tempdir("fetch-sha");
+    let remote_dir = root.join("remote.git");
+    let (_commit_a, commit_b) = init_bare_remote_with_feature(&remote_dir);
+    let remote_url = format!("file://{}", remote_dir.display());
+
+    let mut cfg = Config::test_defaults(&root);
+    cfg.repo_storage_root = root.join("repos");
+    cfg.git_timeout_seconds = 30;
+    let runner = GitRunner::new(&cfg);
+
+    let mirror = BareMirror::ensure(&runner, &cfg, "fshaowner", "fsharepo", &remote_url, "main")
+        .await
+        .expect("ensure");
+
+    let refs_before = sorted_show_refs(&mirror.path);
+    mirror
+        .fetch_sha(&runner, &commit_b)
+        .await
+        .expect("fetch_sha should fetch the PR head SHA");
+    let refs_after = sorted_show_refs(&mirror.path);
+
+    assert_eq!(
+        refs_before, refs_after,
+        "SHA-anchored fetch must not create branch or ref artefacts"
+    );
+    let oid = mirror
+        .rev_parse(&runner, &commit_b)
+        .await
+        .expect("rev_parse should resolve the fetched SHA");
+    assert_eq!(oid, commit_b, "PR head SHA should be present in the mirror");
+}
+
+#[tokio::test]
+async fn mirror_rejects_unavailable_sha() {
+    let root = tempdir("unavailable-sha");
+    let remote_dir = root.join("remote.git");
+    let (_commit_a, commit_b) = init_bare_remote_with_feature(&remote_dir);
+    let remote_url = format!("file://{}", remote_dir.display());
+
+    let mut cfg = Config::test_defaults(&root);
+    cfg.repo_storage_root = root.join("repos");
+    cfg.git_timeout_seconds = 30;
+    let runner = GitRunner::new(&cfg);
+
+    let mirror = BareMirror::ensure(&runner, &cfg, "uowner", "urepo", &remote_url, "main")
+        .await
+        .expect("ensure");
+
+    // B is NOT in the local mirror: ensure() fetched main only.
+    // Simulate force-push + GC between discovery and execution: the
+    // feature branch is deleted and B (unreachable, non-ancestor of
+    // main) is pruned from the remote.
+    run_command(Command::new("git").current_dir(&remote_dir).args([
+        "update-ref",
+        "-d",
+        "refs/heads/feature",
+    ]));
+    run_command(Command::new("git").current_dir(&remote_dir).args([
+        "reflog",
+        "expire",
+        "--expire=now",
+        "--all",
+    ]));
+    run_command(
+        Command::new("git")
+            .current_dir(&remote_dir)
+            .args(["gc", "--prune=now"]),
+    );
+
+    let err = mirror
+        .fetch_sha(&runner, &commit_b)
+        .await
+        .expect_err("fetch_sha must reject an unavailable SHA");
+    assert!(
+        matches!(
+            err,
+            CaduceusError::HeadShaUnavailable { ref sha } if sha == &commit_b
+        ),
+        "expected HeadShaUnavailable with sha {commit_b}, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn mirror_fetch_sha_is_idempotent() {
+    let root = tempdir("fetch-sha-idempotent");
+    let remote_dir = root.join("remote.git");
+    let (_commit_a, commit_b) = init_bare_remote_with_feature(&remote_dir);
+    let remote_url = format!("file://{}", remote_dir.display());
+
+    let mut cfg = Config::test_defaults(&root);
+    cfg.repo_storage_root = root.join("repos");
+    cfg.git_timeout_seconds = 30;
+    let runner = GitRunner::new(&cfg);
+
+    let mirror = BareMirror::ensure(&runner, &cfg, "iowner", "irepo", &remote_url, "main")
+        .await
+        .expect("ensure");
+
+    mirror
+        .fetch_sha(&runner, &commit_b)
+        .await
+        .expect("first fetch_sha");
+    mirror
+        .fetch_sha(&runner, &commit_b)
+        .await
+        .expect("second fetch_sha should be a safe no-op");
+
+    let oid = mirror
+        .rev_parse(&runner, &commit_b)
+        .await
+        .expect("rev_parse should resolve the fetched SHA");
+    assert_eq!(oid, commit_b, "PR head SHA should still be present");
 }


### PR DESCRIPTION
Implements #297: SHA-anchored PR-head mirror fetch with reject-on-unavailable-SHA.

What changed
- `BareMirror::fetch_sha` fetches a same-repo PR head SHA into the mirror via `git fetch origin <sha>` (SHA-anchored, creates no branch/ref artefacts, idempotent). Runner operation `mirror-fetch-sha`.
- `CaduceusError::HeadShaUnavailable { sha }` is returned when the SHA no longer exists upstream (force-push + GC between discovery and execution). On fetch failure a local `git cat-file -e <sha>^{commit}` presence check discriminates "unavailable" from a transient fetch error on an already-present SHA — no transport-dependent stderr parsing.
- Classification: `HeadShaUnavailable` → `FailureClass::Infrastructure` (self-resolving per DAR §8.1; #339 owns the actual skip routing).
- Existing base-branch fetch behaviour (`ensure`/`fetch`) unchanged. No daemon call-site changes.

Tests (tests/repo/mirror_test.rs — 4 existing + 3 new)
- `mirror_fetches_pr_head_sha` — PR head SHA fetched into the mirror; `show-ref` unchanged (no branch artefacts).
- `mirror_rejects_unavailable_sha` — delete feature ref on a file:// remote, `git gc --prune=now`, re-fetch → `HeadShaUnavailable { sha }`.
- `mirror_fetch_sha_is_idempotent` — second fetch of an already-present SHA is a safe no-op (pre-worktree-materialisation re-fetch story).

Verification
- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo test --locked --all-targets` — 2276 passed, 0 failed, 35 ignored
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 181 passed

Deviations from the plan: none. Minor test hardening: the reject test also runs `git reflog expire --expire=now --all` on the remote before `git gc --prune=now` (guards plan §R3 reflog retention).

Closes #297