### PR TITLE
feat(github): add pull request wire model and comment wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -576,6 +576,10 @@ name = "pr_test"
 path = "tests/github/pr_test.rs"
 
 [[test]]
+name = "pr_wire_test"
+path = "tests/github/pr_wire_test.rs"
+
+[[test]]
 name = "prompt_test"
 path = "tests/github/prompt_test.rs"
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -4,6 +4,7 @@
 //! - [`client`] — the HTTP client, ETag cache, and rate-limit parsing.
 //! - [`issue`] — `IssueKey`, `IssueDetail`, and the fetch helper.
 //! - [`poll`] — repository discovery, label polling, merge outcomes.
+//! - [`pr`] — pull-request wire model, list/fetch, comment create/update.
 //! - [`verify`] — second-pass label verification before claiming.
 
 pub mod client;
@@ -11,6 +12,7 @@ pub mod issue;
 pub mod link_header;
 pub mod merge_detect;
 pub mod poll;
+pub mod pr;
 pub mod verify;
 
 // Explicit re-exports of every public symbol from each leaf module.
@@ -30,5 +32,9 @@ pub use crate::github::merge_detect::{poll_pr_merge_status, MergeStatus};
 pub use crate::github::poll::{
     discover_watched_repos, poll_code, IssuePollDiagnostic, IssuePollOutcome,
     IssueSummary as PollIssueSummary,
+};
+pub use crate::github::pr::{
+    create_pr_comment, fetch_pull_request, list_pull_requests, update_pr_comment,
+    PullRequestBranch, PullRequestDetail, PullRequestRepo,
 };
 pub use crate::github::verify::{verify_trigger, SkipReason, VerifyOutcome};

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -1,0 +1,249 @@
+//! Typed pull-request wire model and endpoint wrappers.
+//!
+//! [`PullRequestDetail`] decodes `GET /repos/{owner}/{repo}/pulls`
+//! rows with all-`Option` fields (GitHub omits or nullifies fields
+//! benignly; `head.repo` becomes `None` when the head branch is
+//! deleted). [`list_pull_requests`] follows `rel="next"` Link
+//! headers with the daemon-wide page cap and per-page rate-limit
+//! check; [`fetch_pull_request`] maps a 404 to `Ok(None)`
+//! (auto-review gone-state B, §9.3 of the spec);
+//! [`create_pr_comment`] and [`update_pr_comment`] ride the
+//! public-voice gate ([`check_voice_or_error`],
+//! `VoiceChannel::Comment`) before any HTTP.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use url::Url;
+
+use crate::github::link_header::next_url_from_link_header;
+use crate::github::poll::MAX_PAGES_PER_ENDPOINT;
+use crate::github::{
+    check_voice_or_error, rate_limit_from_headers, Client, RateLimitInfo, Response, VoiceChannel,
+    ACCEPT_VALUE,
+};
+use crate::infra::config::Config;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+/// Number of rows fetched per page on `/repos/{slug}/pulls`. The
+/// contract pins the GitHub-side maximum so a single page always
+/// fits the documented 100-row envelope.
+pub const PRS_PER_PAGE: u32 = 100;
+
+/// One pull request as returned by the GitHub pulls endpoints.
+///
+/// The wire shape is deliberately all-optional: GitHub adds and
+/// nullifies fields benignly, and the auto-review contract needs
+/// `head.repo` to be `None` (deleted head branch) rather than a
+/// parse failure. `draft` defaults to `false` when omitted,
+/// matching the `RepoObject.archived` convention.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct PullRequestDetail {
+    pub number: Option<u64>,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    #[serde(default)]
+    pub draft: bool,
+    /// `user.login` from the wire payload; `None` for bots or
+    /// deleted accounts where GitHub omits/nullifies `user`.
+    #[serde(default, rename = "user", deserialize_with = "de_login_of_user")]
+    pub author: Option<String>,
+    /// `"open"` | `"closed"` as reported by the API.
+    pub state: Option<String>,
+    pub merged: Option<bool>,
+    pub merged_at: Option<DateTime<Utc>>,
+    pub base: Option<PullRequestBranch>,
+    /// `head.repo: null` (deleted head branch) lands here as
+    /// `repo: None` — never a parse failure.
+    pub head: Option<PullRequestBranch>,
+}
+
+/// One side of the PR's `base` / `head` pair.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct PullRequestBranch {
+    #[serde(rename = "ref")]
+    pub ref_name: Option<String>,
+    pub sha: Option<String>,
+    pub repo: Option<PullRequestRepo>,
+}
+
+/// The repository a PR branch points at; `full_name` is the
+/// `owner/name` pair used to detect fork PRs (`head.repo !=
+/// base.repo`).
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct PullRequestRepo {
+    pub full_name: Option<String>,
+}
+
+/// Decode the wire's `user` object into just its `login`. The
+/// `user` key is an object (`{"login": "octocat"}`) or `null`,
+/// while the model exposes the flattened `author` string.
+fn de_login_of_user<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct UserWire {
+        login: Option<String>,
+    }
+    Ok(Option::<UserWire>::deserialize(deserializer)?.and_then(|u| u.login))
+}
+
+/// List pull requests for *owner/repo*.
+///
+/// `state=all` is deliberate: the auto-review discovery step needs
+/// closed/merged rows as discrimination inputs too (§5.1). The
+/// loop follows `Link: rel="next"` headers, caps at
+/// [`MAX_PAGES_PER_ENDPOINT`] with a hard error (never silent
+/// truncation), and surfaces a typed [`CaduceusError::RateLimited`]
+/// when a page reports `x-ratelimit-remaining: 0`.
+pub async fn list_pull_requests(
+    client: &Client,
+    owner: &str,
+    repo: &str,
+) -> CaduceusResult<Vec<PullRequestDetail>> {
+    let initial_path =
+        format!("/repos/{owner}/{repo}/pulls?state=all&per_page={PRS_PER_PAGE}&sort=updated");
+    let mut next: Option<Url> = Some(client.base_url().clone().join(&initial_path).map_err(
+        |err| CaduceusError::Config(format!("cannot join {initial_path} onto api_base: {err}")),
+    )?);
+    let mut collected: Vec<PullRequestDetail> = Vec::new();
+    let mut pages = 0usize;
+    while let Some(url) = next.take() {
+        if pages >= MAX_PAGES_PER_ENDPOINT {
+            return Err(CaduceusError::Other(format!(
+                "pull request list for {owner}/{repo} exceeded {MAX_PAGES_PER_ENDPOINT} pages"
+            )));
+        }
+        pages += 1;
+        let response = client.get_url(&url, ACCEPT_VALUE).await?;
+        if let Some(observation) = rate_limit_from_headers(&response.headers, response.status) {
+            if observation.remaining == 0 {
+                return Err(rate_limited(observation));
+            }
+        }
+        let wire: Vec<PullRequestDetail> =
+            serde_json::from_slice(&response.body).map_err(|err| {
+                CaduceusError::Other(format!(
+                    "pull request list for {owner}/{repo} page {pages}: JSON parse: {err}"
+                ))
+            })?;
+        collected.extend(wire);
+        next = parse_next_link(&response);
+    }
+    Ok(collected)
+}
+
+/// Fetch a single pull request by number.
+///
+/// A 404 surfaces from the transport as
+/// [`CaduceusError::GitHubApi { status: 404, .. }`] and maps to
+/// `Ok(None)` — the auto-review gone-state B input (§9.3, "never
+/// recreate"). Every other error propagates unchanged; a 200 body
+/// that does not parse as a [`PullRequestDetail`] is a malformed
+/// response error.
+pub async fn fetch_pull_request(
+    client: &Client,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> CaduceusResult<Option<PullRequestDetail>> {
+    let path = format!("/repos/{owner}/{repo}/pulls/{number}");
+    let response = match client.get(&path, ACCEPT_VALUE).await {
+        Ok(response) => response,
+        Err(CaduceusError::GitHubApi { status: 404, .. }) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let wire: PullRequestDetail = serde_json::from_slice(&response.body).map_err(|err| {
+        CaduceusError::Other(format!(
+            "pull request {number} JSON parse for {owner}/{repo}: {err}"
+        ))
+    })?;
+    Ok(Some(wire))
+}
+
+/// Create the auto-review sticky comment on PR *pr_number*.
+///
+/// The public-voice gate runs **before any HTTP**: a rejected body
+/// returns [`CaduceusError::Other`] without touching the network.
+/// On success the comment `id` is parsed from the 201 response so
+/// the caller can persist it as `ReviewState.sticky_comment_id`
+/// (§9.2).
+pub async fn create_pr_comment(
+    client: &Client,
+    cfg: &Config,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    body: &str,
+) -> CaduceusResult<u64> {
+    check_voice_or_error(body, cfg, VoiceChannel::Comment)?;
+    let path = format!("/repos/{owner}/{repo}/issues/{pr_number}/comments");
+    let payload = serde_json::to_vec(&serde_json::json!({ "body": body }))
+        .map_err(|err| CaduceusError::Other(format!("serialize comment body: {err}")))?;
+    let response = client.post(&path, ACCEPT_VALUE, &payload).await?;
+    if response.status != 201 {
+        return Err(CaduceusError::GitHubApi {
+            status: response.status,
+            message: format!("create PR comment: expected 201, got {}", response.status),
+        });
+    }
+    let id = serde_json::from_slice::<serde_json::Value>(&response.body)
+        .ok()
+        .and_then(|value| value.get("id").and_then(serde_json::Value::as_u64))
+        .ok_or_else(|| {
+            CaduceusError::Other(format!(
+                "create PR comment for {owner}/{repo}#{pr_number}: response missing id"
+            ))
+        })?;
+    Ok(id)
+}
+
+/// Update an existing comment by id (`PATCH /issues/comments/{id}`).
+///
+/// Same voice gate as [`create_pr_comment`]; a non-2xx (e.g. a 404
+/// when a human deleted the comment) arrives from the transport as
+/// [`CaduceusError::GitHubApi`] and propagates — the caller (#310)
+/// discriminates gone-state A from it.
+pub async fn update_pr_comment(
+    client: &Client,
+    cfg: &Config,
+    owner: &str,
+    repo: &str,
+    comment_id: u64,
+    body: &str,
+) -> CaduceusResult<()> {
+    check_voice_or_error(body, cfg, VoiceChannel::Comment)?;
+    let path = format!("/repos/{owner}/{repo}/issues/comments/{comment_id}");
+    let payload = serde_json::to_vec(&serde_json::json!({ "body": body }))
+        .map_err(|err| CaduceusError::Other(format!("serialize comment body: {err}")))?;
+    let response = client.patch(&path, ACCEPT_VALUE, &payload).await?;
+    if response.status != 200 {
+        return Err(CaduceusError::GitHubApi {
+            status: response.status,
+            message: format!("update PR comment: expected 200, got {}", response.status),
+        });
+    }
+    Ok(())
+}
+
+/// Parse the GitHub Link header and return the URL marked
+/// `rel="next"` if any. Mirrors the poll loop's helper.
+fn parse_next_link(response: &Response) -> Option<Url> {
+    use reqwest::header::LINK;
+    let header = response.headers.get(LINK)?.to_str().ok()?;
+    next_url_from_link_header(header).and_then(|raw| Url::parse(&raw).ok())
+}
+
+/// Translate a [`RateLimitInfo`] into the typed
+/// [`CaduceusError::RateLimited`] variant the daemon's outer loop
+/// recognises. The list wrapper calls this only for a
+/// `remaining == 0` observation.
+fn rate_limited(observation: RateLimitInfo) -> CaduceusError {
+    let now = chrono::Utc::now().timestamp();
+    let reset_at = (observation.reset_at_unix.saturating_sub(now)).max(0) as u64;
+    CaduceusError::RateLimited {
+        reset_at,
+        remaining: observation.remaining,
+        limit: observation.limit,
+    }
+}

--- a/tests/github/pr_wire_test.rs
+++ b/tests/github/pr_wire_test.rs
@@ -1,0 +1,516 @@
+//! PR wire-model and endpoint wrapper tests (issue #301).
+//!
+//! - L1-L5 list: happy path, `next_page` pagination, page cap,
+//!   rate-limit exhaustion, malformed page.
+//! - F1-F4 fetch: typed parse, nullable `head.repo`, 404 → `Ok(None)`,
+//!   closed+merged fixture.
+//! - C1-C6 comments: create/update happy path, voice-gate-before-HTTP,
+//!   oversize cap, 404 propagation.
+//!
+//! Follows the `issue_detail_test.rs` client/config construction and
+//! the `rate_limit_test.rs` header-carrying mock pattern.
+
+use caduceus::config::Config;
+use caduceus::error::CaduceusError;
+use caduceus::github::{
+    create_pr_comment, fetch_pull_request, list_pull_requests, update_pr_comment, Client, HttpCache,
+};
+use chrono::{DateTime, Utc};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::{tempdir, MockGitHub};
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+
+fn mock_client(gh: &MockGitHub) -> (Client, Config) {
+    let state_dir = tempdir("pr-wire");
+    let mut cfg = Config::test_defaults(&state_dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&state_dir).expect("cache opens");
+    let client = Client::with_cache(&cfg, cache).expect("client builds");
+    (client, cfg)
+}
+
+/// A realistic `/pulls` row. `state == "closed"` implies merged so
+/// the closed+merged discrimination fixture shares one builder.
+fn pr_json(number: u64, title: &str, state: &str) -> serde_json::Value {
+    let mut row = serde_json::json!({
+        "number": number,
+        "title": title,
+        "body": "Fixes the thing",
+        "draft": false,
+        "user": {"login": "octocat"},
+        "state": state,
+        "base": {
+            "ref": "main",
+            "sha": "aaaa",
+            "repo": {"full_name": "octocat/hello-world"}
+        },
+        "head": {
+            "ref": "feature-x",
+            "sha": "bbbb",
+            "repo": {"full_name": "octocat/hello-world"}
+        }
+    });
+    row["merged"] = serde_json::json!(state == "closed");
+    if state == "closed" {
+        row["merged_at"] = serde_json::json!("2026-07-13T12:00:00Z");
+    } else {
+        row["merged_at"] = serde_json::Value::Null;
+    }
+    row
+}
+
+// L1: list happy path, one page
+
+#[tokio::test]
+async fn list_returns_typed_rows() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        "/repos/octocat/hello-world/pulls",
+        serde_json::json!([
+            pr_json(12, "Add widget", "open"),
+            pr_json(13, "Merge done work", "closed")
+        ]),
+    )
+    .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let prs = list_pull_requests(&client, "octocat", "hello-world")
+        .await
+        .expect("list succeeds");
+    assert_eq!(prs.len(), 2);
+
+    let first = &prs[0];
+    assert_eq!(first.number, Some(12));
+    assert_eq!(first.title.as_deref(), Some("Add widget"));
+    assert_eq!(first.state.as_deref(), Some("open"));
+    assert_eq!(first.merged, Some(false));
+    assert!(first.merged_at.is_none());
+    assert!(!first.draft);
+    assert_eq!(first.author.as_deref(), Some("octocat"));
+    assert_eq!(
+        first.base.as_ref().and_then(|b| b.ref_name.as_deref()),
+        Some("main")
+    );
+    assert_eq!(
+        first
+            .head
+            .as_ref()
+            .and_then(|h| h.repo.as_ref())
+            .and_then(|r| r.full_name.as_deref()),
+        Some("octocat/hello-world")
+    );
+
+    let closed = &prs[1];
+    assert_eq!(closed.state.as_deref(), Some("closed"));
+    assert_eq!(closed.merged, Some(true));
+    assert!(closed.merged_at.is_some());
+}
+
+// L2: list pagination
+
+#[tokio::test]
+async fn list_follows_next_page() {
+    let gh = MockGitHub::start().await;
+    gh.mount_paged(
+        "/repos/octocat/hello-world/pulls",
+        vec![
+            vec![pr_json(1, "One", "open")],
+            vec![pr_json(2, "Two", "closed")],
+        ],
+    )
+    .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let prs = list_pull_requests(&client, "octocat", "hello-world")
+        .await
+        .expect("list succeeds");
+    assert_eq!(prs.len(), 2);
+    assert_eq!(prs[0].number, Some(1));
+    assert_eq!(prs[1].number, Some(2));
+
+    let counts = gh.counts();
+    assert_eq!(counts.get, 2, "one GET per page");
+    let requests = gh.received_requests();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests[1].url.as_str().contains("page=2"),
+        "page-2 URL carried page=2: {}",
+        requests[1].url
+    );
+}
+
+// L3: list page cap
+
+#[tokio::test]
+async fn list_page_cap_errors_instead_of_truncating() {
+    let gh = MockGitHub::start().await;
+    let pages: Vec<Vec<serde_json::Value>> = (1..=21)
+        .map(|i| vec![pr_json(i, &format!("PR {i}"), "open")])
+        .collect();
+    gh.mount_paged("/repos/octocat/hello-world/pulls", pages)
+        .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let err = list_pull_requests(&client, "octocat", "hello-world")
+        .await
+        .expect_err("page cap must error");
+    let text = format!("{err:?}");
+    assert!(text.contains("exceeded"), "expected page-cap error: {text}");
+    assert_eq!(gh.counts().get, 20, "cap is 20 pages, no silent truncation");
+}
+
+// L4: list rate limit
+
+#[tokio::test]
+async fn list_rate_limit_zero_remaining_is_typed_error() {
+    let gh = MockGitHub::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-ratelimit-remaining", "0")
+                .insert_header("x-ratelimit-limit", "5000")
+                .insert_header("x-ratelimit-reset", "0")
+                .set_body_string("[]"),
+        )
+        .mount(gh.server())
+        .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let err = list_pull_requests(&client, "octocat", "hello-world")
+        .await
+        .expect_err("zero remaining errors");
+    let text = format!("{err:?}");
+    assert!(text.contains("RateLimited"), "expected RateLimited: {text}");
+}
+
+// L5: list malformed page
+
+#[tokio::test]
+async fn list_malformed_page_is_parse_error() {
+    let gh = MockGitHub::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"[{"number": "not-a-number"}]"#))
+        .mount(gh.server())
+        .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let err = list_pull_requests(&client, "octocat", "hello-world")
+        .await
+        .expect_err("malformed page errors");
+    let text = format!("{err:?}");
+    assert!(text.contains("JSON parse"), "expected JSON parse: {text}");
+}
+
+// F1: fetch happy path
+
+#[tokio::test]
+async fn fetch_returns_typed_detail() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        "/repos/octocat/hello-world/pulls/7",
+        pr_json(7, "Add widget", "open"),
+    )
+    .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let detail = fetch_pull_request(&client, "octocat", "hello-world", 7)
+        .await
+        .expect("fetch succeeds")
+        .expect("PR exists");
+    assert_eq!(detail.number, Some(7));
+    assert_eq!(detail.title.as_deref(), Some("Add widget"));
+    assert_eq!(detail.state.as_deref(), Some("open"));
+    assert_eq!(detail.merged, Some(false));
+    assert!(detail.merged_at.is_none());
+    assert_eq!(detail.author.as_deref(), Some("octocat"));
+    assert_eq!(
+        detail
+            .base
+            .as_ref()
+            .and_then(|b| b.repo.as_ref())
+            .and_then(|r| r.full_name.as_deref()),
+        Some("octocat/hello-world")
+    );
+    let head = detail.head.as_ref().expect("head present");
+    assert_eq!(head.ref_name.as_deref(), Some("feature-x"));
+    assert_eq!(head.sha.as_deref(), Some("bbbb"));
+    assert_eq!(
+        head.repo.as_ref().and_then(|r| r.full_name.as_deref()),
+        Some("octocat/hello-world")
+    );
+}
+
+// F2: fetch with head.repo null (deleted head branch)
+
+#[tokio::test]
+async fn fetch_null_head_repo_is_optional_skip() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        "/repos/octocat/hello-world/pulls/7",
+        serde_json::json!({
+            "number": 7,
+            "title": "Deleted head",
+            "body": null,
+            "draft": false,
+            "user": null,
+            "state": "open",
+            "merged": false,
+            "merged_at": null,
+            "base": {
+                "ref": "main",
+                "sha": "aaaa",
+                "repo": {"full_name": "octocat/hello-world"}
+            },
+            "head": {"ref": "deleted-branch", "sha": "bbbb", "repo": null}
+        }),
+    )
+    .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let detail = fetch_pull_request(&client, "octocat", "hello-world", 7)
+        .await
+        .expect("fetch succeeds")
+        .expect("PR exists");
+    let head = detail.head.as_ref().expect("head present");
+    assert!(
+        head.repo.is_none(),
+        "deleted head repo is None, not a crash"
+    );
+    assert_eq!(head.ref_name.as_deref(), Some("deleted-branch"));
+    assert_eq!(detail.author, None, "null user maps to None author");
+}
+
+// F3: fetch 404 maps to None
+
+#[tokio::test]
+async fn fetch_404_maps_to_none() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "GET",
+        "/repos/octocat/hello-world/pulls/7",
+        404,
+        serde_json::json!({"message": "Not Found"}),
+    )
+    .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let detail = fetch_pull_request(&client, "octocat", "hello-world", 7)
+        .await
+        .expect("404 maps to Ok(None), not an error");
+    assert!(detail.is_none());
+}
+
+// F4: fetch closed + merged fixture
+
+#[tokio::test]
+async fn fetch_closed_merged_round_trips_state_fields() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        "/repos/octocat/hello-world/pulls/7",
+        pr_json(7, "Merged PR", "closed"),
+    )
+    .await;
+
+    let (client, _cfg) = mock_client(&gh);
+    let detail = fetch_pull_request(&client, "octocat", "hello-world", 7)
+        .await
+        .expect("fetch succeeds")
+        .expect("PR exists");
+    assert_eq!(detail.state.as_deref(), Some("closed"));
+    assert_eq!(detail.merged, Some(true));
+    let expected = DateTime::parse_from_rfc3339("2026-07-13T12:00:00Z")
+        .expect("fixture timestamp parses")
+        .with_timezone(&Utc);
+    assert_eq!(detail.merged_at, Some(expected));
+}
+
+// C1: create comment happy path
+
+#[tokio::test]
+async fn create_comment_returns_id() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "POST",
+        "/repos/octocat/hello-world/issues/7/comments",
+        201,
+        serde_json::json!({"id": 4242}),
+    )
+    .await;
+
+    let (client, cfg) = mock_client(&gh);
+    let id = create_pr_comment(&client, &cfg, "octocat", "hello-world", 7, "looks good")
+        .await
+        .expect("create succeeds");
+    assert_eq!(id, 4242);
+    assert_eq!(gh.counts().post, 1);
+    let requests = gh.received_requests();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+    assert_eq!(
+        body["body"], "looks good",
+        "request body carries exactly the sent text"
+    );
+}
+
+// C2: create voice rejection before any HTTP
+
+#[tokio::test]
+async fn create_comment_voice_rejection_runs_before_http() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "POST",
+        "/repos/octocat/hello-world/issues/7/comments",
+        201,
+        serde_json::json!({"id": 4242}),
+    )
+    .await;
+
+    let (client, mut cfg) = mock_client(&gh);
+    cfg.comment_forbidden_strings = vec!["secret".to_string()];
+    let err = create_pr_comment(
+        &client,
+        &cfg,
+        "octocat",
+        "hello-world",
+        7,
+        "this contains secret material",
+    )
+    .await
+    .expect_err("forbidden term rejects");
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("public-voice"),
+        "expected voice rejection: {text}"
+    );
+    assert_eq!(gh.counts().post, 0, "voice gate ran before any HTTP");
+}
+
+// C3: create oversize cap before any HTTP
+
+#[tokio::test]
+async fn create_comment_oversize_rejects_before_http() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "POST",
+        "/repos/octocat/hello-world/issues/7/comments",
+        201,
+        serde_json::json!({"id": 4242}),
+    )
+    .await;
+
+    let (client, cfg) = mock_client(&gh);
+    let oversized = "x".repeat(70_000);
+    let err = create_pr_comment(&client, &cfg, "octocat", "hello-world", 7, &oversized)
+        .await
+        .expect_err("oversize rejects");
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("public-voice"),
+        "expected voice rejection: {text}"
+    );
+    assert!(
+        text.contains("65536"),
+        "expected the 65 536-byte cap: {text}"
+    );
+    assert_eq!(gh.counts().post, 0, "voice gate ran before any HTTP");
+}
+
+// C4: update comment happy path
+
+#[tokio::test]
+async fn update_comment_succeeds() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "PATCH",
+        "/repos/octocat/hello-world/issues/comments/4242",
+        serde_json::json!({"id": 4242, "body": "revised"}),
+    )
+    .await;
+
+    let (client, cfg) = mock_client(&gh);
+    update_pr_comment(
+        &client,
+        &cfg,
+        "octocat",
+        "hello-world",
+        4242,
+        "revised review",
+    )
+    .await
+    .expect("update succeeds");
+    assert_eq!(gh.counts().patch, 1);
+    let requests = gh.received_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].url.path(),
+        "/repos/octocat/hello-world/issues/comments/4242"
+    );
+}
+
+// C5: update voice rejection before any HTTP
+
+#[tokio::test]
+async fn update_comment_voice_rejection_runs_before_http() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "PATCH",
+        "/repos/octocat/hello-world/issues/comments/4242",
+        serde_json::json!({"id": 4242}),
+    )
+    .await;
+
+    let (client, mut cfg) = mock_client(&gh);
+    cfg.comment_forbidden_strings = vec!["secret".to_string()];
+    let err = update_pr_comment(
+        &client,
+        &cfg,
+        "octocat",
+        "hello-world",
+        4242,
+        "secret updated review",
+    )
+    .await
+    .expect_err("forbidden term rejects");
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("public-voice"),
+        "expected voice rejection: {text}"
+    );
+    assert_eq!(gh.counts().patch, 0, "voice gate ran before any HTTP");
+}
+
+// C6: update non-2xx propagates
+
+#[tokio::test]
+async fn update_comment_404_propagates_as_github_api() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "PATCH",
+        "/repos/octocat/hello-world/issues/comments/4242",
+        404,
+        serde_json::json!({"message": "Not Found"}),
+    )
+    .await;
+
+    let (client, cfg) = mock_client(&gh);
+    let err = update_pr_comment(&client, &cfg, "octocat", "hello-world", 4242, "updated")
+        .await
+        .expect_err("404 propagates");
+    match err {
+        CaduceusError::GitHubApi { status: 404, .. } => {}
+        other => panic!("expected GitHubApi 404, got {other:?}"),
+    }
+}


### PR DESCRIPTION

Add PullRequestDetail/PullRequestBranch/PullRequestRepo wire types and
four wrappers: list_pull_requests (state=all, next_page pagination,
rate-limit and page-cap checks), fetch_pull_request (404 -> Ok(None)),
create_pr_comment and update_pr_comment (public-voice gate before any
HTTP). head.repo is nullable so a deleted head branch parses to None
instead of crashing. Comment bodies ride VoiceChannel::Comment with
the 65 536-byte cap. No eligibility/skip logic (issues #308/#310/#312).

Closes #301

Endpoint decision: sticky comments use the issue-comments API
(POST /repos/{o}/{r}/issues/{n}/comments, PATCH .../issues/comments/{id})
as a self-consistent pair; the card's "POST pulls/{n}/comments" names
the review-comment endpoint, which is not what the auto-review sticky
comment needs.

Note for #308: merge_detect.rs:36 checks resp.status == 404 on the Ok
path, which is dead code — the transport surfaces 404 as
Err(GitHubApi { status: 404 }). fetch_pull_request matches that Err
variant (gone-state B) instead of imitating merge_detect.

author (wire user.login) decodes through a small deserialize_with
helper so the public field stays Option<String>.