### PR TITLE
feat(state): add review schema migration framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,6 +372,10 @@ name = "migration_test"
 path = "tests/state/migration_test.rs"
 
 [[test]]
+name = "migration_framework_test"
+path = "tests/state/migration_framework_test.rs"
+
+[[test]]
 name = "migrate_recover_sqlite_test"
 path = "tests/state/migrate_recover_sqlite_test.rs"
 

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -165,6 +165,7 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         }
         CaduceusError::Queue { .. } => FailureClass::Infrastructure,
         CaduceusError::StateCorrupt { .. } => FailureClass::Infrastructure,
+        CaduceusError::StoreVersionUnsupported { .. } => FailureClass::Infrastructure,
         CaduceusError::ReconciliationFailed { .. } => FailureClass::Infrastructure,
         CaduceusError::ConflictingMarker { .. } => FailureClass::Worker,
         CaduceusError::Config(_) => FailureClass::Infrastructure,
@@ -229,6 +230,10 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         // result validation land here. Voice rejections and
         // content-shape failures are worker-attributable.
         CaduceusError::Other(_) => FailureClass::Worker,
+        // Unknown review-typed schema_version on a worker result: the
+        // document did not execute — worker-attributable (DAR §8; the
+        // wire into ExecutionStatus is #305's).
+        CaduceusError::ReviewSchemaVersion { .. } => FailureClass::Worker,
 
         // IO and JSON errors during state mutation are
         // infrastructure.

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -140,6 +140,31 @@ pub enum CaduceusError {
     #[error("corrupt state file at {}: {message}", path.display())]
     StateCorrupt { path: PathBuf, message: String },
 
+    /// The on-disk store (SQLite or JSON) carries a version this daemon
+    /// does not know. Startup hard-fail; the operator must upgrade or
+    /// reinitialise. Distinct from `StateCorrupt` (damaged data) — the
+    /// data may be perfectly valid for a newer/older daemon.
+    #[error(
+        "store version unsupported: {backend} store at {path} has version {found}; this daemon supports up to {supported}. {guidance}"
+    )]
+    StoreVersionUnsupported {
+        backend: &'static str,
+        path: PathBuf,
+        found: i64,
+        supported: i64,
+        guidance: String,
+    },
+
+    /// A worker result document carries a `schema_version` this daemon
+    /// does not know. Distinct from `StoreVersionUnsupported`: this is
+    /// a worker-result rejection, not a store-open failure. The
+    /// worker-result layer classifies it as an execution failure
+    /// (#305 composes the full validator; DAR §4.3, §8).
+    #[error(
+        "review result: schema_version {found} is not supported (this daemon accepts {supported})"
+    )]
+    ReviewSchemaVersion { found: u32, supported: u32 },
+
     /// Reconciliation of an external side effect failed: the
     /// remote marker disagrees with the local checkpoint. The
     /// operator must inspect the run and resolve the conflict.
@@ -411,6 +436,24 @@ pub enum CaduceusError {
 /// Canonical `Result` alias used everywhere in the daemon.
 pub type CaduceusResult<T> = Result<T, CaduceusError>;
 
+/// Operator instructions for [`CaduceusError::StoreVersionUnsupported`]
+/// (DAR §4.2). Single source for both backends and both directions so
+/// the wording cannot drift from the tests that assert on it.
+pub fn store_version_guidance(newer_file: bool) -> String {
+    if newer_file {
+        "this state was written by a NEWER caduceus: upgrade the daemon \
+         (git pull && cargo install --path .) or move the state directory \
+         aside and reinitialise; see \
+         https://github.com/barkley-assistant/caduceus/wiki/State-Recovery"
+            .to_string()
+    } else {
+        "this state was written by an OLDER caduceus: upgrade the daemon \
+         to this version or newer and restart; see \
+         https://github.com/barkley-assistant/caduceus/wiki/State-Recovery"
+            .to_string()
+    }
+}
+
 impl fmt::Debug for CaduceusError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Render via Display, scrubbed through the redaction helper.
@@ -478,6 +521,24 @@ impl fmt::Debug for CaduceusError {
                 "StateCorrupt {{ path: {:?}, message: {} }}",
                 path,
                 scrub(message)
+            ),
+            CaduceusError::StoreVersionUnsupported {
+                backend,
+                path,
+                found,
+                supported,
+                guidance,
+            } => format!(
+                "StoreVersionUnsupported {{ backend: {:?}, path: {:?}, found: {}, supported: {}, guidance: {} }}",
+                backend,
+                path,
+                found,
+                supported,
+                scrub(guidance)
+            ),
+            CaduceusError::ReviewSchemaVersion { found, supported } => format!(
+                "ReviewSchemaVersion {{ found: {}, supported: {} }}",
+                found, supported
             ),
             CaduceusError::ReconciliationFailed { stage, details } => format!(
                 "ReconciliationFailed {{ stage: {:?}, details: {} }}",

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -345,14 +345,20 @@ pub fn parse_review_result(json: &str) -> CaduceusResult<ReviewResult> {
         CaduceusError::Config(format!("review result: malformed document: {err}"))
     })?;
     if result.schema_version != REVIEW_SCHEMA_VERSION {
-        return Err(CaduceusError::Config(format!(
-            "review result: schema_version {} is not supported (this daemon accepts \
-             {REVIEW_SCHEMA_VERSION})",
-            result.schema_version
-        )));
+        return Err(CaduceusError::ReviewSchemaVersion {
+            found: result.schema_version,
+            supported: REVIEW_SCHEMA_VERSION,
+        });
     }
     validate_review_result(&result)?;
     Ok(result)
+}
+
+/// Would a document with this `schema_version` be accepted by this
+/// daemon? Plumbing for the worker-result layer (#305 composes this
+/// into the full validator; DAR §4.3, §8).
+pub fn review_schema_version_supported(v: u32) -> bool {
+    v == REVIEW_SCHEMA_VERSION
 }
 
 /// Cap validation for a [`ReviewResult`] (exposed so #305's full

--- a/src/state/queue/mod.rs
+++ b/src/state/queue/mod.rs
@@ -52,7 +52,7 @@ use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
 use crate::github::issue::IssueKey;
-use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::infra::error::{store_version_guidance, CaduceusError, CaduceusResult};
 
 /// Canonical queue-file schema version. Bumping it is a breaking
 /// change — the daemon refuses any other value. Tested by
@@ -377,13 +377,26 @@ pub fn parse_queue_state(text: &str) -> CaduceusResult<QueueState> {
             path: PathBuf::from("<queue-state>"),
             message: format!("queue state JSON parse: {err}"),
         })?;
-    if state.version != QUEUE_FILE_VERSION {
-        return Err(CaduceusError::StateCorrupt {
+    if state.version > QUEUE_FILE_VERSION {
+        return Err(CaduceusError::StoreVersionUnsupported {
+            backend: "json",
             path: PathBuf::from("<queue-state>"),
-            message: format!(
-                "unsupported queue state version: got {}, expected {}",
-                state.version, QUEUE_FILE_VERSION
-            ),
+            found: state.version as i64,
+            supported: QUEUE_FILE_VERSION as i64,
+            guidance: store_version_guidance(true),
+        });
+    }
+    if state.version < QUEUE_FILE_VERSION {
+        // Dormant until #295 bumps the envelope and lands the JSON
+        // migration step: an older file has no JSON migration
+        // machinery yet, so the branch exists now so the bump is
+        // one-line.
+        return Err(CaduceusError::StoreVersionUnsupported {
+            backend: "json",
+            path: PathBuf::from("<queue-state>"),
+            found: state.version as i64,
+            supported: QUEUE_FILE_VERSION as i64,
+            guidance: store_version_guidance(false),
         });
     }
     // Every map key must be the lowercase display form of its

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 
 use rusqlite::{params, Connection, Transaction};
 
-use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::infra::error::{store_version_guidance, CaduceusError, CaduceusResult};
 
 /// Current schema version. Bumping it is a breaking change — the
 /// store refuses to open a database with a *higher* version.
@@ -60,6 +60,17 @@ use crate::infra::error::{CaduceusError, CaduceusResult};
 ///   supported state contract. There is intentionally no v6 -> v7
 ///   migration: v6 state must be reinitialised rather than being read
 ///   with different lifecycle semantics.
+///
+/// ## v8 (not yet live — armed by #295)
+///
+/// - The review-era structures activate as v8 atomically with #295 in
+///   ONE commit: append a `Migration { from: 7, to: 8, label:
+///   "review-era structures", apply: m_v7_v8 }` entry to
+///   `SQLITE_MIGRATIONS`, bump `SCHEMA_VERSION` to 8, bump
+///   `QUEUE_FILE_VERSION` to 2 (with the JSON migration step), and add
+///   the v8 review tables to the schema DDL. `assert_registry_wellformed`
+///   rejects any step whose `to` exceeds `SCHEMA_VERSION`, so the
+///   registry entry and the version bump cannot land separately.
 pub const SCHEMA_VERSION: i64 = 7;
 
 /// The last schema version that is deliberately rejected instead of
@@ -163,8 +174,11 @@ CREATE INDEX IF NOT EXISTS idx_oci_runs_state ON oci_runs(state);
 ///
 /// - Equal to [`SCHEMA_VERSION`] → open, apply any missing tables.
 /// - Higher than [`SCHEMA_VERSION`] → reject with
-///   [`CaduceusError::StateCorrupt`] (future schema, must upgrade).
-/// - Lower → migration is performed (future task).
+///   [`CaduceusError::StoreVersionUnsupported`] (future schema, must
+///   upgrade or reinitialise).
+/// - Equal to [`STALE_SCHEMA_VERSION`] → reject with
+///   [`CaduceusError::StateCorrupt`] (stale v6, must reinitialise).
+/// - Lower → run the migration chain ([`SQLITE_MIGRATIONS`]).
 ///
 /// The connection uses WAL mode for concurrent reads and is created
 /// with `PRAGMA journal_mode=WAL`.
@@ -209,30 +223,47 @@ pub fn open(path: &Path) -> CaduceusResult<Connection> {
             })?;
 
         if existing_version > SCHEMA_VERSION {
-            return Err(CaduceusError::StateCorrupt {
+            return Err(CaduceusError::StoreVersionUnsupported {
+                backend: "sqlite",
                 path: db_path,
-                message: format!(
-                    "SQLite store has schema v{existing_version} but this daemon only supports v{SCHEMA_VERSION} — upgrade required"
-                ),
+                found: existing_version,
+                supported: SCHEMA_VERSION,
+                guidance: store_version_guidance(true),
             });
         }
 
         if existing_version == STALE_SCHEMA_VERSION {
             return Err(CaduceusError::StateCorrupt {
                 path: db_path,
-                message: "SQLite store has stale schema v6; v6 state is not migrated and must be reinitialized with fresh state".to_string(),
+                message: format!(
+                    "SQLite store has stale schema v6; v6 state is not migrated and must be reinitialized with fresh state. {}",
+                    store_version_guidance(false)
+                ),
             });
         }
 
         if existing_version < SCHEMA_VERSION {
-            // Run migration from existing_version to SCHEMA_VERSION.
-            migrate_v1_to_v2(&conn, &db_path, existing_version)?;
-            migrate_v2_to_v3(&conn, &db_path, existing_version)?;
-            migrate_v3_to_v4(&conn, &db_path, existing_version)?;
-            migrate_v4_to_v5(&conn, &db_path, existing_version)?;
-            migrate_v5_to_v6(&conn, &db_path, existing_version)?;
-            apply_schema(&conn, &db_path)?;
-            record_version(&conn, &db_path)?;
+            // Run the migration chain from existing_version toward
+            // SCHEMA_VERSION. A step fires iff the store's current
+            // version equals the step's `from`; one transaction + one
+            // schema_version row write per step keeps the chain
+            // idempotent and crash-resumable (D2).
+            let mut current = existing_version;
+            for step in SQLITE_MIGRATIONS {
+                if current == step.from {
+                    run_migration_step(&conn, &db_path, step)?;
+                    current = step.to;
+                }
+            }
+            if current < SCHEMA_VERSION {
+                tracing::warn!(
+                    from = current,
+                    to = SCHEMA_VERSION,
+                    "migration registry gap: chain reaches v{current}, below SCHEMA_VERSION v{SCHEMA_VERSION}; applying schema and recording the current version"
+                );
+                apply_schema(&conn, &db_path)?;
+                record_version(&conn, &db_path)?;
+            }
         }
 
         // Ensure missing tables are created (idempotent).
@@ -303,81 +334,207 @@ fn record_version_in_tx(tx: &Transaction, db_path: &Path) -> CaduceusResult<()> 
     Ok(())
 }
 
-/// Migrate from schema v1 to v2 by adding the `operation_id` and
-/// `remote_marker` columns to the `checkpoints` table. Both columns
-/// are nullable so existing rows get NULL defaults.
-fn migrate_v1_to_v2(conn: &Connection, db_path: &Path, from_version: i64) -> CaduceusResult<()> {
-    if from_version >= 2 {
-        return Ok(());
+/// One structural migration step in the SQLite chain (DAR §4.4).
+///
+/// The chain is declarative data: a step fires iff the store's current
+/// `schema_version` equals `from`, runs inside ONE transaction, and
+/// writes `to` to the `schema_version` row in that same transaction.
+/// Structural-only — a step whose behaviour depends on which binary
+/// opens the store is a version-semantics violation.
+pub(crate) struct Migration {
+    /// Version this step takes the store FROM (must equal the current
+    /// `schema_version` row when it fires).
+    pub from: i64,
+    /// Version this step takes the store TO (written to the
+    /// `schema_version` row in the same transaction as the DDL).
+    pub to: i64,
+    /// Human label used in logs and the test harness.
+    pub label: &'static str,
+    /// Structural DDL / data transform, executed inside one transaction.
+    pub apply: fn(&Transaction) -> CaduceusResult<()>,
+}
+
+/// The declarative migration chain (D1/D4).
+///
+/// The chain deliberately ends at v6: v6 is the stale-reinitialise
+/// boundary ([`STALE_SCHEMA_VERSION`]) and v8 does not exist yet — #295
+/// arms v7→v8 by appending one entry + bumping [`SCHEMA_VERSION`] in
+/// the same commit.
+const SQLITE_MIGRATIONS: &[Migration] = &[
+    Migration {
+        from: 1,
+        to: 2,
+        label: "checkpoints operation columns",
+        apply: m_v1_v2,
+    },
+    Migration {
+        from: 2,
+        to: 3,
+        label: "leases table (apply_schema)",
+        apply: m_v2_v3,
+    },
+    Migration {
+        from: 3,
+        to: 4,
+        label: "circuit_state replaces circuit_breakers",
+        apply: m_v3_v4,
+    },
+    Migration {
+        from: 4,
+        to: 5,
+        label: "oci_runs table (apply_schema)",
+        apply: m_v4_v5,
+    },
+    Migration {
+        from: 5,
+        to: 6,
+        label: "queue_entries blocked columns",
+        apply: m_v5_v6,
+    },
+];
+
+/// Validate the registry's chain invariants (D1/D4): steps are strictly
+/// increasing and contiguous (`from[i] == to[i-1]`), the chain starts
+/// at v1, no step migrates FROM the stale boundary
+/// [`STALE_SCHEMA_VERSION`], and no step's `to` exceeds
+/// [`SCHEMA_VERSION`]. The last clause makes arming v8 (a
+/// `from: 7, to: 8` entry) impossible without bumping
+/// [`SCHEMA_VERSION`] in the same change (#295).
+pub fn assert_registry_wellformed() -> CaduceusResult<()> {
+    let steps = SQLITE_MIGRATIONS;
+    if steps.is_empty() {
+        return Err(CaduceusError::Other(
+            "migration registry must not be empty".to_string(),
+        ));
     }
-    conn.execute_batch(
-        "ALTER TABLE checkpoints ADD COLUMN operation_id TEXT;
-         ALTER TABLE checkpoints ADD COLUMN remote_marker TEXT;",
+    if steps[0].from != 1 {
+        return Err(CaduceusError::Other(format!(
+            "migration registry must start at v1, found v{}",
+            steps[0].from
+        )));
+    }
+    for (i, step) in steps.iter().enumerate() {
+        if step.from >= step.to {
+            return Err(CaduceusError::Other(format!(
+                "migration registry step {i} ({}) is not upward: v{} → v{}",
+                step.label, step.from, step.to
+            )));
+        }
+        if step.from == STALE_SCHEMA_VERSION {
+            return Err(CaduceusError::Other(format!(
+                "migration registry step {i} ({}) would migrate the stale v{STALE_SCHEMA_VERSION} boundary, which is reinitialise-only by policy",
+                step.label
+            )));
+        }
+        if step.to > SCHEMA_VERSION {
+            return Err(CaduceusError::Other(format!(
+                "migration registry step {i} ({}) targets v{} above SCHEMA_VERSION v{SCHEMA_VERSION}; bump SCHEMA_VERSION in the same change",
+                step.label, step.to
+            )));
+        }
+        if i > 0 && step.from != steps[i - 1].to {
+            return Err(CaduceusError::Other(format!(
+                "migration registry gap at step {i} ({}): starts at v{} but previous step ends at v{}",
+                step.label,
+                step.from,
+                steps[i - 1].to
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Expose the migration registry as `(from, to, label)` triples so
+/// tests (and #295/#327) can assert chain invariants and iterate the
+/// chain without reaching into the registry internals.
+pub fn sqlite_migration_chain() -> Vec<(i64, i64, &'static str)> {
+    SQLITE_MIGRATIONS
+        .iter()
+        .map(|migration| (migration.from, migration.to, migration.label))
+        .collect()
+}
+
+/// Execute one registry step inside its own transaction, then write the
+/// step's target version into `schema_version` in the same transaction
+/// (D2: one step = one transaction = one visible version bump). A crash
+/// between steps leaves the store at the last committed version; the
+/// next open re-enters the chain from there.
+fn run_migration_step(conn: &Connection, db_path: &Path, step: &Migration) -> CaduceusResult<()> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| CaduceusError::StateCorrupt {
+            path: db_path.to_path_buf(),
+            message: format!("cannot start migration transaction ({}): {e}", step.label),
+        })?;
+    (step.apply)(&tx).map_err(|e| CaduceusError::StateCorrupt {
+        path: db_path.to_path_buf(),
+        message: format!("{} migration failed: {e}", step.label),
+    })?;
+    let now = chrono::Utc::now().to_rfc3339();
+    tx.execute(
+        "INSERT INTO schema_version (version, migrated_at) VALUES (?1, ?2)",
+        params![step.to, now],
     )
     .map_err(|e| CaduceusError::StateCorrupt {
         path: db_path.to_path_buf(),
-        message: format!("v1→v2 migration failed: {e}"),
+        message: format!("cannot record schema version {}: {e}", step.to),
     })?;
+    tx.commit().map_err(|e| CaduceusError::StateCorrupt {
+        path: db_path.to_path_buf(),
+        message: format!("cannot commit migration transaction ({}): {e}", step.label),
+    })?;
+    Ok(())
+}
+
+/// Migrate from schema v1 to v2 by adding the `operation_id` and
+/// `remote_marker` columns to the `checkpoints` table. Both columns
+/// are nullable so existing rows get NULL defaults.
+fn m_v1_v2(tx: &Transaction) -> CaduceusResult<()> {
+    tx.execute_batch(
+        "ALTER TABLE checkpoints ADD COLUMN operation_id TEXT;
+         ALTER TABLE checkpoints ADD COLUMN remote_marker TEXT;",
+    )
+    .map_err(|e| CaduceusError::Other(format!("v1→v2 ALTER checkpoints: {e}")))?;
     Ok(())
 }
 
 /// Migrate from schema v2 to v3. The `leases` table is created by
 /// `apply_schema`, so this is a no-op migration that exists for
 /// the migration wiring convention.
-fn migrate_v2_to_v3(conn: &Connection, db_path: &Path, from_version: i64) -> CaduceusResult<()> {
-    if from_version >= 3 {
-        return Ok(());
-    }
+fn m_v2_v3(tx: &Transaction) -> CaduceusResult<()> {
     // The `leases` table is created by `apply_schema` via `SCHEMA_SQL`.
     // No ALTER TABLE statements are needed for v2→v3.
-    let _ = conn;
-    let _ = db_path;
+    let _ = tx;
     Ok(())
 }
 
 /// Migrate from schema v3 to v4. Drops the dead `circuit_breakers`
 /// table and creates the new `circuit_state` table via `apply_schema`.
-fn migrate_v3_to_v4(conn: &Connection, db_path: &Path, from_version: i64) -> CaduceusResult<()> {
-    if from_version >= 4 {
-        return Ok(());
-    }
-    conn.execute_batch("DROP TABLE IF EXISTS circuit_breakers;")
-        .map_err(|e| CaduceusError::StateCorrupt {
-            path: db_path.to_path_buf(),
-            message: format!("v3→v4 migration failed: {e}"),
-        })?;
+fn m_v3_v4(tx: &Transaction) -> CaduceusResult<()> {
+    tx.execute_batch("DROP TABLE IF EXISTS circuit_breakers;")
+        .map_err(|e| CaduceusError::Other(format!("v3→v4 DROP circuit_breakers: {e}")))?;
     Ok(())
 }
 
 /// Migrate from schema v4 to v5. The `oci_runs` table is created by
 /// `apply_schema`, so this is a no-op migration that exists for the
 /// migration wiring convention.
-fn migrate_v4_to_v5(conn: &Connection, db_path: &Path, from_version: i64) -> CaduceusResult<()> {
-    if from_version >= 5 {
-        return Ok(());
-    }
+fn m_v4_v5(tx: &Transaction) -> CaduceusResult<()> {
     // The `oci_runs` table is created by `apply_schema` via `SCHEMA_SQL`.
     // No ALTER TABLE statements are needed for v4→v5.
-    let _ = conn;
-    let _ = db_path;
+    let _ = tx;
     Ok(())
 }
 
 /// Migrate from schema v5 to v6 by adding `blocked_source` and
 /// `blocked_recovery_hint` columns to `queue_entries`. Both columns
 /// are nullable so existing rows get NULL defaults.
-fn migrate_v5_to_v6(conn: &Connection, db_path: &Path, from_version: i64) -> CaduceusResult<()> {
-    if from_version >= 6 {
-        return Ok(());
-    }
-    conn.execute_batch(
+fn m_v5_v6(tx: &Transaction) -> CaduceusResult<()> {
+    tx.execute_batch(
         "ALTER TABLE queue_entries ADD COLUMN blocked_source TEXT;
          ALTER TABLE queue_entries ADD COLUMN blocked_recovery_hint TEXT;",
     )
-    .map_err(|e| CaduceusError::StateCorrupt {
-        path: db_path.to_path_buf(),
-        message: format!("v5→v6 migration failed: {e}"),
-    })?;
+    .map_err(|e| CaduceusError::Other(format!("v5→v6 ALTER queue_entries: {e}")))?;
     Ok(())
 }
 

--- a/tests/state/migration_framework_test.rs
+++ b/tests/state/migration_framework_test.rs
@@ -1,0 +1,508 @@
+//! Migration framework tests for both state backends (issue #293,
+//! DAR §15).
+//!
+//! Acceptance coverage:
+//!
+//! - AC1 — the SQLite chain runs from any older version, is idempotent,
+//!   side-effect-tracked, and structural-only (no drain-by-execution).
+//! - AC2 — unknown store versions hard-fail at open with operator
+//!   guidance for both backends.
+//! - AC3 — per-type `schema_version` plumbing rejects unknown
+//!   review-typed versions with a dedicated, matchable variant.
+//! - AC4 — no live version flip: `SCHEMA_VERSION` stays 7 and
+//!   `QUEUE_FILE_VERSION` stays 1; the registry ships no v7→v8 entry.
+//!
+//! The harness builders (`harness::sqlite_store_at_version`,
+//! `harness::json_state_at_version`) take a path and are the shape
+//! #295's activation tests and #327's frozen-fixture suite consume:
+//! build a store at version N, run the chain, assert version +
+//! structure.
+
+use caduceus::error::{store_version_guidance, CaduceusError};
+use caduceus::queue::{parse_queue_state, StateStore, QUEUE_FILE_VERSION};
+use caduceus::review::{parse_review_result, review_schema_version_supported};
+use caduceus::store::{
+    assert_registry_wellformed, open, sqlite_migration_chain, SCHEMA_VERSION, STALE_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Harness builders shared by the matrix below (consumed by #295/#327).
+mod harness {
+    use super::*;
+
+    /// Unique temp dir per call, tagged for failure readability.
+    pub fn temp_dir(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "migration-framework-{tag}-{}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// Build a real SQLite store whose `schema_version` MAX equals
+    /// `version` and whose tables match that era closely enough for the
+    /// migration chain to run (each chain step must find its
+    /// pre-migration shape). Returns the database path.
+    pub fn sqlite_store_at_version(dir: &Path, version: i64) -> PathBuf {
+        let path = dir.join("state.db");
+        if version == SCHEMA_VERSION {
+            // The current era is created by the daemon itself.
+            let conn = open(&path).expect("open fresh current-era store");
+            drop(conn);
+            return path;
+        }
+        let conn = Connection::open(&path).expect("open raw db");
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER NOT NULL, migrated_at TEXT NOT NULL);",
+        )
+        .expect("create schema_version");
+        conn.execute(
+            "INSERT INTO schema_version (version, migrated_at) VALUES (?1, ?2)",
+            params![version, "2026-01-01T00:00:00Z"],
+        )
+        .expect("seed schema version");
+        conn.execute_batch(&era_ddl(version))
+            .expect("create era tables");
+        seed_queue_entry(&conn, version);
+        drop(conn);
+        path
+    }
+
+    /// Write a `state.json` whose envelope carries the given version.
+    /// For version ≠ 1 the body is the same and only the version field
+    /// differs — sufficient to exercise the version guard.
+    pub fn json_state_at_version(dir: &Path, version: u32) -> PathBuf {
+        let path = dir.join("state.json");
+        fs::write(&path, format!(r#"{{"version":{version},"entries":{{}}}}"#))
+            .expect("write state.json");
+        path
+    }
+
+    /// Assert the store's `schema_version` MAX equals `expected`.
+    pub fn assert_sqlite_version(path: &Path, expected: i64) {
+        let conn = Connection::open(path).expect("open raw for version check");
+        let version: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+                row.get(0)
+            })
+            .expect("read schema_version");
+        assert_eq!(version, expected, "schema version at {}", path.display());
+        drop(conn);
+    }
+
+    /// Per-era DDL for versions 1-6. Hand-written per era so each chain
+    /// step finds its pre-migration shape; `apply_schema` supplies the
+    /// post-migration tables idempotently.
+    fn era_ddl(version: i64) -> String {
+        let mut sql = String::new();
+        // `blocked_source` / `blocked_recovery_hint` land at v6; the
+        // pre-v6 shape must NOT carry them or the v5→v6 ALTER would
+        // fail with a duplicate-column error.
+        sql.push_str(if version >= 6 {
+            "CREATE TABLE queue_entries (issue_key TEXT PRIMARY KEY, phase TEXT NOT NULL, ticket_type TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, next_attempt_at TEXT, finalization TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, generation INTEGER NOT NULL DEFAULT 1, blocked_source TEXT, blocked_recovery_hint TEXT);"
+        } else {
+            "CREATE TABLE queue_entries (issue_key TEXT PRIMARY KEY, phase TEXT NOT NULL, ticket_type TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, next_attempt_at TEXT, finalization TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, generation INTEGER NOT NULL DEFAULT 1);"
+        });
+        sql.push_str("CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);");
+        sql.push_str("CREATE TABLE claims (claim_id TEXT PRIMARY KEY, issue_key TEXT NOT NULL, worker_pid INTEGER, token TEXT NOT NULL, claimed_at TEXT NOT NULL, expires_at TEXT NOT NULL);");
+        // `operation_id` / `remote_marker` land at v2; the v1 shape must
+        // NOT carry them or the v1→v2 ALTER would fail.
+        sql.push_str(if version >= 2 {
+            "CREATE TABLE checkpoints (run_id TEXT NOT NULL, stage TEXT NOT NULL, checkpoint_data TEXT, created_at TEXT NOT NULL, operation_id TEXT, remote_marker TEXT, PRIMARY KEY (run_id, stage));"
+        } else {
+            "CREATE TABLE checkpoints (run_id TEXT NOT NULL, stage TEXT NOT NULL, checkpoint_data TEXT, created_at TEXT NOT NULL, PRIMARY KEY (run_id, stage));"
+        });
+        // The dead `circuit_breakers` table existed from v1 until
+        // v3→v4 dropped it; `circuit_state` replaces it at v4.
+        if version <= 3 {
+            sql.push_str("CREATE TABLE circuit_breakers (issue_key TEXT PRIMARY KEY, failure_count INTEGER NOT NULL DEFAULT 0, last_failure_at TEXT, opened_at TEXT);");
+        } else {
+            sql.push_str("CREATE TABLE circuit_state (scope TEXT NOT NULL, scope_id TEXT NOT NULL, state TEXT NOT NULL DEFAULT 'closed', consecutive_failures INTEGER NOT NULL DEFAULT 0, last_failure_at INTEGER, opened_at INTEGER, last_probe_at INTEGER, PRIMARY KEY (scope, scope_id));");
+        }
+        // `leases` lands at v3; `oci_runs` at v5.
+        if version >= 3 {
+            sql.push_str("CREATE TABLE leases (issue_key TEXT PRIMARY KEY, owner_id TEXT NOT NULL, fencing_token INTEGER NOT NULL, expires_at INTEGER NOT NULL, state TEXT NOT NULL CHECK(state IN ('held', 'released', 'expired')));");
+        }
+        if version >= 5 {
+            sql.push_str("CREATE TABLE oci_runs (run_id TEXT PRIMARY KEY, container_id TEXT, state TEXT NOT NULL, engine TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, daemon_id TEXT NOT NULL, issue_id TEXT NOT NULL, worker_command_sha256 TEXT NOT NULL);");
+        }
+        sql
+    }
+
+    /// Seed one queue row so the matrix can assert data survives
+    /// structural steps.
+    fn seed_queue_entry(conn: &Connection, version: i64) {
+        if version >= 6 {
+            conn.execute(
+                "INSERT INTO queue_entries (issue_key, phase, ticket_type, attempts, queued_at, updated_at, generation, blocked_source, blocked_recovery_hint)
+                 VALUES (?1, 'queued', 'code', 0, ?2, ?2, 1, NULL, NULL)",
+                params!["owner/repo#1", "2026-01-01T00:00:00Z"],
+            )
+            .expect("seed v6+ queue row");
+        } else {
+            conn.execute(
+                "INSERT INTO queue_entries (issue_key, phase, ticket_type, attempts, queued_at, updated_at, generation)
+                 VALUES (?1, 'queued', 'code', 0, ?2, ?2, 1)",
+                params!["owner/repo#1", "2026-01-01T00:00:00Z"],
+            )
+            .expect("seed pre-v6 queue row");
+        }
+    }
+}
+
+/// Assert the store carries every current table and no dead
+/// `circuit_breakers` table.
+fn assert_current_tables(path: &Path) {
+    let conn = Connection::open(path).expect("open raw for table check");
+    let tables: Vec<String> = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .expect("prepare")
+        .query_map([], |row| row.get(0))
+        .expect("query")
+        .filter_map(|r| r.ok())
+        .collect();
+    for table in [
+        "schema_version",
+        "queue_entries",
+        "state_meta",
+        "claims",
+        "checkpoints",
+        "circuit_state",
+        "leases",
+        "oci_runs",
+    ] {
+        assert!(
+            tables.contains(&table.to_string()),
+            "missing table {table} after migration; tables: {tables:?}"
+        );
+    }
+    assert!(
+        !tables.contains(&"circuit_breakers".to_string()),
+        "dead circuit_breakers must be dropped; tables: {tables:?}"
+    );
+    drop(conn);
+}
+
+/// Assert the seeded row survives structural migration steps.
+fn assert_seeded_row_preserved(path: &Path) {
+    let conn = Connection::open(path).expect("open raw");
+    let (phase, source, hint): (String, Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT phase, blocked_source, blocked_recovery_hint
+             FROM queue_entries WHERE issue_key = 'owner/repo#1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("seeded row readable after migration");
+    assert_eq!(phase, "queued", "phase preserved");
+    assert!(source.is_none(), "pre-v6 row gets NULL blocked_source");
+    assert!(hint.is_none(), "pre-v6 row gets NULL blocked_recovery_hint");
+    drop(conn);
+}
+
+/// Row count of `schema_version` (append-only history; MAX is truth).
+fn schema_version_row_count(path: &Path) -> i64 {
+    let conn = Connection::open(path).expect("open raw");
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM schema_version", [], |row| row.get(0))
+        .expect("count schema_version rows");
+    drop(conn);
+    count
+}
+
+// -----------------------------------------------------------------------
+// Matrix area 1 — chain-from-anywhere (SQLite)
+// -----------------------------------------------------------------------
+
+#[test]
+fn chain_runs_from_each_older_era_to_current() {
+    for version in [1i64, 2, 3, 4, 5] {
+        let dir = harness::temp_dir(&format!("chain-v{version}"));
+        let path = harness::sqlite_store_at_version(&dir, version);
+        let conn = open(&path).unwrap_or_else(|e| panic!("open v{version} store: {e}"));
+        drop(conn);
+        harness::assert_sqlite_version(&path, SCHEMA_VERSION);
+        assert_current_tables(&path);
+        assert_seeded_row_preserved(&path);
+        let _ = fs::remove_dir_all(&dir);
+    }
+}
+
+#[test]
+fn current_era_store_opens_without_chain() {
+    let dir = harness::temp_dir("current-era");
+    let path = harness::sqlite_store_at_version(&dir, SCHEMA_VERSION);
+    let conn = open(&path).expect("open v7 store");
+    drop(conn);
+    harness::assert_sqlite_version(&path, SCHEMA_VERSION);
+    assert_current_tables(&path);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn stale_v6_is_rejected_not_migrated() {
+    let dir = harness::temp_dir("stale-v6");
+    let path = harness::sqlite_store_at_version(&dir, STALE_SCHEMA_VERSION);
+    let err = open(&path).expect_err("v6 must be rejected by policy");
+    let text = err.to_string();
+    // The existing substring pin (sqlite_store_test.rs) and the
+    // structured operator-instruction block added by D3/D5.
+    assert!(text.contains("stale schema v6"), "got: {text}");
+    assert!(
+        text.contains("https://github.com/barkley-assistant/caduceus/wiki/State-Recovery"),
+        "got: {text}"
+    );
+    harness::assert_sqlite_version(&path, STALE_SCHEMA_VERSION);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// -----------------------------------------------------------------------
+// Matrix area 2 — idempotency (SQLite)
+// -----------------------------------------------------------------------
+
+#[test]
+fn second_open_performs_no_migration_steps() {
+    let dir = harness::temp_dir("idempotent");
+    let path = harness::sqlite_store_at_version(&dir, 1);
+    open(&path).expect("first open migrates to current");
+    harness::assert_sqlite_version(&path, SCHEMA_VERSION);
+    let rows_after_first = schema_version_row_count(&path);
+    assert!(
+        rows_after_first > 1,
+        "chain steps recorded: {rows_after_first}"
+    );
+
+    open(&path).expect("second open is a no-op");
+    harness::assert_sqlite_version(&path, SCHEMA_VERSION);
+    let rows_after_second = schema_version_row_count(&path);
+    assert_eq!(
+        rows_after_first, rows_after_second,
+        "second open must not record additional version rows"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// -----------------------------------------------------------------------
+// Matrix area 3 — unknown-version rejection (SQLite)
+// -----------------------------------------------------------------------
+
+#[test]
+fn unknown_sqlite_version_is_rejected_with_guidance() {
+    let dir = harness::temp_dir("future-sqlite");
+    let path = harness::sqlite_store_at_version(&dir, SCHEMA_VERSION);
+    // Bump the store to a version this daemon does not know.
+    let conn = Connection::open(&path).expect("open raw");
+    conn.execute(
+        "INSERT INTO schema_version (version, migrated_at) VALUES (99, '2026-01-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert future version");
+    drop(conn);
+
+    let err = open(&path).expect_err("v99 must be rejected");
+    match err {
+        CaduceusError::StoreVersionUnsupported {
+            backend,
+            found,
+            supported,
+            ref guidance,
+            ..
+        } => {
+            assert_eq!(backend, "sqlite", "got: {err:?}");
+            assert_eq!(found, 99, "got: {err:?}");
+            assert_eq!(supported, SCHEMA_VERSION, "got: {err:?}");
+            assert!(guidance.contains("NEWER"), "got: {guidance}");
+            assert!(guidance.contains("upgrade the daemon"), "got: {guidance}");
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// Area 3b (below-floor version 0) does not exist by design: the floor
+// is v1 — a fresh store is always initialised at SCHEMA_VERSION and a
+// v0 file that already carries a schema_version table is not a
+// constructible state, so there is no codepath to exercise.
+
+// -----------------------------------------------------------------------
+// Matrix areas 4/5 — unknown-version rejection (JSON)
+// -----------------------------------------------------------------------
+
+#[test]
+fn json_future_version_is_rejected_with_guidance() {
+    let dir = harness::temp_dir("json-future");
+    let path = harness::json_state_at_version(&dir, 2);
+    let text = fs::read_to_string(&path).expect("read state.json");
+    let err = parse_queue_state(&text).expect_err("v2 rejected");
+    match err {
+        CaduceusError::StoreVersionUnsupported {
+            backend,
+            found,
+            supported,
+            ref guidance,
+            ..
+        } => {
+            assert_eq!(backend, "json", "got: {err:?}");
+            assert_eq!(found, 2, "got: {err:?}");
+            assert_eq!(supported, QUEUE_FILE_VERSION as i64, "got: {err:?}");
+            assert!(guidance.contains("NEWER"), "got: {guidance}");
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_older_version_is_rejected_with_guidance() {
+    let dir = harness::temp_dir("json-older");
+    let path = harness::json_state_at_version(&dir, 0);
+    let text = fs::read_to_string(&path).expect("read state.json");
+    let err = parse_queue_state(&text).expect_err("v0 rejected");
+    match err {
+        CaduceusError::StoreVersionUnsupported {
+            backend,
+            found,
+            supported,
+            ref guidance,
+            ..
+        } => {
+            assert_eq!(backend, "json", "got: {err:?}");
+            assert_eq!(found, 0, "got: {err:?}");
+            assert_eq!(supported, QUEUE_FILE_VERSION as i64, "got: {err:?}");
+            assert!(guidance.contains("OLDER"), "got: {guidance}");
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_store_open_hard_fails_on_future_envelope() {
+    // The real disk-load path hard-fails the whole store open (startup
+    // hard-fail), not best-effort parse.
+    let dir = harness::temp_dir("json-v2-file");
+    let path = harness::json_state_at_version(&dir, 2);
+    let err = StateStore::open(&dir).expect_err("open of a v2 store must hard-fail");
+    match err {
+        CaduceusError::StoreVersionUnsupported { backend, .. } => {
+            assert_eq!(backend, "json", "got: {err:?}");
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
+    let _ = fs::remove_dir_all(&dir);
+    let _ = path;
+}
+
+#[test]
+fn json_v1_parses_and_missing_file_yields_empty_v1() {
+    let parsed = parse_queue_state(r#"{"version":1,"entries":{}}"#).expect("v1 parses");
+    assert_eq!(parsed.version, QUEUE_FILE_VERSION);
+    assert!(parsed.entries.is_empty());
+
+    // Missing state.json → empty v1 envelope (existing behaviour).
+    let dir = harness::temp_dir("json-missing");
+    let store = StateStore::open(&dir).expect("open store");
+    let snap = store.snapshot().expect("snapshot empty dir");
+    assert_eq!(snap.version, QUEUE_FILE_VERSION);
+    assert!(snap.entries.is_empty());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// -----------------------------------------------------------------------
+// Matrix area 6 — per-type schema_version plumbing (review)
+// -----------------------------------------------------------------------
+
+#[test]
+fn review_schema_version_plumbing_rejects_unknown_versions() {
+    assert!(
+        review_schema_version_supported(1),
+        "v1 is the supported version"
+    );
+    for bad in [0u32, 2, u32::MAX] {
+        assert!(
+            !review_schema_version_supported(bad),
+            "v{bad} must be unsupported"
+        );
+    }
+
+    // The parse seam classifies wrong versions as a dedicated, matchable
+    // variant carrying found/supported; the message keeps the
+    // "schema_version" substring pinned by review_domain_test.
+    let doc = r#"{"schema_version":2,"status":"success","review":null}"#;
+    let err = parse_review_result(doc).expect_err("v2 doc rejected");
+    match err {
+        CaduceusError::ReviewSchemaVersion { found, supported } => {
+            assert_eq!(found, 2, "got: {err:?}");
+            assert_eq!(supported, 1, "got: {err:?}");
+            assert!(err.to_string().contains("schema_version"), "got: {err}");
+        }
+        other => panic!("expected ReviewSchemaVersion; got: {other:?}"),
+    }
+}
+
+// -----------------------------------------------------------------------
+// Matrix area 7 — registry well-formedness + AC4 no-flip pin
+// -----------------------------------------------------------------------
+
+#[test]
+fn registry_is_wellformed_and_ceiling_is_one_below_current() {
+    assert_registry_wellformed().expect("registry invariants hold");
+
+    let chain = sqlite_migration_chain();
+    assert!(!chain.is_empty(), "registry must not be empty");
+    let (first_from, _, _) = chain[0];
+    assert_eq!(first_from, 1, "chain starts at v1");
+
+    for i in 1..chain.len() {
+        let (from, _, _) = chain[i];
+        let (prev_from, prev_to, _) = chain[i - 1];
+        assert_eq!(from, prev_to, "chain must be contiguous at step {i}");
+        assert!(
+            from > prev_from,
+            "chain must be strictly increasing at step {i}"
+        );
+    }
+    for (from, _, _) in &chain {
+        assert_ne!(
+            *from, STALE_SCHEMA_VERSION,
+            "the stale v6 boundary is never migratable"
+        );
+    }
+    let (_, last_to, _) = chain.last().expect("non-empty chain");
+    assert_eq!(
+        *last_to,
+        SCHEMA_VERSION - 1,
+        "no v7→v8 entry ships in this change (AC4's structural assertion)"
+    );
+    assert!(*last_to < SCHEMA_VERSION);
+}
+
+#[test]
+fn no_live_version_flip() {
+    // AC4: the store still reports v7 and the pre-review JSON envelope
+    // version; #295 bumps both atomically with the review structures.
+    assert_eq!(SCHEMA_VERSION, 7);
+    assert_eq!(QUEUE_FILE_VERSION, 1);
+}
+
+// -----------------------------------------------------------------------
+// Matrix area 8 — guidance wording source
+// -----------------------------------------------------------------------
+
+#[test]
+fn guidance_wording_carries_wiki_and_direction() {
+    const WIKI: &str = "https://github.com/barkley-assistant/caduceus/wiki/State-Recovery";
+    let newer = store_version_guidance(true);
+    assert!(newer.contains(WIKI), "got: {newer}");
+    assert!(newer.contains("NEWER"), "got: {newer}");
+    let older = store_version_guidance(false);
+    assert!(older.contains(WIKI), "got: {older}");
+    assert!(older.contains("OLDER"), "got: {older}");
+}

--- a/tests/state/queue_model_test.rs
+++ b/tests/state/queue_model_test.rs
@@ -1,5 +1,5 @@
 //! "Issue identity and queue schema" and the contract that a future
-//! queue-file version produces a `StateCorrupt`-style error rather
+//! queue-file version produces a `StoreVersionUnsupported` error rather
 //! than best-effort parsing.
 
 use caduceus::config::Config;
@@ -245,15 +245,22 @@ fn queue_state_with_future_version_is_rejected() {
     let bad = r#"{"version":999,"entries":{}}"#;
     let err = parse_queue_state(bad).expect_err("future version");
     match err {
-        CaduceusError::StateCorrupt { message, .. } => {
-            assert!(
-                message.contains("unsupported queue state version"),
-                "got: {message}"
-            );
-            assert!(message.contains("999"), "got: {message}");
-            assert!(message.contains("expected 1"), "got: {message}");
+        CaduceusError::StoreVersionUnsupported {
+            backend,
+            found,
+            supported,
+            ref guidance,
+            ..
+        } => {
+            assert_eq!(backend, "json", "got: {err:?}");
+            assert_eq!(found, 999, "got: {err:?}");
+            assert_eq!(supported, 1, "got: {err:?}");
+            assert!(guidance.contains("NEWER"), "got: {guidance}");
+            let text = err.to_string();
+            assert!(text.contains("999"), "got: {text}");
+            assert!(text.contains("supports up to 1"), "got: {text}");
         }
-        other => panic!("expected StateCorrupt; got: {other:?}"),
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
     }
 }
 
@@ -261,9 +268,21 @@ fn queue_state_with_future_version_is_rejected() {
 fn queue_state_with_version_zero_is_rejected() {
     let bad = r#"{"version":0,"entries":{}}"#;
     let err = parse_queue_state(bad).expect_err("version 0");
-    let msg = format!("{err:?}");
-    assert!(msg.contains("StateCorrupt"), "got: {msg}");
-    assert!(msg.contains("unsupported"), "got: {msg}");
+    match err {
+        CaduceusError::StoreVersionUnsupported {
+            backend,
+            found,
+            supported,
+            ref guidance,
+            ..
+        } => {
+            assert_eq!(backend, "json", "got: {err:?}");
+            assert_eq!(found, 0, "got: {err:?}");
+            assert_eq!(supported, 1, "got: {err:?}");
+            assert!(guidance.contains("OLDER"), "got: {guidance}");
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
 }
 
 // Map key / entry invariant


### PR DESCRIPTION
## What

Implements issue #293: the versioned migration framework for Auto Review
across both state backends.

- **SQLite migration-chain framework** (`src/state/store.rs`): declarative
  `Migration` registry (from/to/label/apply) replacing the flat
  `migrate_vN_to_vNplus1` call list. One transaction + one `schema_version`
  row INSERT per step — idempotent, side-effect-tracked, crash-resumable,
  structural-only (no drain-by-execution). Registry invariants enforced by
  `assert_registry_wellformed()`; `sqlite_migration_chain()` exposes the
  chain for tests and #295/#327.
- **Symmetric JSON envelope guard** (`src/state/queue/mod.rs`): the flat
  version equality in `parse_queue_state` is now two-sided, both directions
  classified as `StoreVersionUnsupported` with operator guidance. The
  older-file branch is dormant until #295 bumps the envelope.
- **Per-type `schema_version` plumbing** (`src/review/mod.rs`):
  `review_schema_version_supported(u32)` helper +
  `CaduceusError::ReviewSchemaVersion { found, supported }` — a dedicated,
  matchable rejection (message keeps the `schema_version` substring pinned
  by existing tests). #305 owns the `ExecutionStatus` wiring.
- **Unknown store version → startup hard-fail** with operator instructions
  for both backends: `CaduceusError::StoreVersionUnsupported` plus the
  single-source `store_version_guidance(newer_file)` helper; the stale-v6
  rejection stays `StateCorrupt` and gains the same structured block.
- **Test harness** (`tests/state/migration_framework_test.rs`, 13 tests):
  chain-from-anywhere, idempotency, unknown-version rejection (SQLite +
  JSON), review plumbing, registry well-formedness, no-flip pin, guidance
  wording.

## No live version flip (AC4)

`SCHEMA_VERSION` stays 7, `QUEUE_FILE_VERSION` stays 1, and the registry
ships no v7→v8 entry. #295 arms v8 atomically with the review structures
(the well-formedness check refuses a step whose `to` exceeds
`SCHEMA_VERSION`, so the entry and the bump cannot land separately).

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo test --locked --all-targets` — all pass (documented hermetic
  `hermes_lifecycle`/`release_canary` skips)
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 181 passed

Closes #293