### PR TITLE
feat(repo): add review worktree mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   `ReviewResult`/`Review`/`Finding` worker contract with strict serde,
   snake_case enums, and parse-time field caps. Foundation for the Auto
   Review epic (#290); no behaviour change yet. Closes #292.
+- **Review worktree mode.** Review worktrees are materialised as
+  disposable, non-pushable detached-HEAD checkouts at the exact PR
+  head SHA against the daemon-owned bare mirror — no issue-dispatch
+  branch artefact — carrying a versioned `review-worktree.json`
+  metadata sidecar with the frozen `base_sha` / `base_ref` /
+  `merge_base` for merge-base (three-dot) diffing. A review reaper
+  reclaims stale entries via `worktree-gc` / the tick. Closes #299.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,10 @@ name = "worktree_gc_test"
 path = "tests/repo/worktree_gc_test.rs"
 
 [[test]]
+name = "worktree_review_test"
+path = "tests/repo/worktree_review_test.rs"
+
+[[test]]
 name = "worktree_remove_test"
 path = "tests/repo/worktree_remove_test.rs"
 

--- a/docs/architecture/auto-review.md
+++ b/docs/architecture/auto-review.md
@@ -84,6 +84,19 @@ the frozen `head_sha`; it is never recomputed from a re-resolved base.
 (`git merge-base` already runs through the hardened GitRunner for ancestor
 checks; the review diff computation reuses it.)
 
+### 2.3 Checkout model (#299)
+
+The review worktree is materialised as a **detached HEAD at the exact frozen
+`head_sha`**, created against the daemon-owned bare mirror
+(`git worktree add --detach <path> <head_sha>` after the `#297` SHA-anchored
+fetch). No issue-dispatch branch is created — review worktrees are
+non-pushable by construction (no `refs/heads/*` artefact ever exists). The
+worktree lives at `<repo_storage_root>/worktrees/review/<owner>/<repo>/<run_id>/`
+and carries a `review-worktree.json` sidecar persisting `base_sha`, `base_ref`,
+and the admission-computed `merge_base` (frozen context, §2.1); the review diff
+is always `git diff <merge_base> <head_sha>` (§2.2). Stale review worktrees are
+reclaimed by the review reaper (`worktree-gc` / tick step 3.5).
+
 ---
 
 ## 3. Domain model

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -545,10 +545,21 @@ fn run_worktree_gc(older_than_days: u64, dry_run: bool) -> CaduceusResult<()> {
             stderr: format!("build tokio runtime: {err}"),
         })?;
     let removed = rt.block_on(caduceus::worktree::gc(&config, older_than_days, dry_run))?;
+    let review_removed = {
+        let runner = caduceus::worktree::GitRunner::new(&config);
+        rt.block_on(caduceus::repo::review_worktree::gc_review_worktrees(
+            &config,
+            &runner,
+            older_than_days,
+            dry_run,
+        ))?
+    };
     if dry_run {
         println!("caduceus worktree-gc: dry-run complete; 0 worktrees removed (use without --dry-run to apply)");
     } else {
-        println!("caduceus worktree-gc: removed {removed} worktree(s)");
+        println!(
+            "caduceus worktree-gc: removed {removed} worktree(s) and {review_removed} review worktree(s)"
+        );
     }
     Ok(())
 }

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -393,6 +393,22 @@ pub async fn tick(
                         tracing::warn!(error = %err, "auto worktree gc failed; continuing tick")
                     }
                 }
+                // Review worktree sweep (#299): same lock, same
+                // best-effort log-and-continue contract.
+                let review_runner = GitRunner::new(&cfg);
+                match crate::repo::review_worktree::gc_review_worktrees(
+                    &cfg,
+                    &review_runner,
+                    cfg.worktree_gc_older_than_days,
+                    false,
+                )
+                .await
+                {
+                    Ok(removed) => info!(removed, "review worktree gc completed"),
+                    Err(err) => {
+                        tracing::warn!(error = %err, "review worktree gc failed; continuing tick")
+                    }
+                }
             }
             Ok(None) => info!("auto worktree gc skipped; daemon lock is contended"),
             Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub use crate::daemon::orchestration::{
 };
 pub use crate::github::issue::{IssueDetail, IssueKey};
 pub use crate::infra::error::{CaduceusError, CaduceusResult};
+pub use crate::repo::review_worktree::ReviewWorktree as RepoReviewWorktree;
 pub use crate::repo::worktree::Worktree as RepoWorktree;
 pub use crate::scheduler::{Admission, CircuitStore, Pool, PoolState};
 pub use crate::state::queue::{

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -3,8 +3,10 @@
 //! Every git subprocess created here goes through the hardened `GitRunner`.
 
 pub mod mirror;
+pub mod review_worktree;
 pub mod storage;
 pub mod worktree;
 
 pub use mirror::BareMirror;
+pub use review_worktree::{ReviewWorktree, ReviewWorktreeMetadata};
 pub use storage::Storage;

--- a/src/repo/review_worktree.rs
+++ b/src/repo/review_worktree.rs
@@ -481,17 +481,24 @@ pub async fn gc_review_worktrees(
             .join("mirrors")
             .join(&owner)
             .join(format!("{repo_name}.git"));
-        if !mirror_path.is_dir() {
-            continue;
-        }
-        let mirror = BareMirror {
-            path: mirror_path,
-            remote_url: String::new(),
+        // A missing mirror means no git registration can exist, so the
+        // registration set is empty and the orphan sweep is the only
+        // work (crash leftovers with no mirror are swept, not skipped).
+        let mirror_opt = if mirror_path.is_dir() {
+            Some(BareMirror {
+                path: mirror_path,
+                remote_url: String::new(),
+            })
+        } else {
+            None
         };
 
         let in_use = collect_review_in_use_paths(cfg, &owner, &repo_name)?;
 
-        let entries = list_review_worktrees_porcelain(runner, &mirror.path).await?;
+        let entries = match &mirror_opt {
+            Some(mirror) => list_review_worktrees_porcelain(runner, &mirror.path).await?,
+            None => Vec::new(),
+        };
 
         // Registered canonical paths for the orphan sweep.
         let registered_paths: std::collections::HashSet<PathBuf> = entries
@@ -533,6 +540,19 @@ pub async fn gc_review_worktrees(
                 continue;
             }
 
+            // A registered worktree implies its mirror exists (the
+            // registration lives in the mirror's metadata). Defensive
+            // skip if that invariant broke.
+            let mirror = match &mirror_opt {
+                Some(m) => m.clone(),
+                None => {
+                    eprintln!(
+                        "caduceus worktree-gc: cannot remove {} without its mirror",
+                        entry.path.display()
+                    );
+                    continue;
+                }
+            };
             let run_id = entry
                 .path
                 .file_name()

--- a/src/repo/review_worktree.rs
+++ b/src/repo/review_worktree.rs
@@ -528,6 +528,14 @@ pub async fn gc_review_worktrees(
             entries.iter().map(|e| canonical_or_raw(&e.path)).collect();
 
         for entry in &entries {
+            // The mirror's own porcelain entry
+            // (`worktree <mirror>` + `bare`) is not a worktree to
+            // sweep.
+            if let Some(mirror) = &mirror_opt {
+                if entry.path == mirror.path {
+                    continue;
+                }
+            }
             // Only detached review entries are swept; a branch-based
             // worktree in the review dir is an anomaly — refuse, do
             // not sweep.

--- a/src/repo/review_worktree.rs
+++ b/src/repo/review_worktree.rs
@@ -1,0 +1,828 @@
+//! Review worktrees: disposable, detached-HEAD checkouts at an exact
+//! PR head SHA, created against the daemon-owned bare mirror.
+//!
+//! The issue-dispatch worktree path (`worktree::Worktree`, branch-based)
+//! is deliberately untouched: a review worktree is detached by
+//! construction (DAR §6.1 — no synthetic `IssueKey`, no branch name at
+//! the type level) and **non-pushable by construction** — no
+//! `refs/heads/*` artefact is created and the create flow performs no
+//! push-side git operation; the mirror's `origin` remote is only ever
+//! fetched.
+//!
+//! Dir shape (D3): `<repo_storage_root>/worktrees/review/<owner>/<repo>/<run_id>/`
+//! — namespaced under a literal `review/` segment so the review sweep
+//! (GC) can iterate per mirror and no future co-tenant of the flat
+//! `worktrees/` namespace can collide.
+//!
+//! The metadata sidecar (`review-worktree.json`, written once at
+//! materialisation) carries the frozen `ReviewTarget` context
+//! (`base_sha`, `base_ref`, the persisted `merge_base`) so the prompt
+//! builder (#303) and dispatch (#339) can read it without a live
+//! handle — the merge-base (three-dot) diff is
+//! `git diff <merge_base> <head_sha>` (DAR §2.2).
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::infra::config::Config;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::review::{
+    RepositoryId, ReviewTarget, MAX_REF_BYTES, MAX_REPO_COMPONENT_BYTES, MAX_RUN_ID_BYTES,
+    MAX_SHA_BYTES,
+};
+use crate::worktree::GitRunner;
+
+use super::mirror::BareMirror;
+use super::storage::Storage;
+use super::worktree::validate_run_id;
+
+/// Schema version of the review-worktree metadata sidecar.
+pub const REVIEW_WORKTREE_SCHEMA_VERSION: u32 = 1;
+
+/// A disposable review worktree: detached HEAD at the exact PR head
+/// SHA, created against the daemon-owned bare mirror. Non-pushable by
+/// construction (no branch ref exists to push; the create flow
+/// performs no push-side git operation).
+#[derive(Clone, Debug)]
+pub struct ReviewWorktree {
+    /// The bare mirror this worktree was created from.
+    pub mirror: BareMirror,
+    /// Daemon-allocated execution identifier (directory basename).
+    pub run_id: String,
+    /// `<repo_storage_root>/worktrees/review/<owner>/<repo>/<run_id>/`
+    pub path: PathBuf,
+    /// The exact PR head SHA checked out (identity, DAR §2.1).
+    pub head_sha: String,
+    /// Metadata sidecar path: `<path>/review-worktree.json`.
+    pub metadata_path: PathBuf,
+    /// When this worktree was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Persisted review-worktree metadata (DAR §2.1 context). Written once
+/// at materialisation; read by #303 (merge-base diff) and #339.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct ReviewWorktreeMetadata {
+    /// Sidecar schema version; must equal
+    /// [`REVIEW_WORKTREE_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    pub run_id: String,
+    pub repository: RepositoryId,
+    pub pull_request: u64,
+    /// Identity (DAR §2.1) — the exact checked-out SHA.
+    pub head_sha: String,
+    /// Context, frozen at admission; never a diff endpoint.
+    pub base_sha: String,
+    pub base_ref: String,
+    /// Persisted merge base (DAR §2.1) — the three-dot diff anchor.
+    pub merge_base: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ReviewWorktree {
+    /// Materialise the review worktree for `target` (#299 primitive).
+    ///
+    /// Flow: (1) validate inputs; (2) SHA-anchored re-fetch via
+    /// `BareMirror::fetch_sha` (idempotent; surfaces
+    /// `HeadShaUnavailable` here — AC 4); (3) resolve the review dir
+    /// (D3); (4) refuse existing path (`WorktreeReuseAfterFailure`);
+    /// (5) `git worktree add --detach <path> <head_sha>` from the
+    /// mirror (umask 0o022 → restore); (6) write the metadata sidecar
+    /// (D2); (7) verify `HEAD == head_sha` via
+    /// `git -C <path> rev-parse HEAD` (AC 1 enforcement at runtime);
+    /// (8) return the handle. A failure between (5) and (7) tears the
+    /// worktree down — no half-materialised state.
+    pub async fn create_review(
+        runner: &GitRunner,
+        mirror: &BareMirror,
+        run_id: &str,
+        target: &ReviewTarget,
+    ) -> CaduceusResult<Self> {
+        validate_run_id(run_id)?;
+        crate::review::validate_review_target(target)?;
+
+        // D5: the SHA-anchored re-fetch happens before any path work;
+        // HeadShaUnavailable surfaces at this boundary (AC 4).
+        mirror.fetch_sha(runner, &target.head_sha).await?;
+
+        // D3: resolve the namespaced review dir under the storage root.
+        let worktree_path = review_worktree_path(
+            mirror,
+            &target.repository.owner,
+            &target.repository.repo,
+            run_id,
+        )?;
+
+        // D4: refuse to reuse a path from a prior attempt.
+        if worktree_path.exists() {
+            return Err(CaduceusError::WorktreeReuseAfterFailure {
+                run_id: run_id.to_string(),
+                worktree_path,
+                last_state: "exists".to_string(),
+            });
+        }
+
+        let parent_dir = worktree_path.parent().ok_or_else(|| CaduceusError::Worktree {
+            context: "review-create",
+            stderr: format!(
+                "worktree path {} has no parent directory",
+                worktree_path.display()
+            ),
+        })?;
+        std::fs::create_dir_all(parent_dir).map_err(|err| CaduceusError::Worktree {
+            context: "review-create",
+            stderr: format!("create review dir {} failed: {err}", parent_dir.display()),
+        })?;
+
+        let path_str = worktree_path.to_string_lossy().into_owned();
+        let mirror_str = mirror.path.to_string_lossy().into_owned();
+
+        // The umask is switched to 0o022 for the worktree-add call so
+        // source-file executable bits are preserved, and restored
+        // afterwards. The spawn in the runner's `run_args` is
+        // synchronous (command.spawn() before any await points), so
+        // the child inherits the temporary umask.
+        let prev = nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o022));
+        let add_result = runner
+            .run_args(
+                "review-worktree-add",
+                [
+                    "-C",
+                    &mirror_str,
+                    "worktree",
+                    "add",
+                    "--detach",
+                    &path_str,
+                    &target.head_sha,
+                ],
+            )
+            .await;
+        nix::sys::stat::umask(prev);
+        let add_output = add_result?;
+
+        if add_output.cancelled {
+            return Err(CaduceusError::Cancelled);
+        }
+        if add_output.timed_out || add_output.status != Some(0) {
+            return Err(CaduceusError::Worktree {
+                context: "review-create",
+                stderr: format!(
+                    "git worktree add --detach {} {} failed: {}",
+                    worktree_path.display(),
+                    target.head_sha,
+                    add_output.stderr
+                ),
+            });
+        }
+
+        let created_at = Utc::now();
+        let metadata_path = worktree_path.join("review-worktree.json");
+        let handle = Self {
+            mirror: mirror.clone(),
+            run_id: run_id.to_string(),
+            path: worktree_path.clone(),
+            head_sha: target.head_sha.clone(),
+            metadata_path: metadata_path.clone(),
+            created_at,
+        };
+
+        // D2: write the metadata sidecar. On failure, tear the
+        // checkout down — no half-materialised state.
+        let metadata = ReviewWorktreeMetadata {
+            schema_version: REVIEW_WORKTREE_SCHEMA_VERSION,
+            run_id: run_id.to_string(),
+            repository: target.repository.clone(),
+            pull_request: target.pull_request,
+            head_sha: target.head_sha.clone(),
+            base_sha: target.base_sha.clone(),
+            base_ref: target.base_ref.clone(),
+            merge_base: target.merge_base.clone(),
+            created_at,
+        };
+        let bytes = serde_json::to_vec_pretty(&metadata).map_err(|err| CaduceusError::Worktree {
+            context: "review-create",
+            stderr: format!("serialise review metadata: {err}"),
+        })?;
+        if let Err(err) = std::fs::write(&metadata_path, bytes) {
+            let _ = Self::remove(runner, &handle).await;
+            return Err(CaduceusError::Worktree {
+                context: "review-create",
+                stderr: format!(
+                    "write review metadata {} failed: {err}",
+                    metadata_path.display()
+                ),
+            });
+        }
+
+        // AC 1 enforcement at runtime: the checked-out HEAD must equal
+        // the requested head_sha.
+        let head_output = runner
+            .run_args(
+                "review-head-verify",
+                ["-C", &worktree_path.to_string_lossy(), "rev-parse", "HEAD"],
+            )
+            .await?;
+        if head_output.cancelled {
+            let _ = Self::remove(runner, &handle).await;
+            return Err(CaduceusError::Cancelled);
+        }
+        if head_output.timed_out || head_output.status != Some(0) {
+            let _ = Self::remove(runner, &handle).await;
+            return Err(CaduceusError::Worktree {
+                context: "review-create",
+                stderr: format!("verify review HEAD failed: {}", head_output.stderr),
+            });
+        }
+        let head = head_output.stdout.trim().to_string();
+        if head != target.head_sha {
+            let _ = Self::remove(runner, &handle).await;
+            return Err(CaduceusError::Worktree {
+                context: "review-create",
+                stderr: format!(
+                    "review worktree HEAD {head} != requested head_sha {}",
+                    target.head_sha
+                ),
+            });
+        }
+
+        Ok(handle)
+    }
+
+    /// Load the persisted metadata sidecar (for #303/#339 and the
+    /// reaper's orphan sweep).
+    pub fn load_metadata(&self) -> CaduceusResult<ReviewWorktreeMetadata> {
+        let raw = std::fs::read_to_string(&self.metadata_path).map_err(|err| {
+            CaduceusError::Worktree {
+                context: "review-load",
+                stderr: format!(
+                    "read review metadata {} failed: {err}",
+                    self.metadata_path.display()
+                ),
+            }
+        })?;
+        let meta: ReviewWorktreeMetadata =
+            serde_json::from_str(&raw).map_err(|err| CaduceusError::Worktree {
+                context: "review-load",
+                stderr: format!(
+                    "parse review metadata {} failed: {err}",
+                    self.metadata_path.display()
+                ),
+            })?;
+        validate_review_worktree_metadata(&meta)?;
+        Ok(meta)
+    }
+
+    /// Remove: `git worktree remove --force` from the mirror +
+    /// filesystem fallback + `worktree prune`. No branch ref can
+    /// exist (nothing created one), so "no leftover refs" (AC 5)
+    /// holds by construction; tests assert it anyway.
+    pub async fn remove(runner: &GitRunner, worktree: &Self) -> CaduceusResult<()> {
+        let path_str = worktree.path.to_string_lossy().into_owned();
+        let mirror_str = worktree.mirror.path.to_string_lossy().into_owned();
+        let output = runner
+            .run_args(
+                "review-worktree-remove",
+                [
+                    "-C",
+                    &mirror_str,
+                    "worktree",
+                    "remove",
+                    "--force",
+                    &path_str,
+                ],
+            )
+            .await?;
+
+        if output.cancelled {
+            return Err(CaduceusError::Cancelled);
+        }
+
+        // `git worktree remove --force` returns nonzero for
+        // filesystem errors; clean up what we can regardless.
+        if worktree.path.exists() {
+            std::fs::remove_dir_all(&worktree.path).map_err(|err| CaduceusError::Worktree {
+                context: "review-remove",
+                stderr: format!(
+                    "fs remove_dir_all {} failed: {err}",
+                    worktree.path.display()
+                ),
+            })?;
+        }
+
+        // Best-effort registration prune: clears stale entries left
+        // when the removal above raced a directory deletion.
+        let _ = runner
+            .run_args(
+                "review-worktree-prune",
+                ["-C", &mirror_str, "worktree", "prune"],
+            )
+            .await;
+
+        Ok(())
+    }
+}
+
+/// Resolve the review worktree path for `(owner, repo, run_id)` under
+/// the storage root derived from the mirror path:
+/// `<storage>/mirrors/<owner>/<repo>.git/` → `<storage>` →
+/// `<storage>/worktrees/review/<owner>/<repo>/<run_id>/`.
+fn review_worktree_path(
+    mirror: &BareMirror,
+    owner: &str,
+    repo: &str,
+    run_id: &str,
+) -> CaduceusResult<PathBuf> {
+    let storage_root = mirror
+        .path
+        .parent() // <owner>/
+        .and_then(|p| p.parent()) // mirrors/
+        .and_then(|p| p.parent()) // <storage>/
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| {
+            CaduceusError::Config("cannot resolve storage root from mirror path".to_string())
+        })?;
+
+    // Guard (Risk 2): the mirror must actually live under
+    // `<storage>/mirrors/` so the walk cannot land somewhere
+    // unexpected.
+    let mirrors_dir = storage_root.join("mirrors");
+    if !mirror.path.starts_with(&mirrors_dir) {
+        return Err(CaduceusError::Config(format!(
+            "mirror path {} does not live under {}",
+            mirror.path.display(),
+            mirrors_dir.display()
+        )));
+    }
+
+    Ok(storage_root
+        .join("worktrees")
+        .join("review")
+        .join(owner)
+        .join(repo)
+        .join(run_id))
+}
+
+/// Required string: non-empty and at most `max` bytes (same shape as
+/// `review::validate_review_target`'s helper; the review-module
+/// helpers are private so this is a local copy).
+fn required_string(scope: &str, field: &str, value: &str, max: usize) -> CaduceusResult<()> {
+    if value.is_empty() {
+        return Err(CaduceusError::Config(format!(
+            "{scope}: {field} must not be empty"
+        )));
+    }
+    if value.len() > max {
+        return Err(CaduceusError::Config(format!(
+            "{scope}: {field} exceeds limit of {max} bytes (got {})",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Cap validation for a [`ReviewWorktreeMetadata`] document.
+fn validate_review_worktree_metadata(meta: &ReviewWorktreeMetadata) -> CaduceusResult<()> {
+    if meta.schema_version != REVIEW_WORKTREE_SCHEMA_VERSION {
+        return Err(CaduceusError::Config(format!(
+            "review worktree metadata: schema_version {} is not supported \
+             (this daemon accepts {REVIEW_WORKTREE_SCHEMA_VERSION})",
+            meta.schema_version
+        )));
+    }
+    required_string("review worktree metadata", "run_id", &meta.run_id, MAX_RUN_ID_BYTES)?;
+    required_string(
+        "review worktree metadata",
+        "repository.owner",
+        &meta.repository.owner,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    required_string(
+        "review worktree metadata",
+        "repository.repo",
+        &meta.repository.repo,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    required_string("review worktree metadata", "head_sha", &meta.head_sha, MAX_SHA_BYTES)?;
+    required_string("review worktree metadata", "base_sha", &meta.base_sha, MAX_SHA_BYTES)?;
+    required_string("review worktree metadata", "base_ref", &meta.base_ref, MAX_REF_BYTES)?;
+    required_string(
+        "review worktree metadata",
+        "merge_base",
+        &meta.merge_base,
+        MAX_SHA_BYTES,
+    )?;
+    Ok(())
+}
+
+/// Sweep stale review worktrees across the configured repositories
+/// (DAR §15, AC 5 second half).
+///
+/// For each watched repo the sweep:
+///
+/// 1. resolves `worktrees/review/<owner>/<repo>/` under
+///    `cfg.repo_storage_root` (skip when absent);
+/// 2. reads `git worktree list --porcelain` from the matching mirror
+///    and parses the detached entries (`worktree <path>` + `HEAD
+///    <sha>` + `detached` triples — a review-side parser, NOT the
+///    state-dir parser which deliberately drops detached entries);
+/// 3. protects in-use entries: any `.claim` file whose
+///    `worktree_path` matches, or a fresh
+///    `<state_dir>/runs/<run_id>.heartbeat` whose run_id matches the
+///    worktree directory basename;
+/// 4. removes entries whose directory mtime is older than
+///    `older_than_days` via [`ReviewWorktree::remove`] (sidecar load
+///    is best-effort — a missing sidecar does not block sweeping);
+/// 5. sweeps orphan directories that git no longer registers, with
+///    the same age + in-use + symlink checks (refuses symlinks).
+///
+/// `dry_run = true` reports what would be removed without mutating
+/// state. Returns the number of worktrees actually removed.
+pub async fn gc_review_worktrees(
+    cfg: &Config,
+    runner: &GitRunner,
+    older_than_days: u64,
+    dry_run: bool,
+) -> CaduceusResult<u64> {
+    // TOCTOU: validate the storage root before any sweep work.
+    Storage::new(cfg.repo_storage_root.clone()).validate_root()?;
+
+    let now = Utc::now();
+    let age_cutoff = now - chrono::Duration::days(older_than_days as i64);
+
+    let mut total_removed: u64 = 0;
+    for repo in &cfg.watched_repos {
+        let (owner, repo_name) = match parse_watched_repo(repo) {
+            Some(p) => p,
+            None => {
+                tracing::warn!(
+                    entry = %repo,
+                    "review worktree gc: invalid watched_repos entry"
+                );
+                continue;
+            }
+        };
+
+        let review_repo_dir = cfg
+            .repo_storage_root
+            .join("worktrees")
+            .join("review")
+            .join(&owner)
+            .join(&repo_name);
+        if !review_repo_dir.is_dir() {
+            continue;
+        }
+
+        let mirror_path = cfg
+            .repo_storage_root
+            .join("mirrors")
+            .join(&owner)
+            .join(format!("{repo_name}.git"));
+        if !mirror_path.is_dir() {
+            continue;
+        }
+        let mirror = BareMirror {
+            path: mirror_path,
+            remote_url: String::new(),
+        };
+
+        let in_use = collect_review_in_use_paths(cfg, &owner, &repo_name)?;
+
+        let entries = list_review_worktrees_porcelain(runner, &mirror.path).await?;
+
+        // Registered canonical paths for the orphan sweep.
+        let registered_paths: std::collections::HashSet<PathBuf> = entries
+            .iter()
+            .map(|e| canonical_or_raw(&e.path))
+            .collect();
+
+        for entry in &entries {
+            // Only detached review entries are swept; a branch-based
+            // worktree in the review dir is an anomaly — refuse, do
+            // not sweep.
+            if !entry.detached {
+                tracing::warn!(
+                    path = %entry.path.display(),
+                    "review worktree gc: skipping non-detached entry"
+                );
+                continue;
+            }
+
+            let canonical = canonical_or_raw(&entry.path);
+            if in_use.contains(&canonical) {
+                continue;
+            }
+
+            let mtime = match mtime_of(&entry.path) {
+                Some(t) => t,
+                None => continue, // can't tell → leave alone
+            };
+            if mtime > age_cutoff {
+                continue;
+            }
+
+            if dry_run {
+                println!(
+                    "would remove review worktree {} (head {})",
+                    entry.path.display(),
+                    entry.head
+                );
+                continue;
+            }
+
+            let run_id = entry
+                .path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            let handle = ReviewWorktree {
+                mirror: mirror.clone(),
+                run_id,
+                path: entry.path.clone(),
+                head_sha: entry.head.clone(),
+                metadata_path: entry.path.join("review-worktree.json"),
+                created_at: mtime,
+            };
+            // Sidecar load is best-effort: a missing/corrupt sidecar
+            // (crash between checkout and metadata write) must not
+            // block sweeping.
+            let _ = handle.load_metadata();
+            match ReviewWorktree::remove(runner, &handle).await {
+                Ok(()) => {
+                    total_removed += 1;
+                    println!(
+                        "removed review worktree {} (head {})",
+                        entry.path.display(),
+                        entry.head
+                    );
+                }
+                Err(err) => {
+                    eprintln!(
+                        "caduceus worktree-gc: remove {} failed: {err}",
+                        entry.path.display()
+                    );
+                }
+            }
+        }
+
+        // Orphan sweep: unregistered directories under the per-repo
+        // review dir. Git cannot remove what it does not know, so
+        // orphans are removed with a direct `fs::remove_dir_all`.
+        let orphans = collect_review_orphans(&review_repo_dir, &registered_paths, &in_use, age_cutoff);
+        for orphan in orphans {
+            if dry_run {
+                println!("would remove review orphan {}", orphan.display());
+                continue;
+            }
+            match std::fs::remove_dir_all(&orphan) {
+                Ok(()) => {
+                    total_removed += 1;
+                    println!("removed review orphan {}", orphan.display());
+                }
+                Err(err) => {
+                    eprintln!(
+                        "caduceus worktree-gc: review orphan remove {} failed: {err}",
+                        orphan.display()
+                    );
+                }
+            }
+        }
+    }
+    Ok(total_removed)
+}
+
+/// Parse `git worktree list --porcelain` output into detached review
+/// entries, keeping the `worktree <path>` + `HEAD <sha>` + `detached`
+/// triple. Entries without `detached` are returned with
+/// `detached == false` so the caller can refuse (not sweep) them.
+fn parse_review_porcelain(stdout: &str) -> Vec<ReviewPorcelainEntry> {
+    let mut entries: Vec<ReviewPorcelainEntry> = Vec::new();
+    let mut current: Option<ReviewPorcelainEntry> = None;
+    for line in stdout.lines() {
+        if line.is_empty() {
+            if let Some(e) = current.take() {
+                entries.push(e);
+            }
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            if let Some(e) = current.take() {
+                entries.push(e);
+            }
+            current = Some(ReviewPorcelainEntry {
+                path: PathBuf::from(rest.trim()),
+                head: String::new(),
+                detached: false,
+            });
+        } else if let Some(rest) = line.strip_prefix("HEAD ") {
+            if let Some(e) = current.as_mut() {
+                e.head = rest.trim().to_string();
+            }
+        } else if line.strip_prefix("detached").is_some() {
+            if let Some(e) = current.as_mut() {
+                e.detached = true;
+            }
+        }
+    }
+    if let Some(e) = current.take() {
+        entries.push(e);
+    }
+    entries
+}
+
+/// One detached review entry of `git worktree list --porcelain`.
+#[derive(Debug, Clone)]
+struct ReviewPorcelainEntry {
+    path: PathBuf,
+    head: String,
+    detached: bool,
+}
+
+/// Read `git worktree list --porcelain` for a mirror and return the
+/// parsed entries.
+async fn list_review_worktrees_porcelain(
+    runner: &GitRunner,
+    mirror_path: &Path,
+) -> CaduceusResult<Vec<ReviewPorcelainEntry>> {
+    let mirror_str = mirror_path.to_string_lossy().into_owned();
+    let output = runner
+        .run_args(
+            "review-worktree-list",
+            ["-C", &mirror_str, "worktree", "list", "--porcelain"],
+        )
+        .await?;
+    if output.cancelled {
+        return Err(CaduceusError::Cancelled);
+    }
+    if output.timed_out || output.status != Some(0) {
+        return Err(CaduceusError::Worktree {
+            context: "review-gc",
+            stderr: format!("git worktree list --porcelain failed: {}", output.stderr),
+        });
+    }
+    Ok(parse_review_porcelain(&output.stdout))
+}
+
+/// Canonical worktree paths currently referenced by an active claim
+/// file or a fresh heartbeat, scoped to one `(owner, repo)`.
+/// Freshness for heartbeats is mtime within the last hour (twice the
+/// documented 30-minute heartbeat interval) — same semantics as the
+/// state-dir GC.
+fn collect_review_in_use_paths(
+    cfg: &Config,
+    owner: &str,
+    repo: &str,
+) -> CaduceusResult<std::collections::HashSet<PathBuf>> {
+    let mut paths: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+
+    // Claims: every `.claim` file under `<state_dir>/claims/` whose
+    // parsed `worktree_path` matches. Review claims don't have an
+    // IssueKey digest — the GC reads all claim files, path-keyed.
+    let claims_dir = cfg.state_dir.join("claims");
+    if claims_dir.is_dir() {
+        let entries = std::fs::read_dir(&claims_dir).map_err(|err| CaduceusError::Worktree {
+            context: "review-gc",
+            stderr: format!("read_dir {}: {err}", claims_dir.display()),
+        })?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.ends_with(".claim"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            if let Ok(bytes) = std::fs::read(&path) {
+                if let Ok(body) =
+                    serde_json::from_slice::<crate::state::queue::ClaimFileBody>(&bytes)
+                {
+                    if let Some(wt) = body.worktree_path {
+                        paths.insert(canonical_or_raw(&wt));
+                    }
+                }
+            }
+        }
+    }
+
+    // Heartbeats: a fresh `<state_dir>/runs/<run_id>.heartbeat`
+    // protects `worktrees/review/<owner>/<repo>/<run_id>`.
+    let runs = cfg.state_dir.join("runs");
+    if runs.is_dir() {
+        let heartbeat_fresh_cutoff = Utc::now() - chrono::Duration::hours(1);
+        let entries = std::fs::read_dir(&runs).map_err(|err| CaduceusError::Worktree {
+            context: "review-gc",
+            stderr: format!("read_dir {}: {err}", runs.display()),
+        })?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if !name.ends_with(".heartbeat") {
+                continue;
+            }
+            let mtime = match mtime_of(&path) {
+                Some(t) => t,
+                None => continue,
+            };
+            if mtime < heartbeat_fresh_cutoff {
+                continue;
+            }
+            let run_id = name.trim_end_matches(".heartbeat");
+            let candidate = cfg
+                .repo_storage_root
+                .join("worktrees")
+                .join("review")
+                .join(owner)
+                .join(repo)
+                .join(run_id);
+            if candidate.is_dir() {
+                paths.insert(canonical_or_raw(&candidate));
+            }
+        }
+    }
+    Ok(paths)
+}
+
+/// Find unregistered directories under the per-repo review dir that
+/// the sweep may remove: regular dirs (not symlinks), not registered,
+/// not in use, old enough.
+fn collect_review_orphans(
+    review_repo_dir: &Path,
+    registered_paths: &std::collections::HashSet<PathBuf>,
+    in_use: &std::collections::HashSet<PathBuf>,
+    age_cutoff: DateTime<Utc>,
+) -> Vec<PathBuf> {
+    if !review_repo_dir.is_dir() {
+        return Vec::new();
+    }
+    let mut orphans = Vec::new();
+    let entries = match std::fs::read_dir(review_repo_dir) {
+        Ok(rd) => rd,
+        Err(_) => return orphans,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Reject symlinks. The daemon never follows them.
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            eprintln!(
+                "caduceus worktree-gc: refusing review orphan {}: is a symlink",
+                path.display()
+            );
+            continue;
+        }
+        if !meta.is_dir() {
+            continue;
+        }
+        if entry.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let canonical = canonical_or_raw(&path);
+        if registered_paths.contains(&canonical) {
+            continue;
+        }
+        if in_use.contains(&canonical) {
+            continue;
+        }
+        let mtime = match mtime_of(&canonical) {
+            Some(t) => t,
+            None => continue,
+        };
+        if mtime > age_cutoff {
+            continue;
+        }
+        orphans.push(path);
+    }
+    orphans
+}
+
+/// mtime as a `DateTime<Utc>`, or `None` if it cannot be determined.
+fn mtime_of(path: &Path) -> Option<DateTime<Utc>> {
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta.modified().ok()?;
+    Some(mtime.into())
+}
+
+/// Canonicalise a path, falling back to the raw path when the
+/// canonical form is unavailable.
+fn canonical_or_raw(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Parse a `watched_repos` entry like `owner/repo` into
+/// `(owner, repo)`.
+fn parse_watched_repo(s: &str) -> Option<(String, String)> {
+    let (owner, repo) = s.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}

--- a/src/repo/review_worktree.rs
+++ b/src/repo/review_worktree.rs
@@ -126,13 +126,15 @@ impl ReviewWorktree {
             });
         }
 
-        let parent_dir = worktree_path.parent().ok_or_else(|| CaduceusError::Worktree {
-            context: "review-create",
-            stderr: format!(
-                "worktree path {} has no parent directory",
-                worktree_path.display()
-            ),
-        })?;
+        let parent_dir = worktree_path
+            .parent()
+            .ok_or_else(|| CaduceusError::Worktree {
+                context: "review-create",
+                stderr: format!(
+                    "worktree path {} has no parent directory",
+                    worktree_path.display()
+                ),
+            })?;
         std::fs::create_dir_all(parent_dir).map_err(|err| CaduceusError::Worktree {
             context: "review-create",
             stderr: format!("create review dir {} failed: {err}", parent_dir.display()),
@@ -203,10 +205,11 @@ impl ReviewWorktree {
             merge_base: target.merge_base.clone(),
             created_at,
         };
-        let bytes = serde_json::to_vec_pretty(&metadata).map_err(|err| CaduceusError::Worktree {
-            context: "review-create",
-            stderr: format!("serialise review metadata: {err}"),
-        })?;
+        let bytes =
+            serde_json::to_vec_pretty(&metadata).map_err(|err| CaduceusError::Worktree {
+                context: "review-create",
+                stderr: format!("serialise review metadata: {err}"),
+            })?;
         if let Err(err) = std::fs::write(&metadata_path, bytes) {
             let _ = Self::remove(runner, &handle).await;
             return Err(CaduceusError::Worktree {
@@ -393,7 +396,12 @@ fn validate_review_worktree_metadata(meta: &ReviewWorktreeMetadata) -> CaduceusR
             meta.schema_version
         )));
     }
-    required_string("review worktree metadata", "run_id", &meta.run_id, MAX_RUN_ID_BYTES)?;
+    required_string(
+        "review worktree metadata",
+        "run_id",
+        &meta.run_id,
+        MAX_RUN_ID_BYTES,
+    )?;
     required_string(
         "review worktree metadata",
         "repository.owner",
@@ -406,9 +414,24 @@ fn validate_review_worktree_metadata(meta: &ReviewWorktreeMetadata) -> CaduceusR
         &meta.repository.repo,
         MAX_REPO_COMPONENT_BYTES,
     )?;
-    required_string("review worktree metadata", "head_sha", &meta.head_sha, MAX_SHA_BYTES)?;
-    required_string("review worktree metadata", "base_sha", &meta.base_sha, MAX_SHA_BYTES)?;
-    required_string("review worktree metadata", "base_ref", &meta.base_ref, MAX_REF_BYTES)?;
+    required_string(
+        "review worktree metadata",
+        "head_sha",
+        &meta.head_sha,
+        MAX_SHA_BYTES,
+    )?;
+    required_string(
+        "review worktree metadata",
+        "base_sha",
+        &meta.base_sha,
+        MAX_SHA_BYTES,
+    )?;
+    required_string(
+        "review worktree metadata",
+        "base_ref",
+        &meta.base_ref,
+        MAX_REF_BYTES,
+    )?;
     required_string(
         "review worktree metadata",
         "merge_base",
@@ -501,10 +524,8 @@ pub async fn gc_review_worktrees(
         };
 
         // Registered canonical paths for the orphan sweep.
-        let registered_paths: std::collections::HashSet<PathBuf> = entries
-            .iter()
-            .map(|e| canonical_or_raw(&e.path))
-            .collect();
+        let registered_paths: std::collections::HashSet<PathBuf> =
+            entries.iter().map(|e| canonical_or_raw(&e.path)).collect();
 
         for entry in &entries {
             // Only detached review entries are swept; a branch-based
@@ -592,7 +613,8 @@ pub async fn gc_review_worktrees(
         // Orphan sweep: unregistered directories under the per-repo
         // review dir. Git cannot remove what it does not know, so
         // orphans are removed with a direct `fs::remove_dir_all`.
-        let orphans = collect_review_orphans(&review_repo_dir, &registered_paths, &in_use, age_cutoff);
+        let orphans =
+            collect_review_orphans(&review_repo_dir, &registered_paths, &in_use, age_cutoff);
         for orphan in orphans {
             if dry_run {
                 println!("would remove review orphan {}", orphan.display());

--- a/src/repo/worktree.rs
+++ b/src/repo/worktree.rs
@@ -30,8 +30,9 @@ pub struct Worktree {
 }
 
 /// Run ID validation: only ASCII alphanumeric, underscore, dash;
-/// non-empty; max 64 chars.
-fn validate_run_id(run_id: &str) -> CaduceusResult<()> {
+/// non-empty; max 64 chars. Shared with `review_worktree` (one
+/// definition — the review path validates run ids with the same rule).
+pub(crate) fn validate_run_id(run_id: &str) -> CaduceusResult<()> {
     if run_id.is_empty() {
         return Err(CaduceusError::Worktree {
             context: "repo-create",

--- a/tests/repo/worktree_review_test.rs
+++ b/tests/repo/worktree_review_test.rs
@@ -484,3 +484,163 @@ async fn review_worktree_remove_leaves_no_artefacts() {
         .to_path_buf();
     assert!(parent.is_dir(), "per-repo review dir must remain");
 }
+
+// ---------------------------------------------------------------------------
+// Reaper (AC 5 second half): gc_review_worktrees
+// ---------------------------------------------------------------------------
+
+/// Backdate a directory's mtime so the review GC treats it as stale.
+fn backdate_to_older_than(path: &Path, days: i64) {
+    let target = chrono::Utc::now() - chrono::Duration::days(days);
+    let ft = filetime::FileTime::from_unix_time(target.timestamp(), target.timestamp_subsec_nanos());
+    filetime::set_file_mtime(path, ft).expect("set mtime");
+}
+
+fn review_gc_config(root: &Path) -> Config {
+    let mut cfg = review_config(root);
+    cfg.watched_repos = vec!["rvowner/rvrepo".to_string()];
+    cfg
+}
+
+// The reaper removes a stale, unregistered review worktree and leaves
+// the mirror's refs untouched.
+#[tokio::test]
+async fn review_gc_removes_stale_review_worktree() {
+    let root = tempdir("rv-gc-stale");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_gc_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    let target = target_for("rvrepo", 20, &b, &a, &a);
+    let wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-stale-1", &target)
+        .await
+        .expect("create_review");
+    let refs_before = sorted_show_refs(&mirror.path);
+    backdate_to_older_than(&wt.path, 30);
+
+    let removed = caduceus::repo::review_worktree::gc_review_worktrees(&cfg, &runner, 7, false)
+        .await
+        .expect("gc");
+    assert_eq!(removed, 1, "one stale review worktree should be removed");
+    assert!(!wt.path.exists(), "stale worktree path should be gone");
+
+    let list = git_out(&mirror.path, &["worktree", "list", "--porcelain"]);
+    assert!(
+        !list.contains(&wt.path.to_string_lossy().to_string()),
+        "stale worktree registration should be gone"
+    );
+    assert_eq!(
+        sorted_show_refs(&mirror.path),
+        refs_before,
+        "gc must not change refs (none were ever created)"
+    );
+}
+
+// A fresh review worktree survives the sweep.
+#[tokio::test]
+async fn review_gc_retains_fresh_review_worktree() {
+    let root = tempdir("rv-gc-fresh");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_gc_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    let target = target_for("rvrepo", 21, &b, &a, &a);
+    let wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-fresh-1", &target)
+        .await
+        .expect("create_review");
+
+    let removed = caduceus::repo::review_worktree::gc_review_worktrees(&cfg, &runner, 7, false)
+        .await
+        .expect("gc");
+    assert_eq!(removed, 0, "fresh review worktree must be retained");
+    assert!(wt.path.exists());
+}
+
+// A stale worktree referenced by a live claim file is in use and
+// survives the sweep.
+#[tokio::test]
+async fn review_gc_retains_claimed_review_worktree() {
+    let root = tempdir("rv-gc-claimed");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_gc_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    let target = target_for("rvrepo", 22, &b, &a, &a);
+    let wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-claimed-1", &target)
+        .await
+        .expect("create_review");
+    backdate_to_older_than(&wt.path, 30);
+
+    // A claim file whose parsed worktree_path matches protects the
+    // worktree (the reaper reads all .claim files, path-keyed).
+    let claims_dir = cfg.state_dir.join("claims");
+    std::fs::create_dir_all(&claims_dir).expect("claims dir");
+    let claim_path = claims_dir.join("review-claimed.claim");
+    let body = serde_json::json!({
+        "version": 1,
+        "key": caduceus::issue::IssueKey {
+            owner: "rvowner".to_string(),
+            repo: "rvrepo".to_string(),
+            number: 22,
+        },
+        "run_id": "run-claimed-1",
+        "pid": 4_000_022_u32,
+        "process_start_identity": "<boot>:0",
+        "started_at": chrono::Utc::now(),
+        "worktree_path": wt.path,
+    });
+    std::fs::write(&claim_path, serde_json::to_vec(&body).unwrap()).expect("write claim");
+
+    let removed = caduceus::repo::review_worktree::gc_review_worktrees(&cfg, &runner, 7, false)
+        .await
+        .expect("gc");
+    assert_eq!(removed, 0, "an in-use review worktree must not be removed");
+    assert!(wt.path.exists());
+}
+
+// An unregistered orphan is swept; a symlinked orphan is refused.
+#[tokio::test]
+async fn review_gc_removes_orphan_without_registration() {
+    let root = tempdir("rv-gc-orphan");
+    let cfg = review_gc_config(&root);
+    let runner = GitRunner::new(&cfg);
+
+    // No mirror exists — the orphan sweep must still run (crash
+    // leftovers with no registration and no mirror are swept).
+    let review_repo_dir = cfg
+        .repo_storage_root
+        .join("worktrees")
+        .join("review")
+        .join("rvowner")
+        .join("rvrepo");
+    std::fs::create_dir_all(&review_repo_dir).expect("review dir");
+
+    let orphan = review_repo_dir.join("orphan-run");
+    std::fs::create_dir_all(&orphan).expect("orphan");
+    backdate_to_older_than(&orphan, 30);
+
+    let removed = caduceus::repo::review_worktree::gc_review_worktrees(&cfg, &runner, 7, false)
+        .await
+        .expect("gc");
+    assert_eq!(removed, 1, "orphan should be removed");
+    assert!(!orphan.exists(), "orphan should be gone");
+
+    // A symlinked entry is refused and survives.
+    let target = root.join("symlink-target");
+    std::fs::create_dir_all(&target).expect("target");
+    backdate_to_older_than(&target, 30);
+    let link = review_repo_dir.join("evil-link");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    let removed2 = caduceus::repo::review_worktree::gc_review_worktrees(&cfg, &runner, 7, false)
+        .await
+        .expect("gc");
+    assert_eq!(removed2, 0, "symlinks must not be removed");
+    assert!(link.exists(), "symlink must remain on disk");
+}

--- a/tests/repo/worktree_review_test.rs
+++ b/tests/repo/worktree_review_test.rs
@@ -1,0 +1,442 @@
+//! Review worktree mode (issue #299).
+//!
+//! Acceptance coverage:
+//! - AC1 — exact-SHA checkout (HEAD == head_sha, detached).
+//! - AC2 — metadata round-trip; merge-base diff three-dot, incl. the
+//!   base-moved fixture.
+//! - AC3 — no refs/heads/* artefacts (show-ref before/after).
+//! - AC4 — HeadShaUnavailable at the worktree boundary, pre-path.
+//! - AC5 — remove leaves no refs/registrations; reaper reclaims
+//!   stale entries, retains fresh/claimed ones, sweeps orphans,
+//!   refuses symlinks.
+
+use caduceus::config::Config;
+use caduceus::error::CaduceusError;
+use caduceus::repo::BareMirror;
+use caduceus::review::ReviewTarget;
+use caduceus::worktree::GitRunner;
+use caduceus::RepoReviewWorktree;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::path::Path;
+use std::process::Command;
+
+fn run_command(cmd: &mut Command) {
+    let output = cmd.output().expect("spawn command");
+    if !output.status.success() {
+        panic!(
+            "command {:?} failed: status={:?}\nstdout={}\nstderr={}",
+            cmd,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+/// Run `git` in *dir* and return trimmed stdout, panicking on
+/// failure.
+fn git_out(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("git {args:?}: {err}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// main = A; feature = B (child of A). Returns (A, B).
+fn init_bare_remote_with_feature(path: &Path) -> (String, String) {
+    run_command(Command::new("git").arg("init").arg("--bare").arg(path));
+    run_command(Command::new("git").current_dir(path).args([
+        "symbolic-ref",
+        "HEAD",
+        "refs/heads/main",
+    ]));
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
+        .output()
+        .expect("hash-object");
+    let tree = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["commit-tree", &tree, "-m", "initial"])
+        .output()
+        .expect("commit-tree");
+    let commit_a = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/main",
+        &commit_a,
+    ]));
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["commit-tree", &tree, "-p", &commit_a, "-m", "feature"])
+        .output()
+        .expect("commit-tree feature");
+    let commit_b = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/feature",
+        &commit_b,
+    ]));
+    (commit_a, commit_b)
+}
+
+/// Hash blob content into the object store (piped stdin).
+fn hash_blob_stdin(git_dir: &Path, content: &str) -> String {
+    use std::io::Write;
+    let mut child = Command::new("git")
+        .current_dir(git_dir)
+        .args(["hash-object", "-w", "--stdin"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn git hash-object");
+    child
+        .stdin
+        .take()
+        .expect("hash-object stdin")
+        .write_all(content.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait hash-object");
+    assert!(
+        out.status.success(),
+        "git hash-object --stdin failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Build a single-file tree object; returns the tree OID.
+fn tree_with_file(git_dir: &Path, name: &str, content: &str) -> String {
+    use std::io::Write;
+    let blob = hash_blob_stdin(git_dir, content);
+    let entry = format!("100644 blob {blob}\t{name}\n");
+    let mut child = Command::new("git")
+        .current_dir(git_dir)
+        .args(["mktree"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn git mktree");
+    child
+        .stdin
+        .take()
+        .expect("mktree stdin")
+        .write_all(entry.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait mktree");
+    assert!(
+        out.status.success(),
+        "git mktree failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// main = A → A' (base moved); feature = B (child of A).
+/// Returns (A, A_prime, B).
+///
+/// B's tree touches `feature.txt`; A' touches `base-moved.txt`, so
+/// endpoint-to-endpoint `git diff A' B` would list both files while
+/// the merge-base form `git diff A B` lists only `feature.txt`.
+fn init_bare_remote_base_moved(path: &Path) -> (String, String, String) {
+    run_command(Command::new("git").arg("init").arg("--bare").arg(path));
+    run_command(Command::new("git").current_dir(path).args([
+        "symbolic-ref",
+        "HEAD",
+        "refs/heads/main",
+    ]));
+
+    // A: empty tree on main.
+    let empty_tree = git_out(path, &["hash-object", "-w", "-t", "tree", "/dev/null"]);
+    let a = git_out(path, &["commit-tree", &empty_tree, "-m", "initial"]);
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/main",
+        &a,
+    ]));
+
+    // B: child of A touching feature.txt.
+    let feature_tree = tree_with_file(path, "feature.txt", "feature content\n");
+    let b = git_out(path, &["commit-tree", &feature_tree, "-p", &a, "-m", "feature"]);
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/feature",
+        &b,
+    ]));
+
+    // A': child of A touching base-moved.txt; main moves past B.
+    let moved_tree = tree_with_file(path, "base-moved.txt", "moved content\n");
+    let a_prime = git_out(
+        path,
+        &["commit-tree", &moved_tree, "-p", &a, "-m", "base moved"],
+    );
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/main",
+        &a_prime,
+    ]));
+
+    (a, a_prime, b)
+}
+
+/// Sorted `git show-ref` output for deterministic before/after
+/// comparison (ref order across ls-refs walks is not guaranteed).
+fn sorted_show_refs(git_dir: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .current_dir(git_dir)
+        .args(["show-ref"])
+        .output()
+        .expect("show-ref");
+    assert!(
+        output.status.success(),
+        "show-ref failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut refs: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+    refs.sort();
+    refs
+}
+
+fn target_for(repo: &str, pr: u64, head: &str, base: &str, merge_base: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: caduceus::review::RepositoryId {
+            owner: "rvowner".to_string(),
+            repo: repo.to_string(),
+        },
+        pull_request: pr,
+        head_sha: head.to_string(),
+        base_sha: base.to_string(),
+        base_ref: "main".to_string(),
+        merge_base: merge_base.to_string(),
+    }
+}
+
+fn review_config(root: &Path) -> Config {
+    let mut cfg = Config::test_defaults(root);
+    cfg.repo_storage_root = root.join("repos");
+    cfg.git_timeout_seconds = 30;
+    cfg
+}
+
+/// Mirror for the standard rvowner/rvrepo fixture.
+async fn ensure_mirror(
+    runner: &GitRunner,
+    cfg: &Config,
+    remote_dir: &Path,
+    repo: &str,
+) -> BareMirror {
+    BareMirror::ensure(
+        runner,
+        cfg,
+        "rvowner",
+        repo,
+        &format!("file://{}", remote_dir.display()),
+        "main",
+    )
+    .await
+    .expect("ensure mirror")
+}
+
+// AC1: the worktree is materialised at exactly head_sha, detached,
+// with no branch refs written (AC3).
+#[tokio::test]
+async fn review_worktree_checks_out_exact_head_sha() {
+    let root = tempdir("rv-exact");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    let refs_before = sorted_show_refs(&mirror.path);
+    let target = target_for("rvrepo", 7, &b, &a, &a);
+    let wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-exact-1", &target)
+        .await
+        .expect("create_review");
+
+    // AC1: HEAD is exactly head_sha.
+    let head = git_out(&wt.path, &["rev-parse", "HEAD"]);
+    assert_eq!(head, b);
+
+    // Detached: abbrev-ref reports "HEAD" for a detached checkout.
+    let abbrev = git_out(&wt.path, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    assert_eq!(abbrev, "HEAD", "review worktree must be detached");
+
+    // AC3: no refs/heads/* written anywhere.
+    assert_eq!(
+        sorted_show_refs(&mirror.path),
+        refs_before,
+        "create_review must not create branch refs"
+    );
+}
+
+// AC2 (first half): every context field round-trips through the
+// metadata sidecar, and the sidecar rejects unknown fields.
+#[tokio::test]
+async fn review_worktree_metadata_round_trip() {
+    let root = tempdir("rv-meta");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    let target = target_for("rvrepo", 8, &b, &a, &a);
+    let wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-meta-1", &target)
+        .await
+        .expect("create_review");
+
+    let meta = wt.load_metadata().expect("load sidecar");
+    assert_eq!(meta.schema_version, 1);
+    assert_eq!(meta.run_id, "run-meta-1");
+    assert_eq!(meta.repository, target.repository);
+    assert_eq!(meta.pull_request, target.pull_request);
+    assert_eq!(meta.head_sha, target.head_sha);
+    assert_eq!(meta.base_sha, target.base_sha);
+    assert_eq!(meta.base_ref, target.base_ref);
+    assert_eq!(meta.merge_base, target.merge_base);
+
+    // deny_unknown_fields: an extra key must fail to parse. The
+    // sidecar is pretty-printed, so inject the key after the first
+    // `{` regardless of surrounding whitespace.
+    let raw = std::fs::read_to_string(&wt.metadata_path).unwrap();
+    let tampered = raw.replacen('{', "{\"extra\":1,", 1);
+    assert!(
+        serde_json::from_str::<caduceus::repo::ReviewWorktreeMetadata>(&tampered).is_err(),
+        "sidecar must reject unknown fields"
+    );
+}
+
+// AC2 (second half): the persisted merge_base anchors the three-dot
+// diff even after the base branch moves.
+#[tokio::test]
+async fn review_worktree_base_moved_diff_uses_persisted_merge_base() {
+    let root = tempdir("rv-basemoved");
+    let remote_dir = root.join("remote.git");
+    let (a, a_prime, b) = init_bare_remote_base_moved(&remote_dir);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo2").await;
+
+    // Admission persisted merge_base = A (computed when base was A);
+    // base_ref main has since advanced to A'. The worktree must
+    // materialise at B and the three-dot diff must be anchored at
+    // the PERSISTED merge base.
+    let target = target_for("rvrepo2", 9, &b, &a, &a);
+    let wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-moved-1", &target)
+        .await
+        .expect("create_review");
+    assert_eq!(git_out(&wt.path, &["rev-parse", "HEAD"]), b);
+
+    let meta = wt.load_metadata().expect("metadata");
+    assert_eq!(meta.merge_base, a, "persisted merge base is A");
+
+    // Sanity: git's own merge-base(B, A') == A in this fixture —
+    // proves the fixture is the base-moved shape.
+    let live_mb = git_out(&mirror.path, &["merge-base", &b, &a_prime]);
+    assert_eq!(live_mb, a);
+
+    // The three-dot diff (DAR §2.2): git diff <merge_base> <head>.
+    // MUST list B's file; must NOT list A''s base-side file.
+    let diff = git_out(
+        &wt.path,
+        &["diff", "--name-only", &meta.merge_base, &meta.head_sha],
+    );
+    assert!(diff.contains("feature.txt"));
+    assert!(
+        !diff.contains("base-moved.txt"),
+        "endpoint-to-endpoint (..) semantics would include base-side \
+         changes; the merge-base form must not"
+    );
+}
+
+// AC4: an unavailable head SHA rejects at the worktree boundary
+// before any path work happens.
+#[tokio::test]
+async fn review_worktree_unavailable_sha_rejected() {
+    let root = tempdir("rv-unavailable");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    // Simulate force-push + GC between discovery and execution: the
+    // feature branch is deleted and B (unreachable, non-ancestor of
+    // main) is pruned from the remote.
+    run_command(Command::new("git").current_dir(&remote_dir).args([
+        "update-ref",
+        "-d",
+        "refs/heads/feature",
+    ]));
+    run_command(Command::new("git").current_dir(&remote_dir).args([
+        "reflog",
+        "expire",
+        "--expire=now",
+        "--all",
+    ]));
+    run_command(
+        Command::new("git")
+            .current_dir(&remote_dir)
+            .args(["gc", "--prune=now"]),
+    );
+
+    let target = target_for("rvrepo", 10, &b, &a, &a);
+    let err = RepoReviewWorktree::create_review(&runner, &mirror, "run-gone-1", &target)
+        .await
+        .expect_err("unavailable SHA must reject");
+
+    assert!(
+        matches!(&err, CaduceusError::HeadShaUnavailable { sha } if sha == &b),
+        "got: {err:?}"
+    );
+
+    // The fetch happens before any path work: nothing on disk.
+    let expected_path = cfg
+        .repo_storage_root
+        .join("worktrees")
+        .join("review")
+        .join("rvowner")
+        .join("rvrepo")
+        .join("run-gone-1");
+    assert!(!expected_path.exists());
+}
+
+// D4: reusing the same run_id after a materialised worktree is
+// refused with the existing WorktreeReuseAfterFailure variant.
+#[tokio::test]
+async fn review_worktree_reuse_refused() {
+    let root = tempdir("rv-reuse");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    let target = target_for("rvrepo", 11, &b, &a, &a);
+    let _wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-reuse-1", &target)
+        .await
+        .expect("first create_review");
+
+    let err = RepoReviewWorktree::create_review(&runner, &mirror, "run-reuse-1", &target)
+        .await
+        .expect_err("second create_review must refuse reuse");
+    assert!(
+        matches!(&err, CaduceusError::WorktreeReuseAfterFailure { .. }),
+        "got: {err:?}"
+    );
+}

--- a/tests/repo/worktree_review_test.rs
+++ b/tests/repo/worktree_review_test.rs
@@ -160,15 +160,18 @@ fn init_bare_remote_base_moved(path: &Path) -> (String, String, String) {
     // A: empty tree on main.
     let empty_tree = git_out(path, &["hash-object", "-w", "-t", "tree", "/dev/null"]);
     let a = git_out(path, &["commit-tree", &empty_tree, "-m", "initial"]);
-    run_command(Command::new("git").current_dir(path).args([
-        "update-ref",
-        "refs/heads/main",
-        &a,
-    ]));
+    run_command(
+        Command::new("git")
+            .current_dir(path)
+            .args(["update-ref", "refs/heads/main", &a]),
+    );
 
     // B: child of A touching feature.txt.
     let feature_tree = tree_with_file(path, "feature.txt", "feature content\n");
-    let b = git_out(path, &["commit-tree", &feature_tree, "-p", &a, "-m", "feature"]);
+    let b = git_out(
+        path,
+        &["commit-tree", &feature_tree, "-p", &a, "-m", "feature"],
+    );
     run_command(Command::new("git").current_dir(path).args([
         "update-ref",
         "refs/heads/feature",
@@ -492,7 +495,8 @@ async fn review_worktree_remove_leaves_no_artefacts() {
 /// Backdate a directory's mtime so the review GC treats it as stale.
 fn backdate_to_older_than(path: &Path, days: i64) {
     let target = chrono::Utc::now() - chrono::Duration::days(days);
-    let ft = filetime::FileTime::from_unix_time(target.timestamp(), target.timestamp_subsec_nanos());
+    let ft =
+        filetime::FileTime::from_unix_time(target.timestamp(), target.timestamp_subsec_nanos());
     filetime::set_file_mtime(path, ft).expect("set mtime");
 }
 

--- a/tests/repo/worktree_review_test.rs
+++ b/tests/repo/worktree_review_test.rs
@@ -440,3 +440,47 @@ async fn review_worktree_reuse_refused() {
         "got: {err:?}"
     );
 }
+
+// AC5 (first half): remove leaves no refs, no registrations, no
+// directory — but the per-repo review parent stays (reaper territory).
+#[tokio::test]
+async fn review_worktree_remove_leaves_no_artefacts() {
+    let root = tempdir("rv-remove");
+    let remote_dir = root.join("remote.git");
+    let (a, b) = init_bare_remote_with_feature(&remote_dir);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rvrepo").await;
+
+    let target = target_for("rvrepo", 12, &b, &a, &a);
+    let wt = RepoReviewWorktree::create_review(&runner, &mirror, "run-remove-1", &target)
+        .await
+        .expect("create_review");
+
+    let refs_before = sorted_show_refs(&mirror.path);
+    RepoReviewWorktree::remove(&runner, &wt)
+        .await
+        .expect("remove");
+    assert!(!wt.path.exists(), "worktree directory must be gone");
+
+    assert_eq!(
+        sorted_show_refs(&mirror.path),
+        refs_before,
+        "remove must not change refs (none were ever created)"
+    );
+
+    let list = git_out(&mirror.path, &["worktree", "list", "--porcelain"]);
+    assert!(
+        !list.contains(&wt.path.to_string_lossy().to_string()),
+        "worktree registration must be gone"
+    );
+
+    // The per-repo review parent survives — sweeping it is the
+    // reaper's job, not remove's.
+    let parent = wt
+        .path
+        .parent()
+        .expect("review dir has a parent")
+        .to_path_buf();
+    assert!(parent.is_dir(), "per-repo review dir must remain");
+}


### PR DESCRIPTION
## Review worktree mode (issue #299)

Disposable, non-pushable review worktrees: detached HEAD at the exact
PR head SHA, created against the daemon-owned bare mirror — no
issue-dispatch branch artefact (`git worktree add --detach <path>
<head_sha>`, no `refs/heads/*` writes).

### Deviation from the issue letter: namespaced dir shape (D3)

The issue's "reaper-compatible" note assumed the flat
`<storage_root>/worktrees/<run_id>/` shape, but that namespace has no
reaper on main today. Review worktrees live at the namespaced
`<repo_storage_root>/worktrees/review/<owner>/<repo>/<run_id>/` and
this PR ships the review reaper that reclaims them — preserving the
issue's intent (repo-storage-root placement + reaper coverage) rather
than its letter. The `review/` segment also prevents any future
co-tenant of the flat `worktrees/` namespace from colliding.

### What's here

- `ReviewWorktree::create_review` — `git worktree add --detach`
  after #297's idempotent SHA-anchored fetch; `HeadShaUnavailable`
  surfaces unchanged at this boundary (routing is #339's job).
- `review-worktree.json` metadata sidecar (schema v1,
  `deny_unknown_fields`) persisting `base_sha` / `base_ref` / the
  admission-computed `merge_base` for the merge-base (three-dot)
  diff `git diff <merge_base> <head_sha>` (DAR §2.1–2.2).
- `ReviewWorktree::remove` — no refs or registrations left behind.
- `gc_review_worktrees` reaper — claim/heartbeat in-use model,
  orphan sweep refusing symlinks; wired into tick step 3.5 and
  `caduceus worktree-gc`.
- Tests: exact-SHA checkout + detached, metadata round-trip +
  deny_unknown_fields, no-branch-artefact (show-ref before/after),
  base-moved three-dot diff fixture, unavailable-SHA propagation,
  remove-no-residue, and reaper stale/fresh/claimed/orphan coverage.

### Note for #339

The reaper's in-use reader is path-keyed on
`ClaimFileBody.worktree_path` and fresh
`<state_dir>/runs/<run_id>.heartbeat` — if #339's review claims use a
different shape, only that reader needs to follow.

Closes #299