### PR TITLE
feat(github): add Phase-1 fork gate predicate and skip event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   metadata sidecar with the frozen `base_sha` / `base_ref` /
   `merge_base` for merge-base (three-dot) diffing. A review reaper
   reclaims stale entries via `worktree-gc` / the tick. Closes #299.
+- **Phase-1 fork gate for PR discovery.** Fork PRs — and PRs whose head
+  repository cannot be identified, such as deleted head branches — are
+  skipped before admission with a structured
+  `review_skipped_fork_unsupported` event. The gate is unconditional:
+  there is no configuration to enable fork review in Phase 1. Closes
+  #316.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -588,6 +588,10 @@ name = "pr_wire_test"
 path = "tests/github/pr_wire_test.rs"
 
 [[test]]
+name = "fork_gate_test"
+path = "tests/github/fork_gate_test.rs"
+
+[[test]]
 name = "prompt_test"
 path = "tests/github/prompt_test.rs"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,3 +33,10 @@ do not edit daemon-owned state files directly.
 The public-comment filter is a security-relevant control. Report any bypass
 that exposes internal tools, credentials, or other sensitive information through
 the private contact above.
+
+Fork pull requests are not reviewed in Phase 1. Discovery skips them
+unconditionally — there is no configuration to enable fork review —
+because the daemon's single-origin mirror cannot check out fork SHAs.
+Skips are recorded as structured `review_skipped_fork_unsupported`
+events (including PRs whose head repository is gone), so the exclusion
+is auditable rather than silent.

--- a/src/github/fork_gate.rs
+++ b/src/github/fork_gate.rs
@@ -1,0 +1,103 @@
+//! Phase-1 fork gate for PR discovery (issue #316).
+//!
+//! Fork pull requests are **unsupported** in Phase 1 (DAR §5.1, §11.2):
+//! discovery skips them unconditionally because the daemon's
+//! single-origin mirror cannot check out fork SHAs. This module owns
+//! the eligibility predicate and the structured skip event; #312 wires
+//! them into the discovery loop. There is deliberately **no config
+//! knob** — dead config would advertise a posture the system cannot
+//! deliver (DAR §11.2).
+//!
+//! The predicate is fail-closed by construction: only a *proven*
+//! same-repo row passes the gate. Every other wire shape — fork,
+//! missing head repo (deleted head branch), missing base repo —
+//! yields a non-passing verdict and, at the emit site, the
+//! [`FORK_SKIP_EVENT`] (DAR §13 registry). `classify_fork` is pure:
+//! no I/O, no logging, no panics on any wire shape.
+
+use crate::github::pr::PullRequestDetail;
+
+/// DAR §13 event name for the Phase-1 fork-gate skip.
+pub const FORK_SKIP_EVENT: &str = "review_skipped_fork_unsupported";
+
+/// Verdict of the Phase-1 fork gate for one PR row (DAR §5.1, §11.2).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ForkStatus {
+    /// `head.repo.full_name == base.repo.full_name`, both present —
+    /// the ONLY verdict that passes the gate.
+    SameRepo,
+    /// Proven fork: both full names present and different. Carries the
+    /// head repo's full name for the skip event.
+    Fork { head_repo: String },
+    /// Head side unidentifiable: `head` absent, `head.repo: null`
+    /// (deleted head branch), or `head.repo.full_name` absent.
+    HeadRepoMissing,
+    /// Base side unidentifiable (never seen on real payloads;
+    /// wire-model defense). Carries the head identity that was
+    /// readable. Fails closed.
+    BaseRepoMissing { head_repo: String },
+}
+
+impl ForkStatus {
+    /// Does this verdict pass the Phase-1 fork gate?
+    pub fn passes(&self) -> bool {
+        matches!(self, ForkStatus::SameRepo)
+    }
+
+    /// Head-repo identity for the skip-event payload (DAR §5.1:
+    /// "head-repo identity or null"). `Some(full_name)` whenever the
+    /// head side was readable, `None` for `SameRepo` (never emitted)
+    /// and `HeadRepoMissing`.
+    pub fn head_repo_identity(&self) -> Option<&str> {
+        match self {
+            ForkStatus::SameRepo | ForkStatus::HeadRepoMissing => None,
+            ForkStatus::Fork { head_repo } | ForkStatus::BaseRepoMissing { head_repo } => {
+                Some(head_repo)
+            }
+        }
+    }
+}
+
+/// Classify a PR row for the Phase-1 fork gate. Pure: no I/O, no
+/// logging, never panics on any wire shape. Evaluation order: head
+/// side, then base side, then exact string comparison.
+pub fn classify_fork(pr: &PullRequestDetail) -> ForkStatus {
+    let head_full = pr
+        .head
+        .as_ref()
+        .and_then(|b| b.repo.as_ref())
+        .and_then(|r| r.full_name.as_deref());
+    let Some(head_full) = head_full else {
+        return ForkStatus::HeadRepoMissing;
+    };
+    let base_full = pr
+        .base
+        .as_ref()
+        .and_then(|b| b.repo.as_ref())
+        .and_then(|r| r.full_name.as_deref());
+    let Some(base_full) = base_full else {
+        return ForkStatus::BaseRepoMissing {
+            head_repo: head_full.to_string(),
+        };
+    };
+    if head_full == base_full {
+        ForkStatus::SameRepo
+    } else {
+        ForkStatus::Fork {
+            head_repo: head_full.to_string(),
+        }
+    }
+}
+
+/// Emit the DAR §13 fork-gate skip event: repo, PR number, head-repo
+/// identity (or `"null"`). `tracing::info!`, `target: "caduceus"`.
+pub fn emit_fork_gate_skip(repo: &str, pr_number: u64, head_repo: Option<&str>) {
+    tracing::info!(
+        target: "caduceus",
+        event = FORK_SKIP_EVENT,
+        repo = repo,
+        pr = pr_number,
+        head_repo = head_repo.unwrap_or("null"),
+        "PR skipped: fork review unsupported in Phase 1"
+    );
+}

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -8,6 +8,7 @@
 //! - [`verify`] — second-pass label verification before claiming.
 
 pub mod client;
+pub mod fork_gate;
 pub mod issue;
 pub mod link_header;
 pub mod merge_detect;
@@ -26,6 +27,9 @@ pub use crate::github::client::{
     IssueSummary, PullRequest, RateLimitInfo, Response, VoiceChannel, ACCEPT_VALUE,
     GITHUB_API_VERSION_HEADER, GITHUB_API_VERSION_VALUE, MAX_BODY_BYTES, MAX_REDIRECTS,
     USER_AGENT_PREFIX,
+};
+pub use crate::github::fork_gate::{
+    classify_fork, emit_fork_gate_skip, ForkStatus, FORK_SKIP_EVENT,
 };
 pub use crate::github::issue::{IssueComment, IssueDetail, IssueEvent, IssueKey};
 pub use crate::github::merge_detect::{poll_pr_merge_status, MergeStatus};

--- a/tests/github/fork_gate_test.rs
+++ b/tests/github/fork_gate_test.rs
@@ -1,0 +1,385 @@
+//! Phase-1 fork-gate predicate and skip-event tests (issue #316).
+//!
+//! Coverage:
+//!
+//! - Predicate truth table over wire-shaped JSON fixtures: same-repo,
+//!   fork, and every `Option` degenerate row (null/absent head repo —
+//!   the deleted-head-branch fixture — plus base-side degenerates).
+//! - Fail-closed property: only a proven `SameRepo` row passes the
+//!   gate (AC3 by construction until #312 wires the gate into
+//!   discovery).
+//! - Skip-event emission: the DAR §13
+//!   `review_skipped_fork_unsupported` event carries repo + PR +
+//!   head-repo identity, and the nullable-head-repo row emits the same
+//!   event with a `"null"` identity sentinel.
+//! - Purity guard: `classify_fork` emits no events under a capture
+//!   subscriber.
+//!
+//! Fixtures are built as `serde_json::json!` values and deserialised
+//! through [`PullRequestDetail`], pinning the wire→`Option` decode
+//! (explicit `null` and absent keys both map to `None`) together with
+//! the classification, following the `pr_wire_test.rs` fixture shape.
+//!
+//! The event-capture tests are `#[serial_test::serial]`: `tracing_core`
+//! caches callsite interest process-wide, so a sibling test exercising
+//! the same callsite without a subscriber installed would silently
+//! drop the captured event (the #167 finding).
+
+use caduceus::github::fork_gate::{
+    classify_fork, emit_fork_gate_skip, ForkStatus, FORK_SKIP_EVENT,
+};
+use caduceus::github::PullRequestDetail;
+use caduceus::logging::build_test_subscriber;
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+
+/// Decode a wire row into the typed model. Fixtures must round-trip:
+/// a panic here means the fixture is not a valid `/pulls` row.
+fn decode(row: serde_json::Value) -> PullRequestDetail {
+    serde_json::from_value(row).expect("wire row decodes into PullRequestDetail")
+}
+
+/// A `/pulls` row with the given base/head repo identities. `None`
+/// renders `"repo": null` (the deleted-head-branch / absent-repo
+/// wire shape); `Some(full_name)` renders a populated repo object.
+fn pr_row(base_repo: Option<&str>, head_repo: Option<&str>) -> serde_json::Value {
+    let mut row = serde_json::json!({
+        "number": 7,
+        "title": "Fork gate row",
+        "state": "open",
+        "base": {"ref": "main", "sha": "aaaa"},
+        "head": {"ref": "feature-x", "sha": "bbbb"}
+    });
+    row["base"]["repo"] = base_repo
+        .map(|name| serde_json::json!({"full_name": name}))
+        .unwrap_or(serde_json::Value::Null);
+    row["head"]["repo"] = head_repo
+        .map(|name| serde_json::json!({"full_name": name}))
+        .unwrap_or(serde_json::Value::Null);
+    row
+}
+
+/// A row with no `head` key at all.
+fn row_without_head() -> serde_json::Value {
+    serde_json::json!({
+        "number": 7,
+        "title": "No head",
+        "state": "open",
+        "base": {"ref": "main", "sha": "aaaa", "repo": {"full_name": "octocat/hello-world"}}
+    })
+}
+
+/// A row with a `head` object but no `repo` key inside it.
+fn row_without_head_repo_key() -> serde_json::Value {
+    serde_json::json!({
+        "number": 7,
+        "title": "Head without repo key",
+        "state": "open",
+        "base": {"ref": "main", "sha": "aaaa", "repo": {"full_name": "octocat/hello-world"}},
+        "head": {"ref": "feature-x", "sha": "bbbb"}
+    })
+}
+
+/// A row with a `head.repo` object but no `full_name` key inside it.
+fn row_without_head_full_name_key() -> serde_json::Value {
+    serde_json::json!({
+        "number": 7,
+        "title": "Head repo without full_name",
+        "state": "open",
+        "base": {"ref": "main", "sha": "aaaa", "repo": {"full_name": "octocat/hello-world"}},
+        "head": {"ref": "feature-x", "sha": "bbbb", "repo": {}}
+    })
+}
+
+/// A row with no `base` key at all.
+fn row_without_base() -> serde_json::Value {
+    serde_json::json!({
+        "number": 7,
+        "title": "No base",
+        "state": "open",
+        "head": {"ref": "feature-x", "sha": "bbbb", "repo": {"full_name": "octocat/hello-world"}}
+    })
+}
+
+/// A row with a `base.repo` object but no `full_name` key inside it.
+fn row_without_base_full_name_key() -> serde_json::Value {
+    serde_json::json!({
+        "number": 7,
+        "title": "Base repo without full_name",
+        "state": "open",
+        "base": {"ref": "main", "sha": "aaaa", "repo": {}},
+        "head": {"ref": "feature-x", "sha": "bbbb", "repo": {"full_name": "octocat/hello-world"}}
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Predicate truth table (pure tests — no subscriber, no async)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn same_repo_row_passes_gate() {
+    let pr = decode(pr_row(
+        Some("octocat/hello-world"),
+        Some("octocat/hello-world"),
+    ));
+    let status = classify_fork(&pr);
+    assert_eq!(status, ForkStatus::SameRepo);
+    assert!(status.passes(), "proven same-repo must pass the gate");
+}
+
+#[test]
+fn fork_row_classifies_fork_with_identity() {
+    let pr = decode(pr_row(Some("octocat/hello-world"), Some("octocat/other")));
+    let status = classify_fork(&pr);
+    assert_eq!(
+        status,
+        ForkStatus::Fork {
+            head_repo: "octocat/other".to_string(),
+        }
+    );
+    assert!(!status.passes(), "proven fork must fail the gate");
+    assert_eq!(status.head_repo_identity(), Some("octocat/other"));
+}
+
+// The nullable-head-repo fixture: `"head": {..., "repo": null}` (a
+// deleted head branch) decodes to `repo: None` and classifies as
+// `HeadRepoMissing` — its own verdict, never a panic, never a fork.
+#[test]
+fn null_head_repo_classifies_head_repo_missing() {
+    let pr = decode(pr_row(Some("octocat/hello-world"), None));
+    let status = classify_fork(&pr);
+    assert_eq!(status, ForkStatus::HeadRepoMissing);
+    assert!(!status.passes());
+    assert_eq!(status.head_repo_identity(), None);
+}
+
+#[test]
+fn absent_head_repo_classifies_head_repo_missing() {
+    let pr = decode(row_without_head_repo_key());
+    let status = classify_fork(&pr);
+    assert_eq!(status, ForkStatus::HeadRepoMissing);
+    assert!(!status.passes());
+}
+
+#[test]
+fn null_head_full_name_classifies_head_repo_missing() {
+    let row = serde_json::json!({
+        "number": 7,
+        "title": "Null head full_name",
+        "state": "open",
+        "base": {"ref": "main", "sha": "aaaa", "repo": {"full_name": "octocat/hello-world"}},
+        "head": {"ref": "feature-x", "sha": "bbbb", "repo": {"full_name": null}}
+    });
+    let pr = decode(row);
+    let status = classify_fork(&pr);
+    assert_eq!(status, ForkStatus::HeadRepoMissing);
+    assert!(!status.passes());
+}
+
+#[test]
+fn absent_head_full_name_key_classifies_head_repo_missing() {
+    let pr = decode(row_without_head_full_name_key());
+    let status = classify_fork(&pr);
+    assert_eq!(status, ForkStatus::HeadRepoMissing);
+    assert!(!status.passes());
+}
+
+#[test]
+fn absent_head_classifies_head_repo_missing() {
+    let pr = decode(row_without_head());
+    let status = classify_fork(&pr);
+    assert_eq!(status, ForkStatus::HeadRepoMissing);
+    assert!(!status.passes());
+}
+
+#[test]
+fn null_base_repo_classifies_base_repo_missing() {
+    let pr = decode(pr_row(None, Some("octocat/hello-world")));
+    let status = classify_fork(&pr);
+    assert_eq!(
+        status,
+        ForkStatus::BaseRepoMissing {
+            head_repo: "octocat/hello-world".to_string(),
+        }
+    );
+    assert!(!status.passes());
+    assert_eq!(status.head_repo_identity(), Some("octocat/hello-world"));
+}
+
+#[test]
+fn absent_base_classifies_base_repo_missing() {
+    let pr = decode(row_without_base());
+    let status = classify_fork(&pr);
+    assert_eq!(
+        status,
+        ForkStatus::BaseRepoMissing {
+            head_repo: "octocat/hello-world".to_string(),
+        }
+    );
+    assert!(!status.passes());
+    assert_eq!(status.head_repo_identity(), Some("octocat/hello-world"));
+}
+
+#[test]
+fn null_base_full_name_classifies_base_repo_missing() {
+    let pr = decode(row_without_base_full_name_key());
+    let status = classify_fork(&pr);
+    assert_eq!(
+        status,
+        ForkStatus::BaseRepoMissing {
+            head_repo: "octocat/hello-world".to_string(),
+        }
+    );
+    assert!(!status.passes());
+}
+
+#[test]
+fn full_name_comparison_is_exact_not_case_folded() {
+    let pr = decode(pr_row(Some("Octo/Repo"), Some("octo/repo")));
+    let status = classify_fork(&pr);
+    assert_eq!(
+        status,
+        ForkStatus::Fork {
+            head_repo: "octo/repo".to_string(),
+        }
+    );
+    assert!(!status.passes(), "strict inequality fails closed");
+}
+
+// The AC3-by-construction test: every non-SameRepo verdict (the full
+// degenerate family plus a proven fork) fails the gate, so only a
+// proven same-repo row can ever be admitted.
+#[test]
+fn only_proven_same_repo_passes_gate() {
+    let rows = vec![
+        pr_row(Some("octocat/hello-world"), Some("octocat/other")),
+        pr_row(Some("octocat/hello-world"), None),
+        row_without_head_repo_key(),
+        row_without_head_full_name_key(),
+        row_without_head(),
+        pr_row(None, Some("octocat/hello-world")),
+        row_without_base(),
+        row_without_base_full_name_key(),
+        pr_row(Some("Octo/Repo"), Some("octo/repo")),
+    ];
+    for row in rows {
+        let pr = decode(row);
+        let status = classify_fork(&pr);
+        assert!(
+            !status.passes(),
+            "non-SameRepo verdict {:?} must fail the gate",
+            status
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Skip-event emission (capture tests — serial: callsite interest caching)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial]
+fn fork_skip_emits_structured_event_with_full_identity() {
+    let root = tempdir("fork-gate-event");
+    let log_path = root.join("fork.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        emit_fork_gate_skip("octocat/hello-world", 42, Some("octocat/other"));
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        body.contains(&format!("\"event\":\"{FORK_SKIP_EVENT}\"")),
+        "event name missing: {body}"
+    );
+    assert!(
+        body.contains("\"repo\":\"octocat/hello-world\""),
+        "got: {body}"
+    );
+    assert!(body.contains("\"pr\":42"), "got: {body}");
+    assert!(
+        body.contains("\"head_repo\":\"octocat/other\""),
+        "got: {body}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn head_repo_missing_skip_emits_null_identity() {
+    let root = tempdir("fork-gate-null");
+    let log_path = root.join("fork.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        emit_fork_gate_skip("octocat/hello-world", 43, None);
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        body.contains(&format!("\"event\":\"{FORK_SKIP_EVENT}\"")),
+        "event name missing: {body}"
+    );
+    assert!(
+        body.contains("\"repo\":\"octocat/hello-world\""),
+        "got: {body}"
+    );
+    assert!(body.contains("\"pr\":43"), "got: {body}");
+    // The `None` identity renders as the literal `"null"` sentinel —
+    // unambiguous because a real GitHub `full_name` always contains `/`.
+    assert!(body.contains("\"head_repo\":\"null\""), "got: {body}");
+}
+
+#[test]
+#[serial_test::serial]
+fn classify_fork_emits_no_events() {
+    let root = tempdir("fork-gate-pure");
+    let log_path = root.join("classify.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    // One row per verdict family: same-repo, fork, head-missing,
+    // base-missing. `classify_fork` must stay pure — no event, no
+    // logging — so the capture file stays empty of the fork event.
+    let rows = vec![
+        pr_row(Some("octocat/hello-world"), Some("octocat/hello-world")),
+        pr_row(Some("octocat/hello-world"), Some("octocat/other")),
+        pr_row(Some("octocat/hello-world"), None),
+        row_without_base(),
+    ];
+    tracing::subscriber::with_default(subscriber, || {
+        for row in rows {
+            let pr = decode(row);
+            let _ = classify_fork(&pr);
+        }
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        !body.contains(FORK_SKIP_EVENT),
+        "classify_fork must not emit the fork event: {body}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the Phase-1 fork gate for PR discovery (issue #316): fork pull
requests are skipped before admission with a structured
`review_skipped_fork_unsupported` event.

- `classify_fork(&PullRequestDetail) -> ForkStatus` — fail-closed
  four-variant classifier (`SameRepo | Fork | HeadRepoMissing |
  BaseRepoMissing`) over the all-`Option` #301 wire model. Only proven
  same-repo rows (exact `full_name` equality) pass; every other wire
  shape fails closed, so no fork PR can be admitted.
- `emit_fork_gate_skip` — the single DAR §13 skip event carrying repo,
  PR number, and head-repo identity; `head.repo: null` rows (deleted
  head branches) emit the same event with a `"null"` identity sentinel
  and never panic.
- No `allow_fork_prs` config knob — the gate is unconditional in Phase 1
  (DAR §11.2).
- Predicate + skip semantics are delivered here; wiring into discovery
  lands with #312.

## Scope notes

- The issue's required "discovery integration asserting fork-skip
  events" cannot exist yet: there is no discovery loop on `main` (#312
  owns it). Delivered instead: the full predicate truth table over
  wire-shaped JSON fixtures (including the nullable-head-repo fixture)
  plus event-emission capture tests. The end-to-end discovery assertion
  is #312's to add.
- AC3 ("no fork PR ever reaches admission") is enforced by construction
  — the gate's type only passes a proven same-repo row — and becomes
  end-to-end testable when #312 composes it at eligibility. No
  admission/execution path exists on `main` yet, so no speculative
  assert was added.
- D2 interpretation: `head.repo: null` rows emit the same event name
  with a null `head_repo` field (DAR §13 registers exactly one #316
  event; §5.1's "(or null)" payload composes this way). If name-level
  discrimination is wanted later, that is additive and belongs to #318.
- The test file carries 15 tests (plan asked for 14): one extra
  absent-`full_name`-key predicate case covering truth-table row 5's
  absent variant.

Closes #316