### PR TITLE
feat(config): add auto_review block and review admission budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   `review_skipped_fork_unsupported` event. The gate is unconditional:
   there is no configuration to enable fork review in Phase 1. Closes
   #316.
+- **Auto Review configuration block.** New `auto_review:` config section
+  (`enabled`, `draft_pull_requests`, both default `false`) opts a daemon
+  into automatic PR review; enabling it requires `executor_mode: oci`
+  with a valid `sandbox:` section (TrustedHost + `enabled: true` now
+  fails config load with an actionable error). New top-level
+  `max_reviews_per_tick` (default `worker_parallelism * 4`, `0` =
+  unbounded) bounds per-tick review admission. `ticket_label_investigation`
+  is deprecated: explicit config use now emits a warning; the key is
+  removed in a future release. Closes #320.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,6 +332,10 @@ name = "sandbox_config_test"
 path = "tests/infra/config/sandbox_config_test.rs"
 
 [[test]]
+name = "auto_review_config_test"
+path = "tests/infra/config/auto_review_config_test.rs"
+
+[[test]]
 name = "sandbox_pass_env_test"
 path = "tests/config/sandbox_pass_env_test.rs"
 

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -127,6 +127,22 @@ and leaves the rest for the next tick. Set `0` to restore the unbounded
 drain-the-queue behavior. In-flight workers always finish their current
 work on tick exit; the cap only stops claiming new entries.
 
+## Auto Review
+
+The `auto_review:` block (default absent = disabled) opts the daemon
+into automatic review of every eligible PR revision in watched repos.
+`auto_review.enabled: true` requires `executor_mode: oci` with a valid
+`sandbox:` section — TrustedHost + enabled fails at config load (reviews
+execute third-party tooling against untrusted PR content). The
+`autoreview` GitHub label is reserved but inert in Phase 1: no daemon
+code polls it and PR eligibility never requires it. Draft PRs are
+skipped unless `auto_review.draft_pull_requests: true`.
+`max_reviews_per_tick` (default `worker_parallelism * 4`, `0` =
+unbounded) bounds per-tick review admission. Investigation tickets
+(`ticket_label_investigation`) still work but are deprecated: explicit
+config use emits a warning, and the key will be removed in a future
+release.
+
 ## State Recovery Procedure
 
 Both `state.json` and `state_meta.json` use temp-file + `fsync` + atomic

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -104,6 +104,11 @@ pub const DEFAULT_WORKER_PARALLELISM: u32 = 1;
 /// `worker_parallelism: N` processes up to `N * 4` issues, leaving
 /// the rest for the next tick (issue #108).
 pub const DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER: u32 = 4;
+/// Multiplier applied to `worker_parallelism` to derive the default
+/// `max_reviews_per_tick` admission budget (DAR §5). Deliberately a
+/// separate constant from `DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER`
+/// so the two budgets can diverge without cross-talk.
+pub const DEFAULT_MAX_REVIEWS_PER_TICK_MULTIPLIER: u32 = 4;
 pub const DEFAULT_SCHEDULER_LEASE_TTL_SECONDS: u64 = 60;
 pub const DEFAULT_WORKER_LEASE_TTL_SECONDS: u64 = 600;
 pub const DEFAULT_SCHEDULER_TRANSACTION_BUDGET_MS: u64 = 100;
@@ -210,6 +215,30 @@ pub struct RawSandboxResources {
     pub shm_mb: Option<u64>,
 }
 
+/// Resolved `auto_review:` section. `None` on `Config` means the block
+/// is absent — Auto Review is disabled and no downstream code may
+/// read it (DAR §5.2: Phase-1 contract is flag-based; the
+/// `autoreview` GitHub label is reserved and INERT — no daemon code
+/// polls it, and PR eligibility never requires it).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AutoReviewConfig {
+    /// Explicit opt-in for automatic review of every eligible PR
+    /// revision in watched repos. Default `false`.
+    pub enabled: bool,
+    /// Review draft PRs. Default `false` (drafts are skipped with
+    /// `review_skipped_draft` per DAR §5.1).
+    pub draft_pull_requests: bool,
+}
+
+/// Raw layer — mirrors the schema with all-`Option` fields.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawAutoReviewConfig {
+    pub enabled: Option<bool>,
+    pub draft_pull_requests: Option<bool>,
+}
+
 /// Caduceus configuration. Field semantics are pinned here.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -271,6 +300,12 @@ pub struct Config {
     /// `contract/SCHED-001` (bounded single-host concurrency)
     /// bounded across a long cron tick.
     pub max_issues_per_tick: u32,
+    /// Per-tick admission budget for Auto Review targets — the
+    /// maximum number of new PR head revisions a single tick admits
+    /// (DAR §5). Sibling of `max_issues_per_tick`. `0` means
+    /// unbounded. Default `worker_parallelism * 4`. Consumed by the
+    /// PR discovery step (#312); schema owned here.
+    pub max_reviews_per_tick: u32,
     /// Maximum number of pages to follow during paginated API
     /// discovery. Default 20.
     pub discovery_max_pages: u32,
@@ -330,6 +365,12 @@ pub struct Config {
     /// `executor_mode == oci` — `Config::from_raw` rejects OCI configs
     /// without a valid `sandbox.image`.
     pub sandbox: Option<SandboxConfig>,
+    /// Auto Review configuration. `None` = block absent = disabled;
+    /// `Some` = the operator declared an `auto_review:` section (its
+    /// `enabled` flag still defaults to `false`). The `autoreview`
+    /// GitHub label is reserved but inert in Phase 1 — no daemon code
+    /// polls it and PR eligibility never requires it (DAR §5.2).
+    pub auto_review: Option<AutoReviewConfig>,
 }
 
 /// Loose deserialisation layer used to read the YAML before the source
@@ -376,6 +417,7 @@ pub struct RawConfig {
     pub dry_run: Option<bool>,
     pub worker_parallelism: Option<u32>,
     pub max_issues_per_tick: Option<u32>,
+    pub max_reviews_per_tick: Option<u32>,
     pub discovery_max_pages: Option<u32>,
     pub scheduler_lease_ttl_seconds: Option<u64>,
     pub worker_lease_ttl_seconds: Option<u64>,
@@ -393,6 +435,9 @@ pub struct RawConfig {
     /// Optional in the raw layer — absent means `Config.sandbox` is
     /// `None` (valid for TrustedHost) unless `executor_mode == oci`.
     pub sandbox: Option<RawSandboxConfig>,
+    /// Optional in the raw layer — absent means `Config.auto_review`
+    /// is `None` (Auto Review disabled).
+    pub auto_review: Option<RawAutoReviewConfig>,
 }
 
 /// Load context — used to resolve paths and the default worker command
@@ -824,6 +869,15 @@ impl Config {
             Some(raw_sb) => Some(resolve_sandbox(raw_sb, &mut errors)),
         };
 
+        // Auto Review config (DAR §5.2, §6.3). Absent block ⇒ disabled.
+        // Resolution order: block first, then the OCI-required check, so
+        // a TrustedHost+enabled config fails with BOTH required changes
+        // named before any other surface reads it.
+        let auto_review = raw.auto_review.map(|raw_ar| AutoReviewConfig {
+            enabled: raw_ar.enabled.unwrap_or(false),
+            draft_pull_requests: raw_ar.draft_pull_requests.unwrap_or(false),
+        });
+
         // dry_run is resolved by the env overlay. The raw
         // layer may carry a YAML-supplied hint here for tests; we
         // delegate the merge.
@@ -839,6 +893,9 @@ impl Config {
         let max_issues_per_tick = raw
             .max_issues_per_tick
             .unwrap_or(worker_parallelism.saturating_mul(DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER));
+        let max_reviews_per_tick = raw
+            .max_reviews_per_tick
+            .unwrap_or(worker_parallelism.saturating_mul(DEFAULT_MAX_REVIEWS_PER_TICK_MULTIPLIER));
 
         if !errors.is_empty() {
             return Err(CaduceusError::Config(errors.join("; ")));
@@ -898,6 +955,7 @@ impl Config {
             dry_run,
             worker_parallelism,
             max_issues_per_tick,
+            max_reviews_per_tick,
             discovery_max_pages,
             compiled_ignore_patterns,
             scheduler_lease_ttl_seconds: raw
@@ -957,6 +1015,7 @@ impl Config {
             executor_mode,
             reduced_containment_acknowledged,
             sandbox,
+            auto_review,
         })
     }
 
@@ -967,6 +1026,12 @@ impl Config {
         self.sandbox
             .as_ref()
             .expect("sandbox section is required for the OCI executor")
+    }
+
+    /// Auto Review configuration. `None` = block absent = disabled.
+    /// (`#312`'s PR discovery step consumes this.)
+    pub fn auto_review(&self) -> Option<&AutoReviewConfig> {
+        self.auto_review.as_ref()
     }
 
     /// Deterministic root-anchored defaults for tests. Avoids any
@@ -1012,6 +1077,8 @@ impl Config {
             worker_parallelism: DEFAULT_WORKER_PARALLELISM,
             max_issues_per_tick: DEFAULT_WORKER_PARALLELISM
                 .saturating_mul(DEFAULT_MAX_ISSUES_PER_TICK_MULTIPLIER),
+            max_reviews_per_tick: DEFAULT_WORKER_PARALLELISM
+                .saturating_mul(DEFAULT_MAX_REVIEWS_PER_TICK_MULTIPLIER),
             discovery_max_pages: DEFAULT_DISCOVERY_MAX_PAGES,
             compiled_ignore_patterns: Vec::new(),
             scheduler_lease_ttl_seconds: DEFAULT_SCHEDULER_LEASE_TTL_SECONDS,
@@ -1056,6 +1123,9 @@ impl Config {
                 reconcile_timeout_seconds: DEFAULT_SANDBOX_RECONCILE_TIMEOUT_SECONDS,
                 reserved_host_disk_mb: DEFAULT_SANDBOX_RESERVED_HOST_DISK_MB,
             }),
+            // Auto Review disabled by default in tests; tests that
+            // exercise the block set it explicitly.
+            auto_review: None,
         }
     }
 

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -790,6 +790,19 @@ impl Config {
         if ticket_label_code.trim().is_empty() {
             errors.push("ticket_label_code must not be empty".to_string());
         }
+        // `ticket_label_investigation` is DEPRECATED in release N (DAR §12):
+        // Investigation remains admitted (warning only), but the config key
+        // is on the N+1 removal path. Warn once per config load when the
+        // operator explicitly set it; the default (`autofix-investigate`)
+        // resolves silently — its deprecation surfaces per-admission (#329).
+        if raw.ticket_label_investigation.is_some() {
+            tracing::warn!(
+                value = %raw.ticket_label_investigation.as_deref().unwrap_or_default(),
+                "ticket_label_investigation is deprecated and will be removed in a \
+                 future release; migrate to auto_review (docs/architecture/\
+                 auto-review.md §12)"
+            );
+        }
         let mut ticket_label_investigation = raw
             .ticket_label_investigation
             .unwrap_or_else(|| DEFAULT_TICKET_LABEL_INVESTIGATION.to_string());
@@ -877,6 +890,17 @@ impl Config {
             enabled: raw_ar.enabled.unwrap_or(false),
             draft_pull_requests: raw_ar.draft_pull_requests.unwrap_or(false),
         });
+        if let Some(ar) = &auto_review {
+            if ar.enabled && matches!(executor_mode, crate::executor::ExecutorKind::TrustedHost) {
+                errors.push(
+                    "auto_review.enabled requires OCI execution: set executor_mode: oci \
+                     and provide a valid sandbox: section (digest-pinned image). \
+                     TrustedHost offers no containment for reviewing untrusted PR \
+                     content. Run `caduceus doctor` or see the configuration docs"
+                        .to_string(),
+                );
+            }
+        }
 
         // dry_run is resolved by the env overlay. The raw
         // layer may carry a YAML-supplied hint here for tests; we

--- a/src/infra/fixtures.rs
+++ b/src/infra/fixtures.rs
@@ -27,6 +27,7 @@
 /// sorted lexicographically so operators grep-ing docs find every key.
 pub const CANONICAL_CONFIG_KEYS: &[&str] = &[
     "api_base",
+    "auto_review",
     "comment_forbidden_strings",
     "comment_ignore_patterns",
     "discovery_max_pages",
@@ -37,6 +38,7 @@ pub const CANONICAL_CONFIG_KEYS: &[&str] = &[
     "http_timeout_seconds",
     "log_path",
     "max_retries_per_issue",
+    "max_reviews_per_tick",
     "poll_interval_seconds",
     "reduced_containment_acknowledged",
     "retry_backoff_seconds",

--- a/tests/infra/config/auto_review_config_test.rs
+++ b/tests/infra/config/auto_review_config_test.rs
@@ -72,3 +72,216 @@ fn max_reviews_per_tick_saturates_instead_of_overflowing() {
     .expect("saturating_mul must not panic");
     assert_eq!(cfg.max_reviews_per_tick, u32::MAX);
 }
+
+// --- OCI-required validation matrix (DAR §6.3) ---
+
+#[test]
+fn matrix_absent_block_is_fine_on_trusted_host() {
+    let cfg = load(&trusted_host_base()).expect("no block = disabled");
+    assert!(cfg.auto_review.is_none());
+}
+
+#[test]
+fn matrix_enabled_false_block_is_inert_on_trusted_host() {
+    let cfg = load(&format!(
+        "{}auto_review:\n  enabled: false\n",
+        trusted_host_base()
+    ))
+    .expect("enabled: false = explicit no-op");
+    let ar = cfg.auto_review().expect("block present");
+    assert!(!ar.enabled);
+    assert!(!ar.draft_pull_requests);
+}
+
+#[test]
+fn matrix_trusted_host_error_survives_present_valid_sandbox() {
+    // Cell 3: a sandbox: section does NOT soften the TrustedHost
+    // refusal — DAR §6.3 requires executor_mode to BE oci.
+    let err = load(&format!(
+        "{}executor_mode: trusted_host\nsandbox:\n  image: \"{VALID_IMAGE}\"\n\
+         auto_review:\n  enabled: true\n",
+        trusted_host_base()
+    ))
+    .expect_err("sandbox presence must not bypass the oci requirement");
+    let msg = format!("{err}");
+    assert!(msg.contains("auto_review.enabled"), "got: {msg}");
+    assert!(msg.contains("executor_mode: oci"), "got: {msg}");
+}
+
+#[test]
+fn matrix_enabled_oci_missing_sandbox_errors_from_existing_check() {
+    let err = load(&format!(
+        "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
+         state_dir: \"__TMP__/state\"\n\
+         executor_mode: oci\n\
+         auto_review:\n  enabled: true\n"
+    ))
+    .expect_err("oci without sandbox must fail (existing rule)");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("executor_mode 'oci' requires a `sandbox:` section"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn matrix_enabled_oci_valid_sandbox_is_the_ok_shape() {
+    let cfg = load(&format!(
+        "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
+         state_dir: \"__TMP__/state\"\n\
+         executor_mode: oci\n\
+         sandbox:\n  image: \"{VALID_IMAGE}\"\n\
+         auto_review:\n  enabled: true\n  draft_pull_requests: true\n"
+    ))
+    .expect("enabled + oci + valid sandbox loads");
+    let ar = cfg.auto_review().expect("block resolved");
+    assert!(ar.enabled);
+    assert!(ar.draft_pull_requests);
+}
+
+#[test]
+fn matrix_enabled_oci_invalid_image_errors_from_sandbox_validation() {
+    let err = load(&format!(
+        "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
+         state_dir: \"__TMP__/state\"\n\
+         executor_mode: oci\n\
+         sandbox:\n  image: \"not-a-digest\"\n\
+         auto_review:\n  enabled: true\n"
+    ))
+    .expect_err("bad image must fail (existing rule)");
+    let msg = format!("{err}");
+    assert!(msg.contains("sandbox.image"), "got: {msg}");
+}
+
+#[test]
+fn unknown_auto_review_key_is_rejected() {
+    let err = load(&format!(
+        "{}auto_review:\n  enabled: true\n  minimum_severity: warning\n",
+        trusted_host_base()
+    ));
+    assert!(err.is_err(), "Phase-2 keys must fail at parse time");
+}
+
+// --- Deprecation warning (DAR §12) + no silent translation (DAR §5) ---
+//
+// SERIALIZATION RULE (#167 tracing-callsite-interest trap): any test
+// that executes the deprecation-warn callsite with NO subscriber
+// installed can poison the callsite's cached interest as
+// never-enabled, silently dropping the event for later capture tests.
+// Every test whose config sets `ticket_label_investigation` — even
+// the non-capture ones — must run #[serial_test::serial] so no
+// sibling executes the callsite concurrently unhooked. Capture tests
+// additionally run their load inside `init_for_test` so every
+// callsite execution in this binary happens under an active
+// subscriber.
+//
+// The capture assertions check the JSON line level is WARN (the
+// test subscriber runs at TRACE, so a warn line is present; the
+// level tag proves it is a warning, not an info line).
+
+#[test]
+#[serial_test::serial]
+fn explicit_investigation_label_emits_deprecation_warn() {
+    use caduceus::logging::init_for_test;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = dir.path().join("warn.log");
+    let body = format!(
+        "{}ticket_label_investigation: \"autofix-investigate\"\n",
+        trusted_host_base()
+    );
+    let path = dir.path().join("config.yaml");
+    let body = body.replace("__TMP__", &dir.path().to_string_lossy());
+    std::fs::write(&path, body).expect("write config");
+    init_for_test(&log, || {
+        Config::load_from(&path).expect("config loads (warning only)")
+    })
+    .expect("capture body");
+    let logged = std::fs::read_to_string(&log).expect("read log");
+    assert!(
+        logged.contains("ticket_label_investigation is deprecated"),
+        "got: {logged}"
+    );
+    assert!(logged.contains("deprecated"), "got: {logged}");
+    assert!(
+        logged.contains("\"level\":\"WARN\""),
+        "must be WARN level, got: {logged}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn default_investigation_label_does_not_warn() {
+    use caduceus::logging::init_for_test;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = dir.path().join("silent.log");
+    let body = trusted_host_base().replace("__TMP__", &dir.path().to_string_lossy());
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, body).expect("write config");
+    init_for_test(&log, || Config::load_from(&path).expect("config loads")).expect("capture body");
+    let logged = std::fs::read_to_string(&log).expect("read log");
+    assert!(
+        !logged.contains("ticket_label_investigation is deprecated"),
+        "default must not warn, got: {logged}"
+    );
+    // The resolved label is still the transitional default.
+    // (Re-load outside the capture to assert the value.)
+    let cfg = Config::load_from(&path).expect("reload");
+    assert_eq!(cfg.ticket_label_investigation, "autofix-investigate");
+}
+
+#[test]
+#[serial_test::serial]
+fn legacy_emoji_investigation_label_still_translates_and_now_also_warns_deprecation() {
+    // An explicitly-set legacy emoji value hits BOTH warns: the
+    // #291 translation warn and the #320 deprecation warn.
+    use caduceus::logging::init_for_test;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = dir.path().join("both.log");
+    let body = format!(
+        "{}ticket_label_investigation: \"🤖 auto-fix-investigate\"\n",
+        trusted_host_base()
+    )
+    .replace("__TMP__", &dir.path().to_string_lossy());
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, body).expect("write config");
+    init_for_test(&log, || {
+        Config::load_from(&path).expect("config loads (warning only)")
+    })
+    .expect("capture body");
+    let logged = std::fs::read_to_string(&log).expect("read log");
+    assert!(
+        logged.contains("translated at read time"),
+        "#291 translation warn must fire, got: {logged}"
+    );
+    assert!(
+        logged.contains("ticket_label_investigation is deprecated"),
+        "deprecation warn must fire too, got: {logged}"
+    );
+    let cfg = Config::load_from(&path).expect("reload");
+    assert_eq!(cfg.ticket_label_investigation, "autofix-investigate");
+}
+
+#[test]
+#[serial_test::serial]
+fn investigation_config_never_feeds_auto_review() {
+    // AC5: explicit investigation config, no auto_review block ⇒
+    // cfg.auto_review is None. Investigation config has zero effect on
+    // the review block (DAR §12: never mapped). The load runs inside
+    // `init_for_test` so this callsite execution never poisons the
+    // interest cache for the sibling capture tests (#167).
+    use caduceus::logging::init_for_test;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = dir.path().join("no-translate.log");
+    let body = format!(
+        "{}ticket_label_investigation: \"autofix-investigate\"\n",
+        trusted_host_base()
+    )
+    .replace("__TMP__", &dir.path().to_string_lossy());
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, body).expect("write config");
+    let cfg = init_for_test(&log, || {
+        Config::load_from(&path).expect("loads with warning only")
+    })
+    .expect("capture body");
+    assert!(cfg.auto_review.is_none());
+}

--- a/tests/infra/config/auto_review_config_test.rs
+++ b/tests/infra/config/auto_review_config_test.rs
@@ -110,12 +110,12 @@ fn matrix_trusted_host_error_survives_present_valid_sandbox() {
 
 #[test]
 fn matrix_enabled_oci_missing_sandbox_errors_from_existing_check() {
-    let err = load(&format!(
+    let err = load(
         "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
          state_dir: \"__TMP__/state\"\n\
          executor_mode: oci\n\
-         auto_review:\n  enabled: true\n"
-    ))
+         auto_review:\n  enabled: true\n",
+    )
     .expect_err("oci without sandbox must fail (existing rule)");
     let msg = format!("{err}");
     assert!(
@@ -141,13 +141,13 @@ fn matrix_enabled_oci_valid_sandbox_is_the_ok_shape() {
 
 #[test]
 fn matrix_enabled_oci_invalid_image_errors_from_sandbox_validation() {
-    let err = load(&format!(
+    let err = load(
         "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
          state_dir: \"__TMP__/state\"\n\
          executor_mode: oci\n\
          sandbox:\n  image: \"not-a-digest\"\n\
-         auto_review:\n  enabled: true\n"
-    ))
+         auto_review:\n  enabled: true\n",
+    )
     .expect_err("bad image must fail (existing rule)");
     let msg = format!("{err}");
     assert!(msg.contains("sandbox.image"), "got: {msg}");

--- a/tests/infra/config/auto_review_config_test.rs
+++ b/tests/infra/config/auto_review_config_test.rs
@@ -38,3 +38,37 @@ fn auto_review_enabled_with_trusted_host_is_rejected() {
     assert!(msg.contains("sandbox:"), "got: {msg}");
     assert!(msg.contains("caduceus doctor"), "got: {msg}");
 }
+
+#[test]
+fn max_reviews_per_tick_defaults_to_parallelism_x4() {
+    let cfg =
+        load(&format!("{}worker_parallelism: 3\n", trusted_host_base())).expect("config loads");
+    assert_eq!(cfg.max_reviews_per_tick, 12);
+}
+
+#[test]
+fn max_reviews_per_tick_explicit_value_wins() {
+    let cfg = load(&format!(
+        "{}worker_parallelism: 3\nmax_reviews_per_tick: 5\n",
+        trusted_host_base()
+    ))
+    .expect("config loads");
+    assert_eq!(cfg.max_reviews_per_tick, 5);
+}
+
+#[test]
+fn max_reviews_per_tick_zero_is_unbounded_not_rejected() {
+    let cfg = load(&format!("{}max_reviews_per_tick: 0\n", trusted_host_base()))
+        .expect("0 = unbounded opt-in, mirrors max_issues_per_tick");
+    assert_eq!(cfg.max_reviews_per_tick, 0);
+}
+
+#[test]
+fn max_reviews_per_tick_saturates_instead_of_overflowing() {
+    let cfg = load(&format!(
+        "{}worker_parallelism: 4294967295\n",
+        trusted_host_base()
+    ))
+    .expect("saturating_mul must not panic");
+    assert_eq!(cfg.max_reviews_per_tick, u32::MAX);
+}

--- a/tests/infra/config/auto_review_config_test.rs
+++ b/tests/infra/config/auto_review_config_test.rs
@@ -1,0 +1,40 @@
+//! Config-loader tests for the `auto_review:` block, the
+//! OCI-required validation (DAR §6.3), `max_reviews_per_tick`, and
+//! the release-N `ticket_label_investigation` deprecation warning
+//! (DAR §12). Mirrors sandbox_config_test.rs: load through the
+//! canonical `Config::load_from` chain, assert on message content.
+
+use caduceus::infra::config::Config;
+use caduceus::infra::error::CaduceusError;
+
+const VALID_IMAGE: &str =
+    "caduceus-worker@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+fn load(body: &str) -> Result<Config, CaduceusError> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.yaml");
+    let body = body.replace("__TMP__", &dir.path().to_string_lossy());
+    std::fs::write(&path, body).expect("write config");
+    Config::load_from(&path)
+}
+
+fn trusted_host_base() -> String {
+    "worker_command: [\"python3\", \"/tmp/bridge.py\"]\n\
+     state_dir: \"__TMP__/state\"\n\
+     reduced_containment_acknowledged: true\n"
+        .to_string()
+}
+
+#[test]
+fn auto_review_enabled_with_trusted_host_is_rejected() {
+    let err = load(&format!(
+        "{}auto_review:\n  enabled: true\n",
+        trusted_host_base()
+    ))
+    .expect_err("enabled + trusted_host must fail");
+    let msg = format!("{err}");
+    assert!(msg.contains("auto_review.enabled"), "got: {msg}");
+    assert!(msg.contains("executor_mode: oci"), "got: {msg}");
+    assert!(msg.contains("sandbox:"), "got: {msg}");
+    assert!(msg.contains("caduceus doctor"), "got: {msg}");
+}

--- a/tests/state/config_test.rs
+++ b/tests/state/config_test.rs
@@ -6,7 +6,8 @@
 
 use caduceus::config::{
     expand_leading_tilde, is_valid_repo_slug, Config, LoadContext, RawConfig, RawEnv,
-    DEFAULT_API_BASE, DEFAULT_TICKET_LABEL_CODE, DEFAULT_TICKET_LABEL_INVESTIGATION,
+    DEFAULT_API_BASE, DEFAULT_MAX_REVIEWS_PER_TICK_MULTIPLIER, DEFAULT_TICKET_LABEL_CODE,
+    DEFAULT_TICKET_LABEL_INVESTIGATION, DEFAULT_WORKER_PARALLELISM,
 };
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
@@ -60,6 +61,11 @@ fn test_defaults_match_contract() {
     assert!(cfg.github_token.is_none());
     assert!(cfg.compiled_ignore_patterns.is_empty());
     assert_eq!(cfg.state_backend, "json");
+    assert_eq!(
+        cfg.max_reviews_per_tick,
+        DEFAULT_WORKER_PARALLELISM.saturating_mul(DEFAULT_MAX_REVIEWS_PER_TICK_MULTIPLIER)
+    );
+    assert!(cfg.auto_review.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## What

Implements #320 per `docs/architecture/auto-review.md` §5, §5.2, §6.3,
§12 — config surface only (schema-owned), zero daemon behavior changes
beyond the new validation.

- **`auto_review:` block** on `Config` + `RawConfig` (mirrors the
  `sandbox:` Option-block pattern), `deny_unknown_fields` on both
  structs: `enabled: bool` (default false) and
  `draft_pull_requests: bool` (default false). Absent block = disabled.
- **OCI-required validation** (DAR §6.3): `auto_review.enabled: true`
  with `executor_mode: trusted_host` fails `from_raw` with an
  actionable error naming both required changes (`executor_mode: oci`
  and a valid `sandbox:` section) and pointing at `caduceus doctor` /
  config docs. A present sandbox does **not** soften the refusal —
  the mode must be `oci`.
- **`max_reviews_per_tick`**: top-level validated `u32`, sibling of
  `max_issues_per_tick`, default `worker_parallelism * 4` (new
  `DEFAULT_MAX_REVIEWS_PER_TICK_MULTIPLIER`), `0` = unbounded.
  Consumed by the #312 admission budget; schema owned here.
- **Release-N deprecation warning** (DAR §12): warn once per config
  load when `ticket_label_investigation` is explicitly set (the
  default resolves silently; per-admission warnings are #329, removal
  is #331). Warning only — admissions unchanged.
- **No silent translation** of investigation config into `auto_review`
  (DAR §12: transitional label is never mapped to `autoreview`).
- No `allow_fork_prs` knob; no Phase-2 options (`rerun_command`,
  `minimum_severity` — rejected at parse time by
  `deny_unknown_fields`).

New tests in `tests/infra/config/auto_review_config_test.rs`
(registered binary): new/legacy config shapes, the full
enabled×executor_mode×sandbox validation matrix, `max_reviews_per_tick`
default/override/0/saturation, deny-unknown, warn capture (via
`logging::init_for_test`, `#[serial_test::serial]` per the #167
callsite-interest trap), and the no-translation proof.

## Behavior change

TrustedHost installs cannot enable auto_review: `auto_review.enabled:
true` with the default `executor_mode: trusted_host` now fails config
load. No previously-valid config breaks (the block is new), but this is
the deliberate DAR §6.3 security boundary and is called out for release
notes (#325 owns the full migration guide).

## Finding (pre-existing, out of scope)

`Config::from_raw` contains dead validation: the circuit-breaker error
pushes (`circuit_failure_threshold: 0`, empty `circuit_backoff_seconds`,
zero `circuit_open_interval_seconds` / `circuit_max_degraded_seconds`)
land inside the `Ok(Config { ... })` literal — i.e. AFTER the
`if !errors.is_empty()` early return — so those error strings can never
surface and invalid values load silently. Not fixed here (#320 scope is
config-surface for auto_review); tracked separately.

## Verification

- `cargo fmt --check` — ok
- `cargo clippy --locked --all-targets -- -D warnings` — ok
- `cargo test --locked --all-targets` (hermetic skips) — 2376 passed, 0 failed
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 181 passed

Closes #320