### PR TITLE
build(executor): implement target-neutral WorkTarget boundary (issue #346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   unbounded) bounds per-tick review admission. `ticket_label_investigation`
   is deprecated: explicit config use now emits a warning; the key is
   removed in a future release. Closes #320.
+- **Target-neutral worker boundary.** The executor/supervisor boundary
+  now carries a `WorkTarget` — `Issue(IssueWorkTarget)` keeps the
+  historical issue payload (byte-for-byte env and supervisor argv
+  compatibility) while `PullRequest(ReviewTarget)` carries the frozen
+  review identity with no synthetic issue key and no branch name.
+  Review runs export `CADUCEUS_WORK_TARGET=pr` plus
+  `CADUCEUS_PR_NUMBER` / `CADUCEUS_PR_REPO` / `CADUCEUS_PR_BASE_SHA` /
+  `CADUCEUS_PR_HEAD_SHA`; `CANONICAL_WORKER_ENV_VARS` is now the union
+  of the issue and PR path sets. The worker bridge is mode-aware: PR
+  runs resolve only the mode-correct result path and never synthesise
+  a legacy result (missing result file = execution failure). Closes
+  #346.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,10 @@ name = "sandbox_resolve_test"
 path = "tests/executor/sandbox_resolve_test.rs"
 
 [[test]]
+name = "work_target_test"
+path = "tests/executor/work_target_test.rs"
+
+[[test]]
 name = "identity_resolution_test"
 path = "tests/executor/identity_resolution_test.rs"
 

--- a/plugin-assets/worker-bridge.py
+++ b/plugin-assets/worker-bridge.py
@@ -72,27 +72,77 @@ from types import MappingProxyType
 # Constants
 # ---------------------------------------------------------------------------
 
-#: Required ``CADUCEUS_*`` environment variables. The daemon exports every
-#: one of these for the worker; a missing entry means the daemon is not
+#: Required ``CADUCEUS_*`` environment variables — the full union
+#: across both target paths (DAR §6.1). The daemon exports every one of
+#: these for some worker run; the mode-aware :func:`read_required_env`
+#: is the single authority that decides which names a given run must
+#: actually carry (issue path: mode-neutral + ``CADUCEUS_ISSUE_*`` +
+#: branch; PR path: mode-neutral + ``CADUCEUS_PR_*`` + the ``pr`` mode
+#: marker). A missing hard-required entry means the daemon is not
 #: talking to a current bridge.
 REQUIRED_ENV_VARS: tuple[str, ...] = (
-    "CADUCEUS_ISSUE_NUMBER",
-    "CADUCEUS_ISSUE_TITLE",
-    "CADUCEUS_ISSUE_BODY",
-    "CADUCEUS_ISSUE_REPO",
-    "CADUCEUS_CONTEXT_JSON",
-    "CADUCEUS_WORKTREE_PATH",
-    "CADUCEUS_RUN_ID",
-    "CADUCEUS_ISSUE_LABELS_JSON",
     "CADUCEUS_BRANCH_NAME",
+    "CADUCEUS_CONTEXT_JSON",
+    "CADUCEUS_ISSUE_BODY",
+    "CADUCEUS_ISSUE_LABELS_JSON",
+    "CADUCEUS_ISSUE_NUMBER",
+    "CADUCEUS_ISSUE_REPO",
+    "CADUCEUS_ISSUE_TITLE",
+    "CADUCEUS_RUN_ID",
+    "CADUCEUS_WORKTREE_PATH",
     "CADUCEUS_RESULT_PATH",
+    "CADUCEUS_WORK_TARGET",
+    "CADUCEUS_PR_BASE_SHA",
+    "CADUCEUS_PR_HEAD_SHA",
+    "CADUCEUS_PR_NUMBER",
+    "CADUCEUS_PR_REPO",
 )
+
+#: Variables every run needs, regardless of target (DAR §6.1).
+MODE_NEUTRAL_ENV_VARS: frozenset[str] = frozenset(
+    {
+        "CADUCEUS_CONTEXT_JSON",
+        "CADUCEUS_RUN_ID",
+        "CADUCEUS_WORKTREE_PATH",
+    }
+)
+
+#: Issue-path-only variables (DAR §6.1). Required when
+#: ``CADUCEUS_WORK_TARGET`` is absent; never required on the PR path.
+ISSUE_PATH_ENV_VARS: frozenset[str] = frozenset(
+    {
+        "CADUCEUS_BRANCH_NAME",
+        "CADUCEUS_ISSUE_BODY",
+        "CADUCEUS_ISSUE_LABELS_JSON",
+        "CADUCEUS_ISSUE_NUMBER",
+        "CADUCEUS_ISSUE_REPO",
+        "CADUCEUS_ISSUE_TITLE",
+    }
+)
+
+#: PR-path-only variables (DAR §6.1). Required when
+#: ``CADUCEUS_WORK_TARGET=pr``; never required on the issue path.
+PR_PATH_ENV_VARS: frozenset[str] = frozenset(
+    {
+        "CADUCEUS_PR_BASE_SHA",
+        "CADUCEUS_PR_HEAD_SHA",
+        "CADUCEUS_PR_NUMBER",
+        "CADUCEUS_PR_REPO",
+        "CADUCEUS_WORK_TARGET",
+    }
+)
+
+#: The daemon-consumed result location. Soft-required on the issue path
+#: (the bridge falls back to the legacy location with a warning); on the
+#: PR path there is no legacy location, so a missing value is a
+#: hard-required contract failure (DAR §6.2).
+RESULT_PATH_ENV_VAR = "CADUCEUS_RESULT_PATH"
 
 #: Names in :data:`REQUIRED_ENV_VARS` that are soft-required. A missing
 #: entry must not abort the worker: the bridge falls back to the legacy
 #: location (with a stderr warning) instead. Every other required name
 #: is hard-required and aborts with ``EXIT_MISSING_ENV``.
-SOFT_REQUIRED_ENV_VARS: frozenset[str] = frozenset({"CADUCEUS_RESULT_PATH"})
+SOFT_REQUIRED_ENV_VARS: frozenset[str] = frozenset({RESULT_PATH_ENV_VAR})
 
 #: File names inside the worktree the daemon prepares. The bridge never
 #: reads ``worker-result.json`` (the daemon reads it after the worker
@@ -102,6 +152,7 @@ PROMPT_FILE_NAME = "worker-prompt.md"
 #: Exit codes that the bridge maps onto the daemon's worker interface.
 EXIT_OK = 0
 EXIT_MISSING_ENV = 2
+EXIT_MISSING_RESULT = 2
 EXIT_MALFORMED_LABELS = 2
 EXIT_MISSING_PROMPT = 2
 EXIT_HARNESS_NOT_FOUND = 127
@@ -146,18 +197,41 @@ class Issue:
 
 
 @dataclass(frozen=True)
+class PrTarget:
+    """PR review target exposed to a user harness through :class:`Ctx`.
+
+    Mirrors the daemon's ``CADUCEUS_PR_*`` env contract (DAR §6.1): the
+    frozen review identity. ``base_ref``/``merge_base`` do not enter the
+    environment — they reach the worker through the prompt/context.
+    """
+
+    repo: str
+    number: int
+    base_sha: str
+    head_sha: str
+
+
+@dataclass(frozen=True)
 class Ctx:
-    """The explicit worker context passed to ``run_task``."""
+    """The explicit worker context passed to ``run_task``.
+
+    ``issue`` is populated on the issue path (all historical fields
+    identical to pre-#346); ``pr`` is populated on the PR review path.
+    Exactly one of them is ``None`` for any run. ``branch`` is the
+    daemon-owned branch on the issue path and the empty string on the
+    PR path (an empty passthrough, never a synthetic branch name).
+    """
 
     worktree: Path
     prompt: Path
     run_id: str
     branch: str
     labels: list[str]
-    issue: Issue
+    issue: Issue | None
     context_json: str
     dry_run: bool
     env: Mapping[str, str]
+    pr: PrTarget | None = None
 
 
 def _hermes_home(env: Mapping[str, str] | None = None) -> Path:
@@ -181,11 +255,53 @@ def _legacy_bridge_path(env: Mapping[str, str] | None = None) -> Path:
 
 
 def _build_ctx(env: Mapping[str, str]) -> Ctx:
-    """Validate the daemon environment and construct the hook context."""
+    """Validate the daemon environment and construct the hook context.
+
+    Mode-aware (DAR §6.1): the absence of ``CADUCEUS_WORK_TARGET``
+    selects the issue path (historical ``ctx.issue`` shape); the value
+    ``pr`` selects the PR review path (``ctx.pr`` populated, ``issue``
+    ``None``, ``branch`` empty, ``labels`` empty). Any other value is
+    fail-closed — the daemon is the only setter of this variable.
+    """
     values = read_required_env(env)
-    labels = parse_labels(values["CADUCEUS_ISSUE_LABELS_JSON"])
+    mode = env.get("CADUCEUS_WORK_TARGET", "")
     worktree = resolve_worktree(env).expanduser().resolve()
     prompt = verify_prompt(worktree / PROMPT_FILE_NAME)
+    dry_run = env.get("CADUCEUS_DRY_RUN", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if mode == "pr":
+        try:
+            pr_number = int(values["CADUCEUS_PR_NUMBER"])
+        except ValueError as exc:
+            print(
+                f"caduceus bridge: invalid CADUCEUS_PR_NUMBER: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(EXIT_MISSING_ENV)
+        return Ctx(
+            worktree=worktree,
+            prompt=prompt,
+            run_id=values["CADUCEUS_RUN_ID"],
+            # Empty passthrough on the PR path — never a synthetic
+            # branch name (DAR §6.1).
+            branch="",
+            labels=[],
+            issue=None,
+            context_json=values["CADUCEUS_CONTEXT_JSON"],
+            dry_run=dry_run,
+            env=MappingProxyType(dict(env)),
+            pr=PrTarget(
+                repo=values["CADUCEUS_PR_REPO"],
+                number=pr_number,
+                base_sha=values["CADUCEUS_PR_BASE_SHA"],
+                head_sha=values["CADUCEUS_PR_HEAD_SHA"],
+            ),
+        )
+    labels = parse_labels(values["CADUCEUS_ISSUE_LABELS_JSON"])
     try:
         issue_number = int(values["CADUCEUS_ISSUE_NUMBER"])
     except ValueError as exc:
@@ -195,12 +311,6 @@ def _build_ctx(env: Mapping[str, str]) -> Ctx:
             file=sys.stderr,
         )
         sys.exit(EXIT_MISSING_ENV)
-    dry_run = env.get("CADUCEUS_DRY_RUN", "").lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
     return Ctx(
         worktree=worktree,
         prompt=prompt,
@@ -307,15 +417,30 @@ def truncate_pull_request_title(title: str) -> str:
     return title[: MAX_PULL_REQUEST_TITLE_CHARS - 1] + "…"
 
 
-def _result_path(worktree: Path) -> Path:
-    """Return the daemon-consumed result path for a worktree.
+def _result_path(worktree: Path, env: Mapping[str, str] | None = None) -> Path:
+    """Return the daemon-consumed result path for a run.
 
     The daemon may export ``CADUCEUS_RESULT_PATH`` (the agent-neutral
-    result location). When set and non-empty it wins; otherwise the
-    legacy ``<worktree>/worker-result.json`` location is used and a
-    visible but non-fatal warning is written to stderr.
+    result location); when set and non-empty it wins. On the **issue
+    path** a missing value falls back to the legacy
+    ``<worktree>/worker-result.json`` location with a visible but
+    non-fatal warning (unchanged pre-#346 behaviour). On the **PR
+    path** (``CADUCEUS_WORK_TARGET=pr``) there is no legacy location:
+    the mode-correct path is ``CADUCEUS_RESULT_PATH`` only (DAR §6.2),
+    and a missing value aborts — ``read_required_env`` already
+    hard-requires it, this is belt-and-braces.
     """
-    override = os.environ.get("CADUCEUS_RESULT_PATH")
+    source = os.environ if env is None else env
+    mode = source.get("CADUCEUS_WORK_TARGET", "")
+    override = source.get(RESULT_PATH_ENV_VAR)
+    if mode == "pr":
+        if override:
+            return Path(override)
+        sys.stderr.write(
+            "caduceus bridge: pr target requires "
+            f"{RESULT_PATH_ENV_VAR}; no legacy fallback exists\n"
+        )
+        sys.exit(EXIT_MISSING_ENV)
     if override:
         return Path(override)
     sys.stderr.write(
@@ -426,14 +551,36 @@ def invoke_harness(
 def read_required_env(env: Mapping[str, str]) -> dict:
     """Return a new dict containing every required ``CADUCEUS_*`` value.
 
+    Mode-aware (DAR §6.1): ``CADUCEUS_WORK_TARGET`` selects the
+    required set. Absent/empty → issue path (mode-neutral + issue
+    vars; ``CADUCEUS_RESULT_PATH`` stays soft-required). ``pr`` →
+    PR path (mode-neutral + PR vars; ``CADUCEUS_RESULT_PATH`` becomes
+    hard-required because no legacy fallback exists). Any other value
+    is fail-closed — the daemon is the only setter of this variable.
     Raises ``SystemExit(EXIT_MISSING_ENV)`` with a one-line stderr
-    diagnostic naming each missing key. The error message never embeds
-    the values (no echo of titles, bodies, or tokens).
+    diagnostic naming each missing key. The error message never
+    embeds the values (no echo of titles, bodies, or tokens).
     """
+    mode = env.get("CADUCEUS_WORK_TARGET", "")
+    if mode == "pr":
+        required = (
+            MODE_NEUTRAL_ENV_VARS | PR_PATH_ENV_VARS | {RESULT_PATH_ENV_VAR}
+        )
+        soft: frozenset[str] = frozenset()
+    elif mode == "":
+        required = MODE_NEUTRAL_ENV_VARS | ISSUE_PATH_ENV_VARS
+        soft = SOFT_REQUIRED_ENV_VARS
+    else:
+        print(
+            "caduceus bridge: unknown CADUCEUS_WORK_TARGET value: "
+            f"{mode!r} (expected empty or 'pr')",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_MISSING_ENV)
     missing = [
         name
-        for name in REQUIRED_ENV_VARS
-        if name not in SOFT_REQUIRED_ENV_VARS and not env.get(name)
+        for name in sorted(required)
+        if name not in soft and not env.get(name)
     ]
     if missing:
         print(
@@ -444,7 +591,7 @@ def read_required_env(env: Mapping[str, str]) -> dict:
         sys.exit(EXIT_MISSING_ENV)
     return {
         name: env[name]
-        for name in REQUIRED_ENV_VARS
+        for name in required | soft
         if name in env and env[name]
     }
 
@@ -541,7 +688,19 @@ def main(
             sys.stdout.write(stdout)
         if stderr:
             sys.stderr.write(stderr)
-        if not _result_path(ctx.worktree).exists():
+        result_path = _result_path(ctx.worktree, env)
+        if env.get("CADUCEUS_WORK_TARGET", "") == "pr":
+            # PR mode (DAR §6.2): the harness is responsible for the
+            # review result; the bridge never synthesizes one. A run
+            # that produced no result file is a contract failure.
+            if not result_path.exists():
+                sys.stderr.write(
+                    "caduceus bridge: pr target produced no result file at "
+                    f"{result_path}\n"
+                )
+                return EXIT_MISSING_RESULT
+            return returncode
+        if not result_path.exists():
             _synthesize_worker_result(ctx.worktree, returncode, stdout, stderr)
         return returncode
 

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -45,7 +45,14 @@ When triggered, this skill should:
    legacy path. To verify the active path, run
    `ls ~/.hermes/caduceus/`: a `harness.py` file means the new
    contract; only `worker-bridge.py` means the legacy path. The parent
-   resolves this relative to `$HERMES_HOME` (default `~/.hermes`).
+   resolves this relative to `$HERMES_HOME` (default `~/.hermes`). The
+   bridge is target-neutral: a PR review run exports
+   `CADUCEUS_WORK_TARGET=pr` plus the `CADUCEUS_PR_*` vars, resolves
+   only the mode-correct result path, and never synthesizes a result
+   (no result file = execution failure). Re-seed the user-owned bridge
+   (`hermes caduceus setup`) before enabling review runs — an
+   un-updated copy fails closed on a PR env while issue-path runs keep
+   working unchanged.
 5. **If something is broken**: tail `<state_dir>/processor.log` and
    `<state_dir>/runs/<run-id>.log` for the affected run. For a terminal
    failed/skipped entry, show `caduceus queue show OWNER/REPO#N` to

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -496,18 +496,16 @@ async fn run_canary(
         }
     };
     let result = match outcome {
-        Ok(outcome) => {
-            match caduceus::worker::parse_result_file(&outcome.result_path, issue_key) {
-                Ok(result) => DiagnosticCanary {
-                    status: DiagnosticStatus::Pass,
-                    detail: format!("production path completed with {:?} result", result.status),
-                },
-                Err(err) => DiagnosticCanary {
-                    status: DiagnosticStatus::Failure,
-                    detail: format!("result artifact validation failed: {err}"),
-                },
-            }
-        }
+        Ok(outcome) => match caduceus::worker::parse_result_file(&outcome.result_path, issue_key) {
+            Ok(result) => DiagnosticCanary {
+                status: DiagnosticStatus::Pass,
+                detail: format!("production path completed with {:?} result", result.status),
+            },
+            Err(err) => DiagnosticCanary {
+                status: DiagnosticStatus::Failure,
+                detail: format!("result artifact validation failed: {err}"),
+            },
+        },
         Err(err) => DiagnosticCanary {
             status: DiagnosticStatus::Failure,
             detail: format!("production path failed: {err}"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,7 +16,7 @@ use clap::{Parser, Subcommand};
 use caduceus::config::{Config, SetupAction};
 use caduceus::error::{CaduceusError, CaduceusResult};
 use caduceus::executor::oci::OciExecutor;
-use caduceus::executor::{Executor, ExecutorSpec};
+use caduceus::executor::{Executor, ExecutorSpec, IssueWorkTarget, WorkTarget};
 use caduceus::issue::IssueKey;
 use caduceus::queue::{
     display_digest, Phase, QueueEntry, QueueState, RemoveOutcome, StateStore, TicketType,
@@ -466,16 +466,18 @@ async fn run_canary(
     };
     let spec = ExecutorSpec {
         self_exe: std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("caduceus")),
-        issue,
+        target: WorkTarget::Issue(IssueWorkTarget {
+            key: issue,
+            title: "OCI readiness canary".to_string(),
+            body: "Diagnostic only".to_string(),
+            labels: Vec::new(),
+            branch_name: "doctor-canary".to_string(),
+        }),
         worktree: worktree.clone(),
         run_id,
         context_json: "{}".to_string(),
         worker_command: command,
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "OCI readiness canary".to_string(),
-        issue_body: "Diagnostic only".to_string(),
-        labels: Vec::new(),
-        branch_name: "doctor-canary".to_string(),
     };
     let executor = OciExecutor::new(
         canary_config.clone(),
@@ -484,18 +486,28 @@ async fn run_canary(
         )),
     );
     let outcome = executor.run(&spec).await;
-    let result = match outcome {
-        Ok(outcome) => match caduceus::worker::parse_result_file(&outcome.result_path, &spec.issue)
-        {
-            Ok(result) => DiagnosticCanary {
-                status: DiagnosticStatus::Pass,
-                detail: format!("production path completed with {:?} result", result.status),
-            },
-            Err(err) => DiagnosticCanary {
+    let issue_key = match &spec.target {
+        WorkTarget::Issue(issue) => &issue.key,
+        WorkTarget::PullRequest(_) => {
+            return DiagnosticCanary {
                 status: DiagnosticStatus::Failure,
-                detail: format!("result artifact validation failed: {err}"),
-            },
-        },
+                detail: "doctor canary only supports issue targets".to_string(),
+            };
+        }
+    };
+    let result = match outcome {
+        Ok(outcome) => {
+            match caduceus::worker::parse_result_file(&outcome.result_path, issue_key) {
+                Ok(result) => DiagnosticCanary {
+                    status: DiagnosticStatus::Pass,
+                    detail: format!("production path completed with {:?} result", result.status),
+                },
+                Err(err) => DiagnosticCanary {
+                    status: DiagnosticStatus::Failure,
+                    detail: format!("result artifact validation failed: {err}"),
+                },
+            }
+        }
         Err(err) => DiagnosticCanary {
             status: DiagnosticStatus::Failure,
             detail: format!("production path failed: {err}"),

--- a/src/daemon/status.rs
+++ b/src/daemon/status.rs
@@ -18,7 +18,6 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::readiness::{ReadinessReport, ReadinessVerdict};
 use crate::state::meta::{MetaStore, StateMeta, TickOutcome};
@@ -556,7 +555,7 @@ fn collect_live_workers(state_dir: &Path) -> Vec<LiveWorker> {
         // marker tells them which is which.
         workers.push(LiveWorker {
             run_id: record.run_id,
-            issue: record.issue_key.display_key(),
+            issue: record.target.clone(),
             pid: record.pid,
             started_at: record.started_at,
             updated_at: record.updated_at,
@@ -803,7 +802,7 @@ pub fn live_worker_from_heartbeat(record: &Heartbeat, now: DateTime<Utc>) -> Liv
     };
     LiveWorker {
         run_id: record.run_id.clone(),
-        issue: record.issue_key.display_key(),
+        issue: record.target.clone(),
         pid: record.pid,
         started_at: record.started_at,
         updated_at: record.updated_at,
@@ -816,14 +815,14 @@ pub fn live_worker_from_heartbeat(record: &Heartbeat, now: DateTime<Utc>) -> Liv
 /// supervisor's production writer so the
 /// `read_heartbeat_record` round-trip succeeds.
 #[allow(dead_code)]
-pub fn sample_heartbeat(run_id: &str, issue: IssueKey, now: DateTime<Utc>) -> Heartbeat {
+pub fn sample_heartbeat(run_id: &str, target: &str, now: DateTime<Utc>) -> Heartbeat {
     Heartbeat {
         version: crate::worker::supervisor::HEARTBEAT_FILE_VERSION,
         run_id: run_id.to_string(),
         pid: std::process::id(),
         started_at: now,
         updated_at: now,
-        issue_key: issue,
+        target: target.to_string(),
         transcript_path: PathBuf::from(format!("/tmp/runs/{run_id}.log")),
     }
 }

--- a/src/daemon/tick/per_claim.rs
+++ b/src/daemon/tick/per_claim.rs
@@ -243,16 +243,18 @@ pub(crate) async fn run_claim(
     let worker_command = cfg.worker_command.clone();
     let spec = crate::executor::ExecutorSpec {
         self_exe,
-        issue: claimed.entry.key.clone(),
+        target: crate::executor::WorkTarget::Issue(crate::executor::IssueWorkTarget {
+            key: claimed.entry.key.clone(),
+            title: issue.title.clone(),
+            body: issue.body.clone(),
+            labels: issue.labels.clone(),
+            branch_name: worktree.branch_name.clone(),
+        }),
         worktree: worktree.path.clone(),
         run_id: run_id.clone(),
         context_json: context_json.clone(),
         worker_command,
         cancellation: cancellation.clone(),
-        issue_title: issue.title.clone(),
-        issue_body: issue.body.clone(),
-        labels: issue.labels.clone(),
-        branch_name: worktree.branch_name.clone(),
     };
     let exec_outcome = match services.executor.run(&spec).await {
         Ok(o) => o,

--- a/src/executor/engine_probe.rs
+++ b/src/executor/engine_probe.rs
@@ -151,17 +151,10 @@ pub async fn probe_runtime_facts_with_daemon_id(
     create_git_shadow(&git_shadow_host, git_shadow_kind, engine, engine_mode)?;
 
     // 6. Assemble the extended facts.
-    let issue = match &spec.target {
-        crate::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-        crate::executor::WorkTarget::PullRequest(_) => {
-            return Err(CaduceusError::Other(
-                "PR review targets are not yet supported by the OCI probe (issue #346)".to_string(),
-            ));
-        }
-    };
+    let target = spec.target.display();
     Ok(RuntimeFacts {
         run_id: spec.run_id.clone(),
-        issue,
+        target,
         worker_command: spec.worker_command.clone(),
         worktree: spec.worktree.clone(),
         output_dir,

--- a/src/executor/engine_probe.rs
+++ b/src/executor/engine_probe.rs
@@ -151,9 +151,18 @@ pub async fn probe_runtime_facts_with_daemon_id(
     create_git_shadow(&git_shadow_host, git_shadow_kind, engine, engine_mode)?;
 
     // 6. Assemble the extended facts.
+    let issue = match &spec.target {
+        crate::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+        crate::executor::WorkTarget::PullRequest(_) => {
+            return Err(CaduceusError::Other(
+                "PR review targets are not yet supported by the OCI probe (issue #346)"
+                    .to_string(),
+            ));
+        }
+    };
     Ok(RuntimeFacts {
         run_id: spec.run_id.clone(),
-        issue: spec.issue.clone(),
+        issue,
         worker_command: spec.worker_command.clone(),
         worktree: spec.worktree.clone(),
         output_dir,

--- a/src/executor/engine_probe.rs
+++ b/src/executor/engine_probe.rs
@@ -155,8 +155,7 @@ pub async fn probe_runtime_facts_with_daemon_id(
         crate::executor::WorkTarget::Issue(issue) => issue.key.clone(),
         crate::executor::WorkTarget::PullRequest(_) => {
             return Err(CaduceusError::Other(
-                "PR review targets are not yet supported by the OCI probe (issue #346)"
-                    .to_string(),
+                "PR review targets are not yet supported by the OCI probe (issue #346)".to_string(),
             ));
         }
     };

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -62,7 +62,7 @@ pub use sandbox_spec::{
 /// [`ExecutorSpec`] fields); PR review runs carry the frozen review
 /// identity. No variant may be faked into the other: constructing a PR
 /// run never requires an [`IssueKey`] or a branch name, and vice versa.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WorkTarget {
     /// Issue-path payload — byte-for-byte the former flat fields.
     Issue(IssueWorkTarget),
@@ -73,7 +73,7 @@ pub enum WorkTarget {
 /// Issue-path payload — byte-for-byte the former flat `ExecutorSpec`
 /// issue fields, kept so the issue env contract and supervisor argv
 /// stay unchanged (DAR §6.1).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IssueWorkTarget {
     /// The issue key being worked on.
     pub key: IssueKey,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -14,6 +14,15 @@
 //!   CLI. The `create` argv is produced by the pure
 //!   [`sandbox_spec::resolve`] → [`sandbox_renderer::render`] pipeline;
 //!   the single crash-safe lifecycle lives in [`oci_lifecycle`].
+//!
+//! # Target-neutral boundary (DAR §6.1)
+//!
+//! [`ExecutorSpec`] carries a [`WorkTarget`] — the work item a run
+//! addresses — instead of flat issue-shaped fields. Issue runs keep
+//! the historical issue payload byte-for-byte (see
+//! [`IssueWorkTarget`]); PR review runs carry a [`ReviewTarget`] with
+//! no `IssueKey` and no branch name. No variant may be faked into the
+//! other.
 
 use std::future::Future;
 use std::path::PathBuf;
@@ -27,6 +36,7 @@ use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
 use crate::infra::disk::DiskPressureGuard;
 use crate::infra::error::CaduceusResult;
+use crate::review::ReviewTarget;
 use crate::worker::supervisor::SupervisorOutcome;
 
 use self::oci::OciExecutor;
@@ -47,14 +57,58 @@ pub use sandbox_spec::{
     EngineMode, GitShadowKind, MountSpec, RuntimeFacts, SandboxEngine, SandboxSpec,
 };
 
+/// The work item a worker run targets (DAR §6.1). Issue runs carry the
+/// historical issue payload (a lossless rename of the former flat
+/// [`ExecutorSpec`] fields); PR review runs carry the frozen review
+/// identity. No variant may be faked into the other: constructing a PR
+/// run never requires an [`IssueKey`] or a branch name, and vice versa.
+#[derive(Clone, Debug)]
+pub enum WorkTarget {
+    /// Issue-path payload — byte-for-byte the former flat fields.
+    Issue(IssueWorkTarget),
+    /// PR review run — no synthetic issue key, no branch name.
+    PullRequest(ReviewTarget),
+}
+
+/// Issue-path payload — byte-for-byte the former flat `ExecutorSpec`
+/// issue fields, kept so the issue env contract and supervisor argv
+/// stay unchanged (DAR §6.1).
+#[derive(Clone, Debug)]
+pub struct IssueWorkTarget {
+    /// The issue key being worked on.
+    pub key: IssueKey,
+    /// Issue title (UTF-8, NUL-free, may contain newlines).
+    pub title: String,
+    /// Issue body (UTF-8, NUL-free, may contain newlines).
+    pub body: String,
+    /// Label names (e.g. `["autofix"]`).
+    pub labels: Vec<String>,
+    /// Daemon-owned expected branch name.
+    pub branch_name: String,
+}
+
+impl WorkTarget {
+    /// Stable display identity for heartbeats, OCI labels, and the
+    /// `oci_runs.issue_id` column. Issue: `owner/repo#N` (unchanged).
+    /// PR: `owner/repo#pr/N`.
+    pub fn display(&self) -> String {
+        match self {
+            WorkTarget::Issue(issue) => issue.key.display_key(),
+            WorkTarget::PullRequest(pr) => {
+                format!("{}#pr/{}", pr.repository.full_name(), pr.pull_request)
+            }
+        }
+    }
+}
+
 /// Arguments to [`Executor::run`]. Every field the executor needs
 /// to dispatch a worker, regardless of mode.
 #[derive(Clone, Debug)]
 pub struct ExecutorSpec {
     /// Path to the running caduceus binary (re-exec for supervisor mode).
     pub self_exe: PathBuf,
-    /// The issue key being worked on.
-    pub issue: IssueKey,
+    /// The work item this run addresses — issue or PR review.
+    pub target: WorkTarget,
     /// The worktree root path (supervisor cwd; OCI volume mount target).
     pub worktree: PathBuf,
     /// Unique run identifier for this dispatch.
@@ -65,14 +119,6 @@ pub struct ExecutorSpec {
     pub worker_command: Vec<String>,
     /// Cancellation token for daemon shutdown.
     pub cancellation: CancellationToken,
-    /// Issue title (UTF-8, NUL-free, may contain newlines).
-    pub issue_title: String,
-    /// Issue body (UTF-8, NUL-free, may contain newlines).
-    pub issue_body: String,
-    /// Label names (e.g. `["autofix"]`).
-    pub labels: Vec<String>,
-    /// Daemon-owned expected branch name.
-    pub branch_name: String,
 }
 
 /// Result of [`Executor::run`] plus the host-side path the worker

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -25,7 +25,7 @@ use crate::executor::{
 };
 use crate::infra::config::Config;
 use crate::infra::disk::DiskPressureGuard;
-use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::infra::error::CaduceusResult;
 use crate::readiness;
 use crate::state::meta::MetaStore;
 use crate::state::oci_run::OciRunDao;

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -25,7 +25,7 @@ use crate::executor::{
 };
 use crate::infra::config::Config;
 use crate::infra::disk::DiskPressureGuard;
-use crate::infra::error::CaduceusResult;
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::readiness;
 use crate::state::meta::MetaStore;
 use crate::state::oci_run::OciRunDao;
@@ -152,13 +152,24 @@ impl Executor for OciExecutor {
             //    lifecycle token is linked with the watchdog token so
             //    a disk-pressure breach terminates in-flight work via
             //    the existing stop path (issue #245).
+            let (issue_key, issue_id) = match &spec.target {
+                crate::executor::WorkTarget::Issue(issue) => {
+                    (issue.key.clone(), issue.key.display_key())
+                }
+                crate::executor::WorkTarget::PullRequest(_) => {
+                    return Err(CaduceusError::Other(
+                        "PR review targets are not yet supported by the OCI executor (issue #346)"
+                            .to_string(),
+                    ));
+                }
+            };
             let adapter = oci_lifecycle::OciAdapter::new(
                 engine,
                 Arc::new(dao),
                 self.cfg.state_dir.clone(),
                 daemon_id,
-                spec.issue.clone(),
-                spec.issue.display_key(),
+                issue_key,
+                issue_id,
                 sha256_of(&spec.worker_command.join(" ")),
                 argv,
                 Some(env_file),

--- a/src/executor/oci.rs
+++ b/src/executor/oci.rs
@@ -151,24 +151,16 @@ impl Executor for OciExecutor {
             // 8. Run the lifecycle with the rendered argv. The run's
             //    lifecycle token is linked with the watchdog token so
             //    a disk-pressure breach terminates in-flight work via
-            //    the existing stop path (issue #245).
-            let (issue_key, issue_id) = match &spec.target {
-                crate::executor::WorkTarget::Issue(issue) => {
-                    (issue.key.clone(), issue.key.display_key())
-                }
-                crate::executor::WorkTarget::PullRequest(_) => {
-                    return Err(CaduceusError::Other(
-                        "PR review targets are not yet supported by the OCI executor (issue #346)"
-                            .to_string(),
-                    ));
-                }
-            };
+            //    the existing stop path (issue #245). The adapter
+            //    carries the target-neutral display identity
+            //    (`WorkTarget::display()`) — issue runs
+            //    `owner/repo#N`, PR runs `owner/repo#pr/N` (DAR §6.1).
+            let issue_id = spec.target.display();
             let adapter = oci_lifecycle::OciAdapter::new(
                 engine,
                 Arc::new(dao),
                 self.cfg.state_dir.clone(),
                 daemon_id,
-                issue_key,
                 issue_id,
                 sha256_of(&spec.worker_command.join(" ")),
                 argv,

--- a/src/executor/oci_lifecycle.rs
+++ b/src/executor/oci_lifecycle.rs
@@ -58,7 +58,6 @@ pub struct OciAdapter {
     state_dir: PathBuf,
     daemon_id: String,
     issue_id: String,
-    issue: crate::github::issue::IssueKey,
     worker_command_sha256: String,
     create_argv: Vec<String>,
     env_file: Mutex<Option<OciEnvFile>>,
@@ -84,7 +83,6 @@ impl OciAdapter {
         state: Arc<dyn OciRunState>,
         state_dir: PathBuf,
         daemon_id: String,
-        issue: crate::github::issue::IssueKey,
         issue_id: String,
         worker_command_sha256: String,
         create_argv: Vec<String>,
@@ -100,7 +98,6 @@ impl OciAdapter {
             state: Some(state),
             state_dir,
             daemon_id,
-            issue,
             issue_id,
             worker_command_sha256,
             create_argv,
@@ -115,11 +112,6 @@ impl OciAdapter {
             state: Some(state),
             state_dir: cfg.state_dir.clone(),
             daemon_id: daemon_id.to_string(),
-            issue: crate::github::issue::IssueKey {
-                owner: String::new(),
-                repo: String::new(),
-                number: 0,
-            },
             issue_id: String::new(),
             worker_command_sha256: String::new(),
             create_argv: Vec::new(),
@@ -134,11 +126,6 @@ impl OciAdapter {
             state: None,
             state_dir: cfg.state_dir.clone(),
             daemon_id: daemon_id.to_string(),
-            issue: crate::github::issue::IssueKey {
-                owner: String::new(),
-                repo: String::new(),
-                number: 0,
-            },
             issue_id: String::new(),
             worker_command_sha256: String::new(),
             create_argv: Vec::new(),
@@ -231,7 +218,7 @@ pub async fn run_oci_lifecycle(
     let input = RunInput {
         run_id: spec.name().to_string(),
         issue_id: adapter.issue_id.clone(),
-        issue: adapter.issue.clone(),
+        target: adapter.issue_id.clone(),
         worker_command_sha256: adapter.worker_command_sha256.clone(),
     };
     run_lifecycle_core(&input, state.as_ref(), adapter, cfg, cancel, pressure).await
@@ -240,7 +227,10 @@ pub async fn run_oci_lifecycle(
 struct RunInput {
     run_id: String,
     issue_id: String,
-    issue: crate::github::issue::IssueKey,
+    /// [`crate::executor::WorkTarget::display()`] — the heartbeat
+    /// identity for this run (issue `owner/repo#N`, PR
+    /// `owner/repo#pr/N`).
+    target: String,
     worker_command_sha256: String,
 }
 
@@ -292,7 +282,7 @@ async fn run_lifecycle_core(
             pid: std::process::id(),
             started_at,
             updated_at: started_at,
-            target: input.issue.display_key(),
+            target: input.target.clone(),
             transcript_path: paths.transcript_path.clone(),
         },
         &paths.heartbeat_path,
@@ -445,7 +435,7 @@ fn spawn_heartbeat(
     cancellation: CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     let run_id = input.run_id.clone();
-    let target = input.issue.display_key();
+    let target = input.target.clone();
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -638,7 +628,7 @@ pub async fn reconcile_installation(
                 let input = RunInput {
                     run_id: row.run_id.clone(),
                     issue_id: row.issue_id.clone(),
-                    issue: parse_issue_key(&row.issue_id),
+                    target: row.issue_id.clone(),
                     worker_command_sha256: row.worker_command_sha256.clone(),
                 };
                 let _ = teardown_container(
@@ -655,7 +645,7 @@ pub async fn reconcile_installation(
                 let input = RunInput {
                     run_id: row.run_id.clone(),
                     issue_id: row.issue_id.clone(),
-                    issue: parse_issue_key(&row.issue_id),
+                    target: row.issue_id.clone(),
                     worker_command_sha256: row.worker_command_sha256.clone(),
                 };
                 let _ = teardown_container(
@@ -672,7 +662,7 @@ pub async fn reconcile_installation(
                 let input = RunInput {
                     run_id,
                     issue_id: String::new(),
-                    issue: adapter.issue.clone(),
+                    target: String::new(),
                     worker_command_sha256: String::new(),
                 };
                 let _ = teardown_container(
@@ -765,14 +755,6 @@ pub async fn find_orphans(
         }
     }
     Ok(orphans)
-}
-
-fn parse_issue_key(value: &str) -> crate::github::issue::IssueKey {
-    crate::github::issue::IssueKey::parse(value).unwrap_or(crate::github::issue::IssueKey {
-        owner: String::new(),
-        repo: String::new(),
-        number: 0,
-    })
 }
 
 fn parse_exit_code(output: &str) -> i32 {

--- a/src/executor/oci_lifecycle.rs
+++ b/src/executor/oci_lifecycle.rs
@@ -292,7 +292,7 @@ async fn run_lifecycle_core(
             pid: std::process::id(),
             started_at,
             updated_at: started_at,
-            issue_key: input.issue.clone(),
+            target: input.issue.display_key(),
             transcript_path: paths.transcript_path.clone(),
         },
         &paths.heartbeat_path,
@@ -445,7 +445,7 @@ fn spawn_heartbeat(
     cancellation: CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     let run_id = input.run_id.clone();
-    let issue = input.issue.clone();
+    let target = input.issue.display_key();
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -458,7 +458,7 @@ fn spawn_heartbeat(
                         pid: std::process::id(),
                         started_at,
                         updated_at: now,
-                        issue_key: issue.clone(),
+                        target: target.clone(),
                         transcript_path: paths.transcript_path.clone(),
                     };
                     if write_heartbeat_record(&record, &paths.heartbeat_path).is_err() {

--- a/src/executor/sandbox_renderer.rs
+++ b/src/executor/sandbox_renderer.rs
@@ -218,42 +218,72 @@ pub fn render_with_env_files(
     // back into argv, violating the frozen no-values-in-argv
     // invariant (issue #249; design D4).
     if env_files.is_empty() {
-        // `resolve` guarantees both CADUCEUS_* entries; the fallbacks
-        // are a non-panicking safety net for a spec-construction bug.
+        // `resolve` guarantees the canonical CADUCEUS_* entries; the
+        // fallbacks are a non-panicking safety net for a
+        // spec-construction bug. The emitted list mirrors the
+        // resolved target: a PR-target spec carries
+        // `CADUCEUS_WORK_TARGET=pr` in its environment and renders
+        // only the PR-shaped fallbacks; any other spec renders the
+        // historical issue-shaped fallbacks (DAR §6.1, D5).
+        let pr_mode = spec
+            .environment()
+            .iter()
+            .any(|(k, v)| k == "CADUCEUS_WORK_TARGET" && v == "pr");
         argv.push("-e".to_string());
         argv.push(format!(
             "CADUCEUS_RUN_ID={}",
             env_value(spec, "CADUCEUS_RUN_ID", spec.name().to_string())
         ));
-        argv.push("-e".to_string());
-        argv.push(format!(
-            "CADUCEUS_ISSUE_ID={}",
-            env_value(
-                spec,
-                "CADUCEUS_ISSUE_ID",
-                label_value(spec, "caduceus.issue_id").unwrap_or_default(),
-            )
-        ));
-        // Remaining canonical `CADUCEUS_*` entries, in canonical order.
-        // `resolve` guarantees all of them; the fallbacks are a
-        // non-panicking safety net for a spec-construction bug.
-        let result_path_fallback = format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}");
-        for (key, fallback) in [
-            ("CADUCEUS_ISSUE_NUMBER", ""),
-            ("CADUCEUS_ISSUE_REPO", ""),
-            ("CADUCEUS_ISSUE_TITLE", ""),
-            ("CADUCEUS_ISSUE_BODY", ""),
-            ("CADUCEUS_ISSUE_LABELS_JSON", "[]"),
-            ("CADUCEUS_CONTEXT_JSON", "{}"),
-            ("CADUCEUS_BRANCH_NAME", ""),
-            ("CADUCEUS_WORKTREE_PATH", CONTAINER_WORKSPACE_PATH),
-            ("CADUCEUS_RESULT_PATH", result_path_fallback.as_str()),
-        ] {
+        if pr_mode {
+            let result_path_fallback = format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}");
+            for (key, fallback) in [
+                ("CADUCEUS_WORK_TARGET", "pr"),
+                ("CADUCEUS_PR_NUMBER", ""),
+                ("CADUCEUS_PR_REPO", ""),
+                ("CADUCEUS_PR_BASE_SHA", ""),
+                ("CADUCEUS_PR_HEAD_SHA", ""),
+                ("CADUCEUS_CONTEXT_JSON", "{}"),
+                ("CADUCEUS_WORKTREE_PATH", CONTAINER_WORKSPACE_PATH),
+                ("CADUCEUS_RESULT_PATH", result_path_fallback.as_str()),
+            ] {
+                argv.push("-e".to_string());
+                argv.push(format!(
+                    "{key}={}",
+                    env_value(spec, key, fallback.to_string())
+                ));
+            }
+        } else {
             argv.push("-e".to_string());
             argv.push(format!(
-                "{key}={}",
-                env_value(spec, key, fallback.to_string())
+                "CADUCEUS_ISSUE_ID={}",
+                env_value(
+                    spec,
+                    "CADUCEUS_ISSUE_ID",
+                    label_value(spec, "caduceus.issue_id").unwrap_or_default(),
+                )
             ));
+            // Remaining canonical `CADUCEUS_*` entries, in canonical
+            // order. `resolve` guarantees all of them; the fallbacks
+            // are a non-panicking safety net for a spec-construction
+            // bug.
+            let result_path_fallback = format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}");
+            for (key, fallback) in [
+                ("CADUCEUS_ISSUE_NUMBER", ""),
+                ("CADUCEUS_ISSUE_REPO", ""),
+                ("CADUCEUS_ISSUE_TITLE", ""),
+                ("CADUCEUS_ISSUE_BODY", ""),
+                ("CADUCEUS_ISSUE_LABELS_JSON", "[]"),
+                ("CADUCEUS_CONTEXT_JSON", "{}"),
+                ("CADUCEUS_BRANCH_NAME", ""),
+                ("CADUCEUS_WORKTREE_PATH", CONTAINER_WORKSPACE_PATH),
+                ("CADUCEUS_RESULT_PATH", result_path_fallback.as_str()),
+            ] {
+                argv.push("-e".to_string());
+                argv.push(format!(
+                    "{key}={}",
+                    env_value(spec, key, fallback.to_string())
+                ));
+            }
         }
     }
 

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -26,13 +26,18 @@ use crate::github::issue::IssueKey;
 use crate::infra::config::{SandboxConfig, SandboxNetwork};
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::worker_contract::{
-    denied_name, CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH, WORKER_RESULT_FILE,
+    denied_name, validate_pr_env, CONTAINER_OUTPUT_PATH, CONTAINER_WORKSPACE_PATH,
+    WORKER_RESULT_FILE,
 };
 
-/// The canonical `CADUCEUS_*` variable names every OCI worker
-/// receives (the frozen worker-environment contract, issue #249).
-/// Shared authority for `resolve_with_env` assembly and for the
-/// `sandbox.pass_env` reserved-key collision check at config load.
+/// The canonical `CADUCEUS_*` variable names every OCI **issue-path**
+/// worker receives (the frozen worker-environment contract, issue
+/// #249). Shared authority for `resolve_with_env` issue-arm assembly
+/// and for the `sandbox.pass_env` reserved-key collision check at
+/// config load. PR-path names (`CADUCEUS_WORK_TARGET`, `CADUCEUS_PR_*`)
+/// are emitted by `resolve_with_env` for PR targets but are not
+/// reserved here — the canonical layer overrides any colliding
+/// `pass_env` entry anyway (design D3 step 3).
 pub const CANONICAL_ENV_KEYS: &[&str] = &[
     "CADUCEUS_RUN_ID",
     "CADUCEUS_ISSUE_ID",
@@ -409,8 +414,12 @@ impl SandboxSpec {
 pub struct RuntimeFacts {
     /// Unique run identifier.
     pub run_id: String,
-    /// The issue key being worked on.
-    pub issue: IssueKey,
+    /// [`crate::executor::WorkTarget::display()`] — `owner/repo#N` for
+    /// issue runs, `owner/repo#pr/N` for PR review runs. Carried as a
+    /// display string so the OCI path is target-neutral (DAR §6.1):
+    /// the `caduceus.issue_id` label, `CADUCEUS_ISSUE_ID` (issue arm),
+    /// and the `oci_runs.issue_id` column all consume this value.
+    pub target: String,
     /// Worker command argv (bridge script + args).
     pub worker_command: Vec<String>,
     /// Host path to the worktree root.
@@ -706,48 +715,80 @@ pub fn resolve_with_env(
     //     (`write_prompt`). Operator `pass_env` values are NOT
     //     normalized — a newline-bearing one fails closed above
     //     (design D3).
-    let crate::executor::WorkTarget::Issue(issue) = &spec.target else {
-        return Err(CaduceusError::Config(
-            "PR review targets are not yet supported by OCI env resolution (issue #346)"
-                .to_string(),
-        ));
+    //     Issue arm: the historical 10-name canonical contract
+    //     byte-for-byte (including the OCI-only compat
+    //     `CADUCEUS_ISSUE_ID`); PR arm: the `pr` mode marker plus
+    //     the four `CADUCEUS_PR_*` values (DAR §6.1). The
+    //     `caduceus.issue_id` *label* carries the target identity on
+    //     both arms (D5).
+    let canonical: Vec<(String, String)> = match &spec.target {
+        crate::executor::WorkTarget::Issue(issue) => {
+            let labels_json = serde_json::to_string(&issue.labels)
+                .map_err(|err| CaduceusError::Config(format!("labels JSON serialise: {err}")))?;
+            let issue_canonical: Vec<(String, String)> = vec![
+                ("CADUCEUS_RUN_ID".to_string(), runtime.run_id.clone()),
+                ("CADUCEUS_ISSUE_ID".to_string(), runtime.target.clone()),
+                (
+                    "CADUCEUS_ISSUE_NUMBER".to_string(),
+                    issue.key.number.to_string(),
+                ),
+                (
+                    "CADUCEUS_ISSUE_REPO".to_string(),
+                    format!("{}/{}", issue.key.owner, issue.key.repo),
+                ),
+                ("CADUCEUS_ISSUE_TITLE".to_string(), issue.title.clone()),
+                ("CADUCEUS_ISSUE_BODY".to_string(), issue.body.clone()),
+                (
+                    "CADUCEUS_ISSUE_LABELS_JSON".to_string(),
+                    labels_json.clone(),
+                ),
+                (
+                    "CADUCEUS_CONTEXT_JSON".to_string(),
+                    spec.context_json.clone(),
+                ),
+                (
+                    "CADUCEUS_BRANCH_NAME".to_string(),
+                    issue.branch_name.clone(),
+                ),
+                (
+                    "CADUCEUS_WORKTREE_PATH".to_string(),
+                    CONTAINER_WORKSPACE_PATH.to_string(),
+                ),
+                (
+                    "CADUCEUS_RESULT_PATH".to_string(),
+                    format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}"),
+                ),
+            ];
+            issue_canonical
+        }
+        crate::executor::WorkTarget::PullRequest(pr) => {
+            validate_pr_env(pr)?;
+            let pr_canonical: Vec<(String, String)> = vec![
+                ("CADUCEUS_RUN_ID".to_string(), runtime.run_id.clone()),
+                ("CADUCEUS_WORK_TARGET".to_string(), "pr".to_string()),
+                (
+                    "CADUCEUS_PR_NUMBER".to_string(),
+                    pr.pull_request.to_string(),
+                ),
+                ("CADUCEUS_PR_REPO".to_string(), pr.repository.full_name()),
+                ("CADUCEUS_PR_BASE_SHA".to_string(), pr.base_sha.clone()),
+                ("CADUCEUS_PR_HEAD_SHA".to_string(), pr.head_sha.clone()),
+                (
+                    "CADUCEUS_CONTEXT_JSON".to_string(),
+                    spec.context_json.clone(),
+                ),
+                (
+                    "CADUCEUS_WORKTREE_PATH".to_string(),
+                    CONTAINER_WORKSPACE_PATH.to_string(),
+                ),
+                (
+                    "CADUCEUS_RESULT_PATH".to_string(),
+                    format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}"),
+                ),
+            ];
+            pr_canonical
+        }
     };
-    let labels_json = serde_json::to_string(&issue.labels)
-        .map_err(|err| CaduceusError::Config(format!("labels JSON serialise: {err}")))?;
-    let canonical: Vec<(String, String)> = vec![
-        ("CADUCEUS_RUN_ID".to_string(), runtime.run_id.clone()),
-        ("CADUCEUS_ISSUE_ID".to_string(), runtime.issue.display_key()),
-        (
-            "CADUCEUS_ISSUE_NUMBER".to_string(),
-            issue.key.number.to_string(),
-        ),
-        (
-            "CADUCEUS_ISSUE_REPO".to_string(),
-            format!("{}/{}", issue.key.owner, issue.key.repo),
-        ),
-        ("CADUCEUS_ISSUE_TITLE".to_string(), issue.title.clone()),
-        ("CADUCEUS_ISSUE_BODY".to_string(), issue.body.clone()),
-        (
-            "CADUCEUS_ISSUE_LABELS_JSON".to_string(),
-            labels_json.clone(),
-        ),
-        (
-            "CADUCEUS_CONTEXT_JSON".to_string(),
-            spec.context_json.clone(),
-        ),
-        (
-            "CADUCEUS_BRANCH_NAME".to_string(),
-            issue.branch_name.clone(),
-        ),
-        (
-            "CADUCEUS_WORKTREE_PATH".to_string(),
-            CONTAINER_WORKSPACE_PATH.to_string(),
-        ),
-        (
-            "CADUCEUS_RESULT_PATH".to_string(),
-            format!("{CONTAINER_OUTPUT_PATH}/{WORKER_RESULT_FILE}"),
-        ),
-    ];
     for (key, value) in canonical {
         environment.insert(key, normalize_canonical_value(&value));
     }
@@ -777,7 +818,7 @@ pub fn resolve_with_env(
     let labels = crate::executor::sandbox_renderer::render_labels(
         &runtime.daemon_id,
         &runtime.run_id,
-        &runtime.issue.display_key(),
+        &runtime.target,
     );
 
     // 13. Command — worker argv.

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -22,7 +22,6 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::executor::ExecutorSpec;
-use crate::github::issue::IssueKey;
 use crate::infra::config::{SandboxConfig, SandboxNetwork};
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::worker_contract::{

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -706,21 +706,27 @@ pub fn resolve_with_env(
     //     (`write_prompt`). Operator `pass_env` values are NOT
     //     normalized — a newline-bearing one fails closed above
     //     (design D3).
-    let labels_json = serde_json::to_string(&spec.labels)
+    let crate::executor::WorkTarget::Issue(issue) = &spec.target else {
+        return Err(CaduceusError::Config(
+            "PR review targets are not yet supported by OCI env resolution (issue #346)"
+                .to_string(),
+        ));
+    };
+    let labels_json = serde_json::to_string(&issue.labels)
         .map_err(|err| CaduceusError::Config(format!("labels JSON serialise: {err}")))?;
     let canonical: Vec<(String, String)> = vec![
         ("CADUCEUS_RUN_ID".to_string(), runtime.run_id.clone()),
         ("CADUCEUS_ISSUE_ID".to_string(), runtime.issue.display_key()),
         (
             "CADUCEUS_ISSUE_NUMBER".to_string(),
-            spec.issue.number.to_string(),
+            issue.key.number.to_string(),
         ),
         (
             "CADUCEUS_ISSUE_REPO".to_string(),
-            format!("{}/{}", spec.issue.owner, spec.issue.repo),
+            format!("{}/{}", issue.key.owner, issue.key.repo),
         ),
-        ("CADUCEUS_ISSUE_TITLE".to_string(), spec.issue_title.clone()),
-        ("CADUCEUS_ISSUE_BODY".to_string(), spec.issue_body.clone()),
+        ("CADUCEUS_ISSUE_TITLE".to_string(), issue.title.clone()),
+        ("CADUCEUS_ISSUE_BODY".to_string(), issue.body.clone()),
         (
             "CADUCEUS_ISSUE_LABELS_JSON".to_string(),
             labels_json.clone(),
@@ -729,7 +735,7 @@ pub fn resolve_with_env(
             "CADUCEUS_CONTEXT_JSON".to_string(),
             spec.context_json.clone(),
         ),
-        ("CADUCEUS_BRANCH_NAME".to_string(), spec.branch_name.clone()),
+        ("CADUCEUS_BRANCH_NAME".to_string(), issue.branch_name.clone()),
         (
             "CADUCEUS_WORKTREE_PATH".to_string(),
             CONTAINER_WORKSPACE_PATH.to_string(),

--- a/src/executor/sandbox_spec.rs
+++ b/src/executor/sandbox_spec.rs
@@ -735,7 +735,10 @@ pub fn resolve_with_env(
             "CADUCEUS_CONTEXT_JSON".to_string(),
             spec.context_json.clone(),
         ),
-        ("CADUCEUS_BRANCH_NAME".to_string(), issue.branch_name.clone()),
+        (
+            "CADUCEUS_BRANCH_NAME".to_string(),
+            issue.branch_name.clone(),
+        ),
         (
             "CADUCEUS_WORKTREE_PATH".to_string(),
             CONTAINER_WORKSPACE_PATH.to_string(),

--- a/src/executor/trusted_host.rs
+++ b/src/executor/trusted_host.rs
@@ -9,10 +9,9 @@ use std::pin::Pin;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::executor::{Executor, ExecutorOutcome, ExecutorSpec, WorkTarget};
-use crate::github::issue::IssueKey;
+use crate::executor::{Executor, ExecutorOutcome, ExecutorSpec};
 use crate::infra::config::Config;
-use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::infra::error::CaduceusResult;
 use crate::worker::supervisor::supervise;
 use crate::worker::worker_contract::WORKER_RESULT_FILE;
 
@@ -43,48 +42,16 @@ impl Executor for TrustedHostExecutor {
         let worker_command: &'a [String] = &spec.worker_command;
         let cancellation: CancellationToken = spec.cancellation.clone();
 
-        // Issue targets flow through the supervisor's issue-path flags.
-        // PR review targets are refused here until the supervisor
-        // boundary carries a `WorkTarget` (issue #346) — never faked
-        // into an issue.
-        let (issue_key, issue_title, issue_body, labels, branch_name): (
-            &'a IssueKey,
-            &'a str,
-            &'a str,
-            &'a [String],
-            &'a str,
-        ) = match &spec.target {
-            WorkTarget::Issue(issue) => (
-                &issue.key,
-                issue.title.as_str(),
-                issue.body.as_str(),
-                issue.labels.as_slice(),
-                issue.branch_name.as_str(),
-            ),
-            WorkTarget::PullRequest(_) => {
-                return Box::pin(async move {
-                    Err(CaduceusError::Other(
-                        "PR review targets are not yet supported on the trusted host"
-                            .to_string(),
-                    ))
-                });
-            }
-        };
-
         Box::pin(async move {
             let outcome = supervise(
                 self_exe,
                 cfg,
-                issue_key,
+                &spec.target,
                 worktree,
                 run_id,
                 context_json,
                 worker_command,
                 cancellation,
-                issue_title,
-                issue_body,
-                labels,
-                branch_name,
             )
             .await?;
             Ok(ExecutorOutcome {

--- a/src/executor/trusted_host.rs
+++ b/src/executor/trusted_host.rs
@@ -9,10 +9,10 @@ use std::pin::Pin;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::executor::{Executor, ExecutorOutcome, ExecutorSpec};
+use crate::executor::{Executor, ExecutorOutcome, ExecutorSpec, WorkTarget};
 use crate::github::issue::IssueKey;
 use crate::infra::config::Config;
-use crate::infra::error::CaduceusResult;
+use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::supervisor::supervise;
 use crate::worker::worker_contract::WORKER_RESULT_FILE;
 
@@ -37,22 +37,45 @@ impl Executor for TrustedHostExecutor {
     ) -> Pin<Box<dyn Future<Output = CaduceusResult<ExecutorOutcome>> + Send + 'a>> {
         let self_exe: &'a Path = &spec.self_exe;
         let cfg: &'a Config = &self.cfg;
-        let issue: &'a IssueKey = &spec.issue;
         let worktree: &'a Path = &spec.worktree;
         let run_id: &'a str = &spec.run_id;
         let context_json: &'a str = &spec.context_json;
         let worker_command: &'a [String] = &spec.worker_command;
         let cancellation: CancellationToken = spec.cancellation.clone();
-        let issue_title: &'a str = &spec.issue_title;
-        let issue_body: &'a str = &spec.issue_body;
-        let labels: &'a [String] = &spec.labels;
-        let branch_name: &'a str = &spec.branch_name;
+
+        // Issue targets flow through the supervisor's issue-path flags.
+        // PR review targets are refused here until the supervisor
+        // boundary carries a `WorkTarget` (issue #346) — never faked
+        // into an issue.
+        let (issue_key, issue_title, issue_body, labels, branch_name): (
+            &'a IssueKey,
+            &'a str,
+            &'a str,
+            &'a [String],
+            &'a str,
+        ) = match &spec.target {
+            WorkTarget::Issue(issue) => (
+                &issue.key,
+                issue.title.as_str(),
+                issue.body.as_str(),
+                issue.labels.as_slice(),
+                issue.branch_name.as_str(),
+            ),
+            WorkTarget::PullRequest(_) => {
+                return Box::pin(async move {
+                    Err(CaduceusError::Other(
+                        "PR review targets are not yet supported on the trusted host"
+                            .to_string(),
+                    ))
+                });
+            }
+        };
 
         Box::pin(async move {
             let outcome = supervise(
                 self_exe,
                 cfg,
-                issue,
+                issue_key,
                 worktree,
                 run_id,
                 context_json,

--- a/src/infra/fixtures.rs
+++ b/src/infra/fixtures.rs
@@ -56,11 +56,16 @@ pub const CANONICAL_CONFIG_KEYS: &[&str] = &[
     "worker_timeout_seconds",
 ];
 
-/// Canonical worker environment variable names exported by the daemon
-/// for every worker invocation. Each name is mirrored in the Python
-/// bridge's `REQUIRED_ENV_VARS` tuple. The contract requires the daemon
-/// to set every one of these; if the bridge ever needs a new field
-/// the listing here is the contract bump.
+/// Canonical worker environment variable names exported by the daemon.
+/// This is the full **union** across both target paths (DAR §6.1):
+/// the 10 historical issue-path names plus `CADUCEUS_WORK_TARGET` and
+/// the four `CADUCEUS_PR_*` names. Each name is mirrored in the Python
+/// bridge's `REQUIRED_ENV_VARS` tuple (set equality,
+/// `docs_contract_test`). The exact per-path emission sets are pinned
+/// by [`CANONICAL_WORKER_ENV_VARS_ISSUE_PATH`] and
+/// [`CANONICAL_WORKER_ENV_VARS_PR_PATH`]; the union exists so the
+/// bridge keeps a single required-name list while the per-path
+/// fixtures assert byte-for-byte emission.
 pub const CANONICAL_WORKER_ENV_VARS: &[&str] = &[
     "CADUCEUS_BRANCH_NAME",
     "CADUCEUS_CONTEXT_JSON",
@@ -72,6 +77,45 @@ pub const CANONICAL_WORKER_ENV_VARS: &[&str] = &[
     "CADUCEUS_RUN_ID",
     "CADUCEUS_WORKTREE_PATH",
     "CADUCEUS_RESULT_PATH",
+    "CADUCEUS_WORK_TARGET",
+    "CADUCEUS_PR_BASE_SHA",
+    "CADUCEUS_PR_HEAD_SHA",
+    "CADUCEUS_PR_NUMBER",
+    "CADUCEUS_PR_REPO",
+];
+
+/// Exact `CADUCEUS_*` set emitted for an **issue-target** run — the
+/// byte-for-byte v0.1 contract (no `CADUCEUS_WORK_TARGET`, no
+/// `CADUCEUS_PR_*`). `sanitized_env`'s issue arm and the OCI issue
+/// arm both emit exactly this set.
+pub const CANONICAL_WORKER_ENV_VARS_ISSUE_PATH: &[&str] = &[
+    "CADUCEUS_BRANCH_NAME",
+    "CADUCEUS_CONTEXT_JSON",
+    "CADUCEUS_ISSUE_BODY",
+    "CADUCEUS_ISSUE_LABELS_JSON",
+    "CADUCEUS_ISSUE_NUMBER",
+    "CADUCEUS_ISSUE_REPO",
+    "CADUCEUS_ISSUE_TITLE",
+    "CADUCEUS_RUN_ID",
+    "CADUCEUS_WORKTREE_PATH",
+    "CADUCEUS_RESULT_PATH",
+];
+
+/// Exact `CADUCEUS_*` set emitted for a **PR-target** run (DAR §6.1):
+/// the `pr` mode marker plus the four `CADUCEUS_PR_*` values and the
+/// shared run/context/worktree/result vars. No `CADUCEUS_ISSUE_*`, no
+/// `CADUCEUS_ISSUE_ID` (an OCI-only issue-path compat var), no
+/// `CADUCEUS_BRANCH_NAME`.
+pub const CANONICAL_WORKER_ENV_VARS_PR_PATH: &[&str] = &[
+    "CADUCEUS_CONTEXT_JSON",
+    "CADUCEUS_PR_BASE_SHA",
+    "CADUCEUS_PR_HEAD_SHA",
+    "CADUCEUS_PR_NUMBER",
+    "CADUCEUS_PR_REPO",
+    "CADUCEUS_RESULT_PATH",
+    "CADUCEUS_RUN_ID",
+    "CADUCEUS_WORKTREE_PATH",
+    "CADUCEUS_WORK_TARGET",
 ];
 
 /// Default allowlist for the worker environment (the worker-result

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
     let mut issue_body: Option<String> = None;
     let mut issue_labels_json: Option<String> = None;
     let mut branch_name: Option<String> = None;
+    let mut pr_target_json: Option<String> = None;
 
     while let Some(arg) = args.next() {
         let s = arg.to_string_lossy().into_owned();
@@ -151,6 +152,9 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
                 issue_labels_json = args.next().map(|a| a.to_string_lossy().into_owned())
             }
             "--branch-name" => branch_name = args.next().map(|a| a.to_string_lossy().into_owned()),
+            "--pr-target-json" => {
+                pr_target_json = args.next().map(|a| a.to_string_lossy().into_owned())
+            }
             "--" => {
                 for rest in args {
                     worker_command.push(rest.to_string_lossy().into_owned());
@@ -169,10 +173,7 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
         context: "supervisor",
         stderr: "--run-id is required".to_string(),
     })?;
-    let issue_ref = issue_ref.ok_or_else(|| caduceus::CaduceusError::Worker {
-        context: "supervisor",
-        stderr: "--issue is required".to_string(),
-    })?;
+    let issue_ref: Option<String> = issue_ref;
     let context_json = context_json.unwrap_or_default();
     let transcript_path = transcript_path.ok_or_else(|| caduceus::CaduceusError::Worker {
         context: "supervisor",
@@ -188,6 +189,38 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
     let issue_labels_json = issue_labels_json.unwrap_or_else(|| "[]".to_string());
     let branch_name = branch_name.unwrap_or_default();
 
+    // Target selection (DAR §6.1): `--pr-target-json` selects the PR
+    // review path (parse failure is fatal, matching the issue path's
+    // `IssueKey::parse` fail-fast); absence + `--issue` selects the
+    // issue path; absence of both keeps the legacy no-flags behaviour
+    // for hand-driven tests (no sanitized env is built).
+    let target = if let Some(pr_json) = pr_target_json {
+        let pr_target: caduceus::review::ReviewTarget =
+            serde_json::from_str(&pr_json).map_err(|err| {
+                caduceus::CaduceusError::Config(format!("invalid --pr-target-json: {err}"))
+            })?;
+        Some(caduceus::executor::WorkTarget::PullRequest(pr_target))
+    } else if let Some(issue_ref) = issue_ref {
+        let issue = caduceus::issue::IssueKey::parse(&issue_ref)?;
+        Some(caduceus::executor::WorkTarget::Issue(
+            caduceus::executor::IssueWorkTarget {
+                key: issue,
+                title: issue_title,
+                body: issue_body,
+                labels: if issue_labels_json.trim() == "[]" {
+                    Vec::new()
+                } else {
+                    serde_json::from_str(&issue_labels_json).map_err(|err| {
+                        caduceus::CaduceusError::Config(format!("invalid labels JSON: {err}"))
+                    })?
+                },
+                branch_name,
+            },
+        ))
+    } else {
+        None
+    };
+
     if worker_command.is_empty() {
         return Err(caduceus::CaduceusError::Worker {
             context: "supervisor",
@@ -201,11 +234,6 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
         tracing::warn!(error = %err, "could not enable child subreaper");
     }
     let _ = heartbeat_path;
-
-    // Sanity-check the issue ref format. The daemon-side
-    // already validates this, but a malformed ref must fail
-    // fast inside the supervisor too.
-    let issue = caduceus::issue::IssueKey::parse(&issue_ref)?;
 
     // Detach into a new session so the worker has its own
     // process group. The daemon records our PGID via the
@@ -311,38 +339,33 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
-    // When the daemon supplied the new issue-context flags,
-    // build a sanitized worker environment from them and
-    // apply it before the worker starts. Backward-compatible
-    // callers (e.g. existing tests that drive
-    // `__worker-supervisor` by hand) omit these flags; we
-    // leave the inherited environment untouched in that case.
-    if !branch_name.is_empty() {
-        let labels: Vec<String> = if issue_labels_json.trim() == "[]" {
-            Vec::new()
-        } else {
-            serde_json::from_str(&issue_labels_json).map_err(|err| {
-                caduceus::CaduceusError::Config(format!("invalid labels JSON: {err}"))
-            })?
+    // When the daemon supplied a target (issue-context flags or a
+    // `--pr-target-json` review target), build a sanitized worker
+    // environment from it and apply it before the worker starts.
+    // Backward-compatible callers (e.g. existing tests that drive
+    // `__worker-supervisor` by hand) omit these flags; we leave the
+    // inherited environment untouched in that case. Issue-path
+    // preservation: an issue target with an empty branch name skips
+    // the sanitized env exactly as the pre-#346 supervisor did.
+    if let Some(target) = &target {
+        let issue_branch_gate = match target {
+            caduceus::executor::WorkTarget::Issue(issue) => !issue.branch_name.is_empty(),
+            caduceus::executor::WorkTarget::PullRequest(_) => true,
         };
-        let inputs = caduceus::worker::SanitizedEnvInputs {
-            target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-                key: issue,
-                title: issue_title,
-                body: issue_body,
-                labels,
-                branch_name,
-            }),
-            worktree_path: worktree.clone(),
-            run_id: run_id.clone(),
-            allowlist: Vec::new(),
-            context_json,
-        };
-        let parent: std::collections::BTreeMap<std::ffi::OsString, std::ffi::OsString> =
-            std::env::vars_os().collect();
-        let env = caduceus::worker::sanitized_env(&parent, &inputs)?;
-        cmd.env_clear();
-        cmd.envs(env);
+        if issue_branch_gate {
+            let inputs = caduceus::worker::SanitizedEnvInputs {
+                target: target.clone(),
+                worktree_path: worktree.clone(),
+                run_id: run_id.clone(),
+                allowlist: Vec::new(),
+                context_json,
+            };
+            let parent: std::collections::BTreeMap<std::ffi::OsString, std::ffi::OsString> =
+                std::env::vars_os().collect();
+            let env = caduceus::worker::sanitized_env(&parent, &inputs)?;
+            cmd.env_clear();
+            cmd.envs(env);
+        }
     }
 
     cmd.process_group(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,13 +326,15 @@ fn run_supervisor_mode() -> CaduceusResult<()> {
             })?
         };
         let inputs = caduceus::worker::SanitizedEnvInputs {
-            issue,
-            issue_title,
-            issue_body,
-            labels,
+            target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+                key: issue,
+                title: issue_title,
+                body: issue_body,
+                labels,
+                branch_name,
+            }),
             worktree_path: worktree.clone(),
             run_id: run_id.clone(),
-            branch_name,
             allowlist: Vec::new(),
             context_json,
         };

--- a/src/worker/supervisor/dispatch.rs
+++ b/src/worker/supervisor/dispatch.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 use chrono::Utc;
 use tokio::process::{Child, Command as TokioCommand};
 
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 use crate::worker::supervisor::process_lifecycle::{
     decide_deadline_kill, kill_pid, signal_number_from_str, DeadlineKillDecision, IDENTITY, TREE,
@@ -49,16 +48,12 @@ use crate::worker::supervisor::process_lifecycle::{
 pub async fn supervise(
     self_exe: &Path,
     cfg: &crate::infra::config::Config,
-    issue: &IssueKey,
+    target: &crate::executor::WorkTarget,
     worktree: &Path,
     run_id: &str,
     context_json: &str,
     worker_command: &[String],
     cancellation: tokio_util::sync::CancellationToken,
-    issue_title: &str,
-    issue_body: &str,
-    labels: &[String],
-    branch_name: &str,
 ) -> CaduceusResult<SupervisorOutcome> {
     let paths = WorkerRunPaths::new(cfg.state_dir.clone(), run_id.to_string());
     paths.ensure_dirs()?;
@@ -70,7 +65,7 @@ pub async fn supervise(
             pid: std::process::id(),
             started_at,
             updated_at: started_at,
-            issue_key: issue.clone(),
+            target: target.display(),
             transcript_path: paths.transcript_path.clone(),
         },
         &paths.heartbeat_path,
@@ -87,17 +82,13 @@ pub async fn supervise(
     let spawn_result = run_supervisor(
         self_exe,
         cfg,
-        issue,
+        target,
         worktree,
         run_id,
         context_json,
         worker_command,
         &paths,
         cancellation,
-        issue_title,
-        issue_body,
-        labels,
-        branch_name,
     )
     .await;
 
@@ -123,33 +114,25 @@ pub async fn supervise(
 pub(crate) async fn run_supervisor(
     self_exe: &Path,
     cfg: &crate::infra::config::Config,
-    issue: &IssueKey,
+    target: &crate::executor::WorkTarget,
     worktree: &Path,
     run_id: &str,
     context_json: &str,
     worker_command: &[String],
     paths: &WorkerRunPaths,
     cancellation: tokio_util::sync::CancellationToken,
-    issue_title: &str,
-    issue_body: &str,
-    labels: &[String],
-    branch_name: &str,
 ) -> CaduceusResult<SupervisorOutcome> {
     let cmd = build_supervisor_command(
         self_exe,
         worktree,
         run_id,
-        issue,
+        target,
         context_json,
         worker_command,
         &paths.transcript_path,
         &paths.heartbeat_path,
         cfg.worker_timeout_seconds,
         cfg.transcript_max_bytes,
-        issue_title,
-        issue_body,
-        labels,
-        branch_name,
     );
 
     // Convert to a tokio command for async I/O.
@@ -352,7 +335,7 @@ pub(crate) async fn run_supervisor(
     let hb_path = paths.heartbeat_path.clone();
     let hb_cancel = cancellation.clone();
     let started_at_copy = started_at;
-    let issue_clone = issue.clone();
+    let target_display = target.display();
     let transcript_path_clone = paths.transcript_path.clone();
     let run_id_string = run_id.to_string();
     let heartbeat_task = tokio::spawn(async move {
@@ -367,7 +350,7 @@ pub(crate) async fn run_supervisor(
                 pid: std::process::id(),
                 started_at: started_at_copy,
                 updated_at: Utc::now(),
-                issue_key: issue_clone.clone(),
+                target: target_display.clone(),
                 transcript_path: transcript_path_clone.clone(),
             };
             if write_heartbeat_record(&record, &hb_path).is_err() {

--- a/src/worker/supervisor/heartbeat.rs
+++ b/src/worker/supervisor/heartbeat.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 
 // Heartbeat
@@ -27,16 +26,20 @@ pub struct Heartbeat {
     pub pid: u32,
     pub started_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-    pub issue_key: IssueKey,
+    /// [`crate::executor::WorkTarget::display()`] — `owner/repo#N` for
+    /// issue runs, `owner/repo#pr/N` for PR review runs. A string so
+    /// the heartbeat envelope is target-neutral (DAR §6.1).
+    pub target: String,
     pub transcript_path: PathBuf,
 }
 
-/// File-format version the supervisor writes. The first
-/// versioned shape; older unversioned timestamp-only
-/// heartbeats are not recognised by `status` and are
-/// surfaced as `HeartbeatParseError::Malformed` so the
-/// operator can investigate.
-pub const HEARTBEAT_FILE_VERSION: u32 = 1;
+/// File-format version the supervisor writes. The second
+/// versioned shape: v1 carried `issue_key: IssueKey`; v2 carries
+/// the target-neutral `target: String` (DAR §6.1). Older
+/// unversioned timestamp-only heartbeats are not recognised by
+/// `status` and are surfaced as `HeartbeatParseError::Malformed`
+/// so the operator can investigate.
+pub const HEARTBEAT_FILE_VERSION: u32 = 2;
 
 /// Write the heartbeat file atomically. The supervisor
 /// calls this at most once per second while the worker is
@@ -95,11 +98,7 @@ pub fn write_heartbeat(path: &Path) -> CaduceusResult<()> {
         pid: std::process::id(),
         started_at: now,
         updated_at: now,
-        issue_key: IssueKey {
-            owner: String::new(),
-            repo: String::new(),
-            number: 0,
-        },
+        target: String::new(),
         transcript_path: path.with_extension("log"),
     };
     write_heartbeat_record(&record, path)
@@ -140,8 +139,9 @@ pub fn read_heartbeat_record(path: &Path) -> Option<Heartbeat> {
         return None;
     }
     // Legacy format: a single RFC 3339 line. We synthesise
-    // a v1 envelope so the rest of the status surface can
-    // treat heartbeats uniformly.
+    // a v2 envelope so the rest of the status surface can
+    // treat heartbeats uniformly. The target is unknown for
+    // a legacy file — an empty string is the honest value.
     let updated_at = chrono::DateTime::parse_from_rfc3339(buf.trim())
         .ok()?
         .with_timezone(&chrono::Utc);
@@ -156,11 +156,7 @@ pub fn read_heartbeat_record(path: &Path) -> Option<Heartbeat> {
         pid: 0,
         started_at: updated_at,
         updated_at,
-        issue_key: IssueKey {
-            owner: String::new(),
-            repo: String::new(),
-            number: 0,
-        },
+        target: String::new(),
         transcript_path: path.with_extension("log"),
     })
 }

--- a/src/worker/supervisor/process_lifecycle.rs
+++ b/src/worker/supervisor/process_lifecycle.rs
@@ -4,7 +4,6 @@ use std::process::{Command, Stdio};
 #[cfg(target_os = "macos")]
 use libc::{c_int, c_uint, c_void};
 
-use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
 
 // Hidden command name
@@ -475,35 +474,52 @@ pub fn build_supervisor_command(
     self_exe: &Path,
     worktree: &Path,
     run_id: &str,
-    issue: &IssueKey,
+    target: &crate::executor::WorkTarget,
     context_json: &str,
     worker_command: &[String],
     transcript_path: &Path,
     heartbeat_path: &Path,
     timeout_seconds: u64,
     transcript_max_bytes: u64,
-    issue_title: &str,
-    issue_body: &str,
-    labels: &[String],
-    branch_name: &str,
 ) -> Command {
-    let labels_json = serde_json::to_string(labels).unwrap_or_else(|_| "[]".to_string());
     let mut cmd = Command::new(self_exe);
     cmd.arg(HIDDEN_COMMAND);
     cmd.arg("--worktree").arg(worktree);
     cmd.arg("--run-id").arg(run_id);
-    cmd.arg("--issue")
-        .arg(format!("{}/{}#{}", issue.owner, issue.repo, issue.number));
-    cmd.arg("--context-json").arg(context_json);
-    cmd.arg("--transcript").arg(transcript_path);
-    cmd.arg("--heartbeat").arg(heartbeat_path);
-    cmd.arg("--timeout").arg(timeout_seconds.to_string());
-    cmd.arg("--transcript-max-bytes")
-        .arg(transcript_max_bytes.to_string());
-    cmd.arg("--issue-title").arg(issue_title);
-    cmd.arg("--issue-body").arg(issue_body);
-    cmd.arg("--issue-labels-json").arg(&labels_json);
-    cmd.arg("--branch-name").arg(branch_name);
+    match target {
+        crate::executor::WorkTarget::Issue(issue) => {
+            // Issue-path argv is byte-for-byte the historical shape.
+            let labels_json =
+                serde_json::to_string(&issue.labels).unwrap_or_else(|_| "[]".to_string());
+            cmd.arg("--issue").arg(format!(
+                "{}/{}#{}",
+                issue.key.owner, issue.key.repo, issue.key.number
+            ));
+            cmd.arg("--context-json").arg(context_json);
+            cmd.arg("--transcript").arg(transcript_path);
+            cmd.arg("--heartbeat").arg(heartbeat_path);
+            cmd.arg("--timeout").arg(timeout_seconds.to_string());
+            cmd.arg("--transcript-max-bytes")
+                .arg(transcript_max_bytes.to_string());
+            cmd.arg("--issue-title").arg(&issue.title);
+            cmd.arg("--issue-body").arg(&issue.body);
+            cmd.arg("--issue-labels-json").arg(&labels_json);
+            cmd.arg("--branch-name").arg(&issue.branch_name);
+        }
+        crate::executor::WorkTarget::PullRequest(pr) => {
+            // PR-target argv: one `--pr-target-json` flag after
+            // `--run-id`; no `--issue` / issue-shaped flags, no
+            // synthetic branch (DAR §6.1).
+            let pr_json = serde_json::to_string(pr).expect("serialize pr target");
+            cmd.arg("--pr-target-json").arg(pr_json);
+            cmd.arg("--context-json").arg(context_json);
+            cmd.arg("--transcript").arg(transcript_path);
+            cmd.arg("--heartbeat").arg(heartbeat_path);
+            cmd.arg("--timeout").arg(timeout_seconds.to_string());
+            cmd.arg("--transcript-max-bytes")
+                .arg(transcript_max_bytes.to_string());
+        }
+    }
     cmd.arg("--");
     for arg in worker_command {
         cmd.arg(arg);

--- a/src/worker/worker_contract.rs
+++ b/src/worker/worker_contract.rs
@@ -17,26 +17,48 @@
 //!
 //! # Canonical `CADUCEUS_*` environment
 //!
-//! [`sanitized_env`] exports exactly these daemon-owned variables
-//! on every invocation (see also
+//! [`sanitized_env`] exports exactly these daemon-owned variables on
+//! every invocation (see also
 //! `crate::infra::fixtures::CANONICAL_WORKER_ENV_VARS`, mirrored by
-//! the bridge's `REQUIRED_ENV_VARS`):
+//! the bridge's `REQUIRED_ENV_VARS`). The set depends on the run's
+//! [`WorkTarget`] (DAR §6.1): issue runs keep the historical
+//! issue-shaped contract byte-for-byte; PR review runs carry a
+//! `pr` mode marker plus the four `CADUCEUS_PR_*` variables and
+//! **never** an `CADUCEUS_ISSUE_*` or `CADUCEUS_BRANCH_NAME`.
+//!
+//! Shared by both paths:
+//!
+//! | Variable | Value |
+//! |---|---|
+//! | `CADUCEUS_CONTEXT_JSON` | serialised run context |
+//! | `CADUCEUS_RUN_ID` | run identifier |
+//! | `CADUCEUS_WORKTREE_PATH` | host path of the mounted worktree |
+//! | `CADUCEUS_RESULT_PATH` | host result-file path (`<worktree>/worker-result.json`) |
+//!
+//! Issue path (byte-for-byte v0.1 contract, unchanged):
 //!
 //! | Variable | Value |
 //! |---|---|
 //! | `CADUCEUS_BRANCH_NAME` | target branch name |
-//! | `CADUCEUS_CONTEXT_JSON` | serialised run context |
 //! | `CADUCEUS_ISSUE_BODY` | issue body |
 //! | `CADUCEUS_ISSUE_LABELS_JSON` | JSON array of issue labels |
 //! | `CADUCEUS_ISSUE_NUMBER` | issue number |
 //! | `CADUCEUS_ISSUE_REPO` | `owner/repo` |
 //! | `CADUCEUS_ISSUE_TITLE` | issue title |
-//! | `CADUCEUS_RUN_ID` | run identifier |
-//! | `CADUCEUS_WORKTREE_PATH` | host path of the mounted worktree |
-//! | `CADUCEUS_RESULT_PATH` | host result-file path (`<worktree>/worker-result.json`) |
 //!
-//! The bridge writes its result to `CADUCEUS_RESULT_PATH` (legacy
-//! fallback: `<worktree>/worker-result.json`). The daemon then
+//! PR review path (DAR §6.1 — no synthetic issue key, no branch):
+//!
+//! | Variable | Value |
+//! |---|---|
+//! | `CADUCEUS_WORK_TARGET` | `pr` |
+//! | `CADUCEUS_PR_NUMBER` | pull request number |
+//! | `CADUCEUS_PR_REPO` | `owner/repo` |
+//! | `CADUCEUS_PR_BASE_SHA` | base SHA |
+//! | `CADUCEUS_PR_HEAD_SHA` | head SHA |
+//!
+//! The bridge writes its result to `CADUCEUS_RESULT_PATH` (issue-path
+//! legacy fallback: `<worktree>/worker-result.json`; the PR path has
+//! no fallback — the variable is hard-required). The daemon then
 //! [`parse_result_file`]s that file — opening it with
 //! `O_NOFOLLOW`, verifying the descriptor is a regular file, and
 //! reading with a 1 MiB cap before allocating the full document.
@@ -81,8 +103,10 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
+use crate::executor::WorkTarget;
 use crate::github::issue::IssueKey;
 use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::review::ReviewTarget;
 
 /// Container-side workspace mount target: read-write scratch and
 /// working directory bound to the host worktree. Normative for every
@@ -174,22 +198,17 @@ pub enum WorkerStatus {
 /// operator-configured `worker_env_allowlist`. The parent
 /// environment is supplied as a separate argument to keep the
 /// function pure and easy to test.
+///
+/// The run's [`WorkTarget`] selects the emitted set: issue runs
+/// render the historical issue payload, PR review runs render the
+/// `pr` mode marker plus the four `CADUCEUS_PR_*` values (DAR §6.1).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SanitizedEnvInputs {
-    /// GitHub issue the worker is processing. The display key
-    /// (`owner/repo#number`) is rendered to `CADUCEUS_ISSUE_REPO`
-    /// and the number alone to `CADUCEUS_ISSUE_NUMBER`.
-    pub issue: IssueKey,
-    /// Issue title (one line, NUL-free, no embedded newlines
-    /// per the GitHub API contract; the daemon copies it as-is
-    /// because the upstream title is the authoritative value).
-    pub issue_title: String,
-    /// Issue body. NUL-free, may contain newlines.
-    pub issue_body: String,
-    /// Label names. Emitted to `CADUCEUS_ISSUE_LABELS_JSON` as a
-    /// JSON array so embedded commas and quotes survive the env
-    /// boundary intact.
-    pub labels: Vec<String>,
+    /// The work item this run addresses. Issue runs emit
+    /// `CADUCEUS_ISSUE_*` + `CADUCEUS_BRANCH_NAME` byte-for-byte;
+    /// PR runs emit `CADUCEUS_WORK_TARGET=pr` + `CADUCEUS_PR_*` and
+    /// never an issue-shaped variable.
+    pub target: WorkTarget,
     /// Worktree path. Must be an absolute UTF-8 path; the
     /// `sanitized_env` validator rejects relative or non-UTF-8
     /// values to keep the bridge's `os.path` calls deterministic.
@@ -197,10 +216,6 @@ pub struct SanitizedEnvInputs {
     /// Run identifier. Used for `CADUCEUS_RUN_ID` and to
     /// disambiguate concurrent runs in the bridge's logs.
     pub run_id: String,
-    /// Daemon-owned expected branch name. Emitted as
-    /// `CADUCEUS_BRANCH_NAME` so the bridge never has to
-    /// select its own ref.
-    pub branch_name: String,
     /// Operator-configured `worker_env_allowlist`. Each entry is
     /// either an exact variable name or a single terminal-`*`
     /// prefix pattern (the syntax validated in `Config`).
@@ -261,21 +276,6 @@ pub fn sanitized_env(
     if inputs.run_id.contains('\0') {
         return Err(CaduceusError::Config("run_id contains NUL".to_string()));
     }
-    if inputs.branch_name.trim().is_empty() {
-        return Err(CaduceusError::Config(
-            "branch_name must not be empty".to_string(),
-        ));
-    }
-    if inputs.branch_name.contains('\0') {
-        return Err(CaduceusError::Config(
-            "branch_name contains NUL".to_string(),
-        ));
-    }
-    if inputs.issue_title.contains('\0') || inputs.issue_body.contains('\0') {
-        return Err(CaduceusError::Config(
-            "issue title/body contains NUL".to_string(),
-        ));
-    }
     if inputs.context_json.contains('\0') {
         return Err(CaduceusError::Config(
             "context_json contains NUL".to_string(),
@@ -298,27 +298,99 @@ pub fn sanitized_env(
     // Step 3: layer the canonical `CADUCEUS_*` variables on
     // top. These override any parent entry with the same name
     // (a `CADUCEUS_*` value the operator may have set in the
-    // shell is never trusted — the daemon owns them).
-    let labels_json = serde_json::to_string(&inputs.labels)
-        .map_err(|err| CaduceusError::Config(format!("labels JSON serialise: {err}")))?;
-    let repo = format!("{}/{}", inputs.issue.owner, inputs.issue.repo);
-    let canonical: &[(&str, &str)] = &[
-        ("CADUCEUS_ISSUE_NUMBER", &inputs.issue.number.to_string()),
-        ("CADUCEUS_ISSUE_TITLE", &inputs.issue_title),
-        ("CADUCEUS_ISSUE_BODY", &inputs.issue_body),
-        ("CADUCEUS_ISSUE_REPO", &repo),
-        ("CADUCEUS_ISSUE_LABELS_JSON", &labels_json),
+    // shell is never trusted — the daemon owns them). The
+    // emitted set depends on the run's [`WorkTarget`] (DAR §6.1):
+    // issue runs keep the historical 10-name issue contract
+    // byte-for-byte; PR review runs emit the `pr` mode marker plus
+    // the four `CADUCEUS_PR_*` values and never an issue-shaped
+    // variable.
+    let shared: &[(&str, &str)] = &[
         ("CADUCEUS_WORKTREE_PATH", &worktree_str),
         ("CADUCEUS_RESULT_PATH", &result_path_str),
         ("CADUCEUS_RUN_ID", &inputs.run_id),
-        ("CADUCEUS_BRANCH_NAME", &inputs.branch_name),
         ("CADUCEUS_CONTEXT_JSON", &inputs.context_json),
     ];
+    let canonical: Vec<(String, String)> = match &inputs.target {
+        WorkTarget::Issue(issue) => {
+            if issue.branch_name.trim().is_empty() {
+                return Err(CaduceusError::Config(
+                    "branch_name must not be empty".to_string(),
+                ));
+            }
+            if issue.branch_name.contains('\0') {
+                return Err(CaduceusError::Config(
+                    "branch_name contains NUL".to_string(),
+                ));
+            }
+            if issue.title.contains('\0') || issue.body.contains('\0') {
+                return Err(CaduceusError::Config(
+                    "issue title/body contains NUL".to_string(),
+                ));
+            }
+            let labels_json = serde_json::to_string(&issue.labels)
+                .map_err(|err| CaduceusError::Config(format!("labels JSON serialise: {err}")))?;
+            let repo = format!("{}/{}", issue.key.owner, issue.key.repo);
+            let issue_canonical: Vec<(String, String)> = vec![
+                ("CADUCEUS_ISSUE_NUMBER".to_string(), issue.key.number.to_string()),
+                ("CADUCEUS_ISSUE_TITLE".to_string(), issue.title.clone()),
+                ("CADUCEUS_ISSUE_BODY".to_string(), issue.body.clone()),
+                ("CADUCEUS_ISSUE_REPO".to_string(), repo),
+                ("CADUCEUS_ISSUE_LABELS_JSON".to_string(), labels_json),
+                ("CADUCEUS_BRANCH_NAME".to_string(), issue.branch_name.clone()),
+            ];
+            shared
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .chain(issue_canonical)
+                .collect()
+        }
+        WorkTarget::PullRequest(pr) => {
+            validate_pr_env(pr)?;
+            let pr_canonical: Vec<(String, String)> = vec![
+                ("CADUCEUS_WORK_TARGET".to_string(), "pr".to_string()),
+                ("CADUCEUS_PR_NUMBER".to_string(), pr.pull_request.to_string()),
+                ("CADUCEUS_PR_REPO".to_string(), pr.repository.full_name()),
+                ("CADUCEUS_PR_BASE_SHA".to_string(), pr.base_sha.clone()),
+                ("CADUCEUS_PR_HEAD_SHA".to_string(), pr.head_sha.clone()),
+            ];
+            shared
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .chain(pr_canonical)
+                .collect()
+        }
+    };
     for (k, v) in canonical {
-        out.insert(OsString::from(*k), OsString::from(*v));
+        out.insert(OsString::from(k), OsString::from(v));
     }
 
     Ok(out)
+}
+
+/// Validate the PR-path env inputs. Mirrors the issue-arm checks:
+/// every `CADUCEUS_PR_*` string must be non-empty and NUL-free and
+/// the pull request number must be positive. `base_ref`/`merge_base`
+/// are context (DAR §2.1) and do not enter the environment.
+fn validate_pr_env(pr: &ReviewTarget) -> CaduceusResult<()> {
+    for (field, value) in [
+        ("pr.repository.owner", pr.repository.owner.as_str()),
+        ("pr.repository.repo", pr.repository.repo.as_str()),
+        ("pr.base_sha", pr.base_sha.as_str()),
+        ("pr.head_sha", pr.head_sha.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            return Err(CaduceusError::Config(format!("{field} must not be empty")));
+        }
+        if value.contains('\0') {
+            return Err(CaduceusError::Config(format!("{field} contains NUL")));
+        }
+    }
+    if pr.pull_request == 0 {
+        return Err(CaduceusError::Config(
+            "pr.pull_request must be greater than 0".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Spawn *command* with the sanitized environment. The function

--- a/src/worker/worker_contract.rs
+++ b/src/worker/worker_contract.rs
@@ -380,7 +380,11 @@ pub fn sanitized_env(
 /// every `CADUCEUS_PR_*` string must be non-empty and NUL-free and
 /// the pull request number must be positive. `base_ref`/`merge_base`
 /// are context (DAR §2.1) and do not enter the environment.
-fn validate_pr_env(pr: &ReviewTarget) -> CaduceusResult<()> {
+///
+/// `pub(crate)` so the OCI env assembly in
+/// `executor::sandbox_spec::resolve_with_env` reuses this single
+/// authority instead of duplicating the checks.
+pub(crate) fn validate_pr_env(pr: &ReviewTarget) -> CaduceusResult<()> {
     for (field, value) in [
         ("pr.repository.owner", pr.repository.owner.as_str()),
         ("pr.repository.repo", pr.repository.repo.as_str()),

--- a/src/worker/worker_contract.rs
+++ b/src/worker/worker_contract.rs
@@ -331,12 +331,18 @@ pub fn sanitized_env(
                 .map_err(|err| CaduceusError::Config(format!("labels JSON serialise: {err}")))?;
             let repo = format!("{}/{}", issue.key.owner, issue.key.repo);
             let issue_canonical: Vec<(String, String)> = vec![
-                ("CADUCEUS_ISSUE_NUMBER".to_string(), issue.key.number.to_string()),
+                (
+                    "CADUCEUS_ISSUE_NUMBER".to_string(),
+                    issue.key.number.to_string(),
+                ),
                 ("CADUCEUS_ISSUE_TITLE".to_string(), issue.title.clone()),
                 ("CADUCEUS_ISSUE_BODY".to_string(), issue.body.clone()),
                 ("CADUCEUS_ISSUE_REPO".to_string(), repo),
                 ("CADUCEUS_ISSUE_LABELS_JSON".to_string(), labels_json),
-                ("CADUCEUS_BRANCH_NAME".to_string(), issue.branch_name.clone()),
+                (
+                    "CADUCEUS_BRANCH_NAME".to_string(),
+                    issue.branch_name.clone(),
+                ),
             ];
             shared
                 .iter()
@@ -348,7 +354,10 @@ pub fn sanitized_env(
             validate_pr_env(pr)?;
             let pr_canonical: Vec<(String, String)> = vec![
                 ("CADUCEUS_WORK_TARGET".to_string(), "pr".to_string()),
-                ("CADUCEUS_PR_NUMBER".to_string(), pr.pull_request.to_string()),
+                (
+                    "CADUCEUS_PR_NUMBER".to_string(),
+                    pr.pull_request.to_string(),
+                ),
                 ("CADUCEUS_PR_REPO".to_string(), pr.repository.full_name()),
                 ("CADUCEUS_PR_BASE_SHA".to_string(), pr.base_sha.clone()),
                 ("CADUCEUS_PR_HEAD_SHA".to_string(), pr.head_sha.clone()),

--- a/tests/architecture/docs_contract_test.rs
+++ b/tests/architecture/docs_contract_test.rs
@@ -39,7 +39,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use caduceus::fixtures::{
-    CANONICAL_CONFIG_KEYS, CANONICAL_WORKER_ENV_VARS, DEFAULT_ALLOWLIST_EXACT_ENV_NAMES,
+    CANONICAL_CONFIG_KEYS, CANONICAL_WORKER_ENV_VARS, CANONICAL_WORKER_ENV_VARS_ISSUE_PATH,
+    CANONICAL_WORKER_ENV_VARS_PR_PATH, DEFAULT_ALLOWLIST_EXACT_ENV_NAMES,
     DEFAULT_ALLOWLIST_PREFIX_ENV_PATTERNS, DENIED_ENV_NAMES, HERMES_FORBIDDEN_MANIFEST_FIELDS,
     HERMES_MANIFEST_FIELDS,
 };
@@ -173,17 +174,31 @@ fn extract_daemon_config_fields(source: &str) -> BTreeSet<String> {
 /// Worker env names emitted by `crate::worker::sanitized_env`. The
 /// daemon's tests assert them directly; this cross-doc test only
 /// requires that the canonical fixture covers the contract.
+///
+/// The extractor is deliberately format-agnostic: rustfmt may render a
+/// vec entry as `("CADUCEUS_NAME", &value),` on one line or split a
+/// `"CADUCEUS_NAME".to_string(),` value across lines, so we scan for
+/// every quoted `CADUCEUS_*` token instead of pinning one layout.
+/// Over-capture is safe (the caller asserts `canonical ⊆ names`); the
+/// only requirement is that every emitted name appears somewhere in
+/// the file as a quoted literal.
 fn extract_daemon_worker_env_names() -> BTreeSet<String> {
     let source = read_repo_file("src/worker/worker_contract.rs");
     let mut names = BTreeSet::new();
     for line in source.lines() {
-        let trimmed = line.trim_start();
-        if let Some(rest) = trimmed.strip_prefix("(\"") {
-            // Handles `(  "CADUCEUS_...", &value),` entries.
-            if let Some((name, _)) = rest.split_once("\",") {
-                if name.starts_with("CADUCEUS_") {
-                    names.insert(name.to_string());
+        let mut rest = line;
+        while let Some(start) = rest.find('"') {
+            rest = &rest[start + 1..];
+            if let Some(end) = rest.find('"') {
+                let token = &rest[..end];
+                if token.starts_with("CADUCEUS_")
+                    && token
+                        .chars()
+                        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+                {
+                    names.insert(token.to_string());
                 }
+                rest = &rest[end + 1..];
             }
         }
     }
@@ -328,6 +343,99 @@ fn bridge_required_env_vars_match_daemon_canonical() {
         required, canonical,
         "worker-bridge.py REQUIRED_ENV_VARS must equal CANONICAL_WORKER_ENV_VARS"
     );
+}
+
+/// The canonical union decomposes exactly into the issue-path set and
+/// the PR-path set — nothing else, nothing missing (DAR §6.1, D6).
+/// The overlap is exactly the four shared run/context/worktree/result
+/// vars; every other name belongs to exactly one path.
+#[test]
+fn canonical_union_is_exactly_issue_path_plus_pr_path() {
+    let union: BTreeSet<&str> = CANONICAL_WORKER_ENV_VARS.iter().copied().collect();
+    let issue: BTreeSet<&str> = CANONICAL_WORKER_ENV_VARS_ISSUE_PATH
+        .iter()
+        .copied()
+        .collect();
+    let pr: BTreeSet<&str> = CANONICAL_WORKER_ENV_VARS_PR_PATH.iter().copied().collect();
+
+    assert_eq!(
+        union,
+        issue.union(&pr).copied().collect::<BTreeSet<&str>>(),
+        "the canonical union must equal issue-path ∪ pr-path"
+    );
+    // The overlap is exactly the four shared vars (D2).
+    let shared = issue.intersection(&pr).copied().collect::<BTreeSet<&str>>();
+    let expected_shared: BTreeSet<&str> = [
+        "CADUCEUS_CONTEXT_JSON",
+        "CADUCEUS_RESULT_PATH",
+        "CADUCEUS_RUN_ID",
+        "CADUCEUS_WORKTREE_PATH",
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(
+        shared, expected_shared,
+        "only the shared run/context/worktree/result vars may appear on both paths"
+    );
+}
+
+/// The issue-path fixture pins the byte-for-byte v0.1 contract exactly
+/// (AC1): the historical 10 names and nothing else — no
+/// `CADUCEUS_WORK_TARGET`, no `CADUCEUS_PR_*`.
+#[test]
+fn issue_path_fixture_is_exactly_the_historical_contract() {
+    let expected: &[&str] = &[
+        "CADUCEUS_BRANCH_NAME",
+        "CADUCEUS_CONTEXT_JSON",
+        "CADUCEUS_ISSUE_BODY",
+        "CADUCEUS_ISSUE_LABELS_JSON",
+        "CADUCEUS_ISSUE_NUMBER",
+        "CADUCEUS_ISSUE_REPO",
+        "CADUCEUS_ISSUE_TITLE",
+        "CADUCEUS_RUN_ID",
+        "CADUCEUS_WORKTREE_PATH",
+        "CADUCEUS_RESULT_PATH",
+    ];
+    assert_eq!(CANONICAL_WORKER_ENV_VARS_ISSUE_PATH, expected);
+    assert_eq!(CANONICAL_WORKER_ENV_VARS_ISSUE_PATH.len(), 10);
+    assert!(
+        !CANONICAL_WORKER_ENV_VARS_ISSUE_PATH.contains(&"CADUCEUS_WORK_TARGET"),
+        "issue-path fixture must not carry the PR mode marker"
+    );
+}
+
+/// No PR-only name appears in the issue-path fixture and no
+/// issue-only name appears in the PR-path fixture (DAR §6.1).
+#[test]
+fn path_fixtures_do_not_cross_contaminate() {
+    let issue: BTreeSet<&str> = CANONICAL_WORKER_ENV_VARS_ISSUE_PATH
+        .iter()
+        .copied()
+        .collect();
+    let pr: BTreeSet<&str> = CANONICAL_WORKER_ENV_VARS_PR_PATH.iter().copied().collect();
+    for pr_only in [
+        "CADUCEUS_WORK_TARGET",
+        "CADUCEUS_PR_NUMBER",
+        "CADUCEUS_PR_REPO",
+    ] {
+        assert!(
+            !issue.contains(pr_only),
+            "issue-path fixture must not contain {pr_only}"
+        );
+    }
+    for issue_only in [
+        "CADUCEUS_ISSUE_NUMBER",
+        "CADUCEUS_ISSUE_TITLE",
+        "CADUCEUS_ISSUE_BODY",
+        "CADUCEUS_ISSUE_REPO",
+        "CADUCEUS_ISSUE_LABELS_JSON",
+        "CADUCEUS_BRANCH_NAME",
+    ] {
+        assert!(
+            !pr.contains(issue_only),
+            "pr-path fixture must not contain {issue_only}"
+        );
+    }
 }
 
 #[test]

--- a/tests/daemon/runtime_path_test.rs
+++ b/tests/daemon/runtime_path_test.rs
@@ -26,23 +26,14 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use caduceus::fixtures::{CANONICAL_WORKER_ENV_VARS, CANONICAL_WORKER_ENV_VARS_ISSUE_PATH};
+
 //
 // The bridge's REQUIRED_ENV_VARS tuple must exactly match the
-// Python source and compares the two sets.
-
-/// All CADUCEUS_* env vars the daemon exports per RUN-001.
-const DAEMON_ENV_VARS: &[&str] = &[
-    "CADUCEUS_ISSUE_NUMBER",
-    "CADUCEUS_ISSUE_TITLE",
-    "CADUCEUS_ISSUE_BODY",
-    "CADUCEUS_ISSUE_REPO",
-    "CADUCEUS_ISSUE_LABELS_JSON",
-    "CADUCEUS_WORKTREE_PATH",
-    "CADUCEUS_RUN_ID",
-    "CADUCEUS_CONTEXT_JSON",
-    "CADUCEUS_BRANCH_NAME",
-    "CADUCEUS_RESULT_PATH",
-];
+// Python source and compares the two sets. Post-#346 the bridge
+// REQUIRED_ENV_VARS is the full union across both target paths
+// (DAR §6.1), while a single daemon run emits the per-path subset;
+// the issue-path fixture pins the exact 10-name emission set.
 
 #[test]
 fn bridge_required_env_matches_daemon_contract() {
@@ -84,20 +75,27 @@ fn bridge_required_env_matches_daemon_contract() {
         })
         .collect();
 
-    let daemon_set: BTreeSet<&str> = DAEMON_ENV_VARS.iter().copied().collect();
+    // The bridge REQUIRED_ENV_VARS is the canonical union across both
+    // target paths (DAR §6.1) — every name the daemon may emit.
+    let canonical_set: BTreeSet<String> = CANONICAL_WORKER_ENV_VARS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
     let bridge_set: BTreeSet<String> = bridge_vars.iter().cloned().collect();
-
     assert_eq!(
-        daemon_set.len(),
-        bridge_set.len(),
-        "env var count mismatch: daemon={} bridge={}",
-        daemon_set.len(),
-        bridge_set.len()
+        bridge_set, canonical_set,
+        "bridge REQUIRED_ENV_VARS must equal CANONICAL_WORKER_ENV_VARS (the union)"
     );
 
+    // The daemon's issue-path emission set is exactly the historical
+    // 10-name contract and is covered by the bridge's union.
+    let daemon_set: BTreeSet<String> = CANONICAL_WORKER_ENV_VARS_ISSUE_PATH
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
     for var in &daemon_set {
         assert!(
-            bridge_set.contains(*var),
+            bridge_set.contains(var),
             "daemon exports {var} but bridge does not expect it"
         );
     }

--- a/tests/daemon/status_test.rs
+++ b/tests/daemon/status_test.rs
@@ -270,8 +270,7 @@ fn fresh_heartbeat_surfaces_live_worker() {
     let runs_dir = cfg.state_dir.join("runs");
     std::fs::create_dir_all(&runs_dir).expect("runs dir");
     let now = Utc::now();
-    let issue = IssueKey::parse("owner/repo#1").expect("key");
-    let record = sample_heartbeat("RUN-LIVE", issue.clone(), now);
+    let record = sample_heartbeat("RUN-LIVE", "owner/repo#1", now);
     let hb_path = runs_dir.join("RUN-LIVE.heartbeat");
     write_heartbeat_record(&record, &hb_path).expect("write");
     let (report, _) = build_report(&cfg.state_dir).expect("report");
@@ -292,14 +291,13 @@ fn stale_heartbeat_surfaces_with_stale_marker() {
     // A heartbeat written 120 seconds ago is stale per
     // the 90s contract window.
     let now = Utc::now();
-    let issue = IssueKey::parse("owner/repo#1").expect("key");
     let record = Heartbeat {
         version: HEARTBEAT_FILE_VERSION,
         run_id: "RUN-STALE".to_string(),
         pid: std::process::id(),
         started_at: now - chrono::Duration::seconds(120),
         updated_at: now - chrono::Duration::seconds(120),
-        issue_key: issue,
+        target: "owner/repo#1".to_string(),
         transcript_path: PathBuf::from("/tmp/runs/RUN-STALE.log"),
     };
     let hb_path = runs_dir.join("RUN-STALE.heartbeat");
@@ -314,14 +312,13 @@ fn future_heartbeat_does_not_panic() {
     // A heartbeat whose updated_at is in the future is
     // surfaced as "fresh" with saturating age 0 (no panic).
     let now = Utc::now();
-    let issue = IssueKey::parse("owner/repo#1").expect("key");
     let record = Heartbeat {
         version: HEARTBEAT_FILE_VERSION,
         run_id: "RUN-FUTURE".to_string(),
         pid: std::process::id(),
         started_at: now + chrono::Duration::seconds(10),
         updated_at: now + chrono::Duration::seconds(10),
-        issue_key: issue,
+        target: "owner/repo#1".to_string(),
         transcript_path: PathBuf::from("/tmp/runs/RUN-FUTURE.log"),
     };
     let worker = live_worker_from_heartbeat(&record, now);
@@ -353,8 +350,7 @@ fn symlink_heartbeat_is_rejected() {
     // path. The reporter must skip the symlink itself
     // even though its target is a valid record.
     let target = runs_dir.join("target.bin");
-    let issue = IssueKey::parse("owner/repo#1").expect("key");
-    let record = sample_heartbeat("RUN-SYMLINK", issue, Utc::now());
+    let record = sample_heartbeat("RUN-SYMLINK", "owner/repo#1", Utc::now());
     write_heartbeat_record(&record, &target).expect("write");
     let link = runs_dir.join("RUN-SYMLINK.heartbeat");
     std::os::unix::fs::symlink(&target, &link).expect("symlink");
@@ -756,8 +752,7 @@ fn render_human_includes_transcript_for_live_workers() {
     let runs_dir = cfg.state_dir.join("runs");
     std::fs::create_dir_all(&runs_dir).expect("runs dir");
     let now = Utc::now();
-    let issue = IssueKey::parse("owner/repo#1").expect("key");
-    let record = sample_heartbeat("RUN-LIVE", issue, now);
+    let record = sample_heartbeat("RUN-LIVE", "owner/repo#1", now);
     let hb_path = runs_dir.join("RUN-LIVE.heartbeat");
     write_heartbeat_record(&record, &hb_path).expect("write");
     let (report, diag) = build_report(&cfg.state_dir).expect("report");

--- a/tests/executor/executor_oci_test.rs
+++ b/tests/executor/executor_oci_test.rs
@@ -54,16 +54,18 @@ fn test_spec(cfg: &Config) -> ExecutorSpec {
         .join("run-1");
     ExecutorSpec {
         self_exe: "/usr/bin/caduceus".into(),
-        issue: issue_key(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: issue_key(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-1".to_string(),
+        }),
         worktree,
         run_id: "oci-run-1".to_string(),
         context_json: r#"{"x":1}"#.to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: Vec::new(),
-        branch_name: "automation/issue-1".to_string(),
     }
 }
 

--- a/tests/executor/executor_trusted_host_test.rs
+++ b/tests/executor/executor_trusted_host_test.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use caduceus::executor::trusted_host::TrustedHostExecutor;
-use caduceus::executor::{Executor, ExecutorSpec};
+use caduceus::executor::{Executor, ExecutorSpec, IssueWorkTarget, WorkTarget};
 use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
 
@@ -23,16 +23,18 @@ fn test_cfg() -> Config {
 fn test_spec() -> ExecutorSpec {
     ExecutorSpec {
         self_exe: "/usr/bin/caduceus".into(),
-        issue: issue_key(),
+        target: WorkTarget::Issue(IssueWorkTarget {
+            key: issue_key(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-1".to_string(),
+        }),
         worktree: "/tmp/test-worktree".into(),
         run_id: "test-run-1".to_string(),
         context_json: r#"{"x":1}"#.to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: Vec::new(),
-        branch_name: "automation/issue-1".to_string(),
     }
 }
 
@@ -142,16 +144,18 @@ async fn trusted_host_run_reports_host_result_path() {
 
     let spec = ExecutorSpec {
         self_exe: PathBuf::from(env!("CARGO_BIN_EXE_caduceus")),
-        issue: issue_key(),
+        target: WorkTarget::Issue(IssueWorkTarget {
+            key: issue_key(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-1".to_string(),
+        }),
         worktree: worktree.clone(),
         run_id: "test-run-outcome".to_string(),
         context_json: r#"{"x":1}"#.to_string(),
         worker_command: vec!["/bin/true".to_string()],
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: Vec::new(),
-        branch_name: "automation/issue-1".to_string(),
     };
 
     let executor: Arc<dyn Executor> = Arc::new(TrustedHostExecutor::new(cfg));

--- a/tests/executor/oci_env_file_test.rs
+++ b/tests/executor/oci_env_file_test.rs
@@ -347,16 +347,18 @@ async fn create_failure_leaves_no_env_file() {
     let cfg = Config::test_defaults(tmp.path());
     let spec = ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: IssueKey::parse("owner/repo#1").expect("valid key"),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            labels: Vec::new(),
+            branch_name: "b".to_string(),
+        }),
         worktree: tmp.path().join("worktree"),
         run_id: "run-guard".to_string(),
         context_json: "{}".to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: CancellationToken::new(),
-        issue_title: "t".to_string(),
-        issue_body: "b".to_string(),
-        labels: Vec::new(),
-        branch_name: "b".to_string(),
     };
     let argv = vec![
         "docker".to_string(),
@@ -379,8 +381,14 @@ async fn create_failure_leaves_no_env_file() {
         state,
         cfg.state_dir.clone(),
         facts.daemon_id,
-        spec.issue.clone(),
-        spec.issue.display_key(),
+        match &spec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
+        match &spec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
         "test-command-sha".to_string(),
         argv,
         Some(env_file),

--- a/tests/executor/oci_env_file_test.rs
+++ b/tests/executor/oci_env_file_test.rs
@@ -381,14 +381,7 @@ async fn create_failure_leaves_no_env_file() {
         state,
         cfg.state_dir.clone(),
         facts.daemon_id,
-        match &spec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
-        match &spec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
+        spec.target.display(),
         "test-command-sha".to_string(),
         argv,
         Some(env_file),

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -88,16 +88,18 @@ fn executor_spec_for(
 ) -> caduceus::executor::ExecutorSpec {
     caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
-        issue: runtime.issue.clone(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: runtime.issue.clone(),
+            title: "Fix login bug".to_string(),
+            body: "Steps to reproduce".to_string(),
+            labels: vec!["bug".to_string()],
+            branch_name: "caduceus/owner/repo#1".to_string(),
+        }),
         worktree: runtime.worktree.clone(),
         run_id: runtime.run_id.clone(),
         context_json: "{}".to_string(),
         worker_command: runtime.worker_command.clone(),
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "Fix login bug".to_string(),
-        issue_body: "Steps to reproduce".to_string(),
-        labels: vec!["bug".to_string()],
-        branch_name: "caduceus/owner/repo#1".to_string(),
     }
 }
 
@@ -831,20 +833,25 @@ fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
     let result = run.block_on(async move {
         let spec = caduceus::executor::ExecutorSpec {
             self_exe: std::path::PathBuf::from("/proc/self/exe"),
-            issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+            target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+                key: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+                title: "t".to_string(),
+                body: "b".to_string(),
+                labels: Vec::new(),
+                branch_name: "b".to_string(),
+            }),
             worktree: std::path::PathBuf::from("/tmp/worktree"),
             run_id: run_id.clone(),
             context_json: "{}".to_string(),
             worker_command: vec!["sleep".to_string(), "3600".to_string()],
             cancellation: CancellationToken::new(),
-            issue_title: "t".to_string(),
-            issue_body: "b".to_string(),
-            labels: Vec::new(),
-            branch_name: "b".to_string(),
         };
         let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
             run_id: run_id.clone(),
-            issue: spec.issue.clone(),
+            issue: match &spec.target {
+                caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+            },
             worker_command: spec.worker_command.clone(),
             worktree: worktree.clone(),
             output_dir: fx_cfg
@@ -868,8 +875,14 @@ fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
             state,
             fx_cfg.state_dir.clone(),
             runtime.daemon_id,
-            spec.issue.clone(),
-            spec.issue.display_key(),
+            match &spec.target {
+                caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+            },
+            match &spec.target {
+                caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+            },
             "live-test-command-sha".to_string(),
             argv,
             None,
@@ -1368,8 +1381,14 @@ fn timeout_cleans_container_live() {
         Arc::clone(&state),
         fx.cfg.state_dir.clone(),
         "live-test-daemon".to_string(),
-        harness.spec_exec.issue.clone(),
-        harness.spec_exec.issue.display_key(),
+        match &harness.spec_exec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
+        match &harness.spec_exec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
         "live-command-sha".to_string(),
         argv,
         None,
@@ -1426,8 +1445,14 @@ fn cancellation_cleans_container_live() {
         Arc::clone(&state),
         fx.cfg.state_dir.clone(),
         "live-test-daemon".to_string(),
-        harness.spec_exec.issue.clone(),
-        harness.spec_exec.issue.display_key(),
+        match &harness.spec_exec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
+        match &harness.spec_exec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
         "live-command-sha".to_string(),
         argv,
         None,
@@ -1530,7 +1555,10 @@ fn crash_restart_orphan_reconcile_live() {
             created_at: now.clone(),
             updated_at: now,
             daemon_id: "live-test-daemon".to_string(),
-            issue_id: harness.spec_exec.issue.display_key(),
+            issue_id: match &harness.spec_exec.target {
+                caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+            },
             worker_command_sha256: "live-command-sha".to_string(),
         })
         .expect("insert row");
@@ -1589,8 +1617,14 @@ fn heartbeat_advances_during_run_live() {
         Arc::clone(&state),
         fx.cfg.state_dir.clone(),
         "live-test-daemon".to_string(),
-        harness.spec_exec.issue.clone(),
-        harness.spec_exec.issue.display_key(),
+        match &harness.spec_exec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
+        match &harness.spec_exec.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
         "live-command-sha".to_string(),
         argv,
         None,
@@ -1899,16 +1933,18 @@ fn lifecycle_harness(fx: &LiveFixture, worker_command: Vec<String>) -> Lifecycle
     };
     let spec_exec = caduceus::executor::ExecutorSpec {
         self_exe: std::path::PathBuf::from("/proc/self/exe"),
-        issue: runtime.issue.clone(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: runtime.issue.clone(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: vec!["bug".to_string()],
+            branch_name: "caduceus/owner/repo#1".to_string(),
+        }),
         worktree: fx.worktree.clone(),
         run_id: fx.run_id.clone(),
         context_json: "{}".to_string(),
         worker_command,
         cancellation: CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: vec!["bug".to_string()],
-        branch_name: "caduceus/owner/repo#1".to_string(),
     };
     let spec = resolve(fx.cfg.sandbox(), &runtime, &spec_exec).expect("sandbox must resolve");
     LifecycleHarness { spec, spec_exec }

--- a/tests/executor/oci_isolation_live_test.rs
+++ b/tests/executor/oci_isolation_live_test.rs
@@ -89,7 +89,8 @@ fn executor_spec_for(
     caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
         target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-            key: runtime.issue.clone(),
+            key: caduceus::github::issue::IssueKey::parse(&runtime.target)
+                .expect("fixture target parses as issue key"),
             title: "Fix login bug".to_string(),
             body: "Steps to reproduce".to_string(),
             labels: vec!["bug".to_string()],
@@ -216,7 +217,7 @@ fn live_fixture_with(
 
     let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
         run_id: run_id.to_string(),
-        issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: "owner/repo#1".to_string(),
         worker_command: vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -848,10 +849,7 @@ fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
         };
         let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
             run_id: run_id.clone(),
-            issue: match &spec.target {
-                caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-            },
+            target: spec.target.display(),
             worker_command: spec.worker_command.clone(),
             worktree: worktree.clone(),
             output_dir: fx_cfg
@@ -875,14 +873,7 @@ fn disk_pressure_watchdog_terminates_in_flight_and_refuses_new_dispatch() {
             state,
             fx_cfg.state_dir.clone(),
             runtime.daemon_id,
-            match &spec.target {
-                caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-            },
-            match &spec.target {
-                caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-            },
+            spec.target.display(),
             "live-test-command-sha".to_string(),
             argv,
             None,
@@ -1381,14 +1372,7 @@ fn timeout_cleans_container_live() {
         Arc::clone(&state),
         fx.cfg.state_dir.clone(),
         "live-test-daemon".to_string(),
-        match &harness.spec_exec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
-        match &harness.spec_exec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
+        harness.spec_exec.target.display(),
         "live-command-sha".to_string(),
         argv,
         None,
@@ -1445,14 +1429,7 @@ fn cancellation_cleans_container_live() {
         Arc::clone(&state),
         fx.cfg.state_dir.clone(),
         "live-test-daemon".to_string(),
-        match &harness.spec_exec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
-        match &harness.spec_exec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
+        harness.spec_exec.target.display(),
         "live-command-sha".to_string(),
         argv,
         None,
@@ -1555,10 +1532,7 @@ fn crash_restart_orphan_reconcile_live() {
             created_at: now.clone(),
             updated_at: now,
             daemon_id: "live-test-daemon".to_string(),
-            issue_id: match &harness.spec_exec.target {
-                caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-                caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-            },
+            issue_id: harness.spec_exec.target.display(),
             worker_command_sha256: "live-command-sha".to_string(),
         })
         .expect("insert row");
@@ -1617,14 +1591,7 @@ fn heartbeat_advances_during_run_live() {
         Arc::clone(&state),
         fx.cfg.state_dir.clone(),
         "live-test-daemon".to_string(),
-        match &harness.spec_exec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
-        match &harness.spec_exec.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
+        harness.spec_exec.target.display(),
         "live-command-sha".to_string(),
         argv,
         None,
@@ -1909,7 +1876,7 @@ struct LifecycleHarness {
 fn lifecycle_harness(fx: &LiveFixture, worker_command: Vec<String>) -> LifecycleHarness {
     let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
         run_id: fx.run_id.clone(),
-        issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: "owner/repo#1".to_string(),
         worker_command: worker_command.clone(),
         worktree: fx.worktree.clone(),
         output_dir: fx
@@ -1934,7 +1901,8 @@ fn lifecycle_harness(fx: &LiveFixture, worker_command: Vec<String>) -> Lifecycle
     let spec_exec = caduceus::executor::ExecutorSpec {
         self_exe: std::path::PathBuf::from("/proc/self/exe"),
         target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-            key: runtime.issue.clone(),
+            key: caduceus::github::issue::IssueKey::parse(&runtime.target)
+                .expect("fixture target parses as issue key"),
             title: "title".to_string(),
             body: "body".to_string(),
             labels: vec!["bug".to_string()],

--- a/tests/executor/oci_label_test.rs
+++ b/tests/executor/oci_label_test.rs
@@ -206,15 +206,17 @@ fn labels_queryable_via_filter() {
 fn executor_spec_surface_intact() {
     let _ = ExecutorSpec {
         self_exe: PathBuf::from("/usr/bin/caduceus"),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: IssueKey::parse("owner/repo#1").expect("valid key"),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-1".to_string(),
+        }),
         worktree: PathBuf::from("/tmp/worktree"),
         run_id: "surface-001".to_string(),
         context_json: r#"{"x":1}"#.to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: Vec::new(),
-        branch_name: "automation/issue-1".to_string(),
     };
 }

--- a/tests/executor/oci_lifecycle_stub_test.rs
+++ b/tests/executor/oci_lifecycle_stub_test.rs
@@ -171,14 +171,7 @@ async fn run_lifecycle(
         state,
         cfg.state_dir.clone(),
         facts.daemon_id,
-        match &input.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
-        match &input.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
+        input.target.display(),
         "test-command-sha".to_string(),
         create_argv(),
         None,
@@ -212,14 +205,7 @@ async fn canonical_lifecycle_runs_end_to_end() {
         state.clone(),
         cfg.state_dir.clone(),
         "test-daemon".to_string(),
-        match &input.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
-        match &input.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
+        input.target.display(),
         "test-command-sha".to_string(),
         create_argv(),
         None,

--- a/tests/executor/oci_lifecycle_stub_test.rs
+++ b/tests/executor/oci_lifecycle_stub_test.rs
@@ -127,16 +127,18 @@ impl OciRunState for FakeOciRunState {
 fn test_spec(run_id: &str) -> ExecutorSpec {
     ExecutorSpec {
         self_exe: Path::new("/usr/bin/caduceus").to_path_buf(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: IssueKey::parse("owner/repo#1").expect("valid key"),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-1".to_string(),
+        }),
         worktree: Path::new("/tmp/worktree").to_path_buf(),
         run_id: run_id.to_string(),
         context_json: r#"{"x":1}"#.to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: Vec::new(),
-        branch_name: "automation/issue-1".to_string(),
     }
 }
 
@@ -169,8 +171,14 @@ async fn run_lifecycle(
         state,
         cfg.state_dir.clone(),
         facts.daemon_id,
-        input.issue.clone(),
-        input.issue.display_key(),
+        match &input.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
+        match &input.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
         "test-command-sha".to_string(),
         create_argv(),
         None,
@@ -204,8 +212,14 @@ async fn canonical_lifecycle_runs_end_to_end() {
         state.clone(),
         cfg.state_dir.clone(),
         "test-daemon".to_string(),
-        input.issue.clone(),
-        input.issue.display_key(),
+        match &input.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
+        match &input.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
         "test-command-sha".to_string(),
         create_argv(),
         None,

--- a/tests/executor/oci_lifecycle_test.rs
+++ b/tests/executor/oci_lifecycle_test.rs
@@ -134,14 +134,7 @@ async fn run_lifecycle(
         state,
         cfg.state_dir.clone(),
         runtime.daemon_id,
-        match &input.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
-        match &input.target {
-            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
-            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
-        },
+        input.target.display(),
         "test-command-sha".to_string(),
         argv,
         None,

--- a/tests/executor/oci_lifecycle_test.rs
+++ b/tests/executor/oci_lifecycle_test.rs
@@ -85,16 +85,18 @@ fn test_cfg() -> Config {
 fn test_spec(run_id: &str) -> ExecutorSpec {
     ExecutorSpec {
         self_exe: Path::new("/usr/bin/caduceus").to_path_buf(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: IssueKey::parse("owner/repo#1").expect("valid key"),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-1".to_string(),
+        }),
         worktree: Path::new("/tmp/worktree").to_path_buf(),
         run_id: run_id.to_string(),
         context_json: r#"{"x":1}"#.to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: Vec::new(),
-        branch_name: "automation/issue-1".to_string(),
     }
 }
 
@@ -132,8 +134,14 @@ async fn run_lifecycle(
         state,
         cfg.state_dir.clone(),
         runtime.daemon_id,
-        input.issue.clone(),
-        input.issue.display_key(),
+        match &input.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.clone(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
+        match &input.target {
+            caduceus::executor::WorkTarget::Issue(issue) => issue.key.display_key(),
+            caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+        },
         "test-command-sha".to_string(),
         argv,
         None,

--- a/tests/executor/sandbox_renderer_test.rs
+++ b/tests/executor/sandbox_renderer_test.rs
@@ -29,16 +29,18 @@ fn executor_spec_for(
 ) -> caduceus::executor::ExecutorSpec {
     caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
-        issue: runtime.issue.clone(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: runtime.issue.clone(),
+            title: "Fix login bug".to_string(),
+            body: "Steps to reproduce".to_string(),
+            labels: vec!["bug".to_string()],
+            branch_name: "caduceus/owner/repo#1".to_string(),
+        }),
         worktree: runtime.worktree.clone(),
         run_id: runtime.run_id.clone(),
         context_json: "{}".to_string(),
         worker_command: runtime.worker_command.clone(),
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "Fix login bug".to_string(),
-        issue_body: "Steps to reproduce".to_string(),
-        labels: vec!["bug".to_string()],
-        branch_name: "caduceus/owner/repo#1".to_string(),
     }
 }
 

--- a/tests/executor/sandbox_renderer_test.rs
+++ b/tests/executor/sandbox_renderer_test.rs
@@ -30,7 +30,8 @@ fn executor_spec_for(
     caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
         target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-            key: runtime.issue.clone(),
+            key: caduceus::github::issue::IssueKey::parse(&runtime.target)
+                .expect("fixture target parses as issue key"),
             title: "Fix login bug".to_string(),
             body: "Steps to reproduce".to_string(),
             labels: vec!["bug".to_string()],
@@ -64,7 +65,7 @@ fn fixture_with(
     let output = cfg.state_dir.join("oci-runs").join(run_id).join("output");
     let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
         run_id: run_id.to_string(),
-        issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: "owner/repo#1".to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         worktree: worktree.clone(),
         output_dir: output.clone(),
@@ -1046,6 +1047,100 @@ fn renderer_has_no_side_effect_imports() {
         assert!(
             !source.contains(forbidden),
             "sandbox_renderer.rs must not {forbidden}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PR-target `-e` fallback (DAR §6.1, D5)
+// ---------------------------------------------------------------------------
+
+/// The `-e` fallback list mirrors the resolved target: a PR-target
+/// spec (detected via `CADUCEUS_WORK_TARGET=pr` in its environment)
+/// renders only the PR-shaped fallbacks — never `CADUCEUS_ISSUE_*` /
+/// `CADUCEUS_ISSUE_ID` / `CADUCEUS_BRANCH_NAME`.
+#[test]
+fn pr_target_e_fallback_renders_pr_vars_and_no_issue_vars() {
+    let root = Path::new(ROOT);
+    let cfg = Config::test_defaults(root);
+    let worktree = root
+        .join("workdirs")
+        .join("owner")
+        .join("repo")
+        .join("run-pr-9");
+    let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
+        run_id: "run-pr-9".to_string(),
+        target: "owner/repo#pr/9".to_string(),
+        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
+        worktree: worktree.clone(),
+        output_dir: cfg
+            .state_dir
+            .join("oci-runs")
+            .join("run-pr-9")
+            .join("output"),
+        daemon_id: "test-daemon".to_string(),
+        workdir_base: root.join("workdirs"),
+        state_dir: cfg.state_dir.clone(),
+        worktree_uid: 4242,
+        worktree_gid: 4242,
+        engine_mode: EngineMode::Rootful,
+        git_shadow_kind: GitShadowKind::File,
+        git_shadow_host: cfg
+            .state_dir
+            .join("oci-runs")
+            .join("run-pr-9")
+            .join("git-shadow"),
+    };
+    let spec_input = caduceus::executor::ExecutorSpec {
+        self_exe: PathBuf::from("/proc/self/exe"),
+        target: caduceus::executor::WorkTarget::PullRequest(caduceus::review::ReviewTarget {
+            repository: caduceus::review::RepositoryId {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+            },
+            pull_request: 9,
+            head_sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+            base_sha: "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+            base_ref: "main".to_string(),
+            merge_base: "abcdef01abcdef01abcdef01abcdef01abcdef01".to_string(),
+        }),
+        worktree: worktree.clone(),
+        run_id: "run-pr-9".to_string(),
+        context_json: "{}".to_string(),
+        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
+        cancellation: tokio_util::sync::CancellationToken::new(),
+    };
+    let resolved = caduceus::executor::sandbox_spec::resolve(cfg.sandbox(), &runtime, &spec_input)
+        .expect("pr spec must resolve");
+    // Render WITHOUT env files — the `-e` fallback surface (no
+    // production caller, but the mode mirror must hold here too).
+    let argv = render_with_env_files(&resolved, SandboxEngine::Docker, &[]);
+
+    let has = |needle: &str| argv.iter().any(|arg| arg.contains(needle));
+    for expected in [
+        "CADUCEUS_WORK_TARGET=pr",
+        "CADUCEUS_PR_NUMBER=9",
+        "CADUCEUS_PR_REPO=owner/repo",
+        "CADUCEUS_PR_BASE_SHA=cafebabecafebabecafebabecafebabecafebabe",
+        "CADUCEUS_PR_HEAD_SHA=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "CADUCEUS_CONTEXT_JSON={}",
+        "CADUCEUS_WORKTREE_PATH=/workspace",
+        "CADUCEUS_RESULT_PATH=/output/worker-result.json",
+    ] {
+        assert!(has(expected), "PR fallback must carry {expected}: {argv:?}");
+    }
+    for forbidden in [
+        "CADUCEUS_ISSUE_ID",
+        "CADUCEUS_ISSUE_NUMBER",
+        "CADUCEUS_ISSUE_REPO",
+        "CADUCEUS_ISSUE_TITLE",
+        "CADUCEUS_ISSUE_BODY",
+        "CADUCEUS_ISSUE_LABELS_JSON",
+        "CADUCEUS_BRANCH_NAME",
+    ] {
+        assert!(
+            !has(forbidden),
+            "PR fallback must not carry {forbidden}: {argv:?}"
         );
     }
 }

--- a/tests/executor/sandbox_resolve_test.rs
+++ b/tests/executor/sandbox_resolve_test.rs
@@ -316,16 +316,18 @@ fn resolves_full_canonical_environment_with_container_paths() {
     runtime.issue = IssueKey::parse("octocat/hello#42").expect("valid key");
     let spec_input = caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
-        issue: runtime.issue.clone(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: runtime.issue.clone(),
+            title: "A title".to_string(),
+            body: "A body\nwith newline".to_string(),
+            labels: vec!["p1".to_string(), "p2".to_string()],
+            branch_name: "caduceus/octocat/hello#42".to_string(),
+        }),
         worktree: worktree.clone(),
         run_id: "run-100".to_string(),
         context_json: "{\"context\":true}".to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "A title".to_string(),
-        issue_body: "A body\nwith newline".to_string(),
-        labels: vec!["p1".to_string(), "p2".to_string()],
-        branch_name: "caduceus/octocat/hello#42".to_string(),
     };
     let resolved = resolve(cfg.sandbox(), &runtime, &spec_input).expect("must resolve");
     let env = resolved.environment();
@@ -392,16 +394,18 @@ fn multi_line_issue_text_resolves_to_single_line_env_file() {
     let runtime = runtime_for(&cfg, &worktree);
     let spec_input = caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
-        issue: runtime.issue.clone(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: runtime.issue.clone(),
+            title: "A title\nwith lines\r\nand CR".to_string(),
+            body: "A body\r\nwith CRLF\nand LF".to_string(),
+            labels: vec!["p1".to_string()],
+            branch_name: "caduceus/owner/repo#1".to_string(),
+        }),
         worktree: worktree.clone(),
         run_id: "run-101".to_string(),
         context_json: "{}".to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "A title\nwith lines\r\nand CR".to_string(),
-        issue_body: "A body\r\nwith CRLF\nand LF".to_string(),
-        labels: vec!["p1".to_string()],
-        branch_name: "caduceus/owner/repo#1".to_string(),
     };
     let resolved = resolve(cfg.sandbox(), &runtime, &spec_input).expect(
         "multi-line issue title/body must resolve (newline-normalized, \

--- a/tests/executor/sandbox_resolve_test.rs
+++ b/tests/executor/sandbox_resolve_test.rs
@@ -313,11 +313,11 @@ fn resolves_full_canonical_environment_with_container_paths() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.run_id = "run-100".to_string();
-    runtime.issue = IssueKey::parse("octocat/hello#42").expect("valid key");
+    runtime.target = "octocat/hello#42".to_string();
     let spec_input = caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
         target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-            key: runtime.issue.clone(),
+            key: IssueKey::parse(&runtime.target).expect("fixture target parses as issue key"),
             title: "A title".to_string(),
             body: "A body\nwith newline".to_string(),
             labels: vec!["p1".to_string(), "p2".to_string()],
@@ -395,7 +395,7 @@ fn multi_line_issue_text_resolves_to_single_line_env_file() {
     let spec_input = caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
         target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-            key: runtime.issue.clone(),
+            key: IssueKey::parse(&runtime.target).expect("fixture target parses as issue key"),
             title: "A title\nwith lines\r\nand CR".to_string(),
             body: "A body\r\nwith CRLF\nand LF".to_string(),
             labels: vec!["p1".to_string()],
@@ -445,7 +445,7 @@ fn resolves_labels_in_fixed_order() {
     let (cfg, worktree) = base();
     let mut runtime = runtime_for(&cfg, &worktree);
     runtime.run_id = "run-007".to_string();
-    runtime.issue = IssueKey::parse("owner/repo#7").expect("valid key");
+    runtime.target = "owner/repo#7".to_string();
     runtime.daemon_id = "daemon-42".to_string();
     let spec =
         resolve(cfg.sandbox(), &runtime, &support::executor_spec(&runtime)).expect("must resolve");
@@ -734,5 +734,105 @@ fn escalation_validator_is_reachable_through_resolve() {
             Err(CaduceusError::OciMountConflict { ref detail }) if detail.contains("socket")
         ),
         "resolve must run the escalation validator; got: {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PR-target resolution (DAR §6.1, D5)
+// ---------------------------------------------------------------------------
+
+/// A PR review target mirroring the D2 env contract: `pr` mode marker
+/// plus the four `CADUCEUS_PR_*` values, container-side worktree and
+/// result paths, and NO `CADUCEUS_ISSUE_*` / `CADUCEUS_ISSUE_ID` /
+/// `CADUCEUS_BRANCH_NAME` variables. The `caduceus.issue_id` label
+/// carries the PR display identity `owner/repo#pr/9`.
+#[test]
+fn pr_target_resolves_to_pr_contract_environment_and_display_label() {
+    let (cfg, worktree) = base();
+    let mut runtime = runtime_for(&cfg, &worktree);
+    runtime.run_id = "run-pr-9".to_string();
+    runtime.target = "owner/repo#pr/9".to_string();
+    let spec_input = caduceus::executor::ExecutorSpec {
+        self_exe: PathBuf::from("/proc/self/exe"),
+        target: caduceus::executor::WorkTarget::PullRequest(caduceus::review::ReviewTarget {
+            repository: caduceus::review::RepositoryId {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+            },
+            pull_request: 9,
+            head_sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+            base_sha: "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+            base_ref: "main".to_string(),
+            merge_base: "abcdef01abcdef01abcdef01abcdef01abcdef01".to_string(),
+        }),
+        worktree: worktree.clone(),
+        run_id: "run-pr-9".to_string(),
+        context_json: "{\"context\":true}".to_string(),
+        worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
+        cancellation: tokio_util::sync::CancellationToken::new(),
+    };
+    let resolved = resolve(cfg.sandbox(), &runtime, &spec_input).expect("must resolve");
+    let env = resolved.environment();
+
+    // The full PR set: mode marker + four PR vars + the four shared
+    // vars, all with container-side paths. No issue-shaped variable.
+    let expected: &[(&str, String)] = &[
+        ("CADUCEUS_CONTEXT_JSON", "{\"context\":true}".to_string()),
+        (
+            "CADUCEUS_PR_BASE_SHA",
+            "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+        ),
+        (
+            "CADUCEUS_PR_HEAD_SHA",
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+        ),
+        ("CADUCEUS_PR_NUMBER", "9".to_string()),
+        ("CADUCEUS_PR_REPO", "owner/repo".to_string()),
+        (
+            "CADUCEUS_RESULT_PATH",
+            "/output/worker-result.json".to_string(),
+        ),
+        ("CADUCEUS_RUN_ID", "run-pr-9".to_string()),
+        ("CADUCEUS_WORKTREE_PATH", "/workspace".to_string()),
+        ("CADUCEUS_WORK_TARGET", "pr".to_string()),
+        ("HOME", "/tmp".to_string()),
+        ("TMPDIR", "/tmp".to_string()),
+    ];
+    assert_eq!(
+        env.len(),
+        expected.len(),
+        "exactly the PR set plus compat; got: {env:?}"
+    );
+    for (entry, (key, value)) in env.iter().zip(expected.iter()) {
+        assert_eq!(entry.0, *key);
+        assert_eq!(&entry.1, value);
+    }
+    for forbidden in [
+        "CADUCEUS_ISSUE_ID",
+        "CADUCEUS_ISSUE_NUMBER",
+        "CADUCEUS_ISSUE_REPO",
+        "CADUCEUS_ISSUE_TITLE",
+        "CADUCEUS_ISSUE_BODY",
+        "CADUCEUS_ISSUE_LABELS_JSON",
+        "CADUCEUS_BRANCH_NAME",
+    ] {
+        assert!(
+            !env.iter().any(|(k, _)| k == forbidden),
+            "PR env must not contain {forbidden}: {env:?}"
+        );
+    }
+
+    // The label carries the display identity (D5) — same
+    // `caduceus.issue_id` key, PR display value.
+    assert_eq!(
+        resolved.labels(),
+        &[
+            ("caduceus.daemon_id".to_string(), "test-daemon".to_string()),
+            ("caduceus.run_id".to_string(), "run-pr-9".to_string()),
+            (
+                "caduceus.issue_id".to_string(),
+                "owner/repo#pr/9".to_string()
+            ),
+        ]
     );
 }

--- a/tests/executor/support/mod.rs
+++ b/tests/executor/support/mod.rs
@@ -40,7 +40,7 @@ pub fn git_shadow_host(cfg: &Config, run_id: &str) -> PathBuf {
 pub fn runtime_facts(cfg: &Config, run_id: &str, worktree: &Path) -> RuntimeFacts {
     RuntimeFacts {
         run_id: run_id.to_string(),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: "owner/repo#1".to_string(),
         worker_command: vec!["python3".to_string(), "bridge.py".to_string()],
         worktree: worktree.to_path_buf(),
         output_dir: oci_output_dir(cfg, run_id),
@@ -61,10 +61,11 @@ pub fn runtime_facts(cfg: &Config, run_id: &str, worktree: &Path) -> RuntimeFact
 /// needing non-default spec inputs mutate the returned struct.
 #[allow(dead_code)]
 pub fn executor_spec(runtime: &RuntimeFacts) -> caduceus::executor::ExecutorSpec {
+    let key = IssueKey::parse(&runtime.target).expect("fixture target parses as issue key");
     caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
         target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-            key: runtime.issue.clone(),
+            key,
             title: "Fix the thing".to_string(),
             body: "Body text".to_string(),
             labels: vec!["bug".to_string()],

--- a/tests/executor/support/mod.rs
+++ b/tests/executor/support/mod.rs
@@ -63,15 +63,17 @@ pub fn runtime_facts(cfg: &Config, run_id: &str, worktree: &Path) -> RuntimeFact
 pub fn executor_spec(runtime: &RuntimeFacts) -> caduceus::executor::ExecutorSpec {
     caduceus::executor::ExecutorSpec {
         self_exe: PathBuf::from("/proc/self/exe"),
-        issue: runtime.issue.clone(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: runtime.issue.clone(),
+            title: "Fix the thing".to_string(),
+            body: "Body text".to_string(),
+            labels: vec!["bug".to_string()],
+            branch_name: "caduceus/owner/repo#1".to_string(),
+        }),
         worktree: runtime.worktree.clone(),
         run_id: runtime.run_id.clone(),
         context_json: "{\"key\":\"value\"}".to_string(),
         worker_command: runtime.worker_command.clone(),
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "Fix the thing".to_string(),
-        issue_body: "Body text".to_string(),
-        labels: vec!["bug".to_string()],
-        branch_name: "caduceus/owner/repo#1".to_string(),
     }
 }

--- a/tests/executor/work_target_test.rs
+++ b/tests/executor/work_target_test.rs
@@ -1,0 +1,96 @@
+//! Unit tests for the target-neutral `WorkTarget` boundary type
+//! (DAR §6.1, issue #346).
+//!
+//! The issue path is a lossless rename of the historical flat
+//! `ExecutorSpec` fields; the PR path carries a `ReviewTarget` and
+//! never requires an `IssueKey` or a branch name. These tests pin the
+//! display identity and the per-variant payload shapes.
+
+use caduceus::executor::{IssueWorkTarget, WorkTarget};
+use caduceus::github::issue::IssueKey;
+use caduceus::review::{RepositoryId, ReviewTarget};
+
+/// The frozen PR identity used across the boundary tests — the same
+/// shape the supervisor round-trips through `--pr-target-json`.
+fn sample_review_target() -> ReviewTarget {
+    ReviewTarget {
+        repository: RepositoryId {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        },
+        pull_request: 9,
+        head_sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+        base_sha: "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+        base_ref: "main".to_string(),
+        merge_base: "abcdef01abcdef01abcdef01abcdef01abcdef01".to_string(),
+    }
+}
+
+/// The historical issue payload — byte-for-byte the former flat
+/// `ExecutorSpec` fields.
+fn sample_issue_target() -> IssueWorkTarget {
+    IssueWorkTarget {
+        key: IssueKey::parse("owner/repo#7").expect("valid issue key"),
+        title: "Fix the flaky test".to_string(),
+        body: "The integration suite flakes under load.".to_string(),
+        labels: vec!["autofix".to_string()],
+        branch_name: "owner/repo-7".to_string(),
+    }
+}
+
+#[test]
+fn issue_target_display_is_issue_key_display() {
+    let target = WorkTarget::Issue(sample_issue_target());
+    // Unchanged from the pre-#346 display (`IssueKey::display_key`).
+    assert_eq!(target.display(), "owner/repo#7");
+}
+
+#[test]
+fn pr_target_display_is_owner_repo_pr_number() {
+    let target = WorkTarget::PullRequest(sample_review_target());
+    assert_eq!(target.display(), "owner/repo#pr/9");
+}
+
+#[test]
+fn issue_work_target_round_trips_historical_fields() {
+    let payload = sample_issue_target();
+    let WorkTarget::Issue(round_tripped) = WorkTarget::Issue(payload.clone()) else {
+        panic!("WorkTarget::Issue must carry an IssueWorkTarget");
+    };
+    assert_eq!(round_tripped, payload);
+    assert_eq!(round_tripped.key, IssueKey::parse("owner/repo#7").unwrap());
+    assert_eq!(round_tripped.title, "Fix the flaky test");
+    assert_eq!(
+        round_tripped.body,
+        "The integration suite flakes under load."
+    );
+    assert_eq!(round_tripped.labels, vec!["autofix"]);
+    assert_eq!(round_tripped.branch_name, "owner/repo-7");
+}
+
+#[test]
+fn pr_target_requires_no_issue_key_or_branch() {
+    // Constructing a PR run needs only the frozen review identity — no
+    // synthetic IssueKey and no branch name (the type-level contract).
+    let target = WorkTarget::PullRequest(sample_review_target());
+    let WorkTarget::PullRequest(pr) = target else {
+        panic!("WorkTarget::PullRequest must carry a ReviewTarget");
+    };
+    assert_eq!(pr.repository.full_name(), "owner/repo");
+    assert_eq!(pr.pull_request, 9);
+    assert_eq!(pr.head_sha, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+    assert_eq!(pr.base_sha, "cafebabecafebabecafebabecafebabecafebabe");
+    assert_eq!(pr.base_ref, "main");
+    assert_eq!(pr.merge_base, "abcdef01abcdef01abcdef01abcdef01abcdef01");
+}
+
+#[test]
+fn work_target_is_eq_and_cloneable() {
+    let a = WorkTarget::Issue(sample_issue_target());
+    let b = a.clone();
+    assert_eq!(a, b);
+
+    let pr_a = WorkTarget::PullRequest(sample_review_target());
+    let pr_b = pr_a.clone();
+    assert_eq!(pr_a, pr_b);
+}

--- a/tests/fixtures/failure-matrix-stubs/oci_failures.rs
+++ b/tests/fixtures/failure-matrix-stubs/oci_failures.rs
@@ -36,15 +36,17 @@ pub fn failing_worker_script_body() -> &'static str {
 pub fn spec_for_stage(run_id: &str, worker_script: PathBuf) -> ExecutorSpec {
     ExecutorSpec {
         self_exe: PathBuf::from("/usr/bin/caduceus"),
-        issue: IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: IssueKey::parse("owner/repo#1").expect("valid key"),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-1".to_string(),
+        }),
         worktree: PathBuf::from("/tmp/worktree"),
         run_id: run_id.to_string(),
         context_json: r#"{"stage":"fail"}"#.to_string(),
         worker_command: vec![worker_script.to_string_lossy().to_string()],
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "title".to_string(),
-        issue_body: "body".to_string(),
-        labels: Vec::new(),
-        branch_name: "automation/issue-1".to_string(),
     }
 }

--- a/tests/integration/bridge_test.py
+++ b/tests/integration/bridge_test.py
@@ -20,8 +20,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 BRIDGE_PATH = REPO_ROOT / "plugin-assets" / "worker-bridge.py"
 FAKE_HARNESS_PATH = REPO_ROOT / "tests" / "fixtures" / "bridge_harness.py"
 
-# All required CADUCEUS_* environment values. Mirrors
-# ``plugin_assets.worker_bridge.REQUIRED_ENV_VARS``.
+# All required CADUCEUS_* environment values — the union across both
+# target paths. Mirrors ``plugin_assets.worker_bridge.REQUIRED_ENV_VARS``
+# (DAR §6.1). A single run never carries every name: the issue path
+# omits the ``CADUCEUS_PR_*`` set and the PR path omits ``CADUCEUS_ISSUE_*``.
 REQUIRED_ENV_KEYS = (
     "CADUCEUS_ISSUE_NUMBER",
     "CADUCEUS_ISSUE_TITLE",
@@ -33,6 +35,11 @@ REQUIRED_ENV_KEYS = (
     "CADUCEUS_ISSUE_LABELS_JSON",
     "CADUCEUS_BRANCH_NAME",
     "CADUCEUS_RESULT_PATH",
+    "CADUCEUS_WORK_TARGET",
+    "CADUCEUS_PR_BASE_SHA",
+    "CADUCEUS_PR_HEAD_SHA",
+    "CADUCEUS_PR_NUMBER",
+    "CADUCEUS_PR_REPO",
 )
 
 
@@ -88,8 +95,18 @@ class TestReadRequiredEnv:
         self, bridge_module, fake_env
     ):
         result = bridge_module.read_required_env(fake_env)
-        assert set(result.keys()) == set(REQUIRED_ENV_KEYS)
+        # The returned dict carries the issue mode's full name set
+        # (mode-neutral + issue vars + the soft result path) — not the
+        # union, because the PR-only names are absent from an issue env.
+        expected = (
+            set(bridge_module.MODE_NEUTRAL_ENV_VARS)
+            | set(bridge_module.ISSUE_PATH_ENV_VARS)
+            | {bridge_module.RESULT_PATH_ENV_VAR}
+        )
+        assert set(result.keys()) == expected
         assert result["CADUCEUS_ISSUE_NUMBER"] == "42"
+        # The test-side mirror stays in lockstep with the bridge union.
+        assert set(REQUIRED_ENV_KEYS) == set(bridge_module.REQUIRED_ENV_VARS)
 
     def test_empty_string_counts_as_missing(self, bridge_module, fake_env):
         env = dict(fake_env)
@@ -772,6 +789,40 @@ def _new_contract_env(worktree: Path, hermes_home: Path) -> dict:
     return env
 
 
+def _pr_review_env(worktree: Path, hermes_home: Path) -> dict:
+    """A complete PR-mode env (DAR §6.1) with a real prompt file.
+
+    Issue-path variables (``CADUCEUS_ISSUE_*``, ``CADUCEUS_BRANCH_NAME``)
+    are deliberately absent — the PR mode must not require them.
+    """
+    prompt = worktree / "worker-prompt.md"
+    if not prompt.exists():
+        prompt.write_text(
+            "# PR review prompt\n\nReview the pull request.", encoding="utf-8"
+        )
+    return {
+        "HERMES_HOME": str(hermes_home),
+        "CADUCEUS_WORK_TARGET": "pr",
+        "CADUCEUS_RUN_ID": "01J0X0X0X0X0X0X0X0X0X0X0X",
+        "CADUCEUS_WORKTREE_PATH": str(worktree),
+        "CADUCEUS_CONTEXT_JSON": json.dumps(
+            {
+                "pull_request": {
+                    "number": 7,
+                    "repo": "barkley-assistant/caduceus",
+                    "base_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                }
+            }
+        ),
+        "CADUCEUS_PR_REPO": "barkley-assistant/caduceus",
+        "CADUCEUS_PR_NUMBER": "7",
+        "CADUCEUS_PR_BASE_SHA": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "CADUCEUS_PR_HEAD_SHA": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "CADUCEUS_RESULT_PATH": str(worktree / "pr-review-result.json"),
+    }
+
+
 class TestNewContract:
     def test_hook_present_activates_new_contract(
         self, bridge_module, tmp_path
@@ -1189,3 +1240,121 @@ class TestResultPathResolution:
         err = capsys.readouterr().err
         assert "CADUCEUS_RESULT_PATH is not set" in err
         assert "falling back" in err
+
+
+# ---------------------------------------------------------------------------
+# 10. PR review mode (DAR §6.1/§6.2) — target-neutral bridge behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPrMode:
+    """``CADUCEUS_WORK_TARGET=pr`` selects the PR review env contract:
+    the issue vars are not required, ``ctx.pr`` is populated, and the
+    bridge never synthesizes a result file (the harness owns it)."""
+
+    def test_read_required_env_validates_pr_set_without_issue_vars(
+        self, bridge_module, tmp_path
+    ):
+        env = _pr_review_env(tmp_path, tmp_path / "hermes")
+        result = bridge_module.read_required_env(env)
+        expected = (
+            set(bridge_module.MODE_NEUTRAL_ENV_VARS)
+            | set(bridge_module.PR_PATH_ENV_VARS)
+            | {bridge_module.RESULT_PATH_ENV_VAR}
+        )
+        assert set(result.keys()) == expected
+        assert result["CADUCEUS_PR_NUMBER"] == "7"
+        for name in bridge_module.ISSUE_PATH_ENV_VARS:
+            assert name not in result
+
+    def test_unknown_work_target_fails_closed(
+        self, bridge_module, tmp_path, capsys
+    ):
+        env = _pr_review_env(tmp_path, tmp_path / "hermes")
+        env["CADUCEUS_WORK_TARGET"] = "pullrequest"
+        with pytest.raises(SystemExit) as excinfo:
+            bridge_module.read_required_env(env)
+        assert excinfo.value.code == bridge_module.EXIT_MISSING_ENV
+        assert "pullrequest" in capsys.readouterr().err
+
+    def test_pr_mode_hard_requires_result_path(
+        self, bridge_module, tmp_path, capsys
+    ):
+        """On the PR path there is no legacy fallback, so the result
+        path is hard-required — unlike the issue path."""
+        env = _pr_review_env(tmp_path, tmp_path / "hermes")
+        env.pop("CADUCEUS_RESULT_PATH")
+        with pytest.raises(SystemExit) as excinfo:
+            bridge_module.read_required_env(env)
+        assert excinfo.value.code == bridge_module.EXIT_MISSING_ENV
+        assert "CADUCEUS_RESULT_PATH" in capsys.readouterr().err
+
+    def test_pr_mode_builds_pr_context(self, bridge_module, tmp_path):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        env = _pr_review_env(worktree, tmp_path / "hermes")
+        ctx = bridge_module._build_ctx(env)
+        assert ctx.issue is None
+        assert ctx.pr is not None
+        assert ctx.pr.repo == "barkley-assistant/caduceus"
+        assert ctx.pr.number == 7
+        assert ctx.pr.base_sha == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        assert ctx.pr.head_sha == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        # Empty passthrough — the PR path carries no synthetic branch.
+        assert ctx.branch == ""
+        assert ctx.labels == []
+
+    def test_issue_path_ctx_pr_is_none(self, bridge_module, fake_env):
+        ctx = bridge_module._build_ctx(fake_env)
+        assert ctx.pr is None
+        assert ctx.issue is not None
+
+    def test_pr_hook_no_result_exits_missing_result_no_synthesis(
+        self, bridge_module, tmp_path, capsys
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "print('harness ran without result')"]
+            """,
+        )
+        env = _pr_review_env(worktree, hermes_home)
+        rc = bridge_module.main(env=env, argv=["bridge"])
+        assert rc == bridge_module.EXIT_MISSING_RESULT
+        assert "no result file" in capsys.readouterr().err
+        # No synthesis anywhere: neither the mode-correct path nor the
+        # legacy worktree location received a file.
+        assert not Path(env["CADUCEUS_RESULT_PATH"]).exists()
+        assert not (worktree / "worker-result.json").exists()
+
+    def test_pr_hook_prewritten_result_left_byte_identical(
+        self, bridge_module, tmp_path
+    ):
+        worktree = _make_worktree_with_prompt(tmp_path / "worktree")
+        hermes_home = tmp_path / "hermes"
+        env = _pr_review_env(worktree, hermes_home)
+        result_path = Path(env["CADUCEUS_RESULT_PATH"])
+        payload = {
+            "status": "success",
+            "summary": "LGTM",
+            "commit_message": "merge",
+            "pull_request_title": "fix: pr review",
+            "artifacts": {"note": "kept"},
+            "investigation": False,
+        }
+        payload_text = json.dumps(payload, ensure_ascii=False)
+        result_path.write_text(payload_text, encoding="utf-8")
+        _write_hook(
+            hermes_home,
+            f"""
+            def run_task(ctx):
+                return [{sys.executable!r}, "-c", "print('harness ran')"]
+            """,
+        )
+        rc = bridge_module.main(env=env, argv=["bridge"])
+        assert rc == 0
+        # Exists-check skips synthesis: byte-identical pre-written result.
+        assert result_path.read_text(encoding="utf-8") == payload_text
+        assert not (worktree / "worker-result.json").exists()

--- a/tests/integration/oci_env_live_test.rs
+++ b/tests/integration/oci_env_live_test.rs
@@ -198,16 +198,18 @@ fn live_fixture(engine: Option<SandboxEngine>, container_script: &str) -> Option
 
     let spec = caduceus::executor::ExecutorSpec {
         self_exe: std::path::PathBuf::from("/proc/self/exe"),
-        issue: runtime.issue.clone(),
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: runtime.issue.clone(),
+            title: "Live env".to_string(),
+            body: "Live body".to_string(),
+            labels: vec!["bug".to_string()],
+            branch_name: "caduceus/owner/repo#1".to_string(),
+        }),
         worktree: runtime.worktree.clone(),
         run_id: runtime.run_id.clone(),
         context_json: "{}".to_string(),
         worker_command: runtime.worker_command.clone(),
         cancellation: tokio_util::sync::CancellationToken::new(),
-        issue_title: "Live env".to_string(),
-        labels: vec!["bug".to_string()],
-        branch_name: "caduceus/owner/repo#1".to_string(),
-        issue_body: "Live body".to_string(),
     };
     let spec = resolve_with_env(cfg.sandbox(), &runtime, &spec, &daemon_snapshot)
         .expect("live facts must resolve");

--- a/tests/integration/oci_env_live_test.rs
+++ b/tests/integration/oci_env_live_test.rs
@@ -156,7 +156,7 @@ fn live_fixture(engine: Option<SandboxEngine>, container_script: &str) -> Option
 
     let runtime = caduceus::executor::sandbox_spec::RuntimeFacts {
         run_id: run_id.to_string(),
-        issue: caduceus::github::issue::IssueKey::parse("owner/repo#1").expect("valid key"),
+        target: "owner/repo#1".to_string(),
         worker_command: vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -199,7 +199,8 @@ fn live_fixture(engine: Option<SandboxEngine>, container_script: &str) -> Option
     let spec = caduceus::executor::ExecutorSpec {
         self_exe: std::path::PathBuf::from("/proc/self/exe"),
         target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
-            key: runtime.issue.clone(),
+            key: caduceus::github::issue::IssueKey::parse(&runtime.target)
+                .expect("fixture target parses as issue key"),
             title: "Live env".to_string(),
             body: "Live body".to_string(),
             labels: vec!["bug".to_string()],

--- a/tests/runtime/open_no_follow_test.rs
+++ b/tests/runtime/open_no_follow_test.rs
@@ -69,7 +69,7 @@ fn heartbeat_write_rejects_trailing_symlink() {
         pid: std::process::id(),
         started_at: now,
         updated_at: now,
-        issue_key: sample_issue(),
+        target: "owner/repo#1".to_string(),
         transcript_path: PathBuf::from("/tmp"),
     };
 

--- a/tests/worker/supervisor_cancel_vs_done_test.rs
+++ b/tests/worker/supervisor_cancel_vs_done_test.rs
@@ -56,16 +56,18 @@ async fn clean_exit_reports_status_not_cancelled() {
     let outcome = supervise(
         &find_self_exe(),
         &cfg_for(&dir),
-        &issue_key(),
+        &caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: issue_key(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-130".to_string(),
+        }),
         &worktree,
         "RUN_CLEAN_130",
         r#"{}"#,
         &worker_command(&["sh", "-c", "exit 0"]),
         CancellationToken::new(),
-        "title",
-        "body",
-        &[],
-        "automation/issue-130",
     )
     .await
     .expect("supervise ok");
@@ -95,16 +97,18 @@ async fn genuine_cancel_still_reports_cancelled() {
     let outcome = supervise(
         &find_self_exe(),
         &cfg_for(&dir),
-        &issue_key(),
+        &caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: issue_key(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-130".to_string(),
+        }),
         &worktree,
         "RUN_CANCEL_130",
         r#"{}"#,
         &worker_command(&["sh", "-c", "sleep 30"]),
         cancellation,
-        "title",
-        "body",
-        &[],
-        "automation/issue-130",
     )
     .await
     .expect("supervise ok");

--- a/tests/worker/supervisor_env_test.rs
+++ b/tests/worker/supervisor_env_test.rs
@@ -32,17 +32,19 @@ fn env_with(pairs: &[(&str, &str)]) -> BTreeMap<OsString, OsString> {
 
 fn sample_inputs(worktree: &Path) -> SanitizedEnvInputs {
     SanitizedEnvInputs {
-        issue: IssueKey {
-            owner: "owner".to_string(),
-            repo: "repo".to_string(),
-            number: 75,
-        },
-        issue_title: "Issue title".to_string(),
-        issue_body: "Issue body".to_string(),
-        labels: vec!["autofix".to_string()],
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: IssueKey {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+                number: 75,
+            },
+            title: "Issue title".to_string(),
+            body: "Issue body".to_string(),
+            labels: vec!["autofix".to_string()],
+            branch_name: "automation/issue-75-run75".to_string(),
+        }),
         worktree_path: worktree.to_path_buf(),
         run_id: "RUN75".to_string(),
-        branch_name: "automation/issue-75-run75".to_string(),
         allowlist: Vec::new(),
         context_json: r#"{"x":1}"#.to_string(),
     }
@@ -136,7 +138,12 @@ fn supervisor_command_validates_labels_json() {
     let worktree = tempdir("labels_json");
     fs::create_dir_all(&worktree).expect("worktree dir");
     let mut inputs = sample_inputs(&worktree);
-    inputs.labels = vec!["autofix".to_string()];
+    match &mut inputs.target {
+        caduceus::executor::WorkTarget::Issue(issue) => {
+            issue.labels = vec!["autofix".to_string()];
+        }
+        caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+    }
     let env = sanitized_env(&empty_env(), &inputs).expect("sanitized env");
 
     let raw = env

--- a/tests/worker/supervisor_transcript_ownership_test.rs
+++ b/tests/worker/supervisor_transcript_ownership_test.rs
@@ -58,7 +58,13 @@ async fn transcript_keeps_worker_output_after_daemon_handshake() {
     let outcome = supervise(
         &find_self_exe(),
         &cfg,
-        &issue_key(),
+        &caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: issue_key(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            labels: Vec::new(),
+            branch_name: "automation/issue-134".to_string(),
+        }),
         &worktree,
         run_id,
         r#"{}"#,
@@ -68,10 +74,6 @@ async fn transcript_keeps_worker_output_after_daemon_handshake() {
             "echo STDOUT_MARKER_134; echo STDERR_MARKER_134 1>&2; exit 0",
         ]),
         CancellationToken::new(),
-        "title",
-        "body",
-        &[],
-        "automation/issue-134",
     )
     .await
     .expect("supervise ok");

--- a/tests/worker/worker_command_args_test.rs
+++ b/tests/worker/worker_command_args_test.rs
@@ -7,7 +7,10 @@
 
 use std::path::PathBuf;
 
+use caduceus::executor::{IssueWorkTarget, WorkTarget};
 use caduceus::issue::IssueKey;
+use caduceus::review::RepositoryId;
+use caduceus::review::ReviewTarget;
 use caduceus::worker_supervisor::build_supervisor_command;
 
 /// Helper: parse the `Debug` representation of a `Command` into
@@ -54,21 +57,51 @@ fn sample_cmd(worker_command: Vec<String>) -> std::process::Command {
         &PathBuf::from("/usr/bin/caduceus"),
         &PathBuf::from("/tmp/worktree"),
         "run-99",
-        &IssueKey {
-            owner: "o".into(),
-            repo: "r".into(),
-            number: 99,
-        },
+        &WorkTarget::Issue(IssueWorkTarget {
+            key: IssueKey {
+                owner: "o".into(),
+                repo: "r".into(),
+                number: 99,
+            },
+            title: "Test PR title".to_string(),
+            body: "Test PR body".to_string(),
+            labels: vec!["autofix".to_string()],
+            branch_name: "automation/issue-99".to_string(),
+        }),
         r#"{"key":"val"}"#,
         &worker_command,
         &PathBuf::from("/tmp/transcript.log"),
         &PathBuf::from("/tmp/heartbeat.log"),
         3600,
         1024,
-        "Test PR title",
-        "Test PR body",
-        &["autofix".to_string()],
-        "automation/issue-99",
+    )
+}
+
+/// PR-target argv (DAR §6.1): exactly one `--pr-target-json` flag
+/// carrying the serialized `ReviewTarget`, no `--issue`-shaped flags.
+fn sample_pr_cmd(worker_command: Vec<String>) -> std::process::Command {
+    let pr = ReviewTarget {
+        repository: RepositoryId {
+            owner: "o".to_string(),
+            repo: "r".to_string(),
+        },
+        pull_request: 42,
+        head_sha: "abc123".to_string(),
+        base_sha: "def456".to_string(),
+        base_ref: "main".to_string(),
+        merge_base: "def456".to_string(),
+    };
+    build_supervisor_command(
+        &PathBuf::from("/usr/bin/caduceus"),
+        &PathBuf::from("/tmp/worktree"),
+        "run-pr-42",
+        &WorkTarget::PullRequest(pr),
+        r#"{"key":"val"}"#,
+        &worker_command,
+        &PathBuf::from("/tmp/transcript.log"),
+        &PathBuf::from("/tmp/heartbeat.log"),
+        3600,
+        1024,
     )
 }
 
@@ -149,5 +182,68 @@ fn build_supervisor_command_preserves_multi_arg_worker_command() {
         worker_args,
         vec!["python3", "script.py", "--config", "dev.toml"],
         "Worker args must appear exactly as provided, with no extra `--` tokens"
+    );
+}
+
+// ── PR-target argv (DAR §6.1) ─────────────────────────────────
+
+#[test]
+fn pr_target_argv_carries_one_pr_flag_and_no_issue_flags() {
+    let worker_command = vec!["cargo".to_string(), "test".to_string()];
+    let cmd = sample_pr_cmd(worker_command);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    // The PR flag sits immediately after `--run-id` (DAR §6.1).
+    let run_id_pos = args.iter().position(|a| a == "--run-id").unwrap();
+    assert_eq!(args[run_id_pos + 1], "run-pr-42");
+    assert_eq!(args[run_id_pos + 2], "--pr-target-json");
+    let pr_json: caduceus::review::ReviewTarget =
+        serde_json::from_str(&args[run_id_pos + 3]).expect("pr json parses");
+    assert_eq!(pr_json.repository.owner, "o");
+    assert_eq!(pr_json.repository.repo, "r");
+    assert_eq!(pr_json.pull_request, 42);
+    assert_eq!(pr_json.head_sha, "abc123");
+    assert_eq!(pr_json.base_sha, "def456");
+    assert_eq!(pr_json.base_ref, "main");
+    assert_eq!(pr_json.merge_base, "def456");
+
+    // No `--issue`-shaped flags on the PR path.
+    for flag in [
+        "--issue",
+        "--issue-title",
+        "--issue-body",
+        "--issue-labels-json",
+        "--branch-name",
+    ] {
+        assert!(
+            !args.contains(&flag.to_string()),
+            "PR argv must not contain {flag}: {args:?}"
+        );
+    }
+    // Exactly one `--` separator, worker command after it.
+    let sep_pos = args.iter().position(|a| a == "--").unwrap();
+    assert_eq!(args[sep_pos + 1], "cargo");
+    assert_eq!(args[sep_pos + 2], "test");
+}
+
+#[test]
+fn issue_target_argv_still_carries_issue_flags_and_no_pr_flag() {
+    let cmd = sample_cmd(vec!["cargo".to_string(), "test".to_string()]);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    assert!(args.contains(&"--issue".to_string()));
+    assert!(args.contains(&"--issue-title".to_string()));
+    assert!(args.contains(&"--issue-body".to_string()));
+    assert!(args.contains(&"--issue-labels-json".to_string()));
+    assert!(args.contains(&"--branch-name".to_string()));
+    assert!(
+        !args.contains(&"--pr-target-json".to_string()),
+        "Issue argv must not contain --pr-target-json: {args:?}"
     );
 }

--- a/tests/worker/worker_env_test.rs
+++ b/tests/worker/worker_env_test.rs
@@ -45,17 +45,19 @@ use std::process::Stdio;
 
 fn sample_inputs(worktree: &Path) -> SanitizedEnvInputs {
     SanitizedEnvInputs {
-        issue: IssueKey {
-            owner: "owner".to_string(),
-            repo: "repo".to_string(),
-            number: 7,
-        },
-        issue_title: "The title".to_string(),
-        issue_body: "The body".to_string(),
-        labels: vec!["bug".to_string(), "area,commas".to_string()],
+        target: caduceus::executor::WorkTarget::Issue(caduceus::executor::IssueWorkTarget {
+            key: IssueKey {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+                number: 7,
+            },
+            title: "The title".to_string(),
+            body: "The body".to_string(),
+            labels: vec!["bug".to_string(), "area,commas".to_string()],
+            branch_name: "automation/issue-7-run01abcdefg".to_string(),
+        }),
         worktree_path: worktree.to_path_buf(),
         run_id: "RUN01ABCDEFG".to_string(),
-        branch_name: "automation/issue-7-run01abcdefg".to_string(),
         allowlist: Vec::new(),
         context_json: r#"{"k":"v"}"#.to_string(),
     }
@@ -135,7 +137,10 @@ fn sanitized_env_emits_labels_as_json_array() {
 fn sanitized_env_emits_empty_labels_as_empty_json_array() {
     let worktree = tempdir("labels_empty");
     let mut inputs = sample_inputs(&worktree);
-    inputs.labels.clear();
+    match &mut inputs.target {
+        caduceus::executor::WorkTarget::Issue(issue) => issue.labels.clear(),
+        caduceus::executor::WorkTarget::PullRequest(_) => unreachable!(),
+    }
     let env = sanitized_env(&empty_env(), &inputs).expect("sanitized env");
     let raw = env
         .get(OsStr::new("CADUCEUS_ISSUE_LABELS_JSON"))
@@ -539,4 +544,173 @@ fn sanitized_env_redacts_values_in_debug_output() {
     // definition one the worker sees; the debug-format
     // requirement is about *denied* secrets).
     assert!(!dbg.contains("ghp_should_never_appear"));
+}
+
+// PR-path env contract (DAR §6.1): CADUCEUS_WORK_TARGET=pr + the four
+// CADUCEUS_PR_* variables; no synthetic IssueKey, no branch name.
+
+fn sample_pr_target() -> caduceus::executor::WorkTarget {
+    caduceus::executor::WorkTarget::PullRequest(caduceus::review::ReviewTarget {
+        repository: caduceus::review::RepositoryId {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        },
+        pull_request: 9,
+        head_sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+        base_sha: "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+        base_ref: "main".to_string(),
+        merge_base: "abcdef01abcdef01abcdef01abcdef01abcdef01".to_string(),
+    })
+}
+
+#[test]
+fn sanitized_env_pr_path_emits_pr_contract_and_nothing_else() {
+    let worktree = tempdir("prvars");
+    let inputs = SanitizedEnvInputs {
+        target: sample_pr_target(),
+        worktree_path: worktree.to_path_buf(),
+        run_id: "RUN01ABCDEFG".to_string(),
+        allowlist: Vec::new(),
+        context_json: r#"{"k":"v"}"#.to_string(),
+    };
+    let env = sanitized_env(&empty_env(), &inputs).expect("sanitized env");
+    let caduceus_names: Vec<String> = env
+        .keys()
+        .map(|k| k.to_str().unwrap().to_string())
+        .filter(|k| k.starts_with("CADUCEUS_"))
+        .collect();
+    let expected: Vec<String> = [
+        "CADUCEUS_CONTEXT_JSON",
+        "CADUCEUS_PR_BASE_SHA",
+        "CADUCEUS_PR_HEAD_SHA",
+        "CADUCEUS_PR_NUMBER",
+        "CADUCEUS_PR_REPO",
+        "CADUCEUS_RESULT_PATH",
+        "CADUCEUS_RUN_ID",
+        "CADUCEUS_WORKTREE_PATH",
+        "CADUCEUS_WORK_TARGET",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    assert_eq!(caduceus_names, expected); // exact set: no ISSUE_*, no BRANCH_NAME
+    assert_eq!(
+        env.get(OsStr::new("CADUCEUS_WORK_TARGET")).unwrap(),
+        OsStr::new("pr")
+    );
+    assert_eq!(
+        env.get(OsStr::new("CADUCEUS_PR_NUMBER")).unwrap(),
+        OsStr::new("9")
+    );
+    assert_eq!(
+        env.get(OsStr::new("CADUCEUS_PR_REPO")).unwrap(),
+        OsStr::new("owner/repo")
+    );
+    assert_eq!(
+        env.get(OsStr::new("CADUCEUS_PR_HEAD_SHA")).unwrap(),
+        OsStr::new("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+    );
+    assert_eq!(
+        env.get(OsStr::new("CADUCEUS_PR_BASE_SHA")).unwrap(),
+        OsStr::new("cafebabecafebabecafebabecafebabecafebabe")
+    );
+}
+
+#[test]
+fn sanitized_env_issue_path_matches_issue_fixture_exactly() {
+    // Guards AC1: the emitted CADUCEUS_* set equals the historical
+    // issue contract exactly (no WORK_TARGET leak, no PR vars).
+    let worktree = tempdir("issueexact");
+    let inputs = sample_inputs(&worktree);
+    let env = sanitized_env(&empty_env(), &inputs).expect("sanitized env");
+    let caduceus_names: Vec<String> = env
+        .keys()
+        .map(|k| k.to_str().unwrap().to_string())
+        .filter(|k| k.starts_with("CADUCEUS_"))
+        .collect();
+    let expected: Vec<String> = [
+        "CADUCEUS_BRANCH_NAME",
+        "CADUCEUS_CONTEXT_JSON",
+        "CADUCEUS_ISSUE_BODY",
+        "CADUCEUS_ISSUE_LABELS_JSON",
+        "CADUCEUS_ISSUE_NUMBER",
+        "CADUCEUS_ISSUE_REPO",
+        "CADUCEUS_ISSUE_TITLE",
+        "CADUCEUS_RESULT_PATH",
+        "CADUCEUS_RUN_ID",
+        "CADUCEUS_WORKTREE_PATH",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    assert_eq!(caduceus_names, expected);
+}
+
+#[test]
+fn sanitized_env_pr_rejects_empty_or_nul_sha() {
+    let worktree = tempdir("prbad");
+
+    let empty_sha = SanitizedEnvInputs {
+        target: caduceus::executor::WorkTarget::PullRequest(caduceus::review::ReviewTarget {
+            repository: caduceus::review::RepositoryId {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+            },
+            pull_request: 9,
+            head_sha: "".to_string(),
+            base_sha: "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+            base_ref: "main".to_string(),
+            merge_base: "abcdef01abcdef01abcdef01abcdef01abcdef01".to_string(),
+        }),
+        worktree_path: worktree.to_path_buf(),
+        run_id: "RUN01".to_string(),
+        allowlist: Vec::new(),
+        context_json: "{}".to_string(),
+    };
+    let err = sanitized_env(&empty_env(), &empty_sha).expect_err("empty head_sha must be rejected");
+    assert!(format!("{err:?}").contains("head_sha"));
+
+    let nul_sha = SanitizedEnvInputs {
+        target: caduceus::executor::WorkTarget::PullRequest(caduceus::review::ReviewTarget {
+            repository: caduceus::review::RepositoryId {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+            },
+            pull_request: 9,
+            head_sha: "deadbeef\0deadbeef".to_string(),
+            base_sha: "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+            base_ref: "main".to_string(),
+            merge_base: "abcdef01abcdef01abcdef01abcdef01abcdef01".to_string(),
+        }),
+        worktree_path: worktree.to_path_buf(),
+        run_id: "RUN01".to_string(),
+        allowlist: Vec::new(),
+        context_json: "{}".to_string(),
+    };
+    let err = sanitized_env(&empty_env(), &nul_sha).expect_err("NUL head_sha must be rejected");
+    assert!(format!("{err:?}").contains("NUL"));
+}
+
+#[test]
+fn sanitized_env_pr_rejects_zero_pull_request_number() {
+    let worktree = tempdir("przero");
+    let inputs = SanitizedEnvInputs {
+        target: caduceus::executor::WorkTarget::PullRequest(caduceus::review::ReviewTarget {
+            repository: caduceus::review::RepositoryId {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+            },
+            pull_request: 0,
+            head_sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+            base_sha: "cafebabecafebabecafebabecafebabecafebabe".to_string(),
+            base_ref: "main".to_string(),
+            merge_base: "abcdef01abcdef01abcdef01abcdef01abcdef01".to_string(),
+        }),
+        worktree_path: worktree.to_path_buf(),
+        run_id: "RUN01".to_string(),
+        allowlist: Vec::new(),
+        context_json: "{}".to_string(),
+    };
+    let err = sanitized_env(&empty_env(), &inputs).expect_err("zero PR number must be rejected");
+    assert!(format!("{err:?}").contains("pull_request"));
 }


### PR DESCRIPTION
Closes #346

## Summary

Target-neutral worker/executor boundary (`WorkTarget::Issue | WorkTarget::PullRequest`) plus a mode-aware worker bridge, per the architect's plan (DAR §6.1–6.2).

- `ExecutorSpec` now carries `target: WorkTarget` — the issue path is a lossless rename of the historical flat fields (issue env contract and supervisor argv byte-for-byte unchanged).
- PR-path env contract: `CADUCEUS_WORK_TARGET=pr` + `CADUCEUS_PR_NUMBER` / `CADUCEUS_PR_REPO` / `CADUCEUS_PR_BASE_SHA` / `CADUCEUS_PR_HEAD_SHA`; no synthetic IssueKey, no synthetic branch name.
- Supervisor re-exec: issue argv unchanged; PR runs pass one `--pr-target-json` flag; heartbeat bumped to v2 carrying `WorkTarget::display()`; OCI env/labels/`oci_runs.issue_id` carry the target display identity.
- `CANONICAL_WORKER_ENV_VARS` is now the 15-name union with per-path companion fixtures.
- Bridge is mode-aware: PR runs resolve only the mode-correct result path and never synthesise a legacy result (missing result file = execution failure, `EXIT_MISSING_RESULT`). Issue path keeps legacy behaviour.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo test --locked --all-targets` (with the documented hermetic skip list) — all green, 0 failures
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 188 passed
- `scripts/check-commits.sh` over the PR range — clean