### PR TITLE
feat(state): add review stores with atomic v8 activation (closes #295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,28 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   runs resolve only the mode-correct result path and never synthesise
   a legacy result (missing result file = execution failure). Closes
   #346.
+- **Review persistence stores with atomic v8 activation.** Three
+  sibling review-era stores land under BOTH state backends: the
+  sibling review queue (entries keyed by the canonical
+  `owner/repo#pr@head_sha` form of a persisted `ReviewTarget`
+  including `merge_base`, with the issue queue's claim lifecycle
+  mirrored into a separate `review-claims/` directory), the
+  per-`(repo, pr)` `ReviewState` store (all DAR §3 fields including
+  the monotonic `review_generation`, upserted with a never-regress
+  CAS guard), and the append-only `review_history` (identity =
+  `review_run_id`, unique per completed run; the
+  `(repo, pr, head_sha)` tuple is deliberately NOT unique and the
+  verbatim version-tagged `ReviewResult` JSON blob is the canonical
+  durable result). The store envelope activates atomically:
+  `SCHEMA_VERSION` 7→8 (new `review_queue_entries` / `review_state` /
+  `review_history` tables + indexes, structural `v7→v8` migration
+  step) and the JSON `state.json` envelope 1→2 with an in-place
+  accept-and-upgrade of v1 files — a pre-#295 binary hard-fails on
+  review-era state on both backends. Same-SHA dedup is a read path
+  (`last_reviewed_head_sha` + active-queue check), never a history
+  uniqueness constraint. Known follow-up (owned by the Auto Review
+  epic): `migrate-state --to-sqlite` does not carry the JSON review
+  sidecar files across a backend switch. Closes #295.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,6 +448,14 @@ name = "review_domain_test"
 path = "tests/review/review_domain_test.rs"
 
 [[test]]
+name = "review_store_test"
+path = "tests/state/review_store_test.rs"
+
+[[test]]
+name = "review_activation_test"
+path = "tests/state/review_activation_test.rs"
+
+[[test]]
 name = "state_store_test"
 path = "tests/state/state_store_test.rs"
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -21,6 +21,7 @@ pub mod migrate_to_sqlite;
 pub mod oci_run;
 pub mod queue;
 pub mod retention;
+pub mod review;
 pub mod store;
 
 // Explicit re-exports of the queue's canonical surface — these are
@@ -30,6 +31,15 @@ pub use crate::state::queue::{
     parse_queue_state, serialize_queue_state, ClaimFileBody, ClaimToken, ClaimedEntry, DaemonLock,
     EnqueueOutcome, FinalizationCheckpoint, FinalizationStage, Phase, QueueEntry, QueueState,
     ResetOutcome, StateStore, TicketType,
+};
+
+// Explicit re-exports of the review stores' canonical surface (#295).
+pub use crate::state::review::{
+    parse_review_history, parse_review_queue_state, parse_review_state_map, review_claim_digest,
+    review_queue_key, review_state_key, serialize_review_history, serialize_review_queue_state,
+    serialize_review_state_map, ClaimedReview, ReviewClaimToken, ReviewEnqueueOutcome,
+    ReviewHistoryFile, ReviewHistoryRow, ReviewPhase, ReviewQueueEntry, ReviewQueueState,
+    ReviewStateMap, ReviewStore,
 };
 
 pub use crate::state::checkpoints::{

--- a/src/state/queue/mod.rs
+++ b/src/state/queue/mod.rs
@@ -55,9 +55,21 @@ use crate::github::issue::IssueKey;
 use crate::infra::error::{store_version_guidance, CaduceusError, CaduceusResult};
 
 /// Canonical queue-file schema version. Bumping it is a breaking
-/// change — the daemon refuses any other value. Tested by
+/// change — the daemon refuses any NEWER value. Tested by
 /// [`tests/state/queue_model_test.rs`].
-pub const QUEUE_FILE_VERSION: u32 = 1;
+///
+/// ## v2 (#295, the review-era activation)
+///
+/// The envelope bump landed atomically with the review-era stores
+/// (`crate::state::review`): a pre-#295 binary
+/// (`QUEUE_FILE_VERSION = 1`) hard-fails on a v2 `state.json` with
+/// `StoreVersionUnsupported` (guidance NEWER), which is the
+/// atomic-rejection property. The issue-queue entry shape is
+/// unchanged by #295 — review data lives in sibling files — so
+/// post-#295 binaries accept v1 files via an in-place
+/// accept-and-upgrade in [`parse_queue_state`] (read as v2; the
+/// envelope is rewritten to v2 on the next mutation).
+pub const QUEUE_FILE_VERSION: u32 = 2;
 
 /// Name of the queue state file inside `<state_dir>`.
 pub const STATE_FILENAME: &str = "state.json";
@@ -371,33 +383,53 @@ pub struct ClaimFileBody {
 /// canonical reader; production code that loads from disk calls
 /// this after reading the file. Tests drive it directly so they
 /// don't need a temp file for every schema assertion.
+///
+/// Version handling: a NEWER envelope (`version >
+/// [`QUEUE_FILE_VERSION`]) is a hard
+/// [`CaduceusError::StoreVersionUnsupported`] with upgrade guidance.
+/// A v1 envelope (pre-#295) is accepted in place — the issue-entry
+/// shape is identical, so the document is upgraded to v2 by the
+/// parse itself; the file on disk is NOT rewritten by the parse
+/// (parse is pure) and the next mutating operation persists it at
+/// v2.
 pub fn parse_queue_state(text: &str) -> CaduceusResult<QueueState> {
-    let state: QueueState =
+    const SCOPE: &str = "<queue-state>";
+    let mut state: QueueState =
         serde_json::from_str(text).map_err(|err| CaduceusError::StateCorrupt {
-            path: PathBuf::from("<queue-state>"),
+            path: PathBuf::from(SCOPE),
             message: format!("queue state JSON parse: {err}"),
         })?;
     if state.version > QUEUE_FILE_VERSION {
         return Err(CaduceusError::StoreVersionUnsupported {
             backend: "json",
-            path: PathBuf::from("<queue-state>"),
+            path: PathBuf::from(SCOPE),
             found: state.version as i64,
             supported: QUEUE_FILE_VERSION as i64,
             guidance: store_version_guidance(true),
         });
     }
     if state.version < QUEUE_FILE_VERSION {
-        // Dormant until #295 bumps the envelope and lands the JSON
-        // migration step: an older file has no JSON migration
-        // machinery yet, so the branch exists now so the bump is
-        // one-line.
-        return Err(CaduceusError::StoreVersionUnsupported {
-            backend: "json",
-            path: PathBuf::from("<queue-state>"),
-            found: state.version as i64,
-            supported: QUEUE_FILE_VERSION as i64,
-            guidance: store_version_guidance(false),
-        });
+        // In-place accept-and-upgrade: v1 (the pre-#295 envelope) is
+        // semantically identical to v2 — the issue-queue entry shape
+        // is unchanged and review data lives in sibling files. The
+        // strict serde parse above already rejected any unknown
+        // field, so the upgrade is a pure envelope rewrite. Anything
+        // OLDER than v1 was never a real envelope and stays rejected.
+        if state.version != 1 {
+            return Err(CaduceusError::StoreVersionUnsupported {
+                backend: "json",
+                path: PathBuf::from(SCOPE),
+                found: state.version as i64,
+                supported: QUEUE_FILE_VERSION as i64,
+                guidance: store_version_guidance(false),
+            });
+        }
+        tracing::debug!(
+            found = state.version,
+            supported = QUEUE_FILE_VERSION,
+            "state.json carries a pre-#295 envelope; upgrading in place (rewritten on next mutation)"
+        );
+        state.version = QUEUE_FILE_VERSION;
     }
     // Every map key must be the lowercase display form of its
     // entry's IssueKey; this catches the "matched casing" case

--- a/src/state/review/claim.rs
+++ b/src/state/review/claim.rs
@@ -1,0 +1,100 @@
+//! Review claim lifecycle (issue #295): the issue queue's
+//! `ClaimToken`/`ClaimFileBody` mirrored for review entries, with two
+//! deliberate differences:
+//!
+//! - claim files live under `<state_dir>/review-claims/` — the issue
+//!   reaper parses every `claims/*.claim` as an issue-shaped
+//!   `ClaimFileBody` and would quarantine review claims, so the
+//!   directories never mix;
+//! - the body's identity is a [`ReviewTarget`], not an `IssueKey`.
+//!
+//! The reaping of stale review claims is dispatch's problem
+//! (#312/#339); this change ships the acquire/release primitives.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::review::ReviewTarget;
+
+/// Opaque review claim token, constructed by
+/// [`ReviewStore::acquire_next_review`] and consumed by the matching
+/// terminal transition. The token's digest is the SHA-256 hex of the
+/// canonical review queue key — the same digest used to name the
+/// claim file on disk. Mirrors the issue queue's `ClaimToken`.
+#[derive(Clone, Debug)]
+pub struct ReviewClaimToken {
+    claims_dir: PathBuf,
+    digest: String,
+    run_id: String,
+}
+
+impl ReviewClaimToken {
+    /// SHA-256 hex of the canonical review queue key — the claim
+    /// file's basename stem.
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    /// Run identifier recorded in the claim file and checked against
+    /// the queue entry's `last_run_id` on every state transition.
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    /// Test-only constructor used to exercise the claim-mismatch
+    /// rejection path without going through `acquire_next_review`.
+    #[doc(hidden)]
+    pub fn for_test(claims_dir: PathBuf, digest: &str, run_id: &str) -> Self {
+        Self {
+            claims_dir,
+            digest: digest.to_string(),
+            run_id: run_id.to_string(),
+        }
+    }
+
+    pub(crate) fn claim_path(&self) -> PathBuf {
+        self.claims_dir.join(format!("{}.claim", self.digest))
+    }
+    /// Internal constructor for `ReviewStore::acquire_next_review`
+    /// (same crate, different module — fields stay private so tokens
+    /// cannot be forged outside the crate).
+    pub(crate) fn new(claims_dir: PathBuf, digest: String, run_id: String) -> Self {
+        Self {
+            claims_dir,
+            digest,
+            run_id,
+        }
+    }
+}
+
+/// Result of a successful review claim: the (now `InProgress`) entry
+/// plus the token every later transition must present.
+#[derive(Clone, Debug)]
+pub struct ClaimedReview {
+    pub entry: crate::state::review::ReviewQueueEntry,
+    pub claim: ReviewClaimToken,
+}
+
+/// Body of a review claim file. Versioned and `deny_unknown_fields`
+/// so a future schema bump is rejected loudly rather than
+/// best-effort parsed. Same field set as the issue queue's
+/// `ClaimFileBody` with `target: ReviewTarget` replacing
+/// `key: IssueKey`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewClaimFileBody {
+    pub version: u32,
+    pub target: ReviewTarget,
+    pub run_id: String,
+    pub pid: u32,
+    pub process_start_identity: String,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub worktree_path: Option<PathBuf>,
+}
+
+impl ReviewClaimFileBody {
+    pub fn version_value(&self) -> u32 {
+        crate::state::review::REVIEW_CLAIM_FILE_VERSION
+    }
+}

--- a/src/state/review/history.rs
+++ b/src/state/review/history.rs
@@ -1,0 +1,49 @@
+//! Append-only review history (issue #295, DAR §4.3): one row per
+//! completed run, identity = `review_run_id`; `(repo, pr, head_sha)`
+//! is deliberately NOT unique.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::review::RepositoryId;
+
+/// One completed review run (DAR §4.3). Identity =
+/// `review_run_id`, unique per COMPLETED run; `(repo, pr, head_sha)`
+/// is NOT unique — same-SHA re-review appends additional rows.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewHistoryRow {
+    /// The queue claim's run id (execution identity).
+    pub review_run_id: String,
+    /// Repository the PR lives in. Stored verbatim (no case
+    /// normalisation); queries go through the key columns.
+    pub repository: RepositoryId,
+    pub pull_request: u64,
+    pub head_sha: String,
+    /// The generation the run completed under.
+    pub review_generation: u64,
+    pub completed_at: DateTime<Utc>,
+    /// Verbatim serialized `ReviewResult` document
+    /// (version-tagged by its own `schema_version`). This is the
+    /// canonical durable result (DAR §4.3); the PR comment is
+    /// presentation derived from it, never the reverse. Old versions
+    /// are read-only and never back-migrated.
+    pub result_json: String,
+}
+
+/// Versioned review history file: append order is preserved.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewHistoryFile {
+    pub version: u32,
+    pub rows: Vec<ReviewHistoryRow>,
+}
+
+impl ReviewHistoryFile {
+    pub fn empty() -> Self {
+        Self {
+            version: crate::state::review::REVIEW_HISTORY_FILE_VERSION,
+            rows: Vec::new(),
+        }
+    }
+}

--- a/src/state/review/mod.rs
+++ b/src/state/review/mod.rs
@@ -1,0 +1,223 @@
+//! Review-era persistence (issue #295, DAR §4.1-4.3).
+//!
+//! Three sibling stores live beside the issue queue, one per surface,
+//! each with a JSON mirror file and a SQLite table in the same
+//! `state.db`:
+//!
+//! - review queue (`review_queue.json` / `review_queue_entries`) —
+//!   entries keyed by the canonical [`review_queue_key`] of a
+//!   persisted [`ReviewTarget`];
+//! - per-`(repo, pr)` state (`review_state.json` / `review_state`) —
+//!   keyed by the canonical lowercase [`review_state_key`];
+//! - append-only history (`review_history.json` / `review_history`) —
+//!   identity = `review_run_id`, unique per completed run;
+//!   `(repo, pr, head_sha)` is deliberately NOT unique.
+//!
+//! Version policy: these files are born at v1 in the same change as
+//! their first reader, so there is no legitimate older version — a
+//! parse whose envelope version differs from the module constant in
+//! EITHER direction is [`CaduceusError::StoreVersionUnsupported`].
+//! The review-era activation that makes this module live is the
+//! store-envelope bump v7→v8 plus the `state.json` envelope bump to
+//! `QUEUE_FILE_VERSION = 2` (see [`crate::state::store`]).
+//!
+//! Lock discipline: JSON mutations serialise on an exclusive `flock`
+//! of `<state_dir>/review.lock` — deliberately NOT the issue queue's
+//! `state.lock`, so the two failure domains never nest. Review claim
+//! files live under `<state_dir>/review-claims/` so the issue-queue
+//! reaper (which parses every `claims/*.claim` as an issue-shaped
+//! `ClaimFileBody`) never sees them.
+
+mod claim;
+mod history;
+mod queue;
+mod state;
+
+use std::path::PathBuf;
+
+use crate::infra::error::{store_version_guidance, CaduceusError, CaduceusResult};
+use crate::review::{
+    RepositoryId, ReviewResult, MAX_REPO_COMPONENT_BYTES, MAX_RUN_ID_BYTES, MAX_SHA_BYTES,
+    REVIEW_SCHEMA_VERSION,
+};
+
+pub use claim::{ClaimedReview, ReviewClaimFileBody, ReviewClaimToken};
+pub use history::{ReviewHistoryFile, ReviewHistoryRow};
+pub use queue::{ReviewEnqueueOutcome, ReviewPhase, ReviewQueueEntry, ReviewQueueState};
+pub use state::{
+    parse_review_history, parse_review_queue_state, parse_review_state_map,
+    serialize_review_history, serialize_review_queue_state, serialize_review_state_map,
+    ReviewStateMap, ReviewStore,
+};
+
+use crate::review::ReviewTarget;
+
+/// Envelope version of `review_queue.json`. Born at v1 with its first
+/// reader in this change.
+pub const REVIEW_QUEUE_FILE_VERSION: u32 = 1;
+/// Envelope version of `review_state.json`. Born at v1 with its first
+/// reader in this change.
+pub const REVIEW_STATE_FILE_VERSION: u32 = 1;
+/// Envelope version of `review_history.json`. Born at v1 with its
+/// first reader in this change.
+pub const REVIEW_HISTORY_FILE_VERSION: u32 = 1;
+/// On-disk format of a review claim file.
+pub const REVIEW_CLAIM_FILE_VERSION: u32 = 1;
+
+/// Name of the review queue file inside `<state_dir>`.
+pub const REVIEW_QUEUE_FILENAME: &str = "review_queue.json";
+/// Name of the review state file inside `<state_dir>`.
+pub const REVIEW_STATE_FILENAME: &str = "review_state.json";
+/// Name of the review history file inside `<state_dir>`.
+pub const REVIEW_HISTORY_FILENAME: &str = "review_history.json";
+/// Name of the review claims directory inside `<state_dir>`.
+pub const REVIEW_CLAIMS_DIRNAME: &str = "review-claims";
+/// Name of the `flock` file serialising review-store mutations.
+/// Distinct from the issue queue's `state.lock` (never nested).
+pub const REVIEW_LOCK_FILENAME: &str = "review.lock";
+
+/// Canonical lowercase key for a `(repo, pr)` pair — the JSON
+/// `review_state.json` map key and the normalised identity used by
+/// the SQLite `review_state` primary key. Mirrors the issue queue's
+/// lowercase display-key rule: GitHub owner/repo are case-insensitive
+/// and the store is the normalisation layer (`RepositoryId`
+/// deliberately does no case folding).
+pub fn review_state_key(repository: &RepositoryId, pull_request: u64) -> String {
+    format!(
+        "{}/{}#{}",
+        repository.owner.to_lowercase(),
+        repository.repo.to_lowercase(),
+        pull_request
+    )
+}
+
+/// Canonical key for a review queue entry: the state key plus `"@"`
+/// and the head SHA. The head SHA is already case-normalised hex from
+/// git and is stored verbatim.
+pub fn review_queue_key(target: &ReviewTarget) -> String {
+    format!(
+        "{}@{}",
+        review_state_key(&target.repository, target.pull_request),
+        target.head_sha
+    )
+}
+
+/// SHA-256 hex digest of a canonical review key — the review claim
+/// file's basename. Same construction as the issue queue's
+/// `display_digest`.
+pub fn review_claim_digest(key: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(key.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Enforce a review-file envelope version: these files are born at v1
+/// with their first reader, so any other value — older OR newer —
+/// means a different-era binary wrote the file.
+pub(crate) fn require_review_file_version(
+    file: &str,
+    found: u32,
+    supported: u32,
+) -> CaduceusResult<()> {
+    if found != supported {
+        let (guidance, found, supported) = if found > supported {
+            (store_version_guidance(true), found as i64, supported as i64)
+        } else {
+            (
+                store_version_guidance(false),
+                found as i64,
+                supported as i64,
+            )
+        };
+        return Err(CaduceusError::StoreVersionUnsupported {
+            backend: "json",
+            path: PathBuf::from(file),
+            found,
+            supported,
+            guidance,
+        });
+    }
+    Ok(())
+}
+
+/// Required string: non-empty and at most `max` bytes (shared shape
+/// with the review domain validators, surfaced as `StateCorrupt`).
+pub(crate) fn bounded_string(
+    scope: &str,
+    field: &str,
+    value: &str,
+    max: usize,
+) -> CaduceusResult<()> {
+    if value.is_empty() {
+        return Err(CaduceusError::StateCorrupt {
+            path: PathBuf::from(scope),
+            message: format!("{field} must not be empty"),
+        });
+    }
+    if value.len() > max {
+        return Err(CaduceusError::StateCorrupt {
+            path: PathBuf::from(scope),
+            message: format!("{field} exceeds limit of {max} bytes (got {})", value.len()),
+        });
+    }
+    Ok(())
+}
+
+/// Validate one history row's identity fields and durable result
+/// blob. History rows carry no base/merge_base context, so the target
+/// caps apply to the identity components only. The blob must be a
+/// JSON object carrying an integer `schema_version` — corruption is
+/// caught at append time by the writer, not the reader.
+/// Current-version rows must parse as a full `ReviewResult`; older
+/// versions are accepted as opaque, read-only blobs (DAR §4.3: old
+/// versions are never back-migrated).
+pub(crate) fn validate_history_row(row: &ReviewHistoryRow) -> CaduceusResult<()> {
+    const SCOPE: &str = "<review-history>";
+    bounded_string(
+        SCOPE,
+        "repository.owner",
+        &row.repository.owner,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    bounded_string(
+        SCOPE,
+        "repository.repo",
+        &row.repository.repo,
+        MAX_REPO_COMPONENT_BYTES,
+    )?;
+    bounded_string(SCOPE, "head_sha", &row.head_sha, MAX_SHA_BYTES)?;
+    bounded_string(SCOPE, "review_run_id", &row.review_run_id, MAX_RUN_ID_BYTES)?;
+
+    let value: serde_json::Value =
+        serde_json::from_str(&row.result_json).map_err(|err| CaduceusError::StateCorrupt {
+            path: PathBuf::from(SCOPE),
+            message: format!("result_json is not valid JSON: {err}"),
+        })?;
+    let schema_version = value
+        .get("schema_version")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| CaduceusError::StateCorrupt {
+            path: PathBuf::from(SCOPE),
+            message: "result_json must be an object with an integer schema_version".to_string(),
+        })?;
+    if schema_version == REVIEW_SCHEMA_VERSION as u64 {
+        let result: ReviewResult =
+            serde_json::from_str(&row.result_json).map_err(|err| CaduceusError::StateCorrupt {
+                path: PathBuf::from(SCOPE),
+                message: format!("current-version result_json is not a valid ReviewResult: {err}"),
+            })?;
+        crate::review::validate_review_result(&result)?;
+    }
+    Ok(())
+}
+
+/// Map a strict-caps [`crate::review::ReviewState`] validation error
+/// into the store-layer corruption error (the domain validator
+/// reports via `Config`; the store surface is `StateCorrupt`).
+pub(crate) fn validated_review_state(state: &crate::review::ReviewState) -> CaduceusResult<()> {
+    crate::review::validate_review_state(state).map_err(|e| CaduceusError::StateCorrupt {
+        path: PathBuf::from("<review-store>"),
+        message: format!("review state invalid: {e}"),
+    })
+}

--- a/src/state/review/queue.rs
+++ b/src/state/review/queue.rs
@@ -1,0 +1,109 @@
+//! The sibling review queue: entries keyed by [`ReviewTarget`] with a
+//! lifecycle mirroring the issue queue's, minus the issue-only
+//! variants (issue #295, DAR §4.1).
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::review::ReviewTarget;
+
+/// Phase of one review target in the review queue. Mirrors the issue
+/// queue's `Phase` lifecycle minus issue-only variants (`Previewed`
+/// and `AwaitingReview` are issue-flow concepts). Serde labels are
+/// snake_case and double as the SQLite column encoding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum ReviewPhase {
+    Queued,
+    InProgress,
+    Done,
+    Failed,
+    Skipped,
+    NeedsAttention,
+}
+
+impl ReviewPhase {
+    /// Stable snake_case label, mirroring `Phase::as_str`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::InProgress => "in_progress",
+            Self::Done => "done",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+            Self::NeedsAttention => "needs_attention",
+        }
+    }
+
+    /// Parse the stable label. Unknown labels are a corruption error
+    /// at the store layer, never a best-effort guess.
+    pub fn from_label(label: &str) -> Option<Self> {
+        Some(match label {
+            "queued" => Self::Queued,
+            "in_progress" => Self::InProgress,
+            "done" => Self::Done,
+            "failed" => Self::Failed,
+            "skipped" => Self::Skipped,
+            "needs_attention" => Self::NeedsAttention,
+            _ => return None,
+        })
+    }
+
+    /// Active (non-terminal) phases: an entry in one of these is
+    /// "in flight" for same-SHA dedup.
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Queued | Self::InProgress)
+    }
+}
+
+/// One review queue entry, keyed by the canonical
+/// [`crate::state::review::review_queue_key`] of its persisted
+/// [`ReviewTarget`] (which carries the `merge_base` context verbatim,
+/// DAR §2.1).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewQueueEntry {
+    pub target: ReviewTarget,
+    pub phase: ReviewPhase,
+    /// Execution attempts (queue-owned; `ReviewState` has none).
+    pub attempts: u32,
+    pub last_error: Option<String>,
+    pub last_run_id: Option<String>,
+    pub next_attempt_at: Option<DateTime<Utc>>,
+    pub queued_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    /// Monotonic per-`(repo, pr)` generation, assigned at admission —
+    /// must equal the `ReviewState` row's `review_generation`
+    /// (DAR §9.4).
+    pub review_generation: u64,
+}
+
+/// Versioned review queue file (mirror of the issue queue's
+/// `QueueState` shape).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewQueueState {
+    pub version: u32,
+    pub entries: BTreeMap<String, ReviewQueueEntry>,
+}
+
+impl ReviewQueueState {
+    pub fn empty() -> Self {
+        Self {
+            version: crate::state::review::REVIEW_QUEUE_FILE_VERSION,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+/// Outcome of a review enqueue. Review-local by design — the issue
+/// queue's `EnqueueOutcome::Promoted` is `Previewed`-specific and has
+/// no review meaning.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReviewEnqueueOutcome {
+    Inserted,
+    AlreadyPresent,
+}

--- a/src/state/review/state.rs
+++ b/src/state/review/state.rs
@@ -1,0 +1,1400 @@
+//! Per-`(repo, pr)` review state store and the [`ReviewStore`]
+//! facade over both backends (issue #295, DAR §4.2): the JSON side is
+//! three v1-born versioned files under `<state_dir>/review.lock`;
+//! the SQLite side is three tables in the same `state.db` under the
+//! v8 envelope.
+//!
+//! Connection discipline: every load/persist helper takes a
+//! [`ReviewConn`] so SQLite operations run on the SAME connection
+//! that `with_exclusive` opened and started `BEGIN IMMEDIATE` on —
+//! one operation = one connection = one transaction, with no
+//! thread-local machinery (review mutations are single-shot and
+//! never nest).
+
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use fs2::FileExt;
+use rusqlite::params;
+
+use super::{
+    require_review_file_version, review_queue_key, review_state_key, validate_history_row,
+    validated_review_state, ClaimedReview, ReviewClaimFileBody, ReviewClaimToken,
+    ReviewEnqueueOutcome, ReviewHistoryFile, ReviewHistoryRow, ReviewPhase, ReviewQueueEntry,
+    ReviewQueueState, REVIEW_CLAIMS_DIRNAME, REVIEW_CLAIM_FILE_VERSION, REVIEW_HISTORY_FILENAME,
+    REVIEW_HISTORY_FILE_VERSION, REVIEW_LOCK_FILENAME, REVIEW_QUEUE_FILENAME,
+    REVIEW_QUEUE_FILE_VERSION, REVIEW_STATE_FILENAME, REVIEW_STATE_FILE_VERSION,
+};
+use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
+use crate::review::{RepositoryId, ReviewState, ReviewTarget};
+use crate::state::queue::{atomic_write, process_start_identity, sync_dir};
+
+// ---------------------------------------------------------------------------
+// Parse / serialize (pure functions; the test seam)
+// ---------------------------------------------------------------------------
+
+/// Parse + validate `review_queue.json` from text. Strict at every
+/// layer: unknown fields rejected by serde, envelope version must
+/// equal [`REVIEW_QUEUE_FILE_VERSION`] (either direction is
+/// unsupported — these files are born at v1 with their first
+/// reader), every entry validated, and every map key must equal the
+/// canonical [`review_queue_key`] of its entry.
+pub fn parse_review_queue_state(text: &str) -> CaduceusResult<ReviewQueueState> {
+    const SCOPE: &str = "<review-queue>";
+    let state: ReviewQueueState =
+        serde_json::from_str(text).map_err(|err| CaduceusError::StateCorrupt {
+            path: PathBuf::from(SCOPE),
+            message: format!("review queue JSON parse: {err}"),
+        })?;
+    require_review_file_version(SCOPE, state.version, REVIEW_QUEUE_FILE_VERSION)?;
+    for (map_key, entry) in &state.entries {
+        let expected = review_queue_key(&entry.target);
+        if map_key != &expected {
+            return Err(CaduceusError::StateCorrupt {
+                path: PathBuf::from(SCOPE),
+                message: format!(
+                    "review queue map key {map_key:?} does not match entry {expected}"
+                ),
+            });
+        }
+        crate::review::validate_review_target(&entry.target).map_err(|e| {
+            CaduceusError::StateCorrupt {
+                path: PathBuf::from(SCOPE),
+                message: format!("review queue entry invalid: {e}"),
+            }
+        })?;
+        if entry.review_generation == 0 {
+            return Err(CaduceusError::StateCorrupt {
+                path: PathBuf::from(SCOPE),
+                message: format!("review queue entry {map_key} has review_generation 0"),
+            });
+        }
+    }
+    Ok(state)
+}
+
+/// Serialize the review queue state to canonical one-line JSON.
+pub fn serialize_review_queue_state(state: &ReviewQueueState) -> CaduceusResult<String> {
+    serde_json::to_string(state).map_err(|err| CaduceusError::StateCorrupt {
+        path: PathBuf::from("<review-queue>"),
+        message: format!("review queue JSON serialize: {err}"),
+    })
+}
+
+/// Parse + validate `review_state.json` from text (same strictness
+/// contract as [`parse_review_queue_state`]; map keys are the
+/// lowercase [`review_state_key`] form).
+pub fn parse_review_state_map(text: &str) -> CaduceusResult<ReviewStateMap> {
+    const SCOPE: &str = "<review-state>";
+    let map: ReviewStateMap =
+        serde_json::from_str(text).map_err(|err| CaduceusError::StateCorrupt {
+            path: PathBuf::from(SCOPE),
+            message: format!("review state JSON parse: {err}"),
+        })?;
+    require_review_file_version(SCOPE, map.version, REVIEW_STATE_FILE_VERSION)?;
+    for (map_key, state) in &map.states {
+        let expected = review_state_key(&state.repository, state.pull_request);
+        if map_key != &expected {
+            return Err(CaduceusError::StateCorrupt {
+                path: PathBuf::from(SCOPE),
+                message: format!(
+                    "review state map key {map_key:?} does not match entry {expected}"
+                ),
+            });
+        }
+        validated_review_state(state)?;
+    }
+    Ok(map)
+}
+
+/// Serialize the review state map to canonical one-line JSON.
+pub fn serialize_review_state_map(map: &ReviewStateMap) -> CaduceusResult<String> {
+    serde_json::to_string(map).map_err(|err| CaduceusError::StateCorrupt {
+        path: PathBuf::from("<review-state>"),
+        message: format!("review state JSON serialize: {err}"),
+    })
+}
+
+/// Parse + validate `review_history.json` from text: append order is
+/// the row order, and every row's identity fields and durable result
+/// blob are validated.
+pub fn parse_review_history(text: &str) -> CaduceusResult<ReviewHistoryFile> {
+    const SCOPE: &str = "<review-history>";
+    let file: ReviewHistoryFile =
+        serde_json::from_str(text).map_err(|err| CaduceusError::StateCorrupt {
+            path: PathBuf::from(SCOPE),
+            message: format!("review history JSON parse: {err}"),
+        })?;
+    require_review_file_version(SCOPE, file.version, REVIEW_HISTORY_FILE_VERSION)?;
+    for row in &file.rows {
+        validate_history_row(row)?;
+    }
+    Ok(file)
+}
+
+/// Serialize the review history to canonical one-line JSON.
+pub fn serialize_review_history(file: &ReviewHistoryFile) -> CaduceusResult<String> {
+    serde_json::to_string(file).map_err(|err| CaduceusError::StateCorrupt {
+        path: PathBuf::from("<review-history>"),
+        message: format!("review history JSON serialize: {err}"),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Connection handle
+// ---------------------------------------------------------------------------
+
+/// Versioned `review_state.json` envelope: one `ReviewState` per
+/// `(repo, pr)`, keyed by the lowercase [`review_state_key`] form.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewStateMap {
+    pub version: u32,
+    pub states: BTreeMap<String, ReviewState>,
+}
+
+impl ReviewStateMap {
+    pub fn empty() -> Self {
+        Self {
+            version: REVIEW_STATE_FILE_VERSION,
+            states: BTreeMap::new(),
+        }
+    }
+}
+
+/// The connection a load/persist helper must use. `Json` carries no
+/// connection; `Sqlite` borrows the one connection the enclosing
+/// section opened (inside `with_exclusive` that connection is inside
+/// its `BEGIN IMMEDIATE` transaction, so the writes join it).
+enum ReviewConn<'a> {
+    Json,
+    Sqlite(&'a rusqlite::Connection),
+}
+
+// ---------------------------------------------------------------------------
+// ReviewStore facade
+// ---------------------------------------------------------------------------
+
+/// Back-end implementation for [`ReviewStore`].
+#[derive(Debug)]
+enum ReviewStoreBackend {
+    /// Three JSON files per the module docs; lock = `review.lock`.
+    Json,
+    /// Three tables in `state.db`.
+    Sqlite,
+}
+
+/// Handle over the three review-era stores (queue, per-PR state,
+/// append-only history), mirroring [`crate::state::queue::StateStore`]'s
+/// shape. JSON mutations serialise on an exclusive `flock` of
+/// `<state_dir>/review.lock` (deliberately NOT `state.lock`, so the
+/// two failure domains never nest); SQLite mutations run one
+/// `BEGIN IMMEDIATE` per operation.
+#[derive(Debug)]
+pub struct ReviewStore {
+    state_dir: PathBuf,
+    claims_dir: PathBuf,
+    backend: ReviewStoreBackend,
+}
+
+impl ReviewStore {
+    /// Open the JSON-backed store. Creates the state directory and
+    /// `review-claims/` if missing, then forces a validated load of
+    /// all three files so a corrupt file is reported at open time.
+    /// A missing file is the empty envelope.
+    pub fn open(state_dir: &Path) -> CaduceusResult<Self> {
+        fs::create_dir_all(state_dir)?;
+        let claims_dir = state_dir.join(REVIEW_CLAIMS_DIRNAME);
+        fs::create_dir_all(&claims_dir)?;
+        let store = Self {
+            state_dir: state_dir.to_path_buf(),
+            claims_dir,
+            backend: ReviewStoreBackend::Json,
+        };
+        store.load_queue(&ReviewConn::Json)?;
+        store.load_state_map(&ReviewConn::Json)?;
+        store.load_history(&ReviewConn::Json)?;
+        Ok(store)
+    }
+
+    /// Open a SQLite-backed store. Ensures the database schema (the
+    /// migration chain runs on first open — a v7 store migrates to
+    /// v8 here), then forces a validated load of all three tables.
+    /// Claim files remain on disk for both backends.
+    pub fn open_sqlite(state_dir: &Path) -> CaduceusResult<Self> {
+        fs::create_dir_all(state_dir)?;
+        let claims_dir = state_dir.join(REVIEW_CLAIMS_DIRNAME);
+        fs::create_dir_all(&claims_dir)?;
+        // Open once to run the migration chain / create the schema;
+        // operations below open their own short-lived connections so
+        // the store stays Send/Sync.
+        let conn = crate::state::store::open_in(state_dir)?;
+        let store = Self {
+            state_dir: state_dir.to_path_buf(),
+            claims_dir,
+            backend: ReviewStoreBackend::Sqlite,
+        };
+        store.load_queue(&ReviewConn::Sqlite(&conn))?;
+        store.load_state_map(&ReviewConn::Sqlite(&conn))?;
+        store.load_history(&ReviewConn::Sqlite(&conn))?;
+        Ok(store)
+    }
+
+    /// Directory backing this store.
+    pub fn state_dir(&self) -> PathBuf {
+        self.state_dir.clone()
+    }
+
+    /// Review claims directory (`<state_dir>/review-claims`).
+    pub fn claims_dir(&self) -> PathBuf {
+        self.claims_dir.clone()
+    }
+
+    // --- load helpers ------------------------------------------------------
+
+    fn load_queue(&self, conn: &ReviewConn) -> CaduceusResult<ReviewQueueState> {
+        match conn {
+            ReviewConn::Json => load_queue_json(&self.state_dir.join(REVIEW_QUEUE_FILENAME)),
+            ReviewConn::Sqlite(conn) => load_queue_sqlite(conn, &self.state_dir),
+        }
+    }
+
+    fn load_state_map(&self, conn: &ReviewConn) -> CaduceusResult<ReviewStateMap> {
+        match conn {
+            ReviewConn::Json => load_state_map_json(&self.state_dir.join(REVIEW_STATE_FILENAME)),
+            ReviewConn::Sqlite(conn) => load_state_map_sqlite(conn, &self.state_dir),
+        }
+    }
+
+    fn load_history(&self, conn: &ReviewConn) -> CaduceusResult<ReviewHistoryFile> {
+        match conn {
+            ReviewConn::Json => load_history_json(&self.state_dir.join(REVIEW_HISTORY_FILENAME)),
+            ReviewConn::Sqlite(conn) => load_history_sqlite(conn, &self.state_dir),
+        }
+    }
+
+    // --- review queue ------------------------------------------------------
+
+    /// Snapshot the review queue (validated load; never writes).
+    pub fn review_queue_snapshot(&self) -> CaduceusResult<ReviewQueueState> {
+        self.with_shared(|store, conn| store.load_queue(conn))
+    }
+
+    /// Enqueue a new review target. Assigns
+    /// `review_generation = current ReviewState generation + 1`
+    /// (or 1 when none), upserts the `ReviewState` row's generation,
+    /// and inserts the queue entry at phase `Queued`. Returns
+    /// [`ReviewEnqueueOutcome::AlreadyPresent`] when an ACTIVE
+    /// (`Queued`/`InProgress`) entry already exists for the same
+    /// canonical review key.
+    ///
+    /// The queue entry and the state row always carry the SAME
+    /// `review_generation`: both writes happen inside one exclusive
+    /// section (one flock / one transaction), so a crash between the
+    /// two writes is impossible. This is the load-bearing invariant
+    /// for the stale-publication guard (DAR §9.4).
+    pub fn enqueue_review(&self, target: &ReviewTarget) -> CaduceusResult<ReviewEnqueueOutcome> {
+        crate::review::validate_review_target(target)?;
+        self.with_exclusive(|store, conn| {
+            let mut queue = store.load_queue(conn)?;
+            let mut states = store.load_state_map(conn)?;
+            let now = Utc::now();
+            let key = review_queue_key(target);
+
+            if let Some(existing) = queue.entries.get(&key) {
+                if existing.phase.is_active() {
+                    return Ok(ReviewEnqueueOutcome::AlreadyPresent);
+                }
+            }
+
+            let state_key = review_state_key(&target.repository, target.pull_request);
+            let generation = match states.states.get_mut(&state_key) {
+                Some(existing_state) => {
+                    let generation = existing_state.review_generation + 1;
+                    existing_state.review_generation = generation;
+                    generation
+                }
+                None => {
+                    let fresh = ReviewState::new(target.repository.clone(), target.pull_request, 1);
+                    states.states.insert(state_key, fresh);
+                    1
+                }
+            };
+
+            queue.entries.insert(
+                key,
+                ReviewQueueEntry {
+                    target: target.clone(),
+                    phase: ReviewPhase::Queued,
+                    attempts: 0,
+                    last_error: None,
+                    last_run_id: None,
+                    next_attempt_at: None,
+                    queued_at: now,
+                    updated_at: now,
+                    review_generation: generation,
+                },
+            );
+            store.persist_queue(conn, &queue)?;
+            store.persist_state_map(conn, &states)?;
+            Ok(ReviewEnqueueOutcome::Inserted)
+        })
+    }
+
+    /// Atomically claim the oldest eligible `Queued` entry (its
+    /// `next_attempt_at` elapsed or `None`). The claim file is
+    /// created first with `O_CREAT | O_EXCL` under
+    /// `review-claims/`, then the entry is marked `InProgress` with
+    /// `last_run_id` set. If the queue rewrite fails the claim file
+    /// is removed so the entry can be re-claimed. Returns `None`
+    /// when no eligible entry exists.
+    pub fn acquire_next_review(
+        &self,
+        run_id: &str,
+        pid: u32,
+        now: DateTime<Utc>,
+    ) -> CaduceusResult<Option<ClaimedReview>> {
+        if run_id.is_empty() || run_id.len() > 64 {
+            return Err(CaduceusError::Queue {
+                context: "review-claim",
+                stderr: format!(
+                    "invalid run_id: must be non-empty and at most 64 bytes (got {})",
+                    run_id.len()
+                ),
+            });
+        }
+        self.with_exclusive(|store, conn| {
+            let mut queue = store.load_queue(conn)?;
+            let mut eligible: Vec<(String, ReviewQueueEntry)> = queue
+                .entries
+                .iter()
+                .filter(|(_, e)| e.phase == ReviewPhase::Queued)
+                .filter(|(_, e)| match e.next_attempt_at {
+                    Some(backoff) => backoff <= now,
+                    None => true,
+                })
+                .map(|(k, e)| (k.clone(), e.clone()))
+                .collect();
+            eligible.sort_by(|a, b| {
+                a.1.queued_at
+                    .cmp(&b.1.queued_at)
+                    .then_with(|| a.0.cmp(&b.0))
+            });
+
+            for (key, mut entry) in eligible {
+                let digest = super::review_claim_digest(&key);
+                let claim_path = store.claims_dir.join(format!("{digest}.claim"));
+                let claim_file = match OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&claim_path)
+                {
+                    Ok(f) => f,
+                    Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                        // Race-loss: another process claimed this
+                        // entry; try the next FIFO candidate.
+                        continue;
+                    }
+                    Err(err) => return Err(err.into()),
+                };
+                let body = ReviewClaimFileBody {
+                    version: REVIEW_CLAIM_FILE_VERSION,
+                    target: entry.target.clone(),
+                    run_id: run_id.to_string(),
+                    pid,
+                    process_start_identity: process_start_identity(&store.state_dir, pid),
+                    started_at: now,
+                    worktree_path: None,
+                };
+                let body_text = match serde_json::to_string(&body) {
+                    Ok(text) => text,
+                    Err(err) => {
+                        let _ = fs::remove_file(&claim_path);
+                        return Err(CaduceusError::Queue {
+                            context: "review-claim",
+                            stderr: format!("serialize claim: {err}"),
+                        });
+                    }
+                };
+                if let Err(err) = write_and_sync_claim(&claim_file, body_text.as_bytes()) {
+                    let _ = fs::remove_file(&claim_path);
+                    return Err(err);
+                }
+                if let Err(err) = sync_dir(&store.claims_dir) {
+                    tracing::debug!(error = %err, "review claim dir sync");
+                }
+
+                entry.phase = ReviewPhase::InProgress;
+                entry.last_run_id = Some(run_id.to_string());
+                entry.updated_at = now;
+                queue.entries.insert(key.clone(), entry.clone());
+                if let Err(err) = store.persist_queue(conn, &queue) {
+                    // Roll back the claim file so the entry can be
+                    // re-claimed on the next tick.
+                    if let Err(rm_err) = fs::remove_file(&claim_path) {
+                        tracing::warn!(
+                            error = %rm_err,
+                            path = %claim_path.display(),
+                            "review claim rollback after persist failure failed"
+                        );
+                    }
+                    return Err(err);
+                }
+                return Ok(Some(ClaimedReview {
+                    entry,
+                    claim: ReviewClaimToken::new(
+                        store.claims_dir.clone(),
+                        digest,
+                        run_id.to_string(),
+                    ),
+                }));
+            }
+            Ok(None)
+        })
+    }
+
+    /// Terminal transition for a successful review run: the entry
+    /// moves to `Done`.
+    pub fn complete_review(&self, claim: ReviewClaimToken) -> CaduceusResult<()> {
+        self.terminal_review(claim, ReviewPhase::Done, None)
+    }
+
+    /// Retry-or-fail terminal transition, mirroring the issue
+    /// queue's `retry_or_fail`: `attempts += 1`; `attempts >= budget`
+    /// moves to `Failed`, otherwise back to `Queued` with
+    /// `next_attempt_at = now + 300s`. Returns the new phase.
+    pub fn retry_or_fail_review(
+        &self,
+        claim: ReviewClaimToken,
+        error: &str,
+        budget: u32,
+    ) -> CaduceusResult<ReviewPhase> {
+        if budget == 0 {
+            return Err(CaduceusError::Config(
+                "retry_or_fail_review budget must be > 0".to_string(),
+            ));
+        }
+        self.with_exclusive(|store, conn| {
+            let mut queue = store.load_queue(conn)?;
+            let entry = review_entry_for_claim(&mut queue, &claim)?;
+            entry.attempts = entry.attempts.saturating_add(1);
+            entry.last_error = Some(error.to_string());
+            entry.last_run_id = None;
+            let phase = if entry.attempts >= budget {
+                entry.phase = ReviewPhase::Failed;
+                entry.next_attempt_at = None;
+                entry.phase
+            } else {
+                entry.phase = ReviewPhase::Queued;
+                entry.next_attempt_at = Some(Utc::now() + chrono::Duration::seconds(300));
+                entry.phase
+            };
+            entry.updated_at = Utc::now();
+            store.persist_queue(conn, &queue)?;
+            unlink_review_claim_best_effort(&store.claims_dir, &claim);
+            Ok(phase)
+        })
+    }
+
+    /// Operator-driven skip: the entry moves to `Skipped` and the
+    /// reason is recorded on it (overwriting any prior `last_error`).
+    pub fn skip_review(&self, claim: ReviewClaimToken, reason: &str) -> CaduceusResult<()> {
+        self.terminal_review(claim, ReviewPhase::Skipped, Some(reason))
+    }
+
+    fn terminal_review(
+        &self,
+        claim: ReviewClaimToken,
+        phase: ReviewPhase,
+        reason: Option<&str>,
+    ) -> CaduceusResult<()> {
+        self.with_exclusive(|store, conn| {
+            let mut queue = store.load_queue(conn)?;
+            let entry = review_entry_for_claim(&mut queue, &claim)?;
+            entry.phase = phase;
+            entry.last_error = reason.map(|r| r.to_string());
+            entry.last_run_id = None;
+            entry.next_attempt_at = None;
+            entry.updated_at = Utc::now();
+            store.persist_queue(conn, &queue)?;
+            unlink_review_claim_best_effort(&store.claims_dir, &claim);
+            Ok(())
+        })
+    }
+
+    // --- review state ------------------------------------------------------
+
+    /// Upsert the per-`(repo, pr)` state row. CAS guard (DAR §9.4):
+    /// rejects the write when `state.review_generation` is LOWER than
+    /// the stored generation — an older generation may append history
+    /// but never regress the current pointer.
+    pub fn save_review_state(&self, state: &ReviewState) -> CaduceusResult<()> {
+        validated_review_state(state)?;
+        self.with_exclusive(|store, conn| {
+            let mut states = store.load_state_map(conn)?;
+            let key = review_state_key(&state.repository, state.pull_request);
+            if let Some(existing) = states.states.get(&key) {
+                if state.review_generation < existing.review_generation {
+                    return Err(CaduceusError::StateCorrupt {
+                        path: PathBuf::from("<review-state>"),
+                        message: format!(
+                            "review_generation regression for {key}: stored {}, incoming {}",
+                            existing.review_generation, state.review_generation
+                        ),
+                    });
+                }
+            }
+            states.states.insert(key, state.clone());
+            store.persist_state_map(conn, &states)
+        })
+    }
+
+    /// Read the per-`(repo, pr)` state row, if any.
+    pub fn review_state(
+        &self,
+        repo: &RepositoryId,
+        pr: u64,
+    ) -> CaduceusResult<Option<ReviewState>> {
+        self.with_shared(|store, conn| {
+            let states = store.load_state_map(conn)?;
+            Ok(states.states.get(&review_state_key(repo, pr)).cloned())
+        })
+    }
+
+    // --- same-SHA dedup (AC5) ----------------------------------------------
+
+    /// True when the exact `(repo, pr, head_sha)` is already
+    /// completed (`ReviewState.last_reviewed_head_sha == Some(sha)`)
+    /// OR active (`Queued`/`InProgress`) in the review queue. A
+    /// read path over the existing stores — NOT a uniqueness
+    /// constraint anywhere; history is never consulted.
+    pub fn is_active_or_reviewed(&self, target: &ReviewTarget) -> CaduceusResult<bool> {
+        crate::review::validate_review_target(target)?;
+        self.with_shared(|store, conn| {
+            let key = review_queue_key(target);
+            let queue = store.load_queue(conn)?;
+            if let Some(entry) = queue.entries.get(&key) {
+                if entry.phase.is_active() {
+                    return Ok(true);
+                }
+            }
+            let states = store.load_state_map(conn)?;
+            let state = states
+                .states
+                .get(&review_state_key(&target.repository, target.pull_request));
+            Ok(state
+                .map(|s| {
+                    s.last_reviewed_head_sha
+                        .as_deref()
+                        .map(|sha| sha == target.head_sha)
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false))
+        })
+    }
+
+    // --- review history ----------------------------------------------------
+
+    /// Append one completed run. Rejects a duplicate
+    /// `review_run_id`: an idempotent re-append of the SAME run is an
+    /// error, not a dedup — the caller retried a completed
+    /// finalization and must not double-write (DAR §9.1 resume is
+    /// idempotent via `sticky_comment_id`, not via history re-append).
+    pub fn append_history(&self, row: ReviewHistoryRow) -> CaduceusResult<()> {
+        validate_history_row(&row)?;
+        self.with_exclusive(|store, conn| {
+            let mut history = store.load_history(conn)?;
+            if history
+                .rows
+                .iter()
+                .any(|r| r.review_run_id == row.review_run_id)
+            {
+                return Err(CaduceusError::StateCorrupt {
+                    path: PathBuf::from("<review-history>"),
+                    message: format!(
+                        "duplicate review_run_id {} — completed runs are never re-appended",
+                        row.review_run_id
+                    ),
+                });
+            }
+            history.rows.push(row);
+            store.persist_history(conn, &history)
+        })
+    }
+
+    /// Rows for one `(repo, pr)`, oldest first (append order).
+    pub fn history_for_pull_request(
+        &self,
+        repo: &RepositoryId,
+        pr: u64,
+    ) -> CaduceusResult<Vec<ReviewHistoryRow>> {
+        let owner = repo.owner.to_lowercase();
+        let name = repo.repo.to_lowercase();
+        self.with_shared(|store, conn| {
+            let history = store.load_history(conn)?;
+            Ok(history
+                .rows
+                .into_iter()
+                .filter(|r| {
+                    r.repository.owner.to_lowercase() == owner
+                        && r.repository.repo.to_lowercase() == name
+                        && r.pull_request == pr
+                })
+                .collect())
+        })
+    }
+
+    /// Rows for one `(repo, pr, head_sha)` — MAY be more than one
+    /// (append-only identity is the run id, not the tuple).
+    pub fn history_for_head_sha(
+        &self,
+        repo: &RepositoryId,
+        pr: u64,
+        head_sha: &str,
+    ) -> CaduceusResult<Vec<ReviewHistoryRow>> {
+        Ok(self
+            .history_for_pull_request(repo, pr)?
+            .into_iter()
+            .filter(|r| r.head_sha == head_sha)
+            .collect())
+    }
+
+    /// All rows for one repository (append order).
+    pub fn history_for_repository(
+        &self,
+        repo: &RepositoryId,
+    ) -> CaduceusResult<Vec<ReviewHistoryRow>> {
+        let owner = repo.owner.to_lowercase();
+        let name = repo.repo.to_lowercase();
+        self.with_shared(|store, conn| {
+            let history = store.load_history(conn)?;
+            Ok(history
+                .rows
+                .into_iter()
+                .filter(|r| {
+                    r.repository.owner.to_lowercase() == owner
+                        && r.repository.repo.to_lowercase() == name
+                })
+                .collect())
+        })
+    }
+
+    // --- lock helpers -------------------------------------------------------
+
+    /// Shared-section read. JSON takes a shared `review.lock` flock;
+    /// SQLite opens a fresh connection (WAL allows concurrent
+    /// readers).
+    fn with_shared<R>(
+        &self,
+        op: impl FnOnce(&Self, &ReviewConn) -> CaduceusResult<R>,
+    ) -> CaduceusResult<R> {
+        match &self.backend {
+            ReviewStoreBackend::Json => {
+                let lock_path = self.state_dir.join(REVIEW_LOCK_FILENAME);
+                let lock_file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&lock_path)?;
+                lock_file.lock_shared().map_err(into_lock_error)?;
+                let result = op(self, &ReviewConn::Json);
+                if let Err(err) = lock_file.unlock() {
+                    tracing::debug!(
+                        error = %scrub(&format!("{err:?}")),
+                        "review shared unlock"
+                    );
+                }
+                result
+            }
+            ReviewStoreBackend::Sqlite => {
+                let conn = crate::state::store::open_in(&self.state_dir)?;
+                op(self, &ReviewConn::Sqlite(&conn))
+            }
+        }
+    }
+
+    /// Exclusive section: JSON takes the `review.lock` flock; SQLite
+    /// opens one connection and wraps the operation in a single
+    /// `BEGIN IMMEDIATE` transaction. The connection handle is passed
+    /// to the operation so every load/persist inside it joins the
+    /// same transaction.
+    fn with_exclusive<R>(
+        &self,
+        op: impl FnOnce(&Self, &ReviewConn) -> CaduceusResult<R>,
+    ) -> CaduceusResult<R> {
+        match &self.backend {
+            ReviewStoreBackend::Json => {
+                let lock_path = self.state_dir.join(REVIEW_LOCK_FILENAME);
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&lock_path)?;
+                file.lock_exclusive().map_err(into_lock_error)?;
+                let result = op(self, &ReviewConn::Json);
+                if let Err(err) = file.unlock() {
+                    tracing::debug!(
+                        error = %scrub(&format!("{err:?}")),
+                        "review exclusive unlock"
+                    );
+                }
+                result
+            }
+            ReviewStoreBackend::Sqlite => {
+                let conn = crate::state::store::open_in(&self.state_dir)?;
+                conn.execute("BEGIN IMMEDIATE", [])
+                    .map_err(|e| CaduceusError::StateCorrupt {
+                        path: self.state_dir.join(crate::state::store::DB_FILENAME),
+                        message: format!("cannot begin review IMMEDIATE transaction: {e}"),
+                    })?;
+                let result = op(self, &ReviewConn::Sqlite(&conn));
+                match &result {
+                    Ok(_) => {
+                        if let Err(e) = conn.execute("COMMIT", []) {
+                            return Err(CaduceusError::StateCorrupt {
+                                path: self.state_dir.join(crate::state::store::DB_FILENAME),
+                                message: format!("cannot commit review transaction: {e}"),
+                            });
+                        }
+                        result
+                    }
+                    Err(_) => {
+                        let _ = conn.execute("ROLLBACK", []);
+                        result
+                    }
+                }
+            }
+        }
+    }
+
+    // --- persist helpers ----------------------------------------------------
+
+    fn persist_queue(&self, conn: &ReviewConn, queue: &ReviewQueueState) -> CaduceusResult<()> {
+        match conn {
+            ReviewConn::Json => {
+                let path = self.state_dir.join(REVIEW_QUEUE_FILENAME);
+                let body = serialize_review_queue_state(queue)?;
+                atomic_write(&path, body.as_bytes())?;
+                sync_dir(&self.state_dir)
+            }
+            ReviewConn::Sqlite(conn) => persist_queue_sqlite(conn, queue),
+        }
+    }
+
+    fn persist_state_map(&self, conn: &ReviewConn, states: &ReviewStateMap) -> CaduceusResult<()> {
+        match conn {
+            ReviewConn::Json => {
+                let path = self.state_dir.join(REVIEW_STATE_FILENAME);
+                let body = serialize_review_state_map(states)?;
+                atomic_write(&path, body.as_bytes())?;
+                sync_dir(&self.state_dir)
+            }
+            ReviewConn::Sqlite(conn) => persist_state_map_sqlite(conn, states),
+        }
+    }
+
+    fn persist_history(
+        &self,
+        conn: &ReviewConn,
+        history: &ReviewHistoryFile,
+    ) -> CaduceusResult<()> {
+        match conn {
+            ReviewConn::Json => {
+                let path = self.state_dir.join(REVIEW_HISTORY_FILENAME);
+                let body = serialize_review_history(history)?;
+                atomic_write(&path, body.as_bytes())?;
+                sync_dir(&self.state_dir)
+            }
+            ReviewConn::Sqlite(conn) => persist_history_sqlite(conn, history),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Claim helpers
+// ---------------------------------------------------------------------------
+
+fn write_and_sync_claim(file: &std::fs::File, body: &[u8]) -> CaduceusResult<()> {
+    use std::io::Write;
+    let mut writer = file;
+    writer.write_all(body)?;
+    writer.sync_all()?;
+    set_mode_0600(file)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_mode_0600(file: &std::fs::File) -> CaduceusResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = file.metadata()?.permissions();
+    perms.set_mode(0o600);
+    file.set_permissions(perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_mode_0600(_file: &std::fs::File) -> CaduceusResult<()> {
+    Ok(())
+}
+
+/// The entry an in-progress claim refers to: phase must be
+/// `InProgress`, the run ids must match, and the recomputed digest
+/// must match the token (forged-token defence, mirroring
+/// `matches_token`).
+fn review_entry_for_claim<'a>(
+    queue: &'a mut ReviewQueueState,
+    claim: &ReviewClaimToken,
+) -> CaduceusResult<&'a mut ReviewQueueEntry> {
+    queue
+        .entries
+        .iter_mut()
+        .find(|(key, entry)| {
+            entry.phase == ReviewPhase::InProgress
+                && entry.last_run_id.as_deref() == Some(claim.run_id())
+                && super::review_claim_digest(key.as_str()) == *claim.digest()
+        })
+        .map(|(_, entry)| entry)
+        .ok_or_else(|| review_claim_mismatch(claim))
+}
+
+fn review_claim_mismatch(claim: &ReviewClaimToken) -> CaduceusError {
+    CaduceusError::Queue {
+        context: "review-claim-terminal-mismatch",
+        stderr: format!(
+            "review claim token run_id {:?} digest {} does not match any in-progress review entry",
+            claim.run_id(),
+            claim.digest()
+        ),
+    }
+}
+
+fn unlink_review_claim_best_effort(claims_dir: &Path, claim: &ReviewClaimToken) {
+    let path = claim.claim_path();
+    match fs::remove_file(&path) {
+        Ok(()) => {
+            if let Err(err) = sync_dir(claims_dir) {
+                tracing::debug!(error = %err, "review claim-dir sync");
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                path = %path.display(),
+                "review claim unlink failed"
+            );
+        }
+    }
+}
+
+fn into_lock_error(err: std::io::Error) -> CaduceusError {
+    CaduceusError::Io(err)
+}
+
+// ---------------------------------------------------------------------------
+// JSON load helpers
+// ---------------------------------------------------------------------------
+
+fn read_utf8(path: &Path, what: &str) -> CaduceusResult<String> {
+    let bytes = fs::read(path).map_err(|err| CaduceusError::StateCorrupt {
+        path: path.to_path_buf(),
+        message: format!("cannot read {what}: {err}"),
+    })?;
+    String::from_utf8(bytes).map_err(|err| CaduceusError::StateCorrupt {
+        path: path.to_path_buf(),
+        message: format!("{what} is not UTF-8: {err}"),
+    })
+}
+
+fn load_queue_json(path: &Path) -> CaduceusResult<ReviewQueueState> {
+    match fs::read(path) {
+        Ok(_) => parse_review_queue_state(&read_utf8(path, "review queue file")?),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(ReviewQueueState::empty()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn load_state_map_json(path: &Path) -> CaduceusResult<ReviewStateMap> {
+    match fs::read(path) {
+        Ok(_) => parse_review_state_map(&read_utf8(path, "review state file")?),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(ReviewStateMap::empty()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn load_history_json(path: &Path) -> CaduceusResult<ReviewHistoryFile> {
+    match fs::read(path) {
+        Ok(_) => parse_review_history(&read_utf8(path, "review history file")?),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(ReviewHistoryFile::empty()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SQLite row mapping
+// ---------------------------------------------------------------------------
+
+fn corrupt(path: &Path, message: String) -> CaduceusError {
+    CaduceusError::StateCorrupt {
+        path: path.to_path_buf(),
+        message,
+    }
+}
+
+fn corrupt_store(message: String) -> CaduceusError {
+    CaduceusError::StateCorrupt {
+        path: PathBuf::from("<review-store>"),
+        message,
+    }
+}
+
+fn parse_pr_u64(value: i64) -> CaduceusResult<u64> {
+    u64::try_from(value).map_err(|_| corrupt_store(format!("negative pull_request value {value}")))
+}
+
+fn parse_generation(value: i64) -> u64 {
+    value.max(0) as u64
+}
+
+fn repository_from_columns(owner: &str, repo: &str) -> RepositoryId {
+    RepositoryId {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    }
+}
+
+fn parse_timestamp(value: String, field: &str, db_path: &Path) -> CaduceusResult<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(&value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| corrupt(db_path, format!("invalid {field} timestamp {value:?}: {e}")))
+}
+
+fn parse_optional_timestamp(
+    value: Option<String>,
+    field: &str,
+    db_path: &Path,
+) -> CaduceusResult<Option<DateTime<Utc>>> {
+    match value {
+        None => Ok(None),
+        Some(v) => Ok(Some(parse_timestamp(v, field, db_path)?)),
+    }
+}
+
+fn enum_label<T: serde::de::DeserializeOwned>(
+    label: &str,
+    field: &str,
+    db_path: &Path,
+) -> CaduceusResult<T> {
+    serde_json::from_str::<T>(&format!("\"{label}\""))
+        .map_err(|_| corrupt(db_path, format!("invalid {field} label {label:?}")))
+}
+
+fn load_queue_sqlite(
+    conn: &rusqlite::Connection,
+    state_dir: &Path,
+) -> CaduceusResult<ReviewQueueState> {
+    let db_path = state_dir.join(crate::state::store::DB_FILENAME);
+    let mut stmt = conn
+        .prepare(
+            "SELECT review_key, owner, repo, pull_request, head_sha, base_sha, base_ref,
+                    merge_base, phase, attempts, last_error, last_run_id, next_attempt_at,
+                    queued_at, updated_at, review_generation
+             FROM review_queue_entries",
+        )
+        .map_err(|e| {
+            corrupt(
+                &db_path,
+                format!("cannot prepare review_queue_entries select: {e}"),
+            )
+        })?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, String>(8)?,
+                row.get::<_, i64>(9)?,
+                row.get::<_, Option<String>>(10)?,
+                row.get::<_, Option<String>>(11)?,
+                row.get::<_, Option<String>>(12)?,
+                row.get::<_, String>(13)?,
+                row.get::<_, String>(14)?,
+                row.get::<_, i64>(15)?,
+            ))
+        })
+        .map_err(|e| corrupt(&db_path, format!("cannot read review_queue_entries: {e}")))?;
+
+    let mut entries = BTreeMap::new();
+    for row in rows {
+        let (
+            review_key,
+            owner,
+            repo,
+            pull_request,
+            head_sha,
+            base_sha,
+            base_ref,
+            merge_base,
+            phase_str,
+            attempts,
+            last_error,
+            last_run_id,
+            next_attempt_at,
+            queued_at,
+            updated_at,
+            review_generation,
+        ) = row.map_err(|e| corrupt(&db_path, format!("cannot decode review queue row: {e}")))?;
+        let pull_request =
+            parse_pr_u64(pull_request).map_err(|e| corrupt(&db_path, e.to_string()))?;
+        let target = ReviewTarget {
+            repository: repository_from_columns(&owner, &repo),
+            pull_request,
+            head_sha,
+            base_sha,
+            base_ref,
+            merge_base,
+        };
+        let phase = enum_label::<ReviewPhase>(&phase_str, "review phase", &db_path)?;
+        let entry = ReviewQueueEntry {
+            target,
+            phase,
+            attempts: attempts.max(0) as u32,
+            last_error,
+            last_run_id,
+            next_attempt_at: parse_optional_timestamp(
+                next_attempt_at,
+                "next_attempt_at",
+                &db_path,
+            )?,
+            queued_at: parse_timestamp(queued_at, "queued_at", &db_path)?,
+            updated_at: parse_timestamp(updated_at, "updated_at", &db_path)?,
+            review_generation: parse_generation(review_generation),
+        };
+        crate::review::validate_review_target(&entry.target)
+            .map_err(|e| corrupt(&db_path, format!("review queue row invalid: {e}")))?;
+        let key = review_queue_key(&entry.target);
+        if review_key != key {
+            return Err(corrupt(
+                &db_path,
+                format!("review queue key drift: stored {review_key:?}, computed {key:?}"),
+            ));
+        }
+        entries.insert(key, entry);
+    }
+    Ok(ReviewQueueState {
+        version: REVIEW_QUEUE_FILE_VERSION,
+        entries,
+    })
+}
+
+fn persist_queue_sqlite(
+    conn: &rusqlite::Connection,
+    queue: &ReviewQueueState,
+) -> CaduceusResult<()> {
+    // Mirror the issue queue's DELETE-then-INSERT persist shape; the
+    // review queue is tens of rows at Phase-1 scale.
+    conn.execute("DELETE FROM review_queue_entries", [])
+        .map_err(|e| corrupt_store(format!("cannot clear review_queue_entries: {e}")))?;
+    for (key, entry) in &queue.entries {
+        conn.execute(
+            "INSERT INTO review_queue_entries
+             (review_key, owner, repo, pull_request, head_sha, base_sha, base_ref,
+              merge_base, phase, attempts, last_error, last_run_id, next_attempt_at,
+              queued_at, updated_at, review_generation)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            params![
+                key,
+                entry.target.repository.owner.to_lowercase(),
+                entry.target.repository.repo.to_lowercase(),
+                entry.target.pull_request as i64,
+                entry.target.head_sha,
+                entry.target.base_sha,
+                entry.target.base_ref,
+                entry.target.merge_base,
+                entry.phase.as_str(),
+                entry.attempts as i64,
+                entry.last_error,
+                entry.last_run_id,
+                entry.next_attempt_at.map(|dt| dt.to_rfc3339()),
+                entry.queued_at.to_rfc3339(),
+                entry.updated_at.to_rfc3339(),
+                entry.review_generation as i64,
+            ],
+        )
+        .map_err(|e| corrupt_store(format!("cannot persist review queue entry {key}: {e}")))?;
+    }
+    Ok(())
+}
+
+fn load_state_map_sqlite(
+    conn: &rusqlite::Connection,
+    state_dir: &Path,
+) -> CaduceusResult<ReviewStateMap> {
+    let db_path = state_dir.join(crate::state::store::DB_FILENAME);
+    let mut stmt = conn
+        .prepare(
+            "SELECT owner, repo, pull_request, last_reviewed_head_sha, last_verdict,
+                    last_reviewed_at, sticky_comment_id, last_run_id, review_generation,
+                    publication_state, publication_attempt_count, next_publish_at,
+                    last_publish_error
+             FROM review_state",
+        )
+        .map_err(|e| corrupt(&db_path, format!("cannot prepare review_state select: {e}")))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<i64>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, i64>(8)?,
+                row.get::<_, String>(9)?,
+                row.get::<_, i64>(10)?,
+                row.get::<_, Option<String>>(11)?,
+                row.get::<_, Option<String>>(12)?,
+            ))
+        })
+        .map_err(|e| corrupt(&db_path, format!("cannot read review_state: {e}")))?;
+
+    let mut states = BTreeMap::new();
+    for row in rows {
+        let (
+            owner,
+            repo,
+            pull_request,
+            last_reviewed_head_sha,
+            last_verdict,
+            last_reviewed_at,
+            sticky_comment_id,
+            last_run_id,
+            review_generation,
+            publication_state,
+            publication_attempt_count,
+            next_publish_at,
+            last_publish_error,
+        ) = row.map_err(|e| corrupt(&db_path, format!("cannot decode review state row: {e}")))?;
+        let pr = parse_pr_u64(pull_request).map_err(|e| corrupt(&db_path, e.to_string()))?;
+        let last_verdict = match last_verdict.as_deref() {
+            None => None,
+            Some(label) => Some(enum_label::<crate::review::Verdict>(
+                label,
+                "last_verdict",
+                &db_path,
+            )?),
+        };
+        let publication_state = enum_label::<crate::review::PublicationState>(
+            &publication_state,
+            "publication_state",
+            &db_path,
+        )?;
+        let sticky_comment_id = match sticky_comment_id {
+            Some(v) => Some(
+                u64::try_from(v)
+                    .map_err(|_| corrupt(&db_path, format!("negative sticky_comment_id {v}")))?,
+            ),
+            None => None,
+        };
+        let state = ReviewState {
+            repository: repository_from_columns(&owner, &repo),
+            pull_request: pr,
+            last_reviewed_head_sha,
+            last_verdict,
+            last_reviewed_at: parse_optional_timestamp(
+                last_reviewed_at,
+                "last_reviewed_at",
+                &db_path,
+            )?,
+            sticky_comment_id,
+            last_run_id,
+            review_generation: parse_generation(review_generation),
+            publication_state,
+            publication_attempt_count: publication_attempt_count.max(0) as u32,
+            next_publish_at: parse_optional_timestamp(
+                next_publish_at,
+                "next_publish_at",
+                &db_path,
+            )?,
+            last_publish_error,
+        };
+        validated_review_state(&state).map_err(|e| corrupt(&db_path, e.to_string()))?;
+        let key = review_state_key(&state.repository, state.pull_request);
+        if key != format!("{owner}/{repo}#{pr}") {
+            return Err(corrupt(
+                &db_path,
+                format!("review state key drift: stored {owner}/{repo}#{pr}, computed {key}"),
+            ));
+        }
+        states.insert(key, state);
+    }
+    Ok(ReviewStateMap {
+        version: REVIEW_STATE_FILE_VERSION,
+        states,
+    })
+}
+
+fn persist_state_map_sqlite(
+    conn: &rusqlite::Connection,
+    states: &ReviewStateMap,
+) -> CaduceusResult<()> {
+    // Upsert-by-key: one row per (repo, pr), targeted writes (the
+    // state store is NOT DELETE-all — the current pointer is
+    // per-key).
+    for (key, state) in &states.states {
+        conn.execute(
+            "INSERT INTO review_state
+             (owner, repo, pull_request, last_reviewed_head_sha, last_verdict,
+              last_reviewed_at, sticky_comment_id, last_run_id, review_generation,
+              publication_state, publication_attempt_count, next_publish_at,
+              last_publish_error)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+             ON CONFLICT(owner, repo, pull_request) DO UPDATE SET
+                last_reviewed_head_sha = excluded.last_reviewed_head_sha,
+                last_verdict = excluded.last_verdict,
+                last_reviewed_at = excluded.last_reviewed_at,
+                sticky_comment_id = excluded.sticky_comment_id,
+                last_run_id = excluded.last_run_id,
+                review_generation = excluded.review_generation,
+                publication_state = excluded.publication_state,
+                publication_attempt_count = excluded.publication_attempt_count,
+                next_publish_at = excluded.next_publish_at,
+                last_publish_error = excluded.last_publish_error",
+            params![
+                state.repository.owner.to_lowercase(),
+                state.repository.repo.to_lowercase(),
+                state.pull_request as i64,
+                state.last_reviewed_head_sha,
+                state.last_verdict.as_ref().map(|v| serde_json::to_string(v)
+                    .unwrap_or_default()
+                    .trim_matches('"')
+                    .to_string()),
+                state.last_reviewed_at.map(|dt| dt.to_rfc3339()),
+                state.sticky_comment_id.map(|v| v as i64),
+                state.last_run_id,
+                state.review_generation as i64,
+                serde_json::to_string(&state.publication_state)
+                    .unwrap_or_default()
+                    .trim_matches('"')
+                    .to_string(),
+                state.publication_attempt_count as i64,
+                state.next_publish_at.map(|dt| dt.to_rfc3339()),
+                state.last_publish_error,
+            ],
+        )
+        .map_err(|e| corrupt_store(format!("cannot persist review state {key}: {e}")))?;
+    }
+    Ok(())
+}
+
+fn load_history_sqlite(
+    conn: &rusqlite::Connection,
+    state_dir: &Path,
+) -> CaduceusResult<ReviewHistoryFile> {
+    let db_path = state_dir.join(crate::state::store::DB_FILENAME);
+    let mut stmt = conn
+        .prepare(
+            "SELECT review_run_id, owner, repo, pull_request, head_sha, review_generation,
+                    completed_at, result_json
+             FROM review_history
+             ORDER BY rowid",
+        )
+        .map_err(|e| {
+            corrupt(
+                &db_path,
+                format!("cannot prepare review_history select: {e}"),
+            )
+        })?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+            ))
+        })
+        .map_err(|e| corrupt(&db_path, format!("cannot read review_history: {e}")))?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (
+            review_run_id,
+            owner,
+            repo,
+            pull_request,
+            head_sha,
+            review_generation,
+            completed_at,
+            result_json,
+        ) = row.map_err(|e| corrupt(&db_path, format!("cannot decode review history row: {e}")))?;
+        let pr = parse_pr_u64(pull_request).map_err(|e| corrupt(&db_path, e.to_string()))?;
+        let row = ReviewHistoryRow {
+            review_run_id,
+            repository: repository_from_columns(&owner, &repo),
+            pull_request: pr,
+            head_sha,
+            review_generation: parse_generation(review_generation),
+            completed_at: parse_timestamp(completed_at, "completed_at", &db_path)?,
+            result_json,
+        };
+        validate_history_row(&row).map_err(|e| corrupt(&db_path, e.to_string()))?;
+        out.push(row);
+    }
+    Ok(ReviewHistoryFile {
+        version: REVIEW_HISTORY_FILE_VERSION,
+        rows: out,
+    })
+}
+
+fn persist_history_sqlite(
+    conn: &rusqlite::Connection,
+    history: &ReviewHistoryFile,
+) -> CaduceusResult<()> {
+    // INSERT-only: history is append-only (AC3) — no UPDATE/DELETE
+    // method exists on this store. The unique run_id PK makes a
+    // re-append idempotent no-op at the SQL level while the store's
+    // duplicate check makes the second append a hard error above.
+    for row in &history.rows {
+        conn.execute(
+            "INSERT INTO review_history
+             (review_run_id, owner, repo, pull_request, head_sha, review_generation,
+              completed_at, result_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(review_run_id) DO NOTHING",
+            params![
+                row.review_run_id,
+                row.repository.owner.to_lowercase(),
+                row.repository.repo.to_lowercase(),
+                row.pull_request as i64,
+                row.head_sha,
+                row.review_generation as i64,
+                row.completed_at.to_rfc3339(),
+                row.result_json,
+            ],
+        )
+        .map_err(|e| {
+            corrupt_store(format!(
+                "cannot append review history row {}: {e}",
+                row.review_run_id
+            ))
+        })?;
+    }
+    Ok(())
+}

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -61,17 +61,23 @@ use crate::infra::error::{store_version_guidance, CaduceusError, CaduceusResult}
 ///   migration: v6 state must be reinitialised rather than being read
 ///   with different lifecycle semantics.
 ///
-/// ## v8 (not yet live — armed by #295)
+/// ## v8
 ///
-/// - The review-era structures activate as v8 atomically with #295 in
-///   ONE commit: append a `Migration { from: 7, to: 8, label:
-///   "review-era structures", apply: m_v7_v8 }` entry to
-///   `SQLITE_MIGRATIONS`, bump `SCHEMA_VERSION` to 8, bump
-///   `QUEUE_FILE_VERSION` to 2 (with the JSON migration step), and add
-///   the v8 review tables to the schema DDL. `assert_registry_wellformed`
-///   rejects any step whose `to` exceeds `SCHEMA_VERSION`, so the
-///   registry entry and the version bump cannot land separately.
-pub const SCHEMA_VERSION: i64 = 7;
+/// - The review-era structures activate atomically with #295: three
+///   new tables created via `SCHEMA_SQL` — `review_queue_entries`
+///   (sibling review queue keyed by the canonical `ReviewTarget`
+///   queue key), `review_state` (per-`(repo, pr)` current pointer
+///   with the monotonic `review_generation`), and `review_history`
+///   (append-only, identity = `review_run_id`; the
+///   `(repo, pr, head_sha)` tuple is deliberately NOT unique) — plus
+///   their lookup indexes. The v7→v8 migration step is structural
+///   only (`m_v2_v3` precedent): no pre-v8 review data can exist.
+///   The JSON-side counterpart of this activation is the
+///   `state.json` envelope bump to `QUEUE_FILE_VERSION = 2` (with an
+///   in-place accept-and-upgrade of v1 files) plus three new v1-born
+///   review sidecar files (`review_queue.json`, `review_state.json`,
+///   `review_history.json`); see `crate::state::review`.
+pub const SCHEMA_VERSION: i64 = 8;
 
 /// The last schema version that is deliberately rejected instead of
 /// migrated. Keeping this explicit prevents a future schema bump from
@@ -164,6 +170,58 @@ CREATE TABLE IF NOT EXISTS oci_runs (
 CREATE INDEX IF NOT EXISTS idx_oci_runs_container_id ON oci_runs(container_id);
 CREATE INDEX IF NOT EXISTS idx_oci_runs_daemon_id ON oci_runs(daemon_id);
 CREATE INDEX IF NOT EXISTS idx_oci_runs_state ON oci_runs(state);
+
+CREATE TABLE IF NOT EXISTS review_queue_entries (
+    review_key   TEXT PRIMARY KEY,
+    owner        TEXT NOT NULL,
+    repo         TEXT NOT NULL,
+    pull_request INTEGER NOT NULL,
+    head_sha     TEXT NOT NULL,
+    base_sha     TEXT NOT NULL,
+    base_ref     TEXT NOT NULL,
+    merge_base   TEXT NOT NULL,
+    phase        TEXT NOT NULL,
+    attempts     INTEGER NOT NULL DEFAULT 0,
+    last_error   TEXT,
+    last_run_id  TEXT,
+    next_attempt_at TEXT,
+    queued_at    TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    review_generation INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_review_queue_repo ON review_queue_entries(owner, repo, pull_request);
+CREATE INDEX IF NOT EXISTS idx_review_queue_phase ON review_queue_entries(phase);
+
+CREATE TABLE IF NOT EXISTS review_state (
+    owner        TEXT NOT NULL,
+    repo         TEXT NOT NULL,
+    pull_request INTEGER NOT NULL,
+    last_reviewed_head_sha TEXT,
+    last_verdict TEXT,
+    last_reviewed_at TEXT,
+    sticky_comment_id INTEGER,
+    last_run_id  TEXT,
+    review_generation INTEGER NOT NULL DEFAULT 1,
+    publication_state TEXT NOT NULL DEFAULT 'pending',
+    publication_attempt_count INTEGER NOT NULL DEFAULT 0,
+    next_publish_at TEXT,
+    last_publish_error TEXT,
+    PRIMARY KEY (owner, repo, pull_request)
+);
+
+CREATE TABLE IF NOT EXISTS review_history (
+    review_run_id TEXT PRIMARY KEY,
+    owner        TEXT NOT NULL,
+    repo         TEXT NOT NULL,
+    pull_request INTEGER NOT NULL,
+    head_sha     TEXT NOT NULL,
+    review_generation INTEGER NOT NULL,
+    completed_at TEXT NOT NULL,
+    result_json  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_review_history_repo ON review_history(owner, repo, pull_request);
+CREATE INDEX IF NOT EXISTS idx_review_history_pr ON review_history(pull_request);
+CREATE INDEX IF NOT EXISTS idx_review_history_head_sha ON review_history(owner, repo, pull_request, head_sha);
 ";
 
 // Open / initialise.
@@ -356,10 +414,10 @@ pub(crate) struct Migration {
 
 /// The declarative migration chain (D1/D4).
 ///
-/// The chain deliberately ends at v6: v6 is the stale-reinitialise
-/// boundary ([`STALE_SCHEMA_VERSION`]) and v8 does not exist yet — #295
-/// arms v7→v8 by appending one entry + bumping [`SCHEMA_VERSION`] in
-/// the same commit.
+/// The chain ends at the current [`SCHEMA_VERSION`]: v6 is the
+/// stale-reinitialise boundary ([`STALE_SCHEMA_VERSION`]) and the
+/// v7→v8 review-era step (#295) is structural only — the three
+/// review tables are created by `apply_schema` via `SCHEMA_SQL`.
 const SQLITE_MIGRATIONS: &[Migration] = &[
     Migration {
         from: 1,
@@ -391,15 +449,21 @@ const SQLITE_MIGRATIONS: &[Migration] = &[
         label: "queue_entries blocked columns",
         apply: m_v5_v6,
     },
+    Migration {
+        from: 7,
+        to: 8,
+        label: "review-era structures",
+        apply: m_v7_v8,
+    },
 ];
 
 /// Validate the registry's chain invariants (D1/D4): steps are strictly
-/// increasing and contiguous (`from[i] == to[i-1]`), the chain starts
-/// at v1, no step migrates FROM the stale boundary
-/// [`STALE_SCHEMA_VERSION`], and no step's `to` exceeds
-/// [`SCHEMA_VERSION`]. The last clause makes arming v8 (a
-/// `from: 7, to: 8` entry) impossible without bumping
-/// [`SCHEMA_VERSION`] in the same change (#295).
+/// increasing, the chain starts at v1, no step migrates FROM the stale
+/// boundary [`STALE_SCHEMA_VERSION`], and no step's `to` exceeds
+/// [`SCHEMA_VERSION`]. Contiguity is required across consecutive steps
+/// EXCEPT across the stale boundary: v6 is reinitialise-only by policy,
+/// so a step starting at v7 (after the deliberate 6→7 era break, which
+/// carries no registry entry) is a sanctioned discontinuity, not a gap.
 pub fn assert_registry_wellformed() -> CaduceusResult<()> {
     let steps = SQLITE_MIGRATIONS;
     if steps.is_empty() {
@@ -433,12 +497,20 @@ pub fn assert_registry_wellformed() -> CaduceusResult<()> {
             )));
         }
         if i > 0 && step.from != steps[i - 1].to {
-            return Err(CaduceusError::Other(format!(
-                "migration registry gap at step {i} ({}): starts at v{} but previous step ends at v{}",
-                step.label,
-                step.from,
-                steps[i - 1].to
-            )));
+            // The v6 boundary is the sanctioned discontinuity: v6 is
+            // reinitialise-only and v7 arrived as a policy era change
+            // with no registry entry, so a step starting at v7 after a
+            // chain that ended at v6 is well-formed.
+            let across_stale_boundary =
+                steps[i - 1].to == STALE_SCHEMA_VERSION && step.from == STALE_SCHEMA_VERSION + 1;
+            if !across_stale_boundary {
+                return Err(CaduceusError::Other(format!(
+                    "migration registry gap at step {i} ({}): starts at v{} but previous step ends at v{}",
+                    step.label,
+                    step.from,
+                    steps[i - 1].to
+                )));
+            }
         }
     }
     Ok(())
@@ -535,6 +607,20 @@ fn m_v5_v6(tx: &Transaction) -> CaduceusResult<()> {
          ALTER TABLE queue_entries ADD COLUMN blocked_recovery_hint TEXT;",
     )
     .map_err(|e| CaduceusError::Other(format!("v5→v6 ALTER queue_entries: {e}")))?;
+    Ok(())
+}
+
+/// Migrate from schema v7 to v8. The three review-era tables
+/// (`review_queue_entries`, `review_state`, `review_history`) and
+/// their indexes are created by `apply_schema` via `SCHEMA_SQL`, so
+/// this is a structural no-op that exists for the migration wiring
+/// convention (`m_v2_v3` precedent). No data transform: there is no
+/// pre-v8 review data by construction.
+fn m_v7_v8(tx: &Transaction) -> CaduceusResult<()> {
+    // The review tables are created by `apply_schema` via
+    // `SCHEMA_SQL`. No ALTER TABLE / data statements are needed for
+    // v7→v8.
+    let _ = tx;
     Ok(())
 }
 

--- a/tests/fixtures/scenario-10-golden.json
+++ b/tests/fixtures/scenario-10-golden.json
@@ -1,5 +1,5 @@
 {
-  "schema_version_after_open": 7,
-  "schema_version_again": 7,
+  "schema_version_after_open": 8,
+  "schema_version_again": 8,
   "oci_runs_table_exists": true
 }

--- a/tests/integration/integration_scenarios.rs
+++ b/tests/integration/integration_scenarios.rs
@@ -981,7 +981,7 @@ async fn test_scenario_10_schema_v7_idempotent() {
         v_after_open, SCHEMA_VERSION,
         "fresh DB must be at SCHEMA_VERSION"
     );
-    assert_eq!(v_after_open, 7, "v7 is the canonical current schema");
+    assert_eq!(v_after_open, 8, "v8 is the canonical current schema");
 
     // Second open: idempotent — no migration, schema_version
     // table is unchanged, oci_runs table still exists.
@@ -999,8 +999,8 @@ async fn test_scenario_10_schema_v7_idempotent() {
         )
         .expect("query oci_runs");
     drop(conn2);
-    assert_eq!(v_again, 7, "second open must remain v7 (idempotent)");
-    assert_eq!(oci_runs_count, 1, "oci_runs table must exist at v7");
+    assert_eq!(v_again, 8, "second open must remain v8 (idempotent)");
+    assert_eq!(oci_runs_count, 1, "oci_runs table must exist at v8");
 
     let observed = serde_json::json!({
         "schema_version_after_open": v_after_open,

--- a/tests/state/migration_framework_test.rs
+++ b/tests/state/migration_framework_test.rs
@@ -9,8 +9,10 @@
 //!   guidance for both backends.
 //! - AC3 — per-type `schema_version` plumbing rejects unknown
 //!   review-typed versions with a dedicated, matchable variant.
-//! - AC4 — no live version flip: `SCHEMA_VERSION` stays 7 and
-//!   `QUEUE_FILE_VERSION` stays 1; the registry ships no v7→v8 entry.
+//! - AC4 (superseded by #295) — the live version flip: #295 bumps
+//!   `SCHEMA_VERSION` to 8 and `QUEUE_FILE_VERSION` to 2 atomically
+//!   with the review structures, so `no_live_version_flip` now PINS
+//!   the post-#295 values and the registry's last step is 7→8.
 //!
 //! The harness builders (`harness::sqlite_store_at_version`,
 //! `harness::json_state_at_version`) take a path and are the shape
@@ -133,6 +135,13 @@ mod harness {
         if version >= 5 {
             sql.push_str("CREATE TABLE oci_runs (run_id TEXT PRIMARY KEY, container_id TEXT, state TEXT NOT NULL, engine TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, daemon_id TEXT NOT NULL, issue_id TEXT NOT NULL, worker_command_sha256 TEXT NOT NULL);");
         }
+        // The review-era tables land at v8; a v7-era store (the real
+        // pre-#295 shape) must NOT carry them.
+        if version >= 8 {
+            sql.push_str("CREATE TABLE review_queue_entries (review_key TEXT PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL, pull_request INTEGER NOT NULL, head_sha TEXT NOT NULL, base_sha TEXT NOT NULL, base_ref TEXT NOT NULL, merge_base TEXT NOT NULL, phase TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, next_attempt_at TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, review_generation INTEGER NOT NULL DEFAULT 1);");
+            sql.push_str("CREATE TABLE review_state (owner TEXT NOT NULL, repo TEXT NOT NULL, pull_request INTEGER NOT NULL, last_reviewed_head_sha TEXT, last_verdict TEXT, last_reviewed_at TEXT, sticky_comment_id INTEGER, last_run_id TEXT, review_generation INTEGER NOT NULL DEFAULT 1, publication_state TEXT NOT NULL DEFAULT 'pending', publication_attempt_count INTEGER NOT NULL DEFAULT 0, next_publish_at TEXT, last_publish_error TEXT, PRIMARY KEY (owner, repo, pull_request));");
+            sql.push_str("CREATE TABLE review_history (review_run_id TEXT PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL, pull_request INTEGER NOT NULL, head_sha TEXT NOT NULL, review_generation INTEGER NOT NULL, completed_at TEXT NOT NULL, result_json TEXT NOT NULL);");
+        }
         sql
     }
 
@@ -177,6 +186,9 @@ fn assert_current_tables(path: &Path) {
         "circuit_state",
         "leases",
         "oci_runs",
+        "review_queue_entries",
+        "review_state",
+        "review_history",
     ] {
         assert!(
             tables.contains(&table.to_string()),
@@ -223,7 +235,7 @@ fn schema_version_row_count(path: &Path) -> i64 {
 
 #[test]
 fn chain_runs_from_each_older_era_to_current() {
-    for version in [1i64, 2, 3, 4, 5] {
+    for version in [1i64, 2, 3, 4, 5, 7] {
         let dir = harness::temp_dir(&format!("chain-v{version}"));
         let path = harness::sqlite_store_at_version(&dir, version);
         let conn = open(&path).unwrap_or_else(|e| panic!("open v{version} store: {e}"));
@@ -338,9 +350,10 @@ fn unknown_sqlite_version_is_rejected_with_guidance() {
 #[test]
 fn json_future_version_is_rejected_with_guidance() {
     let dir = harness::temp_dir("json-future");
-    let path = harness::json_state_at_version(&dir, 2);
+    // v2 is CURRENT since #295; the future version is 3.
+    let path = harness::json_state_at_version(&dir, 3);
     let text = fs::read_to_string(&path).expect("read state.json");
-    let err = parse_queue_state(&text).expect_err("v2 rejected");
+    let err = parse_queue_state(&text).expect_err("v3 rejected");
     match err {
         CaduceusError::StoreVersionUnsupported {
             backend,
@@ -350,7 +363,7 @@ fn json_future_version_is_rejected_with_guidance() {
             ..
         } => {
             assert_eq!(backend, "json", "got: {err:?}");
-            assert_eq!(found, 2, "got: {err:?}");
+            assert_eq!(found, 3, "got: {err:?}");
             assert_eq!(supported, QUEUE_FILE_VERSION as i64, "got: {err:?}");
             assert!(guidance.contains("NEWER"), "got: {guidance}");
         }
@@ -387,9 +400,9 @@ fn json_older_version_is_rejected_with_guidance() {
 fn json_store_open_hard_fails_on_future_envelope() {
     // The real disk-load path hard-fails the whole store open (startup
     // hard-fail), not best-effort parse.
-    let dir = harness::temp_dir("json-v2-file");
-    let path = harness::json_state_at_version(&dir, 2);
-    let err = StateStore::open(&dir).expect_err("open of a v2 store must hard-fail");
+    let dir = harness::temp_dir("json-v3-file");
+    let path = harness::json_state_at_version(&dir, 3);
+    let err = StateStore::open(&dir).expect_err("open of a v3 store must hard-fail");
     match err {
         CaduceusError::StoreVersionUnsupported { backend, .. } => {
             assert_eq!(backend, "json", "got: {err:?}");
@@ -401,12 +414,22 @@ fn json_store_open_hard_fails_on_future_envelope() {
 }
 
 #[test]
-fn json_v1_parses_and_missing_file_yields_empty_v1() {
+fn json_v1_parses_and_missing_file_yields_empty_current() {
+    // v1 is an OLDER version since #295: the in-place migration reads
+    // it as the current envelope.
     let parsed = parse_queue_state(r#"{"version":1,"entries":{}}"#).expect("v1 parses");
     assert_eq!(parsed.version, QUEUE_FILE_VERSION);
     assert!(parsed.entries.is_empty());
 
-    // Missing state.json → empty v1 envelope (existing behaviour).
+    // A v1 file carrying a real entry upgrades too.
+    let with_entry = parse_queue_state(
+        r#"{"version":1,"entries":{"owner/repo#1":{"key":{"owner":"owner","repo":"repo","number":1},"phase":"queued","ticket_type":"code","attempts":0,"last_error":null,"last_run_id":null,"next_attempt_at":null,"finalization":null,"queued_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","generation":1}}}"#,
+    )
+    .expect("v1 with entry parses");
+    assert_eq!(with_entry.version, QUEUE_FILE_VERSION);
+    assert_eq!(with_entry.entries.len(), 1);
+
+    // Missing state.json → empty current envelope (existing behaviour).
     let dir = harness::temp_dir("json-missing");
     let store = StateStore::open(&dir).expect("open store");
     let snap = store.snapshot().expect("snapshot empty dir");
@@ -452,7 +475,7 @@ fn review_schema_version_plumbing_rejects_unknown_versions() {
 // -----------------------------------------------------------------------
 
 #[test]
-fn registry_is_wellformed_and_ceiling_is_one_below_current() {
+fn registry_is_wellformed_and_chain_reaches_current() {
     assert_registry_wellformed().expect("registry invariants hold");
 
     let chain = sqlite_migration_chain();
@@ -463,7 +486,14 @@ fn registry_is_wellformed_and_ceiling_is_one_below_current() {
     for i in 1..chain.len() {
         let (from, _, _) = chain[i];
         let (prev_from, prev_to, _) = chain[i - 1];
-        assert_eq!(from, prev_to, "chain must be contiguous at step {i}");
+        // Contiguity holds except across the sanctioned stale-boundary
+        // break: v6 is reinitialise-only, so v7 arrives with no
+        // registry entry (the 6→7 era change carried none).
+        let across_stale_boundary =
+            prev_to == STALE_SCHEMA_VERSION && from == STALE_SCHEMA_VERSION + 1;
+        if !across_stale_boundary {
+            assert_eq!(from, prev_to, "chain must be contiguous at step {i}");
+        }
         assert!(
             from > prev_from,
             "chain must be strictly increasing at step {i}"
@@ -477,19 +507,22 @@ fn registry_is_wellformed_and_ceiling_is_one_below_current() {
     }
     let (_, last_to, _) = chain.last().expect("non-empty chain");
     assert_eq!(
-        *last_to,
-        SCHEMA_VERSION - 1,
-        "no v7→v8 entry ships in this change (AC4's structural assertion)"
+        *last_to, SCHEMA_VERSION,
+        "the chain's last step must reach the current schema version"
     );
-    assert!(*last_to < SCHEMA_VERSION);
+    assert!(
+        chain.iter().any(|&(from, to, _)| from == 7 && to == 8),
+        "the v7→v8 review-era step (#295) must exist in the registry"
+    );
 }
 
 #[test]
 fn no_live_version_flip() {
-    // AC4: the store still reports v7 and the pre-review JSON envelope
-    // version; #295 bumps both atomically with the review structures.
-    assert_eq!(SCHEMA_VERSION, 7);
-    assert_eq!(QUEUE_FILE_VERSION, 1);
+    // #295 flipped the store envelope atomically with the review
+    // structures: SQLite v8, JSON v2. This pin keeps the two bumps
+    // from drifting apart (or reverting) independently.
+    assert_eq!(SCHEMA_VERSION, 8);
+    assert_eq!(QUEUE_FILE_VERSION, 2);
 }
 
 // -----------------------------------------------------------------------

--- a/tests/state/migration_test.rs
+++ b/tests/state/migration_test.rs
@@ -34,7 +34,8 @@ use caduceus::error::CaduceusError;
 use caduceus::issue::IssueKey;
 use caduceus::migrate::{run as migrate_run, MigrationOutcome};
 use caduceus::queue::{
-    parse_queue_state, serialize_queue_state, DaemonLock, Phase, QueueEntry, QueueState, StateStore,
+    parse_queue_state, serialize_queue_state, DaemonLock, Phase, QueueEntry, QueueState,
+    StateStore, QUEUE_FILE_VERSION,
 };
 use chrono::{TimeZone, Utc};
 use tempfile::TempDir;
@@ -111,7 +112,7 @@ fn empty_legacy_state_imports_empty_current_state_and_is_idempotent() {
     let state_path = state_dir.join("state.json");
     assert!(state_path.exists());
     let snap = open_state(&state_path);
-    assert_eq!(snap.version, 1);
+    assert_eq!(snap.version, QUEUE_FILE_VERSION);
     assert!(snap.entries.is_empty());
     // Backup was written alongside.
     assert!(backup_path(&state_dir).exists());
@@ -320,7 +321,7 @@ fn migration_is_atomic_and_leaves_a_backup() {
     // Backup was renamed from the *prior* content. Since the
     // state dir started empty, the backup is a copy of the
     // newly-imported state (it must still parse as v1).
-    assert_eq!(backup_state.version, 1);
+    assert_eq!(backup_state.version, QUEUE_FILE_VERSION);
 }
 
 #[test]

--- a/tests/state/queue_model_test.rs
+++ b/tests/state/queue_model_test.rs
@@ -208,11 +208,18 @@ fn queue_state_round_trip_preserves_timestamps_as_rfc3339_utc() {
 
 #[test]
 fn queue_state_rejects_unknown_field() {
+    // A v1 (pre-#295) document must remain strictly validated after
+    // the in-place envelope upgrade: unknown fields still rejected.
     let bad = r#"{"version":1,"entries":{},"rogue":"leak"}"#;
     let err = parse_queue_state(bad).expect_err("deny_unknown_fields");
     let msg = format!("{err:?}");
     assert!(msg.contains("StateCorrupt"), "got: {msg}");
     assert!(msg.contains("queue state JSON parse"), "got: {msg}");
+
+    let bad_current = r#"{"version":2,"entries":{},"rogue":"leak"}"#;
+    let err = parse_queue_state(bad_current).expect_err("deny_unknown_fields");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("StateCorrupt"), "got: {msg}");
 }
 
 #[test]
@@ -232,7 +239,7 @@ fn queue_entry_rejects_unknown_field() {
 
 #[test]
 fn queue_state_missing_required_field_is_corrupt() {
-    let bad = r#"{"version":1}"#;
+    let bad = r#"{"version":2}"#;
     let err = parse_queue_state(bad).expect_err("missing entries");
     let msg = format!("{err:?}");
     assert!(msg.contains("StateCorrupt"), "got: {msg}");
@@ -254,11 +261,11 @@ fn queue_state_with_future_version_is_rejected() {
         } => {
             assert_eq!(backend, "json", "got: {err:?}");
             assert_eq!(found, 999, "got: {err:?}");
-            assert_eq!(supported, 1, "got: {err:?}");
+            assert_eq!(supported, 2, "got: {err:?}");
             assert!(guidance.contains("NEWER"), "got: {guidance}");
             let text = err.to_string();
             assert!(text.contains("999"), "got: {text}");
-            assert!(text.contains("supports up to 1"), "got: {text}");
+            assert!(text.contains("supports up to 2"), "got: {text}");
         }
         other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
     }
@@ -266,6 +273,8 @@ fn queue_state_with_future_version_is_rejected() {
 
 #[test]
 fn queue_state_with_version_zero_is_rejected() {
+    // Version 0 predates the v1-born review-era files and remains
+    // rejected (guidance OLDER).
     let bad = r#"{"version":0,"entries":{}}"#;
     let err = parse_queue_state(bad).expect_err("version 0");
     match err {
@@ -278,7 +287,7 @@ fn queue_state_with_version_zero_is_rejected() {
         } => {
             assert_eq!(backend, "json", "got: {err:?}");
             assert_eq!(found, 0, "got: {err:?}");
-            assert_eq!(supported, 1, "got: {err:?}");
+            assert_eq!(supported, 2, "got: {err:?}");
             assert!(guidance.contains("OLDER"), "got: {guidance}");
         }
         other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
@@ -293,7 +302,7 @@ fn queue_state_rejects_mismatched_map_key() {
     // entry key is the canonical lowercase form.
     let entry_json = r#"{"key":{"owner":"BarkleyAssistant","repo":"sandbox","number":42},"phase":"queued","ticket_type":"code","attempts":0,"last_error":null,"last_run_id":null,"next_attempt_at":null,"finalization":null,"queued_at":"2026-07-13T14:00:00Z","updated_at":"2026-07-13T14:00:00Z","generation":1}"#;
     let bad =
-        format!(r#"{{"version":1,"entries":{{"BarkleyAssistant/sandbox#42":{entry_json}}}}}"#);
+        format!(r#"{{"version":2,"entries":{{"BarkleyAssistant/sandbox#42":{entry_json}}}}}"#);
     let err = parse_queue_state(&bad).expect_err("map key mismatch");
     let msg = format!("{err:?}");
     assert!(msg.contains("StateCorrupt"), "got: {msg}");
@@ -309,7 +318,7 @@ fn queue_state_empty_is_constructable() {
     assert!(empty.entries.is_empty());
 
     let rendered = serialize_queue_state(&empty).expect("empty serialises");
-    assert_eq!(rendered, "{\"version\":1,\"entries\":{}}");
+    assert_eq!(rendered, "{\"version\":2,\"entries\":{}}");
 }
 
 #[test]

--- a/tests/state/review_activation_test.rs
+++ b/tests/state/review_activation_test.rs
@@ -1,0 +1,229 @@
+//! Review-era activation tests (issue #295, AC2): the envelope bump
+//! is atomic with the review structures, pre-#295 binaries are
+//! structurally locked out, and v8 == exactly the schema this change
+//! implements.
+//!
+//! The rejection contract cannot ship an actual pre-#295 binary in a
+//! test, so it is pinned structurally: the same code path a pre-#295
+//! binary takes on #295-era state (newer-version gate) is exercised
+//! with a further-future version (JSON v3, SQLite v99). A pre-#295
+//! binary has `QUEUE_FILE_VERSION = 1` / `SCHEMA_VERSION = 7`, so
+//! #295-era state (2 / 8) hits exactly those branches.
+
+use caduceus::queue::{parse_queue_state, StateStore, QUEUE_FILE_VERSION};
+use caduceus::store::{open, sqlite_migration_chain, SCHEMA_VERSION};
+use rusqlite::Connection;
+use std::fs;
+use std::path::PathBuf;
+
+fn temp_dir(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!(
+        "review-activation-{tag}-{}-{n}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// The real pre-#295 v7-era DDL (v6 tables + `oci_runs`, no review
+/// tables) — the era shape `migration_framework_test`'s harness also
+/// encodes.
+const V7_ERA_DDL: &str = "
+CREATE TABLE queue_entries (issue_key TEXT PRIMARY KEY, phase TEXT NOT NULL, ticket_type TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, next_attempt_at TEXT, finalization TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, generation INTEGER NOT NULL DEFAULT 1, blocked_source TEXT, blocked_recovery_hint TEXT);
+CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE claims (claim_id TEXT PRIMARY KEY, issue_key TEXT NOT NULL, worker_pid INTEGER, token TEXT NOT NULL, claimed_at TEXT NOT NULL, expires_at TEXT NOT NULL);
+CREATE TABLE checkpoints (run_id TEXT NOT NULL, stage TEXT NOT NULL, checkpoint_data TEXT, created_at TEXT NOT NULL, operation_id TEXT, remote_marker TEXT, PRIMARY KEY (run_id, stage));
+CREATE TABLE circuit_state (scope TEXT NOT NULL, scope_id TEXT NOT NULL, state TEXT NOT NULL DEFAULT 'closed', consecutive_failures INTEGER NOT NULL DEFAULT 0, last_failure_at INTEGER, opened_at INTEGER, last_probe_at INTEGER, PRIMARY KEY (scope, scope_id));
+CREATE TABLE leases (issue_key TEXT PRIMARY KEY, owner_id TEXT NOT NULL, fencing_token INTEGER NOT NULL, expires_at INTEGER NOT NULL, state TEXT NOT NULL CHECK(state IN ('held', 'released', 'expired')));
+CREATE TABLE oci_runs (run_id TEXT PRIMARY KEY, container_id TEXT, state TEXT NOT NULL, engine TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, daemon_id TEXT NOT NULL, issue_id TEXT NOT NULL, worker_command_sha256 TEXT NOT NULL);
+";
+
+#[test]
+fn pre_295_json_state_parses_as_v2_in_place() {
+    let dir = temp_dir("json-v1");
+    let state_path = dir.join("state.json");
+    fs::write(
+        &state_path,
+        r#"{"version":1,"entries":{"owner/repo#1":{"key":{"owner":"owner","repo":"repo","number":1},"phase":"queued","ticket_type":"code","attempts":0,"last_error":null,"last_run_id":null,"next_attempt_at":null,"finalization":null,"queued_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","generation":1}}}"#,
+    )
+    .unwrap();
+
+    // The parse seam upgrades in place.
+    let parsed = parse_queue_state(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    assert_eq!(parsed.version, QUEUE_FILE_VERSION);
+    assert_eq!(parsed.entries.len(), 1);
+
+    // The real store-open path also accepts the pre-#295 file.
+    let store = StateStore::open(&dir).expect("open store on v1 file");
+    let snap = store.snapshot().unwrap();
+    assert_eq!(snap.version, QUEUE_FILE_VERSION);
+    assert!(snap.entries.contains_key("owner/repo#1"));
+
+    // Parse is pure: the file on disk is NOT rewritten by the load.
+    let on_disk = fs::read_to_string(&state_path).unwrap();
+    assert!(
+        on_disk.contains(r#""version":1"#),
+        "parse must not rewrite the file; got: {on_disk}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pre_295_sqlite_v7_opens_and_migrates_to_v8() {
+    let dir = temp_dir("sqlite-v7");
+    let db_path = dir.join("state.db");
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+             INSERT INTO schema_version (version, migrated_at) VALUES (7, '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+        conn.execute_batch(V7_ERA_DDL).unwrap();
+        conn.execute(
+            "INSERT INTO queue_entries (issue_key, phase, ticket_type, attempts, queued_at, updated_at, generation)
+             VALUES ('owner/repo#1', 'queued', 'code', 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+    }
+
+    // A plain `open` runs the chain: v7 → v8 with the review tables.
+    let conn = open(&db_path).expect("open v7 store");
+    drop(conn);
+
+    let conn = Connection::open(&db_path).unwrap();
+    let version: i64 = conn
+        .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(version, 8);
+    for table in ["review_queue_entries", "review_state", "review_history"] {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                [table],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "review table {table} exists after migration");
+    }
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM queue_entries", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 1, "issue data preserved through migration");
+    drop(conn);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pre_295_binary_rejection_is_structural() {
+    // JSON: the newer-version branch keys on state.version >
+    // QUEUE_FILE_VERSION. A pre-#295 binary (QUEUE_FILE_VERSION = 1)
+    // hits exactly this branch on a #295-era v2 state.json; we pin the
+    // branch with version 3.
+    let bad = r#"{"version":3,"entries":{}}"#;
+    let err = parse_queue_state(bad).expect_err("v3 rejected");
+    match err {
+        caduceus::error::CaduceusError::StoreVersionUnsupported {
+            backend,
+            found,
+            supported,
+            ref guidance,
+            ..
+        } => {
+            assert_eq!(backend, "json");
+            assert_eq!(found, 3);
+            assert_eq!(supported, 2);
+            assert!(guidance.contains("NEWER"));
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
+
+    // SQLite: same shape — a version-99 db hits the same gate a
+    // pre-#295 binary (SCHEMA_VERSION = 7) would hit on a v8 db.
+    let dir = temp_dir("sqlite-future");
+    let db_path = dir.join("state.db");
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+             INSERT INTO schema_version (version, migrated_at) VALUES (99, '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+        drop(conn);
+    }
+    let err = open(&db_path).expect_err("v99 rejected");
+    match err {
+        caduceus::error::CaduceusError::StoreVersionUnsupported {
+            backend,
+            found,
+            supported,
+            ..
+        } => {
+            assert_eq!(backend, "sqlite");
+            assert_eq!(found, 99);
+            assert_eq!(supported, 8);
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn v8_is_exactly_the_review_schema() {
+    // "v8 == implemented schema": a fresh v8 store contains exactly
+    // the pre-change table set PLUS the three review tables (and no
+    // other additions).
+    let dir = temp_dir("v8-exact");
+    let db_path = dir.join("state.db");
+    let conn = open(&db_path).expect("open fresh v8 store");
+    drop(conn);
+
+    let conn = Connection::open(&db_path).unwrap();
+    let mut tables: Vec<String> = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+    tables.sort();
+    drop(conn);
+
+    let mut expected: Vec<String> = [
+        // Pre-change (v7) tables, verbatim.
+        "schema_version",
+        "queue_entries",
+        "state_meta",
+        "claims",
+        "checkpoints",
+        "circuit_state",
+        "leases",
+        "oci_runs",
+        // The v8 additions (#295).
+        "review_queue_entries",
+        "review_state",
+        "review_history",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    expected.sort();
+    assert_eq!(tables, expected, "v8 adds exactly the three review tables");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn registry_last_step_is_the_review_activation() {
+    let chain = sqlite_migration_chain();
+    let (last_from, last_to, last_label) = *chain.last().unwrap();
+    assert_eq!(last_from, 7);
+    assert_eq!(last_to, 8);
+    assert_eq!(last_label, "review-era structures");
+    assert_eq!(last_to, SCHEMA_VERSION);
+}

--- a/tests/state/review_store_test.rs
+++ b/tests/state/review_store_test.rs
@@ -1,0 +1,885 @@
+//! Review store tests (issue #295): round-trips, dedup, append-only
+//! history, generation monotonicity, claim lifecycle, and durability
+//! under both backends.
+//!
+//! AC coverage:
+//!
+//! - AC1 — both backends, strict serde, validated load (round-trips,
+//!   unknown-field / wrong-version / key-mismatch / corrupt rejection).
+//! - AC3 — append-only history keyed by `review_run_id`; multiple rows
+//!   per `(repo, pr, head_sha)`; duplicate run id rejected.
+//! - AC4 — `review_generation` persisted and monotonic per (repo, pr).
+//! - AC5 — dedup = `last_reviewed_head_sha` + active queue, never a
+//!   history uniqueness constraint.
+//! - AC6 — persistence durable across restart; corrupted input
+//!   rejected safely on both backends.
+
+use caduceus::review::{
+    ExecutionStatus, RepositoryId, ReviewResult, ReviewState, ReviewTarget, REVIEW_SCHEMA_VERSION,
+};
+use caduceus::state::queue::StateStore;
+use caduceus::state::review::{
+    parse_review_history, parse_review_queue_state, parse_review_state_map, review_queue_key,
+    review_state_key, serialize_review_history, serialize_review_queue_state,
+    serialize_review_state_map, ReviewEnqueueOutcome, ReviewHistoryFile, ReviewHistoryRow,
+    ReviewPhase, ReviewQueueState, ReviewStateMap, ReviewStore, REVIEW_HISTORY_FILE_VERSION,
+    REVIEW_QUEUE_FILE_VERSION, REVIEW_STATE_FILE_VERSION,
+};
+use chrono::{TimeZone, Utc};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+use std::fs;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OWNER: &str = "OwnerOne";
+const REPO: &str = "RepoOne";
+const PR: u64 = 42;
+const SHA_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SHA_D: &str = "dddddddddddddddddddddddddddddddddddddddd";
+
+fn sample_repository() -> RepositoryId {
+    RepositoryId {
+        owner: OWNER.to_string(),
+        repo: REPO.to_string(),
+    }
+}
+
+fn target_with_sha(head_sha: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: sample_repository(),
+        pull_request: PR,
+        head_sha: head_sha.to_string(),
+        base_sha: SHA_B.to_string(),
+        base_ref: "main".to_string(),
+        merge_base: "cccccccccccccccccccccccccccccccccccccccc".to_string(),
+    }
+}
+
+fn sample_target() -> ReviewTarget {
+    target_with_sha(SHA_A)
+}
+
+fn valid_result_json(status: ExecutionStatus) -> String {
+    serde_json::to_string(&ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status,
+        review: None,
+    })
+    .unwrap()
+}
+
+fn history_row(run_id: &str, sha: &str, generation: u64) -> ReviewHistoryRow {
+    ReviewHistoryRow {
+        review_run_id: run_id.to_string(),
+        repository: sample_repository(),
+        pull_request: PR,
+        head_sha: sha.to_string(),
+        review_generation: generation,
+        completed_at: Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap(),
+        result_json: valid_result_json(ExecutionStatus::Success),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Part 1 — parse/serialize contracts (pure functions)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn review_queue_round_trips_strict() {
+    let target = sample_target();
+    let mut entries = std::collections::BTreeMap::new();
+    entries.insert(
+        review_queue_key(&target),
+        caduceus::state::review::ReviewQueueEntry {
+            target: target.clone(),
+            phase: ReviewPhase::Queued,
+            attempts: 0,
+            last_error: None,
+            last_run_id: None,
+            next_attempt_at: None,
+            queued_at: Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap(),
+            review_generation: 1,
+        },
+    );
+    let state = ReviewQueueState {
+        version: REVIEW_QUEUE_FILE_VERSION,
+        entries,
+    };
+    let text = serialize_review_queue_state(&state).unwrap();
+    let back = parse_review_queue_state(&text).unwrap();
+    assert_eq!(back, state);
+}
+
+#[test]
+fn review_queue_rejects_unknown_fields() {
+    // Rogue top-level field on a valid empty envelope.
+    let bad = r#"{"version":1,"entries":{},"rogue":"x"}"#;
+    let err = parse_review_queue_state(bad).expect_err("unknown top-level field rejected");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("StateCorrupt"), "got: {msg}");
+    assert!(msg.contains("rogue"), "got: {msg}");
+
+    // Rogue field inside an entry object (strict serde at every layer).
+    let target = sample_target();
+    let entry_json = serde_json::json!({
+        "target": {
+            "repository": {"owner": OWNER, "repo": REPO},
+            "pull_request": PR,
+            "head_sha": SHA_A,
+            "base_sha": SHA_B,
+            "base_ref": "main",
+            "merge_base": "cccccccccccccccccccccccccccccccccccccccc",
+        },
+        "phase": "queued",
+        "attempts": 0,
+        "last_error": null,
+        "last_run_id": null,
+        "next_attempt_at": null,
+        "queued_at": "2026-09-05T12:00:00Z",
+        "updated_at": "2026-09-05T12:00:00Z",
+        "review_generation": 1,
+    });
+    let bad_entry = format!(
+        r#"{{"version":1,"entries":{{"{key}":{entry_json},"rogue":"y"}}}}"#,
+        key = review_queue_key(&target),
+    );
+    let err = parse_review_queue_state(&bad_entry).expect_err("unknown field rejected");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("StateCorrupt"), "got: {msg}");
+}
+
+#[test]
+fn review_queue_rejects_wrong_version_both_directions() {
+    for version in [0u32, 2] {
+        let bad = format!(r#"{{"version":{version},"entries":{{}}}}"#);
+        let err = parse_review_queue_state(&bad).expect_err("wrong envelope version");
+        match err {
+            caduceus::error::CaduceusError::StoreVersionUnsupported { backend, found, .. } => {
+                assert_eq!(backend, "json");
+                assert_eq!(found, version as i64);
+            }
+            other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn review_queue_rejects_key_entry_mismatch() {
+    let target = sample_target();
+    let entry_json = serde_json::json!({
+        "target": {
+            "repository": {"owner": OWNER, "repo": REPO},
+            "pull_request": PR,
+            "head_sha": SHA_A,
+            "base_sha": SHA_B,
+            "base_ref": "main",
+            "merge_base": "cccccccccccccccccccccccccccccccccccccccc",
+        },
+        "phase": "queued",
+        "attempts": 0,
+        "last_error": null,
+        "last_run_id": null,
+        "next_attempt_at": null,
+        "queued_at": "2026-09-05T12:00:00Z",
+        "updated_at": "2026-09-05T12:00:00Z",
+        "review_generation": 1,
+    });
+    let bad = format!(r#"{{"version":1,"entries":{{"other/repo#1@{SHA_A}":{entry_json}}}}}"#);
+    let err = parse_review_queue_state(&bad).expect_err("map key mismatch");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("does not match entry"), "got: {msg}");
+    assert!(msg.contains(&review_queue_key(&target)), "got: {msg}");
+}
+
+#[test]
+fn review_state_map_round_trips_and_validates() {
+    let mut states = std::collections::BTreeMap::new();
+    let mut state = ReviewState::new(sample_repository(), PR, 7);
+    state.last_reviewed_head_sha = Some(SHA_A.to_string());
+    states.insert(review_state_key(&sample_repository(), PR), state);
+    let map = ReviewStateMap {
+        version: REVIEW_STATE_FILE_VERSION,
+        states,
+    };
+    let text = serialize_review_state_map(&map).unwrap();
+    let back = parse_review_state_map(&text).unwrap();
+    assert_eq!(back, map);
+    // The generation survives verbatim.
+    let stored = back
+        .states
+        .get(&review_state_key(&sample_repository(), PR))
+        .unwrap();
+    assert_eq!(stored.review_generation, 7);
+}
+
+#[test]
+fn review_state_map_rejects_generation_zero_entry() {
+    // Not applicable to the state map (generation 0 is legal before
+    // first admission there) — but the QUEUE rejects it; covered in
+    // review_queue generation tests. Here: state map key mismatch.
+    let mut states = std::collections::BTreeMap::new();
+    states.insert(
+        "wrong/repo#1".to_string(),
+        ReviewState::new(sample_repository(), PR, 1),
+    );
+    let map = ReviewStateMap {
+        version: REVIEW_STATE_FILE_VERSION,
+        states,
+    };
+    let text = serialize_review_state_map(&map).unwrap();
+    let err = parse_review_state_map(&text).expect_err("map key mismatch");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("does not match entry"), "got: {msg}");
+}
+
+#[test]
+fn review_history_round_trips_and_preserves_order() {
+    let file = ReviewHistoryFile {
+        version: REVIEW_HISTORY_FILE_VERSION,
+        rows: vec![
+            history_row("run-1", SHA_A, 1),
+            history_row("run-2", SHA_A, 2),
+        ],
+    };
+    let text = serialize_review_history(&file).unwrap();
+    let back = parse_review_history(&text).unwrap();
+    assert_eq!(back, file);
+    assert_eq!(back.rows.len(), 2);
+    assert_eq!(back.rows[0].review_run_id, "run-1");
+    assert_eq!(back.rows[1].review_run_id, "run-2");
+}
+
+#[test]
+fn review_history_rejects_non_json_result_blob() {
+    let mut row = history_row("run-bad", SHA_A, 1);
+    row.result_json = "not json".to_string();
+    let file = ReviewHistoryFile {
+        version: REVIEW_HISTORY_FILE_VERSION,
+        rows: vec![row],
+    };
+    let text = serialize_review_history(&file).unwrap();
+    let err = parse_review_history(&text).expect_err("non-JSON blob rejected");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("not valid JSON"), "got: {msg}");
+}
+
+#[test]
+fn review_history_accepts_older_schema_version_blob_as_opaque() {
+    // An old-version blob (schema_version 0 — not the current 1) is
+    // accepted as an opaque, read-only row: old versions are never
+    // back-migrated (DAR §4.3).
+    let mut row = history_row("run-old", SHA_A, 1);
+    row.result_json = r#"{"schema_version":0,"status":"success","review":null}"#.to_string();
+    let file = ReviewHistoryFile {
+        version: REVIEW_HISTORY_FILE_VERSION,
+        rows: vec![row],
+    };
+    let text = serialize_review_history(&file).unwrap();
+    parse_review_history(&text).expect("older blob is opaque");
+}
+
+// ---------------------------------------------------------------------------
+// Part 2 — JSON store ops
+// ---------------------------------------------------------------------------
+
+#[test]
+fn json_enqueue_assigns_generation_and_upserts_state() {
+    let dir = tempdir("rv-enq");
+    let store = ReviewStore::open(&dir).unwrap();
+    let outcome = store.enqueue_review(&sample_target()).unwrap();
+    assert!(matches!(outcome, ReviewEnqueueOutcome::Inserted));
+    let st = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    assert_eq!(st.review_generation, 1);
+    let q = store.review_queue_snapshot().unwrap();
+    assert_eq!(q.entries.len(), 1);
+
+    // Second, different SHA → generation 2 on state, second queue entry
+    // (AC4 monotonic).
+    let t2 = target_with_sha(SHA_D);
+    store.enqueue_review(&t2).unwrap();
+    let st2 = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    assert_eq!(st2.review_generation, 2);
+    assert_eq!(store.review_queue_snapshot().unwrap().entries.len(), 2);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_enqueue_same_target_twice_is_already_present() {
+    let dir = tempdir("rv-dup");
+    let store = ReviewStore::open(&dir).unwrap();
+    assert!(matches!(
+        store.enqueue_review(&sample_target()).unwrap(),
+        ReviewEnqueueOutcome::Inserted
+    ));
+    assert!(matches!(
+        store.enqueue_review(&sample_target()).unwrap(),
+        ReviewEnqueueOutcome::AlreadyPresent
+    ));
+    assert_eq!(store.review_queue_snapshot().unwrap().entries.len(), 1);
+    let st = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    assert_eq!(st.review_generation, 1, "generation NOT bumped on dup");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_acquire_claim_and_complete_lifecycle() {
+    let dir = tempdir("rv-lifecycle");
+    let store = ReviewStore::open(&dir).unwrap();
+    store.enqueue_review(&sample_target()).unwrap();
+
+    let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+    let claimed = store
+        .acquire_next_review("run-lc-1", 4242, now)
+        .unwrap()
+        .expect("claim the queued entry");
+    assert_eq!(claimed.entry.phase, ReviewPhase::InProgress);
+    assert_eq!(claimed.entry.last_run_id.as_deref(), Some("run-lc-1"));
+
+    // Claim file exists under review-claims/.
+    let claims_dir = store.claims_dir();
+    let claim_path = claims_dir.join(format!("{}.claim", claimed.claim.digest()));
+    assert!(claim_path.is_file(), "claim file must exist");
+
+    // The claims directory is the REVIEW one, not the issue queue's.
+    assert!(claims_dir.ends_with("review-claims"));
+
+    store.complete_review(claimed.claim).unwrap();
+    let q = store.review_queue_snapshot().unwrap();
+    let entry = q.entries.get(&review_queue_key(&sample_target())).unwrap();
+    assert_eq!(entry.phase, ReviewPhase::Done);
+    assert!(!claim_path.exists(), "claim file gone after completion");
+
+    // Acquire again → None (no eligible entry).
+    let again = store.acquire_next_review("run-lc-2", 4243, now).unwrap();
+    assert!(again.is_none());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_retry_or_fail_matches_issue_queue_semantics() {
+    let dir = tempdir("rv-retry");
+    let store = ReviewStore::open(&dir).unwrap();
+    store.enqueue_review(&sample_target()).unwrap();
+    // next_attempt_at is assigned from the real clock (mirroring the
+    // issue queue's retry_or_fail), so the claim instants derive from
+    // Utc::now() too.
+    let now = Utc::now();
+
+    let claimed = store
+        .acquire_next_review("run-r1", 4242, now)
+        .unwrap()
+        .unwrap();
+    let phase = store
+        .retry_or_fail_review(claimed.claim, "boom", 2)
+        .unwrap();
+    assert_eq!(phase, ReviewPhase::Queued);
+    let q = store.review_queue_snapshot().unwrap();
+    let entry = q.entries.get(&review_queue_key(&sample_target())).unwrap();
+    assert_eq!(entry.attempts, 1);
+    assert!(entry.next_attempt_at.is_some(), "backoff window set");
+
+    // Elapse the backoff, claim again, fail again → Failed.
+    let later = Utc::now() + chrono::Duration::seconds(301);
+    let claimed2 = store
+        .acquire_next_review("run-r2", 4242, later)
+        .unwrap()
+        .unwrap();
+    let phase2 = store
+        .retry_or_fail_review(claimed2.claim, "boom again", 2)
+        .unwrap();
+    assert_eq!(phase2, ReviewPhase::Failed);
+    let q2 = store.review_queue_snapshot().unwrap();
+    let entry2 = q2.entries.get(&review_queue_key(&sample_target())).unwrap();
+    assert_eq!(entry2.attempts, 2);
+    assert!(entry2.next_attempt_at.is_none());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_skip_review_records_reason() {
+    let dir = tempdir("rv-skip");
+    let store = ReviewStore::open(&dir).unwrap();
+    store.enqueue_review(&sample_target()).unwrap();
+    let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+    let claimed = store
+        .acquire_next_review("run-s1", 4242, now)
+        .unwrap()
+        .unwrap();
+    store.skip_review(claimed.claim, "not needed").unwrap();
+    let q = store.review_queue_snapshot().unwrap();
+    let entry = q.entries.get(&review_queue_key(&sample_target())).unwrap();
+    assert_eq!(entry.phase, ReviewPhase::Skipped);
+    assert_eq!(entry.last_error.as_deref(), Some("not needed"));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_claim_mismatch_rejected() {
+    let dir = tempdir("rv-mismatch");
+    let store = ReviewStore::open(&dir).unwrap();
+    store.enqueue_review(&sample_target()).unwrap();
+    let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+    let _claimed = store
+        .acquire_next_review("run-m1", 4242, now)
+        .unwrap()
+        .unwrap();
+    // A forged token with the wrong digest is rejected.
+    let forged = caduceus::state::review::ReviewClaimToken::for_test(
+        store.claims_dir(),
+        "deadbeef",
+        "run-m1",
+    );
+    let err = store.complete_review(forged).expect_err("forged token");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("mismatch"), "got: {msg}");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_generation_never_decreases_via_cas() {
+    let dir = tempdir("rv-cas");
+    let store = ReviewStore::open(&dir).unwrap();
+    store.enqueue_review(&sample_target()).unwrap();
+    let stored = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.review_generation, 1);
+
+    // Regression rejected.
+    let mut regressed = stored.clone();
+    regressed.review_generation = 0;
+    let err = store.save_review_state(&regressed).expect_err("CAS guard");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("regression"), "got: {msg}");
+
+    // Equal-or-higher accepted.
+    let mut advanced = stored.clone();
+    advanced.review_generation = 2;
+    store.save_review_state(&advanced).unwrap();
+    let now_stored = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    assert_eq!(now_stored.review_generation, 2);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// Part 3 — history ops + dedup + durability (JSON)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn json_history_appends_and_permits_same_sha_multiples() {
+    let dir = tempdir("rv-hist");
+    let store = ReviewStore::open(&dir).unwrap();
+    store
+        .append_history(history_row("run-h1", SHA_A, 1))
+        .unwrap();
+    store
+        .append_history(history_row("run-h2", SHA_A, 2))
+        .unwrap();
+    let rows = store
+        .history_for_head_sha(&sample_repository(), PR, SHA_A)
+        .unwrap();
+    assert_eq!(rows.len(), 2, "AC3: same-SHA multiplicity");
+    assert_eq!(rows[0].review_run_id, "run-h1");
+    assert_eq!(rows[1].review_run_id, "run-h2");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_history_rejects_duplicate_run_id() {
+    let dir = tempdir("rv-histdup");
+    let store = ReviewStore::open(&dir).unwrap();
+    store
+        .append_history(history_row("run-d1", SHA_A, 1))
+        .unwrap();
+    let err = store
+        .append_history(history_row("run-d1", SHA_A, 1))
+        .expect_err("duplicate run id");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("duplicate review_run_id"), "got: {msg}");
+    assert_eq!(
+        store
+            .history_for_repository(&sample_repository())
+            .unwrap()
+            .len(),
+        1
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_dedup_is_state_plus_active_queue_not_history() {
+    let dir = tempdir("rv-dedup");
+    let store = ReviewStore::open(&dir).unwrap();
+    let target = sample_target();
+
+    // Fresh target → false.
+    assert!(!store.is_active_or_reviewed(&target).unwrap());
+
+    // Enqueue → true (active queue).
+    store.enqueue_review(&target).unwrap();
+    assert!(store.is_active_or_reviewed(&target).unwrap());
+
+    // Complete + record the reviewed SHA → still true via state even
+    // though the queue entry is terminal (AC5).
+    let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+    let claimed = store
+        .acquire_next_review("run-dd1", 4242, now)
+        .unwrap()
+        .unwrap();
+    store.complete_review(claimed.claim).unwrap();
+    let mut state = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    state.last_reviewed_head_sha = Some(SHA_A.to_string());
+    state.last_verdict = Some(caduceus::review::Verdict::Pass);
+    store.save_review_state(&state).unwrap();
+    assert!(store.is_active_or_reviewed(&target).unwrap());
+
+    // A DIFFERENT sha on the same pr → false.
+    let t2 = target_with_sha(SHA_D);
+    assert!(!store.is_active_or_reviewed(&t2).unwrap());
+
+    // History rows never affect dedup: append one for the different
+    // SHA and confirm dedup still says false for it (dedup is NOT a
+    // history query).
+    store
+        .append_history(history_row("run-dd2", SHA_D, 1))
+        .unwrap();
+    assert!(!store.is_active_or_reviewed(&t2).unwrap());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_restart_durability_round_trip() {
+    let dir = tempdir("rv-durability");
+    {
+        let store = ReviewStore::open(&dir).unwrap();
+        store.enqueue_review(&sample_target()).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+        let claimed = store
+            .acquire_next_review("run-dur", 4242, now)
+            .unwrap()
+            .unwrap();
+        store.complete_review(claimed.claim).unwrap();
+        let mut state = store
+            .review_state(&sample_repository(), PR)
+            .unwrap()
+            .unwrap();
+        state.last_reviewed_head_sha = Some(SHA_A.to_string());
+        store.save_review_state(&state).unwrap();
+        store
+            .append_history(history_row("run-dur", SHA_A, 1))
+            .unwrap();
+    }
+    // Re-open (drop = "restart") → all three surfaces identical.
+    let store = ReviewStore::open(&dir).unwrap();
+    let q = store.review_queue_snapshot().unwrap();
+    assert_eq!(q.entries.len(), 1);
+    assert_eq!(
+        q.entries
+            .get(&review_queue_key(&sample_target()))
+            .unwrap()
+            .phase,
+        ReviewPhase::Done
+    );
+    let st = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    assert_eq!(st.last_reviewed_head_sha.as_deref(), Some(SHA_A));
+    let rows = store.history_for_repository(&sample_repository()).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].review_run_id, "run-dur");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_corrupted_files_rejected_safely() {
+    for (filename, probe) in [
+        ("review_queue.json", "review queue JSON parse"),
+        ("review_state.json", "review state JSON parse"),
+        ("review_history.json", "review history JSON parse"),
+    ] {
+        let dir = tempdir("rv-corrupt");
+        // Open once to create the layout, then corrupt the file.
+        {
+            let _store = ReviewStore::open(&dir).unwrap();
+        }
+        fs::write(dir.join(filename), "{{{not json").unwrap();
+        let err = ReviewStore::open(&dir).expect_err("corrupt file rejected");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("StateCorrupt"), "got: {msg}");
+        assert!(msg.contains(probe), "got: {msg}");
+        // The corrupt file is preserved for diagnosis, never deleted.
+        assert!(dir.join(filename).is_file(), "{filename} not deleted");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Part 4 — SQLite backend
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sqlite_store_round_trips_all_three_surfaces() {
+    let dir = tempdir("rv-sqlite");
+    {
+        let store = ReviewStore::open_sqlite(&dir).unwrap();
+        store.enqueue_review(&sample_target()).unwrap();
+        let t2 = target_with_sha(SHA_D);
+        store.enqueue_review(&t2).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+        let claimed = store
+            .acquire_next_review("run-sq", 4242, now)
+            .unwrap()
+            .unwrap();
+        store.complete_review(claimed.claim).unwrap();
+        let mut state = store
+            .review_state(&sample_repository(), PR)
+            .unwrap()
+            .unwrap();
+        state.last_reviewed_head_sha = Some(SHA_A.to_string());
+        state.sticky_comment_id = Some(99);
+        store.save_review_state(&state).unwrap();
+        store
+            .append_history(history_row("run-sq", SHA_A, 1))
+            .unwrap();
+        store
+            .append_history(history_row("run-sq2", SHA_A, 2))
+            .unwrap();
+    }
+    // Re-open → identical snapshot/state/history (AC1 + AC6).
+    let store = ReviewStore::open_sqlite(&dir).unwrap();
+    let q = store.review_queue_snapshot().unwrap();
+    assert_eq!(q.entries.len(), 2);
+    assert_eq!(
+        q.entries
+            .get(&review_queue_key(&sample_target()))
+            .unwrap()
+            .phase,
+        ReviewPhase::Done
+    );
+    let st = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    assert_eq!(st.last_reviewed_head_sha.as_deref(), Some(SHA_A));
+    assert_eq!(st.sticky_comment_id, Some(99));
+    assert_eq!(st.review_generation, 2, "second enqueue bumped to 2");
+    let rows = store
+        .history_for_head_sha(&sample_repository(), PR, SHA_A)
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn sqlite_dedup_generation_history_mirror_json_semantics() {
+    let dir = tempdir("rv-sq-mirror");
+    let store = ReviewStore::open_sqlite(&dir).unwrap();
+    let target = sample_target();
+
+    // Dedup mirror.
+    assert!(!store.is_active_or_reviewed(&target).unwrap());
+    store.enqueue_review(&target).unwrap();
+    assert!(store.is_active_or_reviewed(&target).unwrap());
+
+    // Generation mirror (AC4): CAS rejects regressions.
+    let stored = store
+        .review_state(&sample_repository(), PR)
+        .unwrap()
+        .unwrap();
+    let mut regressed = stored.clone();
+    regressed.review_generation = 0;
+    assert!(store.save_review_state(&regressed).is_err());
+
+    // History mirror (AC3): duplicate run id rejected; same-SHA
+    // multiplicity allowed.
+    store
+        .append_history(history_row("run-m1", SHA_A, stored.review_generation))
+        .unwrap();
+    assert!(store
+        .append_history(history_row("run-m1", SHA_A, stored.review_generation))
+        .is_err());
+    store
+        .append_history(history_row("run-m2", SHA_A, stored.review_generation))
+        .unwrap();
+    assert_eq!(
+        store
+            .history_for_head_sha(&sample_repository(), PR, SHA_A)
+            .unwrap()
+            .len(),
+        2
+    );
+
+    // Different SHA → false.
+    assert!(!store
+        .is_active_or_reviewed(&target_with_sha(SHA_D))
+        .unwrap());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn sqlite_claim_lifecycle_with_backoff() {
+    let dir = tempdir("rv-sq-claim");
+    let store = ReviewStore::open_sqlite(&dir).unwrap();
+    store.enqueue_review(&sample_target()).unwrap();
+    let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+    let claimed = store
+        .acquire_next_review("run-sc1", 4242, now)
+        .unwrap()
+        .unwrap();
+    let claim_path = store
+        .claims_dir()
+        .join(format!("{}.claim", claimed.claim.digest()));
+    assert!(claim_path.is_file());
+    let phase = store
+        .retry_or_fail_review(claimed.claim, "boom", 1)
+        .unwrap();
+    assert_eq!(phase, ReviewPhase::Failed);
+    assert!(!claim_path.exists(), "claim unlinked on terminal");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn sqlite_corrupt_row_rejected_on_load() {
+    let dir = tempdir("rv-sq-corrupt");
+    {
+        let _store = ReviewStore::open_sqlite(&dir).unwrap();
+    }
+    // Hand-write a bad enum label into review_state.publication_state.
+    let conn = rusqlite::Connection::open(dir.join("state.db")).unwrap();
+    conn.execute(
+        "INSERT INTO review_state (owner, repo, pull_request, review_generation, publication_state)
+         VALUES ('owner', 'repo', 1, 1, 'not_a_real_state')",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+    let err = ReviewStore::open_sqlite(&dir).expect_err("corrupt row rejected");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("StateCorrupt"), "got: {msg}");
+    assert!(msg.contains("publication_state"), "got: {msg}");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn sqlite_unknown_version_rejected_and_v7_migrates() {
+    let dir = tempdir("rv-sq-migrate");
+    // Build a real v7-era store: the current daemon minus the review
+    // tables — construct via the era DDL shape used by
+    // migration_framework_test (v7 = v6 tables + oci_runs, no review
+    // tables).
+    let db_path = dir.join("state.db");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER NOT NULL, migrated_at TEXT NOT NULL);
+             INSERT INTO schema_version (version, migrated_at) VALUES (7, '2026-01-01T00:00:00Z');
+             CREATE TABLE queue_entries (issue_key TEXT PRIMARY KEY, phase TEXT NOT NULL, ticket_type TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, next_attempt_at TEXT, finalization TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, generation INTEGER NOT NULL DEFAULT 1, blocked_source TEXT, blocked_recovery_hint TEXT);
+             CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE claims (claim_id TEXT PRIMARY KEY, issue_key TEXT NOT NULL, worker_pid INTEGER, token TEXT NOT NULL, claimed_at TEXT NOT NULL, expires_at TEXT NOT NULL);
+             CREATE TABLE checkpoints (run_id TEXT NOT NULL, stage TEXT NOT NULL, checkpoint_data TEXT, created_at TEXT NOT NULL, operation_id TEXT, remote_marker TEXT, PRIMARY KEY (run_id, stage));
+             CREATE TABLE circuit_state (scope TEXT NOT NULL, scope_id TEXT NOT NULL, state TEXT NOT NULL DEFAULT 'closed', consecutive_failures INTEGER NOT NULL DEFAULT 0, last_failure_at INTEGER, opened_at INTEGER, last_probe_at INTEGER, PRIMARY KEY (scope, scope_id));
+             CREATE TABLE leases (issue_key TEXT PRIMARY KEY, owner_id TEXT NOT NULL, fencing_token INTEGER NOT NULL, expires_at INTEGER NOT NULL, state TEXT NOT NULL CHECK(state IN ('held', 'released', 'expired')));
+             CREATE TABLE oci_runs (run_id TEXT PRIMARY KEY, container_id TEXT, state TEXT NOT NULL, engine TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, daemon_id TEXT NOT NULL, issue_id TEXT NOT NULL, worker_command_sha256 TEXT NOT NULL);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO queue_entries (issue_key, phase, ticket_type, attempts, queued_at, updated_at, generation)
+             VALUES ('owner/repo#1', 'queued', 'code', 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+    }
+
+    // ReviewStore::open_sqlite migrates v7 → v8 and opens cleanly.
+    {
+        let store = ReviewStore::open_sqlite(&dir).unwrap();
+        store.enqueue_review(&sample_target()).unwrap();
+    }
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let version: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(version, 8, "v7 migrated to v8");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM queue_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "issue row preserved through migration");
+        drop(conn);
+    }
+    // Re-open: the review data survived.
+    let store = ReviewStore::open_sqlite(&dir).unwrap();
+    assert_eq!(store.review_queue_snapshot().unwrap().entries.len(), 1);
+
+    // Future version → rejected.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO schema_version (version, migrated_at) VALUES (99, '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+    }
+    let err = ReviewStore::open_sqlite(&dir).expect_err("v99 rejected");
+    match err {
+        caduceus::error::CaduceusError::StoreVersionUnsupported { backend, found, .. } => {
+            assert_eq!(backend, "sqlite");
+            assert_eq!(found, 99);
+        }
+        other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
+    }
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// Part 5 — cross-backend: JSON side files never collide with issue queue
+// ---------------------------------------------------------------------------
+
+#[test]
+fn json_review_files_are_siblings_of_state_json() {
+    let dir = tempdir("rv-siblings");
+    {
+        let review = ReviewStore::open(&dir).unwrap();
+        let _issue = StateStore::open(&dir).unwrap();
+        // A mutation materialises the review sidecar files (an empty
+        // file is absent, same convention as state.json).
+        review.enqueue_review(&sample_target()).unwrap();
+    }
+    assert!(dir.join("review_queue.json").is_file());
+    assert!(dir.join("review_state.json").is_file());
+    assert!(dir.join("review.lock").is_file());
+    assert!(dir.join("review-claims").is_dir());
+    // The issue queue's own surfaces are untouched (its lock/claims
+    // materialise lazily, same convention).
+    assert!(dir.join("claims").is_dir());
+    // The review store's files do not confuse the issue store…
+    let issue = StateStore::open(&dir).unwrap();
+    assert_eq!(issue.snapshot().unwrap().entries.len(), 0);
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Implements #295 per the architect's plan (`.hermes/plans/caduceus-295-review-stores.md`), spec `docs/architecture/auto-review.md` §3-4.

## What

Three review-era stores under BOTH backends (JSON + SQLite):

- **Sibling review queue** — `ReviewQueueEntry` keyed by the canonical `owner/repo#pr@head_sha` form of a persisted `ReviewTarget` (including `merge_base`); `ReviewPhase` lifecycle mirrors the issue queue minus issue-only variants; claim lifecycle (`acquire_next_review` / `complete_review` / `retry_or_fail_review` / `skip_review`) mirrors the issue queue with `ReviewClaimToken` + `ReviewClaimFileBody` under `<state_dir>/review-claims/` — a separate directory so the issue-queue reaper (which parses every `claims/*.claim` as an issue-shaped `ClaimFileBody`) never sees review claims.
- **Per-`(repo, pr)` `ReviewState` store** — all DAR §3 fields; key = lowercase `owner/repo#pr`; SQLite composite PK stores the same lowercased components; `save_review_state` enforces the never-regress `review_generation` CAS guard (DAR §9.4); `enqueue_review` assigns `generation + 1` and writes the queue entry and state row inside ONE exclusive section (one `review.lock` flock / one `BEGIN IMMEDIATE`), so the two can never disagree on generation.
- **Append-only `review_history`** — identity = `review_run_id` (unique per completed run; duplicate append is an error, not a dedup); `(repo, pr, head_sha)` is NOT unique and multiple rows per tuple are permitted (AC3); the row carries the verbatim serialized `ReviewResult` JSON blob, version-tagged by its own `schema_version` — current-version rows are validated, older versions stay opaque and read-only (DAR §4.3). Indexes over `(owner, repo, pull_request)` / `(pull_request)` / `(…, head_sha)`; no unique constraint anywhere on the tuple.

## Atomic envelope activation (AC2)

One commit activates everything:

- SQLite: `SCHEMA_VERSION` 7→8; `review_queue_entries` / `review_state` / `review_history` tables + indexes in `SCHEMA_SQL`; `Migration { from: 7, to: 8, label: "review-era structures" }` in `SQLITE_MIGRATIONS` (structural no-op body, `m_v2_v3` precedent — no pre-v8 review data can exist). `assert_registry_wellformed` now sanctions the deliberate v6→v7 era break (v6 is reinitialise-only, so the 6→7 era carried no registry entry).
- JSON: `QUEUE_FILE_VERSION` 1→2; `parse_queue_state` upgrades a v1 document in place (strict serde unchanged — the issue-entry shape is identical; the file is rewritten at v2 on the next mutation). v0 and older stay rejected; newer hard-fails with NEWER guidance.

A pre-#295 binary (`SCHEMA_VERSION = 7` / `QUEUE_FILE_VERSION = 1`) hits the existing future-version gates on review-era state on both backends. After this change v8 == exactly the implemented schema (pinned by `v8_is_exactly_the_review_schema`).

## Same-SHA dedup (AC5)

`ReviewStore::is_active_or_reviewed` = `ReviewState.last_reviewed_head_sha == Some(sha)` OR an active (`Queued`/`InProgress`) queue entry exists for the same review key. History is never consulted; no uniqueness constraint anywhere.

## Out of scope / known follow-ups

- No tick wiring (#312), no finalizer FSM (#310), no CLI (#318), no review reaper (#312/#339), no `migrate_to_sqlite` changes.
- **Known follow-up (epic lane #312/#329):** `migrate-state --to-sqlite` does not carry the JSON review sidecar files across a backend switch (they are unread, not lost).
- Frozen pre-N / N-era-v8 compatibility fixtures: #327.

## Test evidence (all real runs on this host)

- `cargo fmt --check` — green
- `cargo clippy --locked --all-targets -- -D warnings` — green
- `env -u GITHUB_TOKEN cargo test --locked --all-targets` (hermetic skip list) — **2435 tests passed, 0 failed** (169 suites ok)
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — **188 passed**

New tests: `tests/state/review_store_test.rs` (38 — round-trips both backends, strict serde, wrong-version both directions, key-mismatch, corrupt file/row rejection, claim lifecycle + mismatch, retry/fail semantics, generation monotonicity + CAS, history multiplicity + duplicate-run-id rejection, dedup semantics, restart durability, v7→v8 migration with data preservation, v99 rejection) and `tests/state/review_activation_test.rs` (5 — v1 JSON parses as v2 in place, v7 SQLite migrates to v8, structural rejection pins, v8 == exact schema, registry step). Updated version pins: `migration_framework_test` (8/2, chain reaches current, v7 era in matrix), `queue_model_test` (v2 literals), `migration_test`, scenario-10 golden (7→8, precedent: #266 did the same for 6→7).

Note: `oci_provenance_test::architecture_abort_is_audited_at_the_architecture_stage` flakes intermittently under parallel test threads on this host — verified failing identically on unmodified `main` (stashed run); unrelated to this change.

Closes #295
