### PR TITLE
feat(review): add result validator and verdict consistency (closes #305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Added
 
+- **ReviewResult verdict-consistency validator and review result
+  ingress.** The review worker's result document is now fully
+  validated: `review` present iff `status` is `success`; `verdict`
+  must be `fail` iff at least one finding is `blocking`; finding
+  paths must be repo-relative (no leading `/`, no `..`, no control
+  characters) and 1-based lines require a path. Every rejection —
+  including unknown `schema_version` values — is an execution
+  failure classified `FailureClass::Worker` and burns normal retry
+  budget (DAR §8). Closes #305.
 - **Review worker prompt and OCI review sandbox profile.** The review
   worker prompt is sectioned and trust-separated in a fixed order
   (daemon policy and output schema trusted first; PR metadata,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,6 +448,10 @@ name = "review_domain_test"
 path = "tests/review/review_domain_test.rs"
 
 [[test]]
+name = "review_result_validation_test"
+path = "tests/review/review_result_validation_test.rs"
+
+[[test]]
 name = "review_store_test"
 path = "tests/state/review_store_test.rs"
 

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -23,9 +23,7 @@
 //! no helper in this module may format a `..`/`...` range string, and
 //! `base_sha` is context, never a diff endpoint.
 //!
-//! Out of scope here (later issues): persistence (#295), migrations
-//! (#293), the full result validator — verdict/severity consistency,
-//! status/review presence, line/path semantics (#305) — executor
+//! Out of scope here (later issues): migrations (#293), executor
 //! targets (#346), CLI (#318).
 
 use chrono::{DateTime, Utc};
@@ -337,9 +335,9 @@ fn optional_string(
 /// Parse and validate a `ReviewResult` document (the v1 parser).
 ///
 /// Strict at every layer: unknown fields rejected by serde, schema
-/// version must equal [`REVIEW_SCHEMA_VERSION`], and all worker-facing
-/// caps below are enforced. Verdict/severity consistency and the
-/// status↔review presence rule are #305's validator, not this parse.
+/// version must equal [`REVIEW_SCHEMA_VERSION`], and the full
+/// validation — status↔review presence, verdict consistency, caps,
+/// path/line semantics — is enforced here (DAR §8, §10.3).
 pub fn parse_review_result(json: &str) -> CaduceusResult<ReviewResult> {
     let result: ReviewResult = serde_json::from_str(json).map_err(|err| {
         CaduceusError::Config(format!("review result: malformed document: {err}"))
@@ -361,36 +359,107 @@ pub fn review_schema_version_supported(v: u32) -> bool {
     v == REVIEW_SCHEMA_VERSION
 }
 
-/// Cap validation for a [`ReviewResult`] (exposed so #305's full
-/// validator can compose it).
+/// Full validation for a [`ReviewResult`] (DAR §8, §10.3): the
+/// status↔review presence rule, verdict consistency against the
+/// blocking-finding count, field caps, and path/line semantics.
+/// Called by [`parse_review_result`] and by the history loader
+/// (`state::review`, #295); the worker ingress
+/// (`worker::parse_review_result_file`, #305) composes it for the
+/// execution-failure classification.
 pub fn validate_review_result(result: &ReviewResult) -> CaduceusResult<()> {
-    if let Some(review) = &result.review {
-        required_string(
-            "review result",
-            "summary",
-            &review.summary,
-            MAX_REVIEW_SUMMARY_BYTES,
+    // Presence rule (DAR §3): review is present iff status Success.
+    match (result.status, &result.review) {
+        (ExecutionStatus::Success, None) => {
+            return Err(CaduceusError::Config(
+                "review result: review must be present when status is success".to_string(),
+            ));
+        }
+        (ExecutionStatus::Failure, Some(_)) => {
+            return Err(CaduceusError::Config(
+                "review result: review must be absent when status is failure".to_string(),
+            ));
+        }
+        _ => {}
+    }
+    let Some(review) = &result.review else {
+        return Ok(());
+    };
+    required_string(
+        "review result",
+        "summary",
+        &review.summary,
+        MAX_REVIEW_SUMMARY_BYTES,
+    )?;
+    if review.findings.len() > MAX_FINDINGS {
+        return Err(CaduceusError::Config(format!(
+            "review result: findings exceed limit of {MAX_FINDINGS} entries (got {})",
+            review.findings.len()
+        )));
+    }
+    for (idx, finding) in review.findings.iter().enumerate() {
+        let scope = format!("review result: finding[{idx}]");
+        required_string(&scope, "title", &finding.title, MAX_FINDING_TITLE_BYTES)?;
+        required_string(&scope, "body", &finding.body, MAX_FINDING_BODY_BYTES)?;
+        optional_string(&scope, "path", &finding.path, MAX_FINDING_PATH_BYTES)?;
+        optional_string(
+            &scope,
+            "remediation",
+            &finding.remediation,
+            MAX_FINDING_REMEDIATION_BYTES,
         )?;
-        if review.findings.len() > MAX_FINDINGS {
+        if let Some(path) = &finding.path {
+            if let Some(reason) = path_rejection_reason(path) {
+                return Err(CaduceusError::Config(format!("{scope}: {reason}")));
+            }
+        }
+        if finding.line == Some(0) {
             return Err(CaduceusError::Config(format!(
-                "review result: findings exceed limit of {MAX_FINDINGS} entries (got {})",
-                review.findings.len()
+                "{scope}: line must be 1-based (got 0)"
             )));
         }
-        for (idx, finding) in review.findings.iter().enumerate() {
-            let scope = format!("review result: finding[{idx}]");
-            required_string(&scope, "title", &finding.title, MAX_FINDING_TITLE_BYTES)?;
-            required_string(&scope, "body", &finding.body, MAX_FINDING_BODY_BYTES)?;
-            optional_string(&scope, "path", &finding.path, MAX_FINDING_PATH_BYTES)?;
-            optional_string(
-                &scope,
-                "remediation",
-                &finding.remediation,
-                MAX_FINDING_REMEDIATION_BYTES,
-            )?;
+        if finding.line.is_some() && finding.path.is_none() {
+            return Err(CaduceusError::Config(format!(
+                "{scope}: line requires a path"
+            )));
         }
     }
+    // Verdict consistency (DAR §8), checked after per-finding
+    // validity so the first reported failure is the most specific.
+    let blocking = review
+        .findings
+        .iter()
+        .filter(|f| f.severity == Severity::Blocking)
+        .count();
+    match (review.verdict, blocking) {
+        (Verdict::Fail, 0) => {
+            return Err(CaduceusError::Config(
+                "review result: verdict fail requires at least one blocking finding".to_string(),
+            ));
+        }
+        (Verdict::Pass, n) if n > 0 => {
+            return Err(CaduceusError::Config(format!(
+                "review result: verdict pass must not carry blocking findings ({n} blocking)"
+            )));
+        }
+        _ => {}
+    }
     Ok(())
+}
+
+/// Why a `Finding.path` is malformed (DAR §8): repo-relative means no
+/// leading `/`, no `..` component, and no control characters (NUL,
+/// newlines, tabs — `char::is_control` covers them all).
+fn path_rejection_reason(path: &str) -> Option<&'static str> {
+    if path.starts_with('/') {
+        return Some("path must be repo-relative (no leading '/')");
+    }
+    if path.split('/').any(|component| component == "..") {
+        return Some("path must not contain '..' components");
+    }
+    if path.chars().any(|c| c.is_control()) {
+        return Some("path contains control characters");
+    }
+    None
 }
 
 /// Cap validation for a [`ReviewTarget`] (the store calls this on

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -17,10 +17,11 @@ pub mod worker_contract;
 // so callers that reach for `WorkerResult`, `parse_result_file`,
 // `sanitized_env`, etc. resolve the same way.
 pub use crate::worker::worker_contract::{
-    parse_result_file, sanitized_env, spawn, truncate_pull_request_title, validate_worker_result,
-    SanitizedEnvInputs, WorkerResult, WorkerStatus, DEFAULT_ALLOWLIST_EXACT,
-    DEFAULT_ALLOWLIST_PREFIXES, MAX_ARTIFACTS, MAX_ARTIFACT_KEY_LEN, MAX_PULL_REQUEST_TITLE_CHARS,
-    MAX_RESULT_FILE_BYTES, MAX_SUMMARY_BYTES,
+    parse_result_file, parse_review_result_file, sanitized_env, spawn, truncate_pull_request_title,
+    validate_worker_result, SanitizedEnvInputs, WorkerResult, WorkerStatus,
+    DEFAULT_ALLOWLIST_EXACT, DEFAULT_ALLOWLIST_PREFIXES, MAX_ARTIFACTS, MAX_ARTIFACT_KEY_LEN,
+    MAX_PULL_REQUEST_TITLE_CHARS, MAX_RESULT_FILE_BYTES, MAX_REVIEW_RESULT_FILE_BYTES,
+    MAX_SUMMARY_BYTES,
 };
 
 // Test seam: re-export the body-truncation helper so integration

--- a/src/worker/worker_contract.rs
+++ b/src/worker/worker_contract.rs
@@ -61,7 +61,11 @@
 //! no fallback — the variable is hard-required). The daemon then
 //! [`parse_result_file`]s that file — opening it with
 //! `O_NOFOLLOW`, verifying the descriptor is a regular file, and
-//! reading with a 1 MiB cap before allocating the full document.
+//! reading with a 1 MiB cap before allocating the full document. The
+//! PR review path reads the same file name through
+//! [`parse_review_result_file`], which enforces the review contract
+//! (DAR §8/§10.3) and classifies every rejection as a
+//! worker-attributable execution failure.
 //!
 //! Every string field is validated:
 //!
@@ -125,6 +129,14 @@ pub const WORKER_RESULT_FILE: &str = "worker-result.json";
 
 /// Hard cap on the worker-result file size.
 pub const MAX_RESULT_FILE_BYTES: u64 = 1 << 20; // 1 MiB
+
+/// Hard cap on the review worker-result file size. Sized above the
+/// ~2.9 MiB sum of the decoded per-field caps (100 findings ×
+/// (title 256 + body 16 KiB + path 4096 + remediation 8 KiB) + 64
+/// KiB summary) so every caps-valid ordinary document fits the read;
+/// pathological escape-heavy serialization beyond this is rejected
+/// at the read as an execution failure (DAR §10.3).
+pub const MAX_REVIEW_RESULT_FILE_BYTES: u64 = 4 << 20; // 4 MiB
 
 /// Maximum size of the `summary` field.
 pub const MAX_SUMMARY_BYTES: usize = 64 * 1024;
@@ -585,6 +597,51 @@ pub fn parse_result_file(path: &Path, issue: &IssueKey) -> CaduceusResult<Worker
         stderr: format!("{}: {err}", path.display()),
     })?;
     Ok(result)
+}
+
+/// Parse + validate a review run's `worker-result.json` at *path*
+/// (the #305 review ingress, DAR §6.2/§8/§10.3).
+///
+/// Same read-side invariants as [`parse_result_file`]: `O_NOFOLLOW`
+/// open, regular-file check, size cap (`MAX_REVIEW_RESULT_FILE_BYTES`)
+/// before allocation. The document is then parsed and fully validated
+/// by [`crate::review::parse_review_result`] (strict serde,
+/// `schema_version`, presence, verdict consistency, caps, path/line
+/// semantics).
+///
+/// Error surface — every rejection is an execution failure
+/// (`FailureClass::Worker`, DAR §8):
+/// - read failures (missing, symlink, oversized, not regular) wrap
+///   as `Worker { context: "read" }`;
+/// - a non-UTF-8 document wraps as `Worker { context: "parse" }`;
+/// - malformed JSON, cap violations, and verdict/presence/path/line
+///   rejections wrap as `Worker { context: "validate" }` (the stderr
+///   carries the self-describing domain message);
+/// - an unknown `schema_version` propagates as the typed
+///   [`CaduceusError::ReviewSchemaVersion`] so callers can match it.
+///
+/// A `status: "failure"` document with no `review` is a VALID parse
+/// result — the run did not execute; the retry decision belongs to
+/// the tick (#312). A `verdict: "fail"` review is a SUCCESSFUL
+/// execution and is never encoded as `status: "failure"` (DAR §8).
+pub fn parse_review_result_file(path: &Path) -> CaduceusResult<crate::review::ReviewResult> {
+    let bytes = read_capped_file(path, MAX_REVIEW_RESULT_FILE_BYTES).map_err(|err| {
+        CaduceusError::Worker {
+            context: "read",
+            stderr: format!("{}: {err}", path.display()),
+        }
+    })?;
+    let text = std::str::from_utf8(&bytes).map_err(|err| CaduceusError::Worker {
+        context: "parse",
+        stderr: format!("{}: {err}", path.display()),
+    })?;
+    crate::review::parse_review_result(text).map_err(|err| match err {
+        CaduceusError::ReviewSchemaVersion { .. } => err,
+        other => CaduceusError::Worker {
+            context: "validate",
+            stderr: format!("{}: {other}", path.display()),
+        },
+    })
 }
 
 /// Pure validator: takes an already-parsed [`WorkerResult`] and

--- a/tests/review/review_result_validation_test.rs
+++ b/tests/review/review_result_validation_test.rs
@@ -1,0 +1,267 @@
+//! ReviewResult validation tests (issue #305, DAR §8, §10.3, §15).
+//!
+//! Acceptance coverage (AC numbers are #305's, verbatim):
+//!
+//! - AC1 — PASS + zero blocking accepted.
+//! - AC2 — FAIL + blocking findings accepted.
+//! - AC3 — FAIL + zero blocking rejected as execution failure.
+//! - AC4 — PASS + blocking findings rejected as execution failure.
+//! - AC5 — unknown schema_version rejected as execution failure.
+//! - AC6 — malformed severity/path/line rejected; field caps
+//!   enforced (per-field caps are pinned in review_domain_test;
+//!   this file pins the single-finding comment-budget invariant
+//!   and the malformed-field matrix).
+//!
+//! Plus the status↔review presence rule (DAR §3 "present iff
+//! status == Success") and, in the ingress section, Worker
+//! classification of every rejection (DAR §8).
+
+use caduceus::review::{
+    parse_review_result, validate_review_result, ExecutionStatus, Finding, Review, ReviewResult,
+    Severity, Verdict, MAX_FINDING_BODY_BYTES, MAX_FINDING_PATH_BYTES,
+    MAX_FINDING_REMEDIATION_BYTES, MAX_FINDING_TITLE_BYTES, REVIEW_SCHEMA_VERSION,
+};
+use serde_json::json;
+
+// -----------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------
+
+fn finding(severity: Severity) -> Finding {
+    Finding {
+        severity,
+        title: "title".to_string(),
+        body: "body".to_string(),
+        path: Some("src/lib.rs".to_string()),
+        line: Some(7),
+        remediation: Some("fix it".to_string()),
+    }
+}
+
+fn review(verdict: Verdict, findings: Vec<Finding>) -> Review {
+    Review {
+        verdict,
+        summary: "summary".to_string(),
+        findings,
+    }
+}
+
+fn success_result(review: Option<Review>) -> ReviewResult {
+    ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status: ExecutionStatus::Success,
+        review,
+    }
+}
+
+fn doc(result: &ReviewResult) -> String {
+    serde_json::to_string(result).unwrap()
+}
+
+// -----------------------------------------------------------------------
+// AC1 / AC2 — consistent combinations accepted
+// -----------------------------------------------------------------------
+
+#[test]
+fn ac1_pass_with_zero_blocking_accepted() {
+    let result = success_result(Some(review(
+        Verdict::Pass,
+        vec![finding(Severity::Warning), finding(Severity::Suggestion)],
+    )));
+    parse_review_result(&doc(&result)).expect("PASS + zero blocking accepted");
+    validate_review_result(&result).expect("validator agrees");
+}
+
+#[test]
+fn ac1_pass_with_zero_findings_accepted() {
+    // A clean review: PASS with no findings at all.
+    let result = success_result(Some(review(Verdict::Pass, vec![])));
+    parse_review_result(&doc(&result)).expect("PASS + no findings accepted");
+}
+
+#[test]
+fn ac2_fail_with_blocking_accepted() {
+    let result = success_result(Some(review(
+        Verdict::Fail,
+        vec![finding(Severity::Blocking), finding(Severity::Warning)],
+    )));
+    parse_review_result(&doc(&result)).expect("FAIL + blocking accepted");
+}
+
+// -----------------------------------------------------------------------
+// AC3 / AC4 — inconsistent combinations rejected
+// -----------------------------------------------------------------------
+
+#[test]
+fn ac3_fail_with_zero_blocking_rejected() {
+    let with_warnings = success_result(Some(review(
+        Verdict::Fail,
+        vec![finding(Severity::Warning), finding(Severity::Suggestion)],
+    )));
+    let err = parse_review_result(&doc(&with_warnings)).unwrap_err();
+    assert!(err.to_string().contains("blocking"), "got: {err}");
+
+    let no_findings = success_result(Some(review(Verdict::Fail, vec![])));
+    assert!(parse_review_result(&doc(&no_findings)).is_err());
+}
+
+#[test]
+fn ac4_pass_with_blocking_rejected() {
+    let result = success_result(Some(review(
+        Verdict::Pass,
+        vec![finding(Severity::Suggestion), finding(Severity::Blocking)],
+    )));
+    let err = parse_review_result(&doc(&result)).unwrap_err();
+    assert!(err.to_string().contains("blocking"), "got: {err}");
+}
+
+// -----------------------------------------------------------------------
+// AC5 — schema_version (typed variant, existing behavior pinned)
+// -----------------------------------------------------------------------
+
+#[test]
+fn ac5_unknown_schema_version_rejected() {
+    for bad in [0u32, 2, 999] {
+        let raw = json!({
+            "schema_version": bad,
+            "status": "success",
+            "review": null
+        });
+        // The version check fires BEFORE the presence rule, so the
+        // typed variant survives (order pinned by the implementation).
+        let err = parse_review_result(&raw.to_string()).unwrap_err();
+        assert!(
+            matches!(err, caduceus::CaduceusError::ReviewSchemaVersion { found, supported }
+                     if found == bad && supported == REVIEW_SCHEMA_VERSION),
+            "v{bad}: {err:?}"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------
+// Presence rule (DAR §3: review present iff status == Success)
+// -----------------------------------------------------------------------
+
+#[test]
+fn success_without_review_rejected() {
+    let result = success_result(None);
+    let err = validate_review_result(&result).unwrap_err();
+    assert!(err.to_string().contains("must be present"), "got: {err}");
+}
+
+#[test]
+fn failure_with_review_rejected() {
+    let result = ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status: ExecutionStatus::Failure,
+        review: Some(review(Verdict::Pass, vec![])),
+    };
+    let err = validate_review_result(&result).unwrap_err();
+    assert!(err.to_string().contains("must be absent"), "got: {err}");
+}
+
+#[test]
+fn failure_without_review_accepted() {
+    // A non-executing run is a VALID document; retry is the tick's
+    // decision (#312), never the validator's.
+    let result = ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status: ExecutionStatus::Failure,
+        review: None,
+    };
+    parse_review_result(&doc(&result)).expect("failure status is valid");
+}
+
+// -----------------------------------------------------------------------
+// AC6 — malformed severity / path / line
+// -----------------------------------------------------------------------
+
+#[test]
+fn malformed_severity_rejected_at_parse() {
+    let raw = json!({
+        "schema_version": 1,
+        "status": "success",
+        "review": {
+            "verdict": "pass",
+            "summary": "s",
+            "findings": [
+                {"severity": "critical", "title": "t", "body": "b"}
+            ]
+        }
+    });
+    assert!(parse_review_result(&raw.to_string()).is_err());
+}
+
+#[test]
+fn malformed_line_zero_rejected() {
+    let mut f = finding(Severity::Warning);
+    f.line = Some(0);
+    let result = success_result(Some(review(Verdict::Pass, vec![f])));
+    let err = parse_review_result(&doc(&result)).unwrap_err();
+    assert!(err.to_string().contains("1-based"), "got: {err}");
+}
+
+#[test]
+fn malformed_line_without_path_rejected() {
+    let mut f = finding(Severity::Warning);
+    f.path = None;
+    // line still Some(7) — a line number with no file is malformed.
+    let result = success_result(Some(review(Verdict::Pass, vec![f])));
+    let err = parse_review_result(&doc(&result)).unwrap_err();
+    assert!(
+        err.to_string().contains("line requires a path"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn path_without_line_accepted() {
+    // File-level findings are legitimate.
+    let mut f = finding(Severity::Warning);
+    f.line = None;
+    let result = success_result(Some(review(Verdict::Pass, vec![f])));
+    parse_review_result(&doc(&result)).expect("path without line accepted");
+}
+
+#[test]
+fn malformed_absolute_path_rejected() {
+    let mut f = finding(Severity::Warning);
+    f.path = Some("/etc/passwd".to_string());
+    let result = success_result(Some(review(Verdict::Pass, vec![f])));
+    let err = parse_review_result(&doc(&result)).unwrap_err();
+    assert!(err.to_string().contains("repo-relative"), "got: {err}");
+}
+
+#[test]
+fn malformed_parent_component_rejected() {
+    let mut f = finding(Severity::Warning);
+    f.path = Some("src/../../etc/passwd".to_string());
+    let result = success_result(Some(review(Verdict::Pass, vec![f])));
+    let err = parse_review_result(&doc(&result)).unwrap_err();
+    assert!(err.to_string().contains("'..'"), "got: {err}");
+}
+
+#[test]
+fn malformed_control_char_path_rejected() {
+    let mut f = finding(Severity::Warning);
+    f.path = Some("src/lib.rs\n".to_string());
+    let result = success_result(Some(review(Verdict::Pass, vec![f])));
+    let err = parse_review_result(&doc(&result)).unwrap_err();
+    assert!(err.to_string().contains("control"), "got: {err}");
+}
+
+// -----------------------------------------------------------------------
+// AC6 — caps: the DAR §10.3 invariant, made executable
+// -----------------------------------------------------------------------
+
+#[test]
+fn single_finding_cannot_exceed_comment_budget_alone() {
+    // DAR §10.3 / §9.2: no single adversarial finding can exceed the
+    // 64 KiB (65,536-byte) sticky-comment budget by itself. The worst
+    // fully-loaded finding is title + body + path + remediation.
+    let worst = MAX_FINDING_TITLE_BYTES
+        + MAX_FINDING_BODY_BYTES
+        + MAX_FINDING_PATH_BYTES
+        + MAX_FINDING_REMEDIATION_BYTES;
+    assert!(worst < 64 * 1024, "DAR §10.3 invariant broken: {worst}");
+}

--- a/tests/review/review_result_validation_test.rs
+++ b/tests/review/review_result_validation_test.rs
@@ -21,6 +21,7 @@ use caduceus::review::{
     Severity, Verdict, MAX_FINDING_BODY_BYTES, MAX_FINDING_PATH_BYTES,
     MAX_FINDING_REMEDIATION_BYTES, MAX_FINDING_TITLE_BYTES, REVIEW_SCHEMA_VERSION,
 };
+use caduceus::worker::{parse_review_result_file, MAX_REVIEW_RESULT_FILE_BYTES};
 use serde_json::json;
 
 // -----------------------------------------------------------------------
@@ -264,4 +265,178 @@ fn single_finding_cannot_exceed_comment_budget_alone() {
         + MAX_FINDING_PATH_BYTES
         + MAX_FINDING_REMEDIATION_BYTES;
     assert!(worst < 64 * 1024, "DAR §10.3 invariant broken: {worst}");
+}
+
+// -----------------------------------------------------------------------
+// File ingress (worker_contract::parse_review_result_file) + Worker
+// classification of every rejection (DAR §8)
+// -----------------------------------------------------------------------
+
+use caduceus::orchestration::{classify_error, FailureClass};
+use caduceus::CaduceusError;
+use std::fs;
+use std::path::Path;
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+
+#[test]
+fn ingress_accepts_consistent_pass_document() {
+    let dir = tempdir("rv-ingress-ok");
+    let path = dir.join("worker-result.json");
+    fs::write(
+        &path,
+        doc(&success_result(Some(review(
+            Verdict::Pass,
+            vec![finding(Severity::Warning)],
+        )))),
+    )
+    .unwrap();
+    let result = parse_review_result_file(&path).expect("consistent document accepted");
+    assert_eq!(result.status, ExecutionStatus::Success);
+    assert_eq!(result.review.as_ref().unwrap().verdict, Verdict::Pass);
+}
+
+#[test]
+fn ingress_accepts_failure_status_document() {
+    let dir = tempdir("rv-ingress-failure");
+    let path = dir.join("worker-result.json");
+    fs::write(
+        &path,
+        r#"{"schema_version":1,"status":"failure","review":null}"#,
+    )
+    .unwrap();
+    let result = parse_review_result_file(&path).expect("failure status is a valid document");
+    assert_eq!(result.status, ExecutionStatus::Failure);
+    assert!(result.review.is_none());
+}
+
+#[test]
+fn ingress_missing_file_is_worker_read_error() {
+    let err = parse_review_result_file(Path::new("/nonexistent/worker-result.json"))
+        .expect_err("missing file rejected");
+    assert!(
+        matches!(
+            err,
+            CaduceusError::Worker {
+                context: "read",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+    assert_eq!(classify_error(&err), FailureClass::Worker);
+}
+
+#[test]
+fn ingress_rejects_symlinked_result_file() {
+    let dir = tempdir("rv-ingress-symlink");
+    let real = dir.join("worker-result.json");
+    fs::write(
+        &real,
+        doc(&success_result(Some(review(Verdict::Pass, vec![])))),
+    )
+    .unwrap();
+    let link = dir.join("link.json");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let err = parse_review_result_file(&link).expect_err("symlink rejected (O_NOFOLLOW)");
+    assert!(
+        matches!(
+            err,
+            CaduceusError::Worker {
+                context: "read",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn ingress_rejects_oversized_result_file() {
+    let dir = tempdir("rv-ingress-oversize");
+    let path = dir.join("worker-result.json");
+    let mut blob = String::new();
+    // Valid JSON shape, but padded past the file cap via the summary.
+    blob.push_str(
+        r#"{"schema_version":1,"status":"success","review":{"verdict":"pass","summary":""#,
+    );
+    blob.push_str(&"x".repeat(MAX_REVIEW_RESULT_FILE_BYTES as usize));
+    blob.push_str(r#"","findings":[]}}"#);
+    fs::write(&path, blob).unwrap();
+    let err = parse_review_result_file(&path).expect_err("oversized file rejected");
+    assert!(
+        matches!(
+            err,
+            CaduceusError::Worker {
+                context: "read",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+    assert!(format!("{err:?}").contains("exceeds cap"), "got: {err:?}");
+}
+
+#[test]
+fn ingress_schema_version_mismatch_is_typed_and_worker_class() {
+    let dir = tempdir("rv-ingress-version");
+    let path = dir.join("worker-result.json");
+    fs::write(
+        &path,
+        r#"{"schema_version":2,"status":"success","review":null}"#,
+    )
+    .unwrap();
+    let err = parse_review_result_file(&path).expect_err("unknown version rejected");
+    assert!(
+        matches!(
+            err,
+            CaduceusError::ReviewSchemaVersion {
+                found: 2,
+                supported: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Worker);
+    assert!(class.counts_against_retry_budget());
+}
+
+#[test]
+fn ingress_verdict_rejection_is_worker_validate_and_burns_budget() {
+    let dir = tempdir("rv-ingress-verdict");
+    let path = dir.join("worker-result.json");
+    fs::write(
+        &path,
+        doc(&success_result(Some(review(Verdict::Fail, vec![])))),
+    )
+    .unwrap();
+    let err = parse_review_result_file(&path).expect_err("FAIL + zero blocking rejected");
+    assert!(
+        matches!(
+            err,
+            CaduceusError::Worker {
+                context: "validate",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+    assert!(format!("{err:?}").contains("blocking"), "got: {err:?}");
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Worker);
+    assert!(class.counts_against_retry_budget());
+}
+
+#[test]
+fn ingress_malformed_json_is_worker_error() {
+    let dir = tempdir("rv-ingress-malformed");
+    let path = dir.join("worker-result.json");
+    fs::write(&path, "not json").unwrap();
+    let err = parse_review_result_file(&path).expect_err("malformed document rejected");
+    assert!(matches!(err, CaduceusError::Worker { .. }), "got: {err:?}");
+    assert_eq!(classify_error(&err), FailureClass::Worker);
 }

--- a/tests/state/review_store_test.rs
+++ b/tests/state/review_store_test.rs
@@ -15,7 +15,8 @@
 //!   rejected safely on both backends.
 
 use caduceus::review::{
-    ExecutionStatus, RepositoryId, ReviewResult, ReviewState, ReviewTarget, REVIEW_SCHEMA_VERSION,
+    ExecutionStatus, RepositoryId, Review, ReviewResult, ReviewState, ReviewTarget, Verdict,
+    REVIEW_SCHEMA_VERSION,
 };
 use caduceus::state::queue::StateStore;
 use caduceus::state::review::{
@@ -69,7 +70,14 @@ fn valid_result_json(status: ExecutionStatus) -> String {
     serde_json::to_string(&ReviewResult {
         schema_version: REVIEW_SCHEMA_VERSION,
         status,
-        review: None,
+        review: match status {
+            ExecutionStatus::Success => Some(Review {
+                verdict: Verdict::Pass,
+                summary: "ok".to_string(),
+                findings: vec![],
+            }),
+            ExecutionStatus::Failure => None,
+        },
     })
     .unwrap()
 }
@@ -283,6 +291,36 @@ fn review_history_accepts_older_schema_version_blob_as_opaque() {
     };
     let text = serialize_review_history(&file).unwrap();
     parse_review_history(&text).expect("older blob is opaque");
+}
+
+#[test]
+fn review_history_rejects_semantically_invalid_current_blob() {
+    // A current-version blob that fails the #305 rules (FAIL with
+    // zero blocking findings) must fail the history load — the store
+    // composes the same domain validator as the ingress.
+    let mut row = history_row("run-bad-verdict", SHA_A, 1);
+    row.result_json = r#"{"schema_version":1,"status":"success","review":{"verdict":"fail","summary":"s","findings":[]}}"#.to_string();
+    let file = ReviewHistoryFile {
+        version: REVIEW_HISTORY_FILE_VERSION,
+        rows: vec![row],
+    };
+    let text = serialize_review_history(&file).unwrap();
+    let err = parse_review_history(&text).expect_err("inconsistent blob rejected");
+    assert!(format!("{err:?}").contains("blocking"), "got: {err:?}");
+
+    // Presence violation, same treatment.
+    let mut row = history_row("run-no-review", SHA_A, 1);
+    row.result_json = r#"{"schema_version":1,"status":"success","review":null}"#.to_string();
+    let file = ReviewHistoryFile {
+        version: REVIEW_HISTORY_FILE_VERSION,
+        rows: vec![row],
+    };
+    let text = serialize_review_history(&file).unwrap();
+    let err = parse_review_history(&text).expect_err("presence violation rejected");
+    assert!(
+        format!("{err:?}").contains("must be present"),
+        "got: {err:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Implements #305 per the architect's plan (`.hermes/plans/caduceus-305-review-result-parser.md`, parent task t_32f95348):

1. **Full domain validator** (`src/review/mod.rs`) — `validate_review_result` now enforces, in order:
   - status↔review presence (DAR §3): `review` present iff `status` is `success`; `status: failure` with `review: null` remains a valid document (retry is #312's decision).
   - existing caps (summary, findings count, per-finding title/body/path/remediation) — unchanged.
   - per-finding path semantics (DAR §8): repo-relative only — no leading `/`, no `..` component, no control characters.
   - per-finding line semantics (DAR §8): 1-based (`line: 0` rejected); a line requires a path; a path without a line is a valid file-level finding.
   - verdict consistency (DAR §8, checked last): `verdict: fail` requires ≥1 `blocking` finding; `verdict: pass` must carry zero blocking findings.
2. **Review file ingress** (`src/worker/worker_contract.rs`) — new `parse_review_result_file(path)` reusing the private `read_capped_file` (O_NOFOLLOW, regular-file check, new 4 MiB cap `MAX_REVIEW_RESULT_FILE_BYTES`, sized above the ~2.9 MiB decoded field-cap sum; issue-path 1 MiB untouched). Read failures wrap as `Worker { context: "read" }`, non-UTF-8 as `Worker { context: "parse" }`, and every serde/cap/verdict/presence/path/line rejection as `Worker { context: "validate" }` — so the existing exhaustive `classify_error` routes them to `FailureClass::Worker` (burns retry budget, DAR §8). Unknown `schema_version` propagates typed (`CaduceusError::ReviewSchemaVersion`), already classified `FailureClass::Worker`. No new `CaduceusError` variant; `classify_error` untouched.
3. **Store fixture fix** (`tests/state/review_store_test.rs`) — the presence rule invalidates the old `valid_result_json(Success) → review: null` shape; the fixture now carries a `Pass` review on success. Plus a regression test pinning that semantically invalid current-version blobs fail the history load (the store composes the same domain validator).
4. Docs: rustdoc updates in `src/review/mod.rs` + `worker_contract.rs` module doc; CHANGELOG `### Added` entry.

**Non-goal respected:** review FAIL is never encoded as `status: failure` — `WorkerResult`/`WorkerStatus`/`parse_result_file`/`validate_worker_result` are untouched (zero diff in the issue-path contract; `worker_result_test` 46/46 green).

Closes #305

## AC → test mapping (DAR §15)

| AC | Tests |
|---|---|
| AC1 PASS + zero blocking accepted | `ac1_pass_with_zero_blocking_accepted`, `ac1_pass_with_zero_findings_accepted` |
| AC2 FAIL + blocking accepted | `ac2_fail_with_blocking_accepted` |
| AC3 FAIL + zero blocking rejected (execution failure) | `ac3_fail_with_zero_blocking_rejected`, `ingress_verdict_rejection_is_worker_validate_and_burns_budget` |
| AC4 PASS + blocking rejected (execution failure) | `ac4_pass_with_blocking_rejected` |
| AC5 unknown schema_version rejected (execution failure) | `ac5_unknown_schema_version_rejected`, `ingress_schema_version_mismatch_is_typed_and_worker_class` |
| AC6 malformed severity/path/line; caps | `malformed_severity_rejected_at_parse`, `malformed_line_zero_rejected`, `malformed_line_without_path_rejected`, `malformed_absolute_path_rejected`, `malformed_parent_component_rejected`, `malformed_control_char_path_rejected`, `single_finding_cannot_exceed_comment_budget_alone`, + existing caps tests in `review_domain_test.rs` (unchanged, green) |
| Presence rule | `success_without_review_rejected`, `failure_with_review_rejected`, `failure_without_review_accepted`, `ingress_accepts_failure_status_document` |
| Ingress/Worker classification | `ingress_accepts_consistent_pass_document`, `ingress_missing_file_is_worker_read_error`, `ingress_rejects_symlinked_result_file`, `ingress_rejects_oversized_result_file`, `ingress_malformed_json_is_worker_error` |

All in the new `tests/review/review_result_validation_test.rs` (36 tests, explicit `[[test]]` entry) + `review_history_rejects_semantically_invalid_current_blob` in `review_store_test.rs`.

## Gates (real output)

- `cargo fmt --check` — pass (exit 0)
- `cargo clippy --locked --all-targets -- -D warnings` — pass (exit 0)
- `cargo test --locked --all-targets` — 2499 passed, 0 failed (172 binaries; 6 environmental skips per the plan's hermetic-failure list)
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 188 passed

Commits (Conventional, scoped):
- `feat(review): enforce verdict consistency and result presence`
- `feat(worker): add review result file ingress with worker class`
- `docs(changelog): record review result validator`

## Deviations from the plan

None. Plan file paths, rule order (presence → caps → path/line → verdict), error surface (no new variant), the 4 MiB cap, and all commit subjects are as specified. One note: `uv` is not on the default agent PATH (found at `/home/agent/.hermes/bin/uv`); the pytest gate ran with that binary — same locked environment (`uv run`), no change to the command.