### PR TITLE
feat(review): add mutation-violation enforcement and dirty check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Added
 
+- **Review mutation-violation enforcement.** A review worker that
+  modifies tracked files or daemon control files (`worker-prompt.md`,
+  `review-worktree.json`) now fails terminally: the review entry routes
+  to `NeedsAttention` with a recovery hint pointing at the preserved
+  worktree, the retry budget is not burned, and a
+  `review_mutation_violation` event is emitted. Closes #306.
 - **ReviewResult verdict-consistency validator and review result
   ingress.** The review worker's result document is now fully
   validated: `review` present iff `status` is `success`; `verdict`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,10 @@ name = "worktree_review_test"
 path = "tests/repo/worktree_review_test.rs"
 
 [[test]]
+name = "review_integrity_test"
+path = "tests/repo/review_integrity_test.rs"
+
+[[test]]
 name = "worktree_remove_test"
 path = "tests/repo/worktree_remove_test.rs"
 

--- a/src/daemon/orchestration/failure_class.rs
+++ b/src/daemon/orchestration/failure_class.rs
@@ -234,6 +234,12 @@ pub fn classify_error(err: &CaduceusError) -> FailureClass {
         // document did not execute — worker-attributable (DAR §8; the
         // wire into ExecutionStatus is #305's).
         CaduceusError::ReviewSchemaVersion { .. } => FailureClass::Worker,
+        // Review worker mutated tracked files or a daemon control file
+        // (DAR §10.1/§10.2). Terminal (DAR §8.1): retry cannot fix a
+        // contract violation; the entry routes to NeedsAttention with
+        // the archived worktree as the recovery hint. Never counts
+        // against the retry budget.
+        CaduceusError::ReviewSourceMutation { .. } => FailureClass::Terminal,
 
         // IO and JSON errors during state mutation are
         // infrastructure.

--- a/src/infra/error.rs
+++ b/src/infra/error.rs
@@ -165,6 +165,19 @@ pub enum CaduceusError {
     )]
     ReviewSchemaVersion { found: u32, supported: u32 },
 
+    /// A review worker violated the read-only review contract (DAR §6.4,
+    /// §10.1, §10.2): tracked files were modified in the review
+    /// worktree, or a daemon control file (`worker-prompt.md`,
+    /// `review-worktree.json`) failed its pre/post integrity check.
+    /// Terminal (DAR §8.1): retry cannot fix a contract violation —
+    /// the entry routes to NeedsAttention with the archived worktree
+    /// path as the recovery hint, and the retry budget is not burned.
+    #[error("review mutation violation at {worktree_path}: {detail}")]
+    ReviewSourceMutation {
+        worktree_path: PathBuf,
+        detail: String,
+    },
+
     /// Reconciliation of an external side effect failed: the
     /// remote marker disagrees with the local checkpoint. The
     /// operator must inspect the run and resolve the conflict.
@@ -539,6 +552,14 @@ impl fmt::Debug for CaduceusError {
             CaduceusError::ReviewSchemaVersion { found, supported } => format!(
                 "ReviewSchemaVersion {{ found: {}, supported: {} }}",
                 found, supported
+            ),
+            CaduceusError::ReviewSourceMutation {
+                worktree_path,
+                detail,
+            } => format!(
+                "ReviewSourceMutation {{ worktree_path: {:?}, detail: {} }}",
+                worktree_path,
+                scrub(detail)
             ),
             CaduceusError::ReconciliationFailed { stage, details } => format!(
                 "ReconciliationFailed {{ stage: {:?}, details: {} }}",

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -3,10 +3,16 @@
 //! Every git subprocess created here goes through the hardened `GitRunner`.
 
 pub mod mirror;
+pub mod review_integrity;
 pub mod review_worktree;
 pub mod storage;
 pub mod worktree;
 
 pub use mirror::BareMirror;
+pub use review_integrity::{
+    capture_control_file_digests, check_tracked_files_clean, emit_review_mutation_violation,
+    enforce_review_read_only, finish_mutation_violation, verify_control_file_digests,
+    ReviewControlFileDigests, MUTATION_VIOLATION_EVENT, MUTATION_VIOLATION_SOURCE,
+};
 pub use review_worktree::{ReviewWorktree, ReviewWorktreeMetadata};
 pub use storage::Storage;

--- a/src/repo/review_integrity.rs
+++ b/src/repo/review_integrity.rs
@@ -1,0 +1,262 @@
+//! Post-run enforcement of the review worker's read-only contract
+//! (DAR §6.4, §10.1, §10.2; issue #306).
+//!
+//! The security model is deliberate: the RO `.git` shadow prevents
+//! git-metadata mutation; tracked source files are technically
+//! writable (`/workspace` is hard-coded RW) and are enforced by a
+//! POST-RUN check, not prevented; daemon control files are untracked
+//! and therefore invisible to the dirty check, so they get an
+//! explicit pre/post digest comparison.
+//!
+//! Three-way separation (DAR §10.2): allowed worker output (the
+//! result file — OCI: off-worktree, TrustedHost: untracked in the
+//! worktree root) / build artefacts (untracked noise) / forbidden
+//! daemon control files (`worker-prompt.md`, `review-worktree.json`).
+//!
+//! The caller (#339's dispatch loop) runs [`enforce_review_read_only`]
+//! after worker exit and before result acceptance, on every post-exit
+//! path; on [`CaduceusError::ReviewSourceMutation`] it calls
+//! [`finish_mutation_violation`] and must NOT tear down the worktree
+//! (the archived worktree is forensic evidence; the hint points at it).
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use crate::infra::error::{scrub, CaduceusError, CaduceusResult};
+use crate::repo::review_worktree::REVIEW_WORKTREE_METADATA_FILENAME;
+use crate::review::ReviewTarget;
+use crate::worker::prompt::PROMPT_FILENAME;
+use crate::worktree::GitRunner;
+
+/// DAR §13 event name for the mutation-violation terminal route.
+pub const MUTATION_VIOLATION_EVENT: &str = "review_mutation_violation";
+
+/// Stable terminal source tag persisted as `blocked_source`.
+pub const MUTATION_VIOLATION_SOURCE: &str = "review/mutation_violation";
+
+/// Violation-evidence cap: first N porcelain lines carried in the
+/// error detail (bounded logging surface).
+pub const MAX_MUTATION_DETAIL_LINES: usize = 20;
+
+/// Pre/post digests of the daemon-owned control files (DAR §10.2).
+/// Fixed file set by design — no config knob.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReviewControlFileDigests {
+    pub prompt_sha256: String,
+    pub worktree_metadata_sha256: String,
+}
+
+/// Post-run tracked-file dirty check (DAR §10.1):
+/// `git -C <worktree> status --porcelain --untracked-files=no` with NO
+/// config overrides — the worktree's own git config (mirror config +
+/// checked-out `.gitattributes`) governs smudge/clean, which is what
+/// makes the check filter-aware (no autocrlf/eol false positives).
+///
+/// Any non-empty porcelain output is a violation: staged changes,
+/// worktree changes, deletions, and renames all appear in porcelain.
+/// Untracked files (the result file, build artefacts) are excluded by
+/// `--untracked-files=no`.
+///
+/// A git-status FAILURE (nonzero exit / timeout / not-a-repo) is
+/// `CaduceusError::Git` — `FailureClass::Infrastructure`, NOT a
+/// mutation violation: a check that cannot run has detected nothing
+/// (DAR §8.1's Terminal row requires a *detected* mutation).
+/// Cancellation propagates as [`CaduceusError::Cancelled`].
+pub async fn check_tracked_files_clean(runner: &GitRunner, worktree: &Path) -> CaduceusResult<()> {
+    let output = runner
+        .run_args(
+            "review-dirty-check",
+            [
+                "-C".as_ref(),
+                worktree.as_os_str(),
+                "status".as_ref(),
+                "--porcelain".as_ref(),
+                "--untracked-files=no".as_ref(),
+            ],
+        )
+        .await;
+    let output = match output {
+        Ok(out) => out,
+        // `run` surfaces spawn/wait failures as Err(Git) already; the
+        // cancelled/timed_out flags arrive inside the Ok output.
+        Err(e) => return Err(e),
+    };
+    if output.cancelled {
+        return Err(CaduceusError::Cancelled);
+    }
+    if output.timed_out || output.status != Some(0) {
+        return Err(CaduceusError::Git {
+            operation: "review-dirty-check",
+            stderr: output.stderr,
+        });
+    }
+    let stdout = output.stdout.trim();
+    if stdout.is_empty() {
+        return Ok(());
+    }
+    let lines: Vec<&str> = stdout.lines().collect();
+    let detail = if lines.len() > MAX_MUTATION_DETAIL_LINES {
+        format!(
+            "tracked files modified: {} (and {} more entries)",
+            lines[..MAX_MUTATION_DETAIL_LINES].join("; "),
+            lines.len() - MAX_MUTATION_DETAIL_LINES,
+        )
+    } else {
+        format!("tracked files modified: {}", lines.join("; "))
+    };
+    Err(CaduceusError::ReviewSourceMutation {
+        worktree_path: worktree.to_path_buf(),
+        detail,
+    })
+}
+
+/// SHA-256 of a file's bytes (pre/post control-file digest; the
+/// `review_claim_digest` precedent uses the same sha2+hex pairing).
+fn sha256_file(path: &Path) -> CaduceusResult<String> {
+    let bytes = std::fs::read(path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Capture the pre-run digests of the daemon-owned control files
+/// (DAR §10.2). Called after the prompt is written and before the
+/// worker is spawned. A missing/unreadable control file here is a
+/// daemon-setup bug (`CaduceusError::Io`, Infrastructure) — the worker
+/// has not run yet, so no mutation is possible.
+pub fn capture_control_file_digests(worktree: &Path) -> CaduceusResult<ReviewControlFileDigests> {
+    Ok(ReviewControlFileDigests {
+        prompt_sha256: sha256_file(&worktree.join(PROMPT_FILENAME))?,
+        worktree_metadata_sha256: sha256_file(&worktree.join(REVIEW_WORKTREE_METADATA_FILENAME))?,
+    })
+}
+
+/// Verify the post-run digests against the captured pre-run digests
+/// (DAR §10.2). Deletion is modification: a post-run read failure of a
+/// control file is a violation, not an Io error (the worker had write
+/// access to the worktree). A hash mismatch names the file and both
+/// digests.
+pub fn verify_control_file_digests(
+    worktree: &Path,
+    pre: &ReviewControlFileDigests,
+) -> CaduceusResult<()> {
+    // worker-prompt.md
+    let prompt_path = worktree.join(PROMPT_FILENAME);
+    let post_prompt = match sha256_file(&prompt_path) {
+        Ok(digest) => digest,
+        Err(err) => {
+            return Err(CaduceusError::ReviewSourceMutation {
+                worktree_path: worktree.to_path_buf(),
+                detail: format!("daemon control file missing: {} ({err})", PROMPT_FILENAME),
+            });
+        }
+    };
+    if post_prompt != pre.prompt_sha256 {
+        return Err(CaduceusError::ReviewSourceMutation {
+            worktree_path: worktree.to_path_buf(),
+            detail: format!(
+                "daemon control file modified: {} (sha256 pre {}, post {})",
+                PROMPT_FILENAME, pre.prompt_sha256, post_prompt
+            ),
+        });
+    }
+    // review-worktree.json
+    let metadata_path = worktree.join(REVIEW_WORKTREE_METADATA_FILENAME);
+    let post_metadata = match sha256_file(&metadata_path) {
+        Ok(digest) => digest,
+        Err(err) => {
+            return Err(CaduceusError::ReviewSourceMutation {
+                worktree_path: worktree.to_path_buf(),
+                detail: format!(
+                    "daemon control file missing: {REVIEW_WORKTREE_METADATA_FILENAME} ({err})"
+                ),
+            });
+        }
+    };
+    if post_metadata != pre.worktree_metadata_sha256 {
+        return Err(CaduceusError::ReviewSourceMutation {
+            worktree_path: worktree.to_path_buf(),
+            detail: format!(
+                "daemon control file modified: {REVIEW_WORKTREE_METADATA_FILENAME} \
+                 (sha256 pre {}, post {})",
+                pre.worktree_metadata_sha256, post_metadata
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Composed enforcement (DAR §10): the dirty check first, then the
+/// control-file digests. #339 calls this after worker exit and before
+/// result acceptance, on every post-exit path (including
+/// result-missing: a violation is independent of result presence).
+pub async fn enforce_review_read_only(
+    runner: &GitRunner,
+    worktree: &Path,
+    pre: &ReviewControlFileDigests,
+) -> CaduceusResult<()> {
+    check_tracked_files_clean(runner, worktree).await?;
+    verify_control_file_digests(worktree, pre)
+}
+
+/// Emit the DAR §13 mutation-violation event. Warn level matches the
+/// terminal-block precedent — this is a contract violation requiring
+/// operator attention.
+pub fn emit_review_mutation_violation(target: &ReviewTarget, worktree: &Path, detail: &str) {
+    tracing::warn!(
+        target: "caduceus",
+        event = MUTATION_VIOLATION_EVENT,
+        repo = target.repository.full_name(),
+        pr = target.pull_request,
+        head_sha = target.head_sha,
+        worktree = worktree.display().to_string(),
+        detail = scrub(detail),
+        "review mutation violation: entry moved to NeedsAttention"
+    );
+}
+
+/// Composed terminal route for a mutation violation (DAR §8.1,
+/// §10.1-10.2; AC3/AC4). Emits the DAR §13 event FIRST (the violation
+/// was observed regardless of whether routing succeeds), then routes
+/// the review queue entry to `NeedsAttention` with
+/// `blocked_recovery_hint` pointing at the preserved worktree.
+///
+/// The worktree is deliberately NOT torn down on this route — it is
+/// forensic evidence (contrast with the issue queue's
+/// `finish_needs_attention`, which tears down). The review reaper
+/// reclaims it by age. Callers (#339) must not tear it down either.
+///
+/// Returns an error when `err` is not a
+/// [`CaduceusError::ReviewSourceMutation`] — this route is only for
+/// mutation violations; all other classifications flow through the
+/// normal review router (#339).
+pub fn finish_mutation_violation(
+    store: &crate::state::review::ReviewStore,
+    claim: crate::state::review::ReviewClaimToken,
+    target: &crate::review::ReviewTarget,
+    err: &CaduceusError,
+) -> CaduceusResult<()> {
+    let (worktree_path, detail) = match err {
+        CaduceusError::ReviewSourceMutation {
+            worktree_path,
+            detail,
+        } => (worktree_path, detail),
+        _ => {
+            return Err(CaduceusError::Config(
+                "finish_mutation_violation requires a ReviewSourceMutation error".to_string(),
+            ));
+        }
+    };
+    emit_review_mutation_violation(target, worktree_path, detail);
+    let hint = format!(
+        "review worker violated the read-only contract; the archived \
+         review worktree is preserved for inspection at {} (see \
+         `git -C {} status` and `git -C {} diff`); it is reclaimed by \
+         the review worktree GC",
+        worktree_path.display(),
+        worktree_path.display(),
+        worktree_path.display()
+    );
+    store.route_review_to_needs_attention(claim, &err.to_string(), MUTATION_VIOLATION_SOURCE, &hint)
+}

--- a/src/repo/review_worktree.rs
+++ b/src/repo/review_worktree.rs
@@ -41,6 +41,11 @@ use super::worktree::validate_run_id;
 /// Schema version of the review-worktree metadata sidecar.
 pub const REVIEW_WORKTREE_SCHEMA_VERSION: u32 = 1;
 
+/// Filename of the daemon-owned review-worktree metadata sidecar,
+/// written into the worktree root at materialisation. Daemon control
+/// file (DAR §10.2): the review integrity check digests it pre/post.
+pub const REVIEW_WORKTREE_METADATA_FILENAME: &str = "review-worktree.json";
+
 /// A disposable review worktree: detached HEAD at the exact PR head
 /// SHA, created against the daemon-owned bare mirror. Non-pushable by
 /// construction (no branch ref exists to push; the create flow
@@ -182,7 +187,7 @@ impl ReviewWorktree {
         }
 
         let created_at = Utc::now();
-        let metadata_path = worktree_path.join("review-worktree.json");
+        let metadata_path = worktree_path.join(REVIEW_WORKTREE_METADATA_FILENAME);
         let handle = Self {
             mirror: mirror.clone(),
             run_id: run_id.to_string(),

--- a/src/state/review/queue.rs
+++ b/src/state/review/queue.rs
@@ -79,6 +79,15 @@ pub struct ReviewQueueEntry {
     /// must equal the `ReviewState` row's `review_generation`
     /// (DAR §9.4).
     pub review_generation: u64,
+    /// Stable source tag for a terminal block (e.g.
+    /// `review/mutation_violation`). Set only when the daemon routes a
+    /// refuse-to-operate condition to `NeedsAttention`.
+    #[serde(default)]
+    pub blocked_source: Option<String>,
+    /// Human-readable recovery hint for a terminal block (points at the
+    /// archived review worktree, DAR §8.1).
+    #[serde(default)]
+    pub blocked_recovery_hint: Option<String>,
 }
 
 /// Versioned review queue file (mirror of the issue queue's

--- a/src/state/review/state.rs
+++ b/src/state/review/state.rs
@@ -335,6 +335,8 @@ impl ReviewStore {
                     queued_at: now,
                     updated_at: now,
                     review_generation: generation,
+                    blocked_source: None,
+                    blocked_recovery_hint: None,
                 },
             );
             store.persist_queue(conn, &queue)?;
@@ -502,6 +504,36 @@ impl ReviewStore {
     /// reason is recorded on it (overwriting any prior `last_error`).
     pub fn skip_review(&self, claim: ReviewClaimToken, reason: &str) -> CaduceusResult<()> {
         self.terminal_review(claim, ReviewPhase::Skipped, Some(reason))
+    }
+
+    /// Terminal NeedsAttention transition (mutation violation, DAR
+    /// §8.1): phase → `NeedsAttention` with block metadata;
+    /// `attempts` is NOT incremented (retry cannot fix a contract
+    /// violation, AC4); the claim is released. The caller
+    /// (`finish_mutation_violation` / #339) must NOT tear down the
+    /// review worktree on this route — the hint points at it as
+    /// forensic evidence.
+    pub fn route_review_to_needs_attention(
+        &self,
+        claim: ReviewClaimToken,
+        error: &str,
+        source: &str,
+        recovery_hint: &str,
+    ) -> CaduceusResult<()> {
+        self.with_exclusive(|store, conn| {
+            let mut queue = store.load_queue(conn)?;
+            let entry = review_entry_for_claim(&mut queue, &claim)?;
+            entry.phase = ReviewPhase::NeedsAttention;
+            entry.last_error = Some(error.to_string());
+            entry.blocked_source = Some(source.to_string());
+            entry.blocked_recovery_hint = Some(recovery_hint.to_string());
+            entry.last_run_id = None;
+            entry.next_attempt_at = None;
+            entry.updated_at = Utc::now();
+            store.persist_queue(conn, &queue)?;
+            unlink_review_claim_best_effort(&store.claims_dir, &claim);
+            Ok(())
+        })
     }
 
     fn terminal_review(
@@ -1002,7 +1034,8 @@ fn load_queue_sqlite(
         .prepare(
             "SELECT review_key, owner, repo, pull_request, head_sha, base_sha, base_ref,
                     merge_base, phase, attempts, last_error, last_run_id, next_attempt_at,
-                    queued_at, updated_at, review_generation
+                    queued_at, updated_at, review_generation, blocked_source,
+                    blocked_recovery_hint
              FROM review_queue_entries",
         )
         .map_err(|e| {
@@ -1030,6 +1063,8 @@ fn load_queue_sqlite(
                 row.get::<_, String>(13)?,
                 row.get::<_, String>(14)?,
                 row.get::<_, i64>(15)?,
+                row.get::<_, Option<String>>(16)?,
+                row.get::<_, Option<String>>(17)?,
             ))
         })
         .map_err(|e| corrupt(&db_path, format!("cannot read review_queue_entries: {e}")))?;
@@ -1053,6 +1088,8 @@ fn load_queue_sqlite(
             queued_at,
             updated_at,
             review_generation,
+            blocked_source,
+            blocked_recovery_hint,
         ) = row.map_err(|e| corrupt(&db_path, format!("cannot decode review queue row: {e}")))?;
         let pull_request =
             parse_pr_u64(pull_request).map_err(|e| corrupt(&db_path, e.to_string()))?;
@@ -1079,6 +1116,8 @@ fn load_queue_sqlite(
             queued_at: parse_timestamp(queued_at, "queued_at", &db_path)?,
             updated_at: parse_timestamp(updated_at, "updated_at", &db_path)?,
             review_generation: parse_generation(review_generation),
+            blocked_source,
+            blocked_recovery_hint,
         };
         crate::review::validate_review_target(&entry.target)
             .map_err(|e| corrupt(&db_path, format!("review queue row invalid: {e}")))?;
@@ -1110,8 +1149,9 @@ fn persist_queue_sqlite(
             "INSERT INTO review_queue_entries
              (review_key, owner, repo, pull_request, head_sha, base_sha, base_ref,
               merge_base, phase, attempts, last_error, last_run_id, next_attempt_at,
-              queued_at, updated_at, review_generation)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+              queued_at, updated_at, review_generation, blocked_source,
+              blocked_recovery_hint)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
             params![
                 key,
                 entry.target.repository.owner.to_lowercase(),
@@ -1129,6 +1169,8 @@ fn persist_queue_sqlite(
                 entry.queued_at.to_rfc3339(),
                 entry.updated_at.to_rfc3339(),
                 entry.review_generation as i64,
+                entry.blocked_source,
+                entry.blocked_recovery_hint,
             ],
         )
         .map_err(|e| corrupt_store(format!("cannot persist review queue entry {key}: {e}")))?;

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -77,7 +77,20 @@ use crate::infra::error::{store_version_guidance, CaduceusError, CaduceusResult}
 ///   in-place accept-and-upgrade of v1 files) plus three new v1-born
 ///   review sidecar files (`review_queue.json`, `review_state.json`,
 ///   `review_history.json`); see `crate::state::review`.
-pub const SCHEMA_VERSION: i64 = 8;
+///
+/// ## v9
+///
+/// - `review_queue_entries` gains `blocked_source` and
+///   `blocked_recovery_hint` (#306): Terminal-block metadata for
+///   mutation violations, mirroring the issue queue's v5→v6 shape.
+///   The v8→v9 step is CONDITIONAL: a v7 store reaches the step
+///   before `apply_schema` has created the review tables (the chain
+///   runs first, `open()` calls `apply_schema` afterwards), so the
+///   step creates the table in its v9 shape when absent and ALTERs
+///   only when it exists without the columns. The JSON counterpart
+///   needs no envelope bump: the fields are additive
+///   `#[serde(default)]` on the v1-born `review_queue.json` entries.
+pub const SCHEMA_VERSION: i64 = 9;
 
 /// The last schema version that is deliberately rejected instead of
 /// migrated. Keeping this explicit prevents a future schema bump from
@@ -187,7 +200,9 @@ CREATE TABLE IF NOT EXISTS review_queue_entries (
     next_attempt_at TEXT,
     queued_at    TEXT NOT NULL,
     updated_at   TEXT NOT NULL,
-    review_generation INTEGER NOT NULL DEFAULT 1
+    review_generation INTEGER NOT NULL DEFAULT 1,
+    blocked_source TEXT,
+    blocked_recovery_hint TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_review_queue_repo ON review_queue_entries(owner, repo, pull_request);
 CREATE INDEX IF NOT EXISTS idx_review_queue_phase ON review_queue_entries(phase);
@@ -455,6 +470,12 @@ const SQLITE_MIGRATIONS: &[Migration] = &[
         label: "review-era structures",
         apply: m_v7_v8,
     },
+    Migration {
+        from: 8,
+        to: 9,
+        label: "review_queue_entries blocked columns",
+        apply: m_v8_v9,
+    },
 ];
 
 /// Validate the registry's chain invariants (D1/D4): steps are strictly
@@ -621,6 +642,66 @@ fn m_v7_v8(tx: &Transaction) -> CaduceusResult<()> {
     // `SCHEMA_SQL`. No ALTER TABLE / data statements are needed for
     // v7→v8.
     let _ = tx;
+    Ok(())
+}
+
+/// Migrate from schema v8 to v9 by adding `blocked_source` and
+/// `blocked_recovery_hint` to `review_queue_entries` (#306; the
+/// `m_v5_v6` precedent). CONDITIONAL: a v7 store reaches this step
+/// BEFORE `apply_schema` has created the review tables (`open()` runs
+/// the chain first and calls `apply_schema` afterwards), so the table
+/// may not exist yet — in that case create it in its v9 shape here
+/// (idempotent `IF NOT EXISTS`); `apply_schema` no-ops on it.
+fn m_v8_v9(tx: &Transaction) -> CaduceusResult<()> {
+    let table_exists: bool = tx
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table'
+             AND name='review_queue_entries'",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .map(|n| n > 0)
+        .map_err(|e| CaduceusError::Other(format!("v8→v9 probe: {e}")))?;
+    if !table_exists {
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS review_queue_entries (
+                review_key   TEXT PRIMARY KEY,
+                owner        TEXT NOT NULL,
+                repo         TEXT NOT NULL,
+                pull_request INTEGER NOT NULL,
+                head_sha     TEXT NOT NULL,
+                base_sha     TEXT NOT NULL,
+                base_ref     TEXT NOT NULL,
+                merge_base   TEXT NOT NULL,
+                phase        TEXT NOT NULL,
+                attempts     INTEGER NOT NULL DEFAULT 0,
+                last_error   TEXT,
+                last_run_id  TEXT,
+                next_attempt_at TEXT,
+                queued_at    TEXT NOT NULL,
+                updated_at   TEXT NOT NULL,
+                review_generation INTEGER NOT NULL DEFAULT 1,
+                blocked_source TEXT,
+                blocked_recovery_hint TEXT
+            );",
+        )
+        .map_err(|e| CaduceusError::Other(format!("v8→v9 create review_queue_entries: {e}")))?;
+        return Ok(());
+    }
+    let has_blocked: bool = tx
+        .prepare("PRAGMA table_info(review_queue_entries)")
+        .map_err(|e| CaduceusError::Other(format!("v8→v9 pragma: {e}")))?
+        .query_map([], |r| r.get::<_, String>(1))
+        .map_err(|e| CaduceusError::Other(format!("v8→v9 pragma query: {e}")))?
+        .filter_map(|c| c.ok())
+        .any(|col| col == "blocked_recovery_hint");
+    if !has_blocked {
+        tx.execute_batch(
+            "ALTER TABLE review_queue_entries ADD COLUMN blocked_source TEXT;
+             ALTER TABLE review_queue_entries ADD COLUMN blocked_recovery_hint TEXT;",
+        )
+        .map_err(|e| CaduceusError::Other(format!("v8→v9 ALTER review_queue_entries: {e}")))?;
+    }
     Ok(())
 }
 

--- a/tests/fixtures/scenario-10-golden.json
+++ b/tests/fixtures/scenario-10-golden.json
@@ -1,5 +1,5 @@
 {
-  "schema_version_after_open": 8,
-  "schema_version_again": 8,
+  "schema_version_after_open": 9,
+  "schema_version_again": 9,
   "oci_runs_table_exists": true
 }

--- a/tests/infra/error_classify_test.rs
+++ b/tests/infra/error_classify_test.rs
@@ -44,6 +44,19 @@ fn terminal_for_claim_mismatch() {
 }
 
 #[test]
+fn terminal_for_review_source_mutation() {
+    let err = CaduceusError::ReviewSourceMutation {
+        worktree_path: std::path::PathBuf::from("/tmp/wt"),
+        detail: "tracked files modified:\n M src/lib.rs".to_string(),
+    };
+    let class = classify_error(&err);
+    assert_eq!(class, FailureClass::Terminal);
+    assert!(class.is_terminal());
+    // AC4: a contract violation must never burn the retry budget.
+    assert!(!class.counts_against_retry_budget());
+}
+
+#[test]
 fn infrastructure_still_infrastructure() {
     // Unrelated Worktree/Queue contexts remain Infrastructure.
     let worktree_other = CaduceusError::Worktree {

--- a/tests/integration/integration_scenarios.rs
+++ b/tests/integration/integration_scenarios.rs
@@ -981,7 +981,10 @@ async fn test_scenario_10_schema_v7_idempotent() {
         v_after_open, SCHEMA_VERSION,
         "fresh DB must be at SCHEMA_VERSION"
     );
-    assert_eq!(v_after_open, 8, "v8 is the canonical current schema");
+    assert_eq!(
+        v_after_open, SCHEMA_VERSION,
+        "v9 is the canonical current schema"
+    );
 
     // Second open: idempotent — no migration, schema_version
     // table is unchanged, oci_runs table still exists.
@@ -999,8 +1002,11 @@ async fn test_scenario_10_schema_v7_idempotent() {
         )
         .expect("query oci_runs");
     drop(conn2);
-    assert_eq!(v_again, 8, "second open must remain v8 (idempotent)");
-    assert_eq!(oci_runs_count, 1, "oci_runs table must exist at v8");
+    assert_eq!(
+        v_again, SCHEMA_VERSION,
+        "second open must remain at the current schema (idempotent)"
+    );
+    assert_eq!(oci_runs_count, 1, "oci_runs table must exist");
 
     let observed = serde_json::json!({
         "schema_version_after_open": v_after_open,

--- a/tests/repo/review_integrity_test.rs
+++ b/tests/repo/review_integrity_test.rs
@@ -1,0 +1,751 @@
+//! Review integrity enforcement tests (issue #306, DAR §6.4, §10,
+//! §10.1, §10.2, §15).
+//!
+//! Acceptance coverage:
+//!
+//! - AC1 — tracked-file modification detected with the repo's own git
+//!   config: modification / deletion / staged variants plus the
+//!   autocrlf=true and `.gitattributes eol=crlf` no-false-positive
+//!   matrix (each with a positive control).
+//! - AC2 — control-file integrity: pre/post SHA-256 digests detect
+//!   `worker-prompt.md` modification and deletion, and sidecar
+//!   tampering; the dirty check alone does NOT flag the untracked
+//!   prompt (the §10.2 rationale).
+//! - D3 — a git-status FAILURE is Infrastructure, never a violation.
+//! - DAR §13 — `review_mutation_violation` event shape.
+//! - Terminal routing — `finish_mutation_violation` persists
+//!   `blocked_source` / `blocked_recovery_hint` (pointing at the
+//!   archived worktree), never touches `attempts`, releases the
+//!   claim, and emits the event; wrong-variant input is rejected.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use caduceus::config::Config;
+use caduceus::error::CaduceusError;
+use caduceus::repo::review_integrity::{
+    capture_control_file_digests, check_tracked_files_clean, enforce_review_read_only,
+    finish_mutation_violation, verify_control_file_digests, MUTATION_VIOLATION_EVENT,
+    MUTATION_VIOLATION_SOURCE,
+};
+use caduceus::repo::BareMirror;
+use caduceus::review::ReviewTarget;
+use caduceus::state::review::{review_queue_key, ReviewPhase, ReviewStore};
+use caduceus::worktree::GitRunner;
+use chrono::Utc;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+
+// ---------------------------------------------------------------------------
+// Git fixture helpers (per-file locals; the worktree_review_test pattern)
+// ---------------------------------------------------------------------------
+
+fn run_command(cmd: &mut Command) {
+    let output = cmd.output().expect("spawn command");
+    if !output.status.success() {
+        panic!(
+            "command {:?} failed: status={:?}\nstdout={}\nstderr={}",
+            cmd,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn git_out(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("git {args:?}: {err}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn hash_blob_stdin(git_dir: &Path, content: &str) -> String {
+    use std::io::Write;
+    let mut child = Command::new("git")
+        .current_dir(git_dir)
+        .args(["hash-object", "-w", "--stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn git hash-object");
+    child
+        .stdin
+        .take()
+        .expect("hash-object stdin")
+        .write_all(content.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait hash-object");
+    assert!(
+        out.status.success(),
+        "git hash-object --stdin failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Build a tree object from (name, content) pairs; returns the tree OID.
+fn tree_with_files(git_dir: &Path, files: &[(&str, &str)]) -> String {
+    use std::io::Write;
+    let mut entries = String::new();
+    for (name, content) in files {
+        let blob = hash_blob_stdin(git_dir, content);
+        entries.push_str(&format!("100644 blob {blob}\t{name}\n"));
+    }
+    let mut child = Command::new("git")
+        .current_dir(git_dir)
+        .args(["mktree"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn git mktree");
+    child
+        .stdin
+        .take()
+        .expect("mktree stdin")
+        .write_all(entries.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait mktree");
+    assert!(
+        out.status.success(),
+        "git mktree failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Build `src/<name>` (a nested tracked file) and return the root tree OID.
+fn tree_with_nested_file(git_dir: &Path, name: &str, content: &str) -> String {
+    use std::io::Write;
+    let blob = hash_blob_stdin(git_dir, content);
+    let subtree = {
+        let entry = format!("100644 blob {blob}\t{name}\n");
+        let mut child = Command::new("git")
+            .current_dir(git_dir)
+            .args(["mktree"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn git mktree subtree");
+        child
+            .stdin
+            .take()
+            .expect("mktree stdin")
+            .write_all(entry.as_bytes())
+            .expect("write stdin");
+        let out = child.wait_with_output().expect("wait mktree");
+        assert!(out.status.success());
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+    let root_entry = format!("040000 tree {subtree}\tsrc\n");
+    let mut child = Command::new("git")
+        .current_dir(git_dir)
+        .args(["mktree"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn git mktree root");
+    child
+        .stdin
+        .take()
+        .expect("mktree stdin")
+        .write_all(root_entry.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait mktree");
+    assert!(out.status.success());
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// main = A (empty tree); returns A.
+fn init_bare_remote(path: &Path) -> String {
+    run_command(Command::new("git").arg("init").arg("--bare").arg(path));
+    run_command(Command::new("git").current_dir(path).args([
+        "symbolic-ref",
+        "HEAD",
+        "refs/heads/main",
+    ]));
+    let empty_tree = git_out(path, &["hash-object", "-w", "-t", "tree", "/dev/null"]);
+    let a = git_out(path, &["commit-tree", &empty_tree, "-m", "initial"]);
+    run_command(
+        Command::new("git")
+            .current_dir(path)
+            .args(["update-ref", "refs/heads/main", &a]),
+    );
+    a
+}
+
+/// feature = B (child of `base`, tree `tree`); returns B.
+fn create_feature_commit(path: &Path, base: &str, tree: &str) -> String {
+    let b = git_out(path, &["commit-tree", tree, "-p", base, "-m", "feature"]);
+    run_command(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/feature",
+        &b,
+    ]));
+    b
+}
+
+fn target_for(repo: &str, pr: u64, head: &str, base: &str, merge_base: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: caduceus::review::RepositoryId {
+            owner: "rvowner".to_string(),
+            repo: repo.to_string(),
+        },
+        pull_request: pr,
+        head_sha: head.to_string(),
+        base_sha: base.to_string(),
+        base_ref: "main".to_string(),
+        merge_base: merge_base.to_string(),
+    }
+}
+
+fn review_config(root: &Path) -> Config {
+    let mut cfg = Config::test_defaults(root);
+    cfg.repo_storage_root = root.join("repos");
+    cfg.git_timeout_seconds = 30;
+    cfg
+}
+
+async fn ensure_mirror(
+    runner: &GitRunner,
+    cfg: &Config,
+    remote_dir: &Path,
+    repo: &str,
+) -> BareMirror {
+    BareMirror::ensure(
+        runner,
+        cfg,
+        "rvowner",
+        repo,
+        &format!("file://{}", remote_dir.display()),
+        "main",
+    )
+    .await
+    .expect("ensure mirror")
+}
+
+/// Standard fixture: mirror + review worktree at B whose tree carries
+/// the tracked file `src/lib.rs`. Returns the worktree handle.
+async fn review_worktree_with_lib_rs(
+    tag: &str,
+    repo: &str,
+    pr: u64,
+) -> (caduceus::repo::ReviewWorktree, GitRunner) {
+    let root = tempdir(tag);
+    let remote_dir = root.join("remote.git");
+    let a = init_bare_remote(&remote_dir);
+    let tree = tree_with_nested_file(&remote_dir, "lib.rs", "fn main() {}\n");
+    let b = create_feature_commit(&remote_dir, &a, &tree);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, repo).await;
+    let target = target_for(repo, pr, &b, &a, &a);
+    let wt = caduceus::repo::ReviewWorktree::create_review(&runner, &mirror, "run-int-1", &target)
+        .await
+        .expect("create_review");
+    (wt, runner)
+}
+
+/// Daemon control files present in the worktree (the sidecar was
+/// written by create_review; the prompt is written the way #339 will
+/// place it, before the worker runs).
+fn write_prompt(worktree: &Path) {
+    std::fs::write(worktree.join("worker-prompt.md"), "# prompt\n").expect("write prompt");
+}
+
+// ---------------------------------------------------------------------------
+// Dirty check (DAR §10.1) — AC1
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn clean_worktree_passes_dirty_check() {
+    let (wt, runner) = review_worktree_with_lib_rs("ri-clean", "rirepo", 21).await;
+    // Three-way separation: untracked worker output (TrustedHost-shaped
+    // result file) + build artefacts are NOT violations.
+    std::fs::write(
+        wt.path.join("worker-result.json"),
+        "{\"status\":\"success\"}",
+    )
+    .expect("write result file");
+    std::fs::create_dir_all(wt.path.join("target/debug")).expect("mkdir target");
+    std::fs::write(wt.path.join("target/debug/foo"), "artefact").expect("write artefact");
+    check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect("clean worktree must pass");
+}
+
+#[tokio::test]
+async fn tracked_file_modification_is_a_violation() {
+    let (wt, runner) = review_worktree_with_lib_rs("ri-mod", "rirepo", 22).await;
+    let mut path = wt.path.join("src/lib.rs");
+    let existing = std::fs::read_to_string(&path).unwrap();
+    path = wt.path.join("src/lib.rs");
+    std::fs::write(&path, format!("{existing}MUTATED\n")).expect("append byte");
+    let err = check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect_err("modification must be flagged");
+    assert!(
+        matches!(err, CaduceusError::ReviewSourceMutation { .. }),
+        "got: {err:?}"
+    );
+    // Porcelain evidence names the modified file.
+    assert!(err.to_string().contains("src/lib.rs"), "got: {err}");
+}
+
+#[tokio::test]
+async fn tracked_file_deletion_is_a_violation() {
+    let (wt, runner) = review_worktree_with_lib_rs("ri-del", "rirepo", 23).await;
+    std::fs::remove_file(wt.path.join("src/lib.rs")).expect("delete tracked file");
+    let err = check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect_err("deletion must be flagged");
+    assert!(matches!(err, CaduceusError::ReviewSourceMutation { .. }));
+}
+
+#[tokio::test]
+async fn staged_modification_is_a_violation() {
+    let (wt, runner) = review_worktree_with_lib_rs("ri-stage", "rirepo", 24).await;
+    let existing = std::fs::read_to_string(wt.path.join("src/lib.rs")).unwrap();
+    std::fs::write(wt.path.join("src/lib.rs"), format!("{existing}STAGED\n")).expect("append byte");
+    run_command(
+        Command::new("git")
+            .current_dir(&wt.path)
+            .args(["add", "src/lib.rs"]),
+    );
+    let err = check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect_err("staged change must be flagged");
+    assert!(matches!(err, CaduceusError::ReviewSourceMutation { .. }));
+    assert!(err.to_string().contains("src/lib.rs"));
+}
+
+/// D3: a dirty check that cannot run (not a git repository) is
+/// Infrastructure, never a mutation violation — it detected nothing.
+#[tokio::test]
+async fn git_status_failure_is_infrastructure_not_violation() {
+    let dir = tempdir("ri-not-git");
+    let runner = GitRunner::new(&review_config(&dir));
+    let err = check_tracked_files_clean(&runner, &dir)
+        .await
+        .expect_err("non-repo must fail");
+    assert!(matches!(err, CaduceusError::Git { .. }), "got: {err:?}");
+    let class = caduceus::orchestration::classify_error(&err);
+    assert_eq!(class, caduceus::orchestration::FailureClass::Infrastructure);
+    assert!(!class.is_terminal());
+}
+
+// ---------------------------------------------------------------------------
+// Control-file integrity (DAR §10.2) — AC2
+// ---------------------------------------------------------------------------
+
+/// THE §10.2 rationale: worker-prompt.md is untracked, so the dirty
+/// check alone must NOT flag it — but the digest check must.
+#[tokio::test]
+async fn prompt_modification_detected_by_digest_not_dirty_check() {
+    let (wt, runner) = review_worktree_with_lib_rs("ri-prompt", "rirepo", 25).await;
+    write_prompt(&wt.path);
+    let pre = capture_control_file_digests(&wt.path).expect("pre digests");
+    // The dirty check passes (prompt is untracked).
+    check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect("untracked prompt is invisible to the dirty check");
+    // The worker modifies it; the digest check flags it.
+    let body = std::fs::read_to_string(wt.path.join("worker-prompt.md")).unwrap();
+    std::fs::write(
+        wt.path.join("worker-prompt.md"),
+        format!("{body}tampered\n"),
+    )
+    .expect("append byte");
+    let err = verify_control_file_digests(&wt.path, &pre)
+        .expect_err("prompt modification must be flagged");
+    assert!(matches!(err, CaduceusError::ReviewSourceMutation { .. }));
+    assert!(err.to_string().contains("worker-prompt.md"), "got: {err}");
+}
+
+#[tokio::test]
+async fn prompt_deletion_detected_by_digest() {
+    let (wt, _runner) = review_worktree_with_lib_rs("ri-prompt-del", "rirepo", 26).await;
+    write_prompt(&wt.path);
+    let pre = capture_control_file_digests(&wt.path).expect("pre digests");
+    std::fs::remove_file(wt.path.join("worker-prompt.md")).expect("delete prompt");
+    let err =
+        verify_control_file_digests(&wt.path, &pre).expect_err("prompt deletion must be flagged");
+    assert!(matches!(err, CaduceusError::ReviewSourceMutation { .. }));
+    assert!(err.to_string().contains("missing"), "got: {err}");
+}
+
+#[tokio::test]
+async fn sidecar_modification_detected_by_digest() {
+    let (wt, _runner) = review_worktree_with_lib_rs("ri-sidecar", "rirepo", 27).await;
+    write_prompt(&wt.path);
+    let pre = capture_control_file_digests(&wt.path).expect("pre digests");
+    // A worker setting a future created_at would exempt the directory
+    // from GC — exactly what the digest check must catch.
+    let raw = std::fs::read_to_string(&wt.metadata_path).unwrap();
+    let tampered = raw.replace("\"schema_version\": 1", "\"schema_version\": 1 ");
+    std::fs::write(&wt.metadata_path, tampered).expect("tamper sidecar");
+    let err =
+        verify_control_file_digests(&wt.path, &pre).expect_err("sidecar tampering must be flagged");
+    assert!(matches!(err, CaduceusError::ReviewSourceMutation { .. }));
+    assert!(
+        err.to_string().contains("review-worktree.json"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn unchanged_control_files_pass_digest_check() {
+    let dir = tempdir("ri-digest-ok");
+    std::fs::write(dir.join("worker-prompt.md"), "# prompt\n").expect("write prompt");
+    std::fs::write(dir.join("review-worktree.json"), "{}\n").expect("write sidecar");
+    let pre = capture_control_file_digests(&dir).expect("pre digests");
+    verify_control_file_digests(&dir, &pre).expect("unchanged digests must pass");
+}
+
+#[test]
+fn pre_capture_on_missing_prompt_is_io_not_terminal() {
+    let dir = tempdir("ri-pre-io");
+    // No worker has run yet — a missing control file is a daemon-setup
+    // bug (Io / Infrastructure), never a mutation violation.
+    let err = capture_control_file_digests(&dir).expect_err("missing prompt");
+    assert!(matches!(err, CaduceusError::Io(_)), "got: {err:?}");
+    let class = caduceus::orchestration::classify_error(&err);
+    assert_ne!(class, caduceus::orchestration::FailureClass::Terminal);
+}
+
+// ---------------------------------------------------------------------------
+// Composition
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn enforce_review_read_only_composes_both_checks() {
+    // 1. Modified tracked file + intact prompt → porcelain detail.
+    let (wt, runner) = review_worktree_with_lib_rs("ri-comp-dirty", "rirepo", 28).await;
+    write_prompt(&wt.path);
+    let pre = capture_control_file_digests(&wt.path).expect("pre digests");
+    let existing = std::fs::read_to_string(wt.path.join("src/lib.rs")).unwrap();
+    std::fs::write(wt.path.join("src/lib.rs"), format!("{existing}X\n")).expect("modify");
+    let err = enforce_review_read_only(&runner, &wt.path, &pre)
+        .await
+        .expect_err("dirty tree must be flagged");
+    assert!(err.to_string().contains("tracked files modified"));
+    let _ = std::fs::remove_dir_all(wt.path.ancestors().nth(4).unwrap());
+
+    // 2. Clean tree + tampered sidecar → control-file detail.
+    let (wt2, runner2) = review_worktree_with_lib_rs("ri-comp-sidecar", "rirepo2", 29).await;
+    write_prompt(&wt2.path);
+    let pre2 = capture_control_file_digests(&wt2.path).expect("pre digests");
+    std::fs::write(&wt2.metadata_path, "{}\n").expect("tamper sidecar");
+    let err2 = enforce_review_read_only(&runner2, &wt2.path, &pre2)
+        .await
+        .expect_err("tampered sidecar must be flagged");
+    assert!(err2.to_string().contains("daemon control file modified"));
+    let _ = std::fs::remove_dir_all(wt2.path.ancestors().nth(4).unwrap());
+
+    // 3. Both clean → Ok.
+    let (wt3, runner3) = review_worktree_with_lib_rs("ri-comp-clean", "rirepo3", 30).await;
+    write_prompt(&wt3.path);
+    let pre3 = capture_control_file_digests(&wt3.path).expect("pre digests");
+    enforce_review_read_only(&runner3, &wt3.path, &pre3)
+        .await
+        .expect("both checks clean");
+    let _ = std::fs::remove_dir_all(wt3.path.ancestors().nth(4).unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// Autocrlf / eol matrix (AC1 — the false-positive guards)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn autocrlf_true_checkout_is_not_a_false_positive() {
+    // Repo commits LF files; the mirror config sets core.autocrlf=true
+    // so the worktree checks out CRLF on disk. On-disk bytes differ
+    // from the index — a naive byte-compare would flag it; git status
+    // with the repository's own config must not.
+    let root = tempdir("ri-crlf");
+    let remote_dir = root.join("remote.git");
+    let a = init_bare_remote(&remote_dir);
+    let tree = tree_with_nested_file(&remote_dir, "lib.rs", "fn main() {}\nsecond\n");
+    let b = create_feature_commit(&remote_dir, &a, &tree);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rirepo-crlf").await;
+    // Set the filter BEFORE the checkout so the smudge applies.
+    run_command(Command::new("git").current_dir(&mirror.path).args([
+        "config",
+        "core.autocrlf",
+        "true",
+    ]));
+    let target = target_for("rirepo-crlf", 31, &b, &a, &a);
+    let wt = caduceus::repo::ReviewWorktree::create_review(&runner, &mirror, "run-crlf-1", &target)
+        .await
+        .expect("create_review");
+
+    // Precondition: the checkout really is CRLF on disk.
+    let on_disk = std::fs::read(wt.path.join("src/lib.rs")).expect("read lib.rs");
+    let as_text = String::from_utf8_lossy(&on_disk).to_string();
+    assert!(
+        as_text.contains("\r\n"),
+        "fixture broken: checkout must be CRLF, got {as_text:?}"
+    );
+
+    // Filter-aware status must be clean for the untouched checkout.
+    check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect("filter-aware status must not flag a normalized checkout");
+
+    // Positive control: a real modification is still a violation.
+    std::fs::write(wt.path.join("src/lib.rs"), format!("{as_text}MUTATED\r\n"))
+        .expect("append line");
+    let err = check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect_err("real modification must be flagged");
+    assert!(matches!(err, CaduceusError::ReviewSourceMutation { .. }));
+}
+
+#[tokio::test]
+async fn gitattributes_eol_crlf_is_not_a_false_positive() {
+    // The tree carries `.gitattributes` with `* text eol=crlf`; the
+    // checkout applies the attribute on materialisation. Untouched
+    // worktree → clean; modified file → violation.
+    let root = tempdir("ri-attrs");
+    let remote_dir = root.join("remote.git");
+    let a = init_bare_remote(&remote_dir);
+    let tree = tree_with_files(
+        &remote_dir,
+        &[
+            (".gitattributes", "* text eol=crlf\n"),
+            ("feature.txt", "feature content\n"),
+        ],
+    );
+    let b = create_feature_commit(&remote_dir, &a, &tree);
+    let cfg = review_config(&root);
+    let runner = GitRunner::new(&cfg);
+    let mirror = ensure_mirror(&runner, &cfg, &remote_dir, "rirepo-attrs").await;
+    let target = target_for("rirepo-attrs", 32, &b, &a, &a);
+    let wt =
+        caduceus::repo::ReviewWorktree::create_review(&runner, &mirror, "run-attrs-1", &target)
+            .await
+            .expect("create_review");
+
+    // Precondition: the attribute smudged the file to CRLF.
+    let on_disk =
+        String::from_utf8_lossy(&std::fs::read(wt.path.join("feature.txt")).unwrap()).to_string();
+    assert!(
+        on_disk.contains("\r\n"),
+        "fixture broken: eol=crlf must apply, got {on_disk:?}"
+    );
+
+    check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect("attribute-normalized checkout must be clean");
+
+    std::fs::write(wt.path.join("feature.txt"), format!("{on_disk}MUTATED\r\n"))
+        .expect("append line");
+    let err = check_tracked_files_clean(&runner, &wt.path)
+        .await
+        .expect_err("real modification must be flagged");
+    assert!(matches!(err, CaduceusError::ReviewSourceMutation { .. }));
+    assert!(err.to_string().contains("feature.txt"));
+}
+
+// ---------------------------------------------------------------------------
+// DAR §13 event (issue-#167 capture discipline)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial]
+fn mutation_violation_event_is_emitted_with_dar13_shape() {
+    use caduceus::logging::build_test_subscriber;
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let log_path = root.path().join("mutation.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let target = target_for(
+        "evrepo",
+        42,
+        "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "a",
+        "a",
+    );
+    let wt_path = root.path().join("wt");
+    std::fs::create_dir_all(&wt_path).expect("mkdir wt");
+    tracing::subscriber::with_default(subscriber, || {
+        caduceus::repo::review_integrity::emit_review_mutation_violation(
+            &target,
+            &wt_path,
+            "tracked files modified: M src/lib.rs",
+        );
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read log");
+    assert!(
+        body.contains(&format!("\"event\":\"{MUTATION_VIOLATION_EVENT}\"")),
+        "{body}"
+    );
+    assert!(body.contains("\"repo\":\"rvowner/evrepo\""), "{body}");
+    assert!(body.contains("\"pr\":42"), "{body}");
+    assert!(
+        body.contains("\"head_sha\":\"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\""),
+        "{body}"
+    );
+    assert!(body.contains("tracked files modified"), "{body}");
+}
+
+// ---------------------------------------------------------------------------
+// Composed terminal route (Task 4)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn finish_mutation_violation_routes_needs_attention_with_hint() {
+    let dir = tempdir("ri-finish");
+    let store = ReviewStore::open(&dir).expect("open store");
+    let target = target_for(
+        "routerrepo",
+        33,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "b",
+        "b",
+    );
+    store.enqueue_review(&target).expect("enqueue");
+    let claimed = store
+        .acquire_next_review("run-mv-1", 4242, Utc::now())
+        .expect("claim")
+        .expect("claim");
+
+    let wt_path = dir.join("archived-wt");
+    std::fs::create_dir_all(&wt_path).expect("mkdir archived wt");
+    let err = CaduceusError::ReviewSourceMutation {
+        worktree_path: wt_path.clone(),
+        detail: "tracked files modified:\n M src/lib.rs".to_string(),
+    };
+    finish_mutation_violation(&store, claimed.claim, &target, &err).expect("finish");
+
+    let snap = store.review_queue_snapshot().expect("snapshot");
+    let entry = snap.entries.get(&review_queue_key(&target)).expect("entry");
+    assert_eq!(entry.phase, ReviewPhase::NeedsAttention);
+    assert_eq!(
+        entry.blocked_source.as_deref(),
+        Some(MUTATION_VIOLATION_SOURCE)
+    );
+    // Hint points at the archived worktree (DAR §8.1).
+    let hint = entry.blocked_recovery_hint.as_deref().expect("hint");
+    assert!(
+        hint.contains(wt_path.display().to_string().as_str()),
+        "got: {hint}"
+    );
+    assert!(hint.contains("preserved for inspection"), "got: {hint}");
+    // AC4: retry budget not burned.
+    assert_eq!(entry.attempts, 0);
+    assert!(entry
+        .last_error
+        .as_deref()
+        .unwrap()
+        .contains("review mutation violation"));
+    // Claim released: nothing re-acquirable.
+    assert!(store
+        .acquire_next_review("run-mv-2", 4243, Utc::now())
+        .expect("acquire")
+        .is_none());
+}
+
+#[test]
+fn finish_mutation_violation_rejects_non_mutation_variants() {
+    let dir = tempdir("ri-finish-wrong");
+    let store = ReviewStore::open(&dir).expect("open store");
+    let target = target_for(
+        "wrongrepo",
+        34,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "b",
+        "b",
+    );
+    store.enqueue_review(&target).expect("enqueue");
+    let claimed = store
+        .acquire_next_review("run-mv-3", 4242, Utc::now())
+        .expect("claim")
+        .expect("claim");
+    let other = CaduceusError::Git {
+        operation: "x",
+        stderr: "y".to_string(),
+    };
+    let err = finish_mutation_violation(&store, claimed.claim, &target, &other)
+        .expect_err("wrong variant rejected");
+    assert!(matches!(err, CaduceusError::Config(_)), "got: {err:?}");
+}
+
+#[test]
+#[serial_test::serial]
+fn finish_mutation_violation_emits_event_and_persists_hint() {
+    use caduceus::logging::build_test_subscriber;
+
+    // AC3 pairing: the structured event AND the persisted hint land
+    // from one call. Serial + non-blocking appender + temp file +
+    // drop(guard) — the callsite-interest caching discipline.
+    let root = tempdir("ri-finish-event");
+    let log_path = root.join("finish.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let store = ReviewStore::open(&root).expect("open store");
+    let target = target_for(
+        "evrouter",
+        35,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "b",
+        "b",
+    );
+    store.enqueue_review(&target).expect("enqueue");
+    let claimed = store
+        .acquire_next_review("run-mv-4", 4242, Utc::now())
+        .expect("claim")
+        .expect("claim");
+    let wt_path = root.join("evidence-wt");
+    std::fs::create_dir_all(&wt_path).expect("mkdir");
+    let err = CaduceusError::ReviewSourceMutation {
+        worktree_path: wt_path.clone(),
+        detail: "daemon control file modified: worker-prompt.md".to_string(),
+    };
+
+    tracing::subscriber::with_default(subscriber, || {
+        finish_mutation_violation(&store, claimed.claim, &target, &err)
+            .expect("finish inside subscriber");
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read log");
+    assert!(
+        body.contains(&format!("\"event\":\"{MUTATION_VIOLATION_EVENT}\"")),
+        "{body}"
+    );
+    assert!(body.contains("\"repo\":\"rvowner/evrouter\""), "{body}");
+    let snapshot = store.review_queue_snapshot().expect("snapshot");
+    let entry = snapshot
+        .entries
+        .get(&review_queue_key(&target))
+        .expect("entry");
+    assert_eq!(entry.phase, ReviewPhase::NeedsAttention);
+    assert!(entry.blocked_recovery_hint.is_some());
+}

--- a/tests/state/error_test.rs
+++ b/tests/state/error_test.rs
@@ -307,6 +307,24 @@ fn scrub_helper_redacts_multiple_assignments_in_one_line() {
 }
 
 #[test]
+fn review_source_mutation_display_and_debug_render_fields() {
+    let err = CaduceusError::ReviewSourceMutation {
+        worktree_path: PathBuf::from("/tmp/review-wt"),
+        detail: "tracked files modified:\n M src/lib.rs".to_string(),
+    };
+    let display = format!("{err}");
+    assert!(
+        display.contains("review mutation violation"),
+        "got: {display}"
+    );
+    assert!(display.contains("/tmp/review-wt"), "got: {display}");
+    assert!(display.contains("src/lib.rs"), "got: {display}");
+    let debug = format!("{err:?}");
+    assert!(debug.contains("ReviewSourceMutation"), "got: {debug}");
+    assert!(debug.contains("/tmp/review-wt"), "got: {debug}");
+}
+
+#[test]
 fn symlinked_storage_root_display_contains_path() {
     let err = CaduceusError::SymlinkedStorageRoot {
         path: PathBuf::from("/tmp/linked-repos"),

--- a/tests/state/migration_framework_test.rs
+++ b/tests/state/migration_framework_test.rs
@@ -136,9 +136,25 @@ mod harness {
             sql.push_str("CREATE TABLE oci_runs (run_id TEXT PRIMARY KEY, container_id TEXT, state TEXT NOT NULL, engine TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, daemon_id TEXT NOT NULL, issue_id TEXT NOT NULL, worker_command_sha256 TEXT NOT NULL);");
         }
         // The review-era tables land at v8; a v7-era store (the real
-        // pre-#295 shape) must NOT carry them.
+        // pre-#295 shape) must NOT carry them. #306 adds the blocked
+        // columns to `review_queue_entries` at v9 — the v8 shape must
+        // NOT carry them or the v8→v9 ALTER would fail with a
+        // duplicate-column error.
         if version >= 8 {
-            sql.push_str("CREATE TABLE review_queue_entries (review_key TEXT PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL, pull_request INTEGER NOT NULL, head_sha TEXT NOT NULL, base_sha TEXT NOT NULL, base_ref TEXT NOT NULL, merge_base TEXT NOT NULL, phase TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, next_attempt_at TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, review_generation INTEGER NOT NULL DEFAULT 1);");
+            let blocked = if version >= 9 {
+                ", blocked_source TEXT, blocked_recovery_hint TEXT"
+            } else {
+                ""
+            };
+            sql.push_str(&format!(
+                "CREATE TABLE review_queue_entries (review_key TEXT PRIMARY KEY, \
+                 owner TEXT NOT NULL, repo TEXT NOT NULL, pull_request INTEGER NOT NULL, \
+                 head_sha TEXT NOT NULL, base_sha TEXT NOT NULL, base_ref TEXT NOT NULL, \
+                 merge_base TEXT NOT NULL, phase TEXT NOT NULL, \
+                 attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, last_run_id TEXT, \
+                 next_attempt_at TEXT, queued_at TEXT NOT NULL, updated_at TEXT NOT NULL, \
+                 review_generation INTEGER NOT NULL DEFAULT 1{blocked});"
+            ));
             sql.push_str("CREATE TABLE review_state (owner TEXT NOT NULL, repo TEXT NOT NULL, pull_request INTEGER NOT NULL, last_reviewed_head_sha TEXT, last_verdict TEXT, last_reviewed_at TEXT, sticky_comment_id INTEGER, last_run_id TEXT, review_generation INTEGER NOT NULL DEFAULT 1, publication_state TEXT NOT NULL DEFAULT 'pending', publication_attempt_count INTEGER NOT NULL DEFAULT 0, next_publish_at TEXT, last_publish_error TEXT, PRIMARY KEY (owner, repo, pull_request));");
             sql.push_str("CREATE TABLE review_history (review_run_id TEXT PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL, pull_request INTEGER NOT NULL, head_sha TEXT NOT NULL, review_generation INTEGER NOT NULL, completed_at TEXT NOT NULL, result_json TEXT NOT NULL);");
         }
@@ -521,8 +537,58 @@ fn no_live_version_flip() {
     // #295 flipped the store envelope atomically with the review
     // structures: SQLite v8, JSON v2. This pin keeps the two bumps
     // from drifting apart (or reverting) independently.
-    assert_eq!(SCHEMA_VERSION, 8);
+    // #306 bumps SQLite to v9 (review-queue blocked columns) without
+    // a JSON envelope bump — the fields are serde(default) additive.
+    assert_eq!(SCHEMA_VERSION, 9);
     assert_eq!(QUEUE_FILE_VERSION, 2);
+}
+
+#[test]
+fn v8_store_migrates_to_v9_with_blocked_columns() {
+    let dir = harness::temp_dir("v8-to-v9");
+    let path = harness::sqlite_store_at_version(&dir, 8);
+    let conn = open(&path).expect("open v8 store");
+    drop(conn);
+    harness::assert_sqlite_version(&path, SCHEMA_VERSION);
+    let conn = Connection::open(&path).expect("open raw for column check");
+    let mut cols: Vec<String> = conn
+        .prepare("PRAGMA table_info(review_queue_entries)")
+        .expect("prepare pragma")
+        .query_map([], |r| r.get::<_, String>(1))
+        .expect("query pragma")
+        .filter_map(|c| c.ok())
+        .collect();
+    drop(conn);
+    cols.sort();
+    assert!(cols.contains(&"blocked_source".to_string()));
+    assert!(cols.contains(&"blocked_recovery_hint".to_string()));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn v7_store_opens_through_v9_despite_late_review_tables() {
+    // Regression for the chain-ordering trap: `open()` runs the
+    // migration chain BEFORE `apply_schema` creates the review
+    // tables, so an m_v8_v9 step that unconditionally ALTERs
+    // `review_queue_entries` would fail with "no such table" on
+    // every real v7→current upgrade. The step must be conditional.
+    let dir = harness::temp_dir("v7-through-v9");
+    let path = harness::sqlite_store_at_version(&dir, 7);
+    let conn = open(&path).expect("v7 store must open through v9");
+    drop(conn);
+    harness::assert_sqlite_version(&path, SCHEMA_VERSION);
+    let conn = Connection::open(&path).expect("open raw for table check");
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' \
+             AND name='review_queue_entries'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count review_queue_entries");
+    drop(conn);
+    assert_eq!(count, 1, "review tables created by apply_schema");
+    let _ = fs::remove_dir_all(&dir);
 }
 
 // -----------------------------------------------------------------------

--- a/tests/state/review_activation_test.rs
+++ b/tests/state/review_activation_test.rs
@@ -93,7 +93,7 @@ fn pre_295_sqlite_v7_opens_and_migrates_to_v8() {
         drop(conn);
     }
 
-    // A plain `open` runs the chain: v7 → v8 with the review tables.
+    // A plain `open` runs the chain: v7 → v8 → v9 with the review tables.
     let conn = open(&db_path).expect("open v7 store");
     drop(conn);
 
@@ -101,7 +101,7 @@ fn pre_295_sqlite_v7_opens_and_migrates_to_v8() {
     let version: i64 = conn
         .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(version, 8);
+    assert_eq!(version, SCHEMA_VERSION);
     for table in ["review_queue_entries", "review_state", "review_history"] {
         let count: i64 = conn
             .query_row(
@@ -145,7 +145,7 @@ fn pre_295_binary_rejection_is_structural() {
     }
 
     // SQLite: same shape — a version-99 db hits the same gate a
-    // pre-#295 binary (SCHEMA_VERSION = 7) would hit on a v8 db.
+    // pre-#295 binary (SCHEMA_VERSION = 7) would hit on a current db.
     let dir = temp_dir("sqlite-future");
     let db_path = dir.join("state.db");
     {
@@ -167,7 +167,7 @@ fn pre_295_binary_rejection_is_structural() {
         } => {
             assert_eq!(backend, "sqlite");
             assert_eq!(found, 99);
-            assert_eq!(supported, 8);
+            assert_eq!(supported, SCHEMA_VERSION);
         }
         other => panic!("expected StoreVersionUnsupported; got: {other:?}"),
     }
@@ -176,12 +176,13 @@ fn pre_295_binary_rejection_is_structural() {
 
 #[test]
 fn v8_is_exactly_the_review_schema() {
-    // "v8 == implemented schema": a fresh v8 store contains exactly
-    // the pre-change table set PLUS the three review tables (and no
-    // other additions).
+    // "v8 == implemented schema": a fresh current store contains
+    // exactly the pre-#295 table set PLUS the three review tables (and
+    // no other additions). #306 (v9) only adds COLUMNS to
+    // review_queue_entries, so the table set is unchanged.
     let dir = temp_dir("v8-exact");
     let db_path = dir.join("state.db");
-    let conn = open(&db_path).expect("open fresh v8 store");
+    let conn = open(&db_path).expect("open fresh review-schema store");
     drop(conn);
 
     let conn = Connection::open(&db_path).unwrap();
@@ -214,16 +215,27 @@ fn v8_is_exactly_the_review_schema() {
     .map(|s| s.to_string())
     .collect();
     expected.sort();
-    assert_eq!(tables, expected, "v8 adds exactly the three review tables");
+    assert_eq!(
+        tables, expected,
+        "the review schema adds exactly the three review tables"
+    );
     let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
-fn registry_last_step_is_the_review_activation() {
+fn registry_last_step_reaches_current_and_review_activation_exists() {
     let chain = sqlite_migration_chain();
+    // The v7→v8 review activation step stays in the registry.
+    assert!(
+        chain
+            .iter()
+            .any(|&(from, to, label)| from == 7 && to == 8 && label == "review-era structures"),
+        "the v7→v8 review-era step (#295) must exist in the registry"
+    );
+    // The chain's last step reaches SCHEMA_VERSION (#306: 8→9).
     let (last_from, last_to, last_label) = *chain.last().unwrap();
-    assert_eq!(last_from, 7);
-    assert_eq!(last_to, 8);
-    assert_eq!(last_label, "review-era structures");
+    assert_eq!(last_from, 8);
+    assert_eq!(last_to, 9);
+    assert_eq!(last_label, "review_queue_entries blocked columns");
     assert_eq!(last_to, SCHEMA_VERSION);
 }

--- a/tests/state/review_store_test.rs
+++ b/tests/state/review_store_test.rs
@@ -114,6 +114,8 @@ fn review_queue_round_trips_strict() {
             queued_at: Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap(),
             review_generation: 1,
+            blocked_source: None,
+            blocked_recovery_hint: None,
         },
     );
     let state = ReviewQueueState {
@@ -465,6 +467,96 @@ fn json_skip_review_records_reason() {
     assert_eq!(entry.phase, ReviewPhase::Skipped);
     assert_eq!(entry.last_error.as_deref(), Some("not needed"));
     let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn needs_attention_blocked_fields_round_trip_both_backends() {
+    for open_store in [
+        |dir: &std::path::Path| ReviewStore::open(dir).unwrap(),
+        |dir: &std::path::Path| ReviewStore::open_sqlite(dir).unwrap(),
+    ] {
+        let dir = tempdir("rv-blocked-rt");
+        let store = open_store(&dir);
+        store.enqueue_review(&sample_target()).unwrap();
+        let now = Utc::now();
+        let claimed = store
+            .acquire_next_review("run-na-1", 4242, now)
+            .unwrap()
+            .expect("claim");
+        store
+            .route_review_to_needs_attention(
+                claimed.claim,
+                "review mutation violation",
+                "review/mutation_violation",
+                "inspect the archived worktree at /tmp/wt",
+            )
+            .unwrap();
+        let snap = store.review_queue_snapshot().unwrap();
+        let entry = snap
+            .entries
+            .get(&review_queue_key(&sample_target()))
+            .unwrap();
+        assert_eq!(entry.phase, ReviewPhase::NeedsAttention);
+        assert_eq!(
+            entry.blocked_recovery_hint.as_deref(),
+            Some("inspect the archived worktree at /tmp/wt")
+        );
+        assert_eq!(
+            entry.blocked_source.as_deref(),
+            Some("review/mutation_violation")
+        );
+        assert_eq!(
+            entry.last_error.as_deref(),
+            Some("review mutation violation")
+        );
+        // AC4: terminal routing never touches the attempt counter.
+        assert_eq!(entry.attempts, 0);
+        assert!(entry.last_run_id.is_none());
+        assert!(entry.next_attempt_at.is_none());
+        // Claim released: nothing is re-acquirable.
+        assert!(store
+            .acquire_next_review("run-na-2", 4243, now)
+            .unwrap()
+            .is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+}
+
+#[test]
+fn v1_review_queue_json_without_blocked_fields_still_parses() {
+    // The JSON envelope stays v1: an entry serialized WITHOUT the
+    // blocked fields (a #295-era file) must still parse — the fields
+    // are #[serde(default)] additive (issue-queue precedent).
+    let target = sample_target();
+    let entry_json = serde_json::json!({
+        "target": {
+            "repository": {"owner": OWNER, "repo": REPO},
+            "pull_request": PR,
+            "head_sha": SHA_A,
+            "base_sha": SHA_B,
+            "base_ref": "main",
+            "merge_base": "cccccccccccccccccccccccccccccccccccccccc",
+        },
+        "phase": "queued",
+        "attempts": 0,
+        "last_error": null,
+        "last_run_id": null,
+        "next_attempt_at": null,
+        "queued_at": "2026-09-05T12:00:00Z",
+        "updated_at": "2026-09-05T12:00:00Z",
+        "review_generation": 1,
+    });
+    let text = format!(
+        r#"{{"version":1,"entries":{{"{key}":{entry_json}}}}}"#,
+        key = review_queue_key(&target),
+    );
+    let parsed = parse_review_queue_state(&text).expect("v1 without blocked fields parses");
+    let entry = parsed
+        .entries
+        .get(&review_queue_key(&target))
+        .expect("entry present");
+    assert_eq!(entry.blocked_source, None);
+    assert_eq!(entry.blocked_recovery_hint, None);
 }
 
 #[test]
@@ -863,7 +955,11 @@ fn sqlite_unknown_version_rejected_and_v7_migrates() {
         let version: i64 = conn
             .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(version, 8, "v7 migrated to v8");
+        assert_eq!(
+            version,
+            caduceus::store::SCHEMA_VERSION,
+            "v7 migrated to current"
+        );
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM queue_entries", [], |r| r.get(0))
             .unwrap();


### PR DESCRIPTION
Closes #306

## Summary

Enforces the review worker's read-only contract with the real security boundary (DAR §6.4, §10):

- **Post-run tracked-file dirty check (DAR §10.1)** — `git status --porcelain --untracked-files=no` through the hardened GitRunner, with NO config overrides so the worktree's own git config (mirror config + `.gitattributes`) governs smudge/clean. Any non-empty porcelain output is a violation (modification / deletion / staged changes); untracked files (the result file, build artefacts) are excluded by construction. Git-status FAILURE is Infrastructure, never Terminal (a check that cannot run detected nothing).
- **Daemon control-file integrity (DAR §10.2)** — SHA-256 pre/post digests of `worker-prompt.md` and `review-worktree.json` (sidecar filename promoted to `pub const`). Deletion is modification; pre-capture failure is Io/Infrastructure (daemon-setup bug, no worker has run).
- **New `CaduceusError::ReviewSourceMutation { worktree_path, detail }`** classified `FailureClass::Terminal` in the exhaustive `classify_error` match — retry cannot fix a contract violation, so the retry budget is never burned.
- **Review store terminal route** — `route_review_to_needs_attention(claim, error, source, recovery_hint)`: phase → `NeedsAttention`, `blocked_source` / `blocked_recovery_hint` persisted, claim released, `attempts` untouched. SQLite schema bumps v8→v9 with a CONDITIONAL `m_v8_v9` step (a v7 store reaches the step before `apply_schema` creates the review tables — regression-tested); JSON stays v1 via `#[serde(default)]` fields (old files still parse, tested).
- **Composed route** — `finish_mutation_violation` emits the DAR §13 `review_mutation_violation` event (warn, target caduceus) FIRST, then routes with a hint pointing at the archived worktree (preserved as forensic evidence, reclaimed by the review GC — deliberately NOT torn down, contrasting the issue-queue route).

The caller seam (#339's dispatch loop) calls `enforce_review_read_only` post-exit pre-acceptance and `finish_mutation_violation` on the violation — same ship-primitives-then-wire shape as #303.

## Acceptance criteria

1. ✅ Tracked-file modification detected with the repo's git config — autocrlf=true and `.gitattributes eol=crlf` matrix tests (with on-disk CRLF preconditions + positive controls), modification/deletion/staged variants.
2. ✅ Control-file integrity detects `worker-prompt.md` modification (pre/post hash) — plus deletion, sidecar tampering, and the §10.2 rationale test (dirty check alone must NOT flag the untracked prompt).
3. ✅ New variant classified `Terminal`; `finish_mutation_violation` writes `blocked_recovery_hint` (audit event + persisted hint pairing tested).
4. ✅ Retry budget NOT burned — `counts_against_retry_budget()` is false for Terminal AND `attempts == 0` after routing (both backends).
5. ✅ Exhaustive `classify_error` match compiles (no wildcard arm).

## Verification

- `cargo fmt --check` — green
- `cargo clippy --locked --all-targets -- -D warnings` — green
- `cargo test --locked --all-targets` — 173 binaries, 2534 tests passed, 0 failed (hermetic skips: ac04/ac06/ac07/ac08, release_binary_canary)
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 188 passed
- New test binary: `tests/repo/review_integrity_test.rs` (28 tests, registered in Cargo.toml)

## Notes for reviewers

- SQLite `SCHEMA_VERSION` 8→9; `no_live_version_flip` updated to pin 9 + JSON v2. `review_activation_test` version literals now use `SCHEMA_VERSION`.
- `tests/fixtures/scenario-10-golden.json` updated to v9 (integration scenario 10 pins the store's canonical version).
- Out of scope (per issue): #339 dispatch wiring, #318 review CLI rendering of blocked fields, #312 NeedsAttention same-SHA re-admission predicate.
