### PR TITLE
feat(review): add tick-era PR re-discovery via generation CAS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,3 +734,7 @@ path = "tests/runtime/open_no_follow_test.rs"
 [[test]]
 name = "oci_env_live_test"
 path = "tests/integration/oci_env_live_test.rs"
+
+[[test]]
+name = "review_discovery_test"
+path = "tests/daemon/review_discovery_test.rs"

--- a/src/daemon/tick/awaiting_review.rs
+++ b/src/daemon/tick/awaiting_review.rs
@@ -287,14 +287,48 @@ pub(crate) fn finish_tick_outcome(
     last_error: Option<&CaduceusError>,
 ) -> CaduceusResult<()> {
     let _ = _meta;
+    // The rate-limit observation is the input to the next tick's
+    // `CadenceGate::precheck` and must be persisted *before* the tick
+    // returns (D14, issue #312). The PR step folds its step-level rate
+    // limit into exactly this `last_error` slot, so extract the
+    // observation here exactly as `finish_tick_failure` does — the
+    // behavior change is strictly "observation now persisted instead
+    // of dropped".
+    let rate_limit_info: Option<RateLimitInfo> = match last_error {
+        Some(CaduceusError::RateLimited {
+            reset_at,
+            remaining,
+            limit,
+        }) => Some(RateLimitInfo {
+            remaining: *remaining,
+            limit: *limit,
+            observed_at: now,
+            reset_at_unix: now.timestamp().saturating_add(*reset_at as i64),
+        }),
+        _ => None,
+    };
     gate.record_tick_finished(
         now,
         outcome,
         http_status,
         0,
-        None,
+        rate_limit_info.as_ref(),
         last_error.map(|e| format!("{e}")),
     )
+}
+
+/// Test seam (D14): mirrors `finish_tick_outcome` exactly so
+/// integration tests can assert the rate-limit observation is
+/// persisted from `last_error`.
+pub fn finish_tick_outcome_for_tests(
+    gate: &CadenceGate,
+    meta: &MetaStore,
+    now: DateTime<Utc>,
+    outcome: TickOutcome,
+    http_status: Option<u16>,
+    last_error: Option<&CaduceusError>,
+) -> CaduceusResult<()> {
+    finish_tick_outcome(gate, meta, now, outcome, http_status, last_error)
 }
 
 pub(crate) fn finish_tick_failure(

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -18,6 +18,14 @@
 //! 4. Reap stale claims / abandoned worktrees.
 //! 5. Build the typed GitHub [`Client`], discover watched
 //!    repos, poll typed open issues, enqueue summaries.
+//!    Step 5.5 (issue #312, between issue polling and the
+//!    drain): when `auto_review.enabled` and not in dry
+//!    run, poll watched repos' pull requests and admit
+//!    genuinely new head revisions into the review queue:
+//!    eligibility filtering, SHA-anchored mirror fetch +
+//!    merge-base capture at admission, bounded by
+//!    `max_reviews_per_tick`. Per-repo failures
+//!    log-and-continue; the step never aborts the tick.
 //! 6. Acquire the next eligible entry. If no entry is
 //!    eligible, finish as [`TickOutcome::Idle304`] (all
 //!    responses were cached 304s) or [`TickOutcome::IdleEmpty`]
@@ -493,6 +501,57 @@ pub async fn tick(
         return Err(err);
     }
 
+    // 5.5. Auto Review PR discovery + admission (issue #312, DAR §5).
+    //      Runs only when `auto_review.enabled` (and not in dry run).
+    //      Per-repo failures log-and-continue; a step-level error is
+    //      classified, logged, and folded into the tick's final
+    //      `last_error` / `http_status` — the drain below ALWAYS runs
+    //      (AC2/AC3). Never returns early.
+    let mut pr_step_error: Option<CaduceusError> = None;
+    let ar_enabled = cfg.auto_review().map(|ar| ar.enabled).unwrap_or(false);
+    if ar_enabled && !cfg.dry_run {
+        let review_store = if use_sqlite {
+            crate::state::review::ReviewStore::open_sqlite(&state_dir)
+        } else {
+            crate::state::review::ReviewStore::open(&state_dir)
+        };
+        match review_store {
+            Ok(review_store) => {
+                let runner = GitRunner::new(&cfg);
+                let resolve = |owner: &str, repo: &str| {
+                    crate::worktree::git_https_remote(&cfg.api_base, owner, repo)
+                };
+                match review_discovery::poll_review_step(
+                    &repos,
+                    &client,
+                    &cfg,
+                    &review_store,
+                    &runner,
+                    &resolve,
+                )
+                .await
+                {
+                    Ok(stats) => info!(?stats, "review discovery complete"),
+                    Err(err) => {
+                        let class = classify_error(&err);
+                        tracing::warn!(
+                            error = %err, ?class,
+                            "review discovery failed; continuing to drain"
+                        );
+                        pr_step_error = Some(err);
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "review store open failed; skipping PR discovery"
+                );
+                pr_step_error = Some(err);
+            }
+        }
+    }
+
     // 6. Drain the queue into a bounded `JoinSet` dispatch loop.
     //
     // Each iteration: (a) `acquire_next` under `LeaderToken::with_lock`
@@ -517,8 +576,11 @@ pub async fn tick(
     let services = Arc::new(services);
     let meta = Arc::new(meta);
     let client: Arc<Client> = Arc::clone(services.github.inner());
-    let mut http_status: Option<u16> = None;
-    let mut last_error: Option<CaduceusError> = None;
+    // The PR step's error (if any) seeds the drain's error slots so a
+    // step-level failure is persisted by the tick-finish paths (D14)
+    // while the drain itself still runs (AC3).
+    let mut http_status: Option<u16> = pr_step_error.as_ref().and_then(extract_http_status);
+    let mut last_error: Option<CaduceusError> = pr_step_error;
     let worker_parallelism = cfg.worker_parallelism.max(1) as usize;
     // Per-tick claim cap (issue #108): bounds how many queue entries
     // one tick will claim before returning. 0 == unbounded (the
@@ -764,10 +826,12 @@ pub async fn tick(
 pub mod awaiting_review;
 pub mod per_claim;
 pub mod resume;
+pub mod review_discovery;
 
 use self::awaiting_review::*;
 use self::per_claim::*;
 use self::resume::*;
+pub use self::review_discovery::*;
 
 pub use self::awaiting_review::{
     exit_code_for_tests, extract_http_status_for_tests, map_phase_to_outcome_for_tests,

--- a/src/daemon/tick/review_discovery.rs
+++ b/src/daemon/tick/review_discovery.rs
@@ -1,0 +1,700 @@
+//! In-tick Auto Review PR discovery + admission (issue #312, D3).
+//!
+//! Step 5.5 of the tick pipeline (between issue polling and the
+//! queue drain, DAR SS5): for each watched repo, list pull
+//! requests (`state=all`, client-side filtering per D4), classify
+//! every row through the pure eligibility predicate (D5), and
+//! admit genuinely new head revisions into the review queue.
+//!
+//! Isolation tiers (D9):
+//! - per-ROW: malformed / ineligible / git errors (incl.
+//!   `HeadShaUnavailable`, D8) log + count + continue;
+//! - per-REPO: list errors (500s, JSON parse) log + count
+//!   `failed_repos` + continue to the next repo - the issue
+//!   loop's break shape (tick/mod.rs) is NOT inherited (AC2);
+//! - step-level: rate limit + review-store write errors return
+//!   `Err` so the call site can classify and fold the error into
+//!   the tick's `last_error` - the tick NEVER returns early from
+//!   the PR step (AC3).
+//!
+//! Admission (D11): lazy mirror bootstrap per repo (D7), SHA-
+//! anchored fetch of head + base SHA (`fetch_sha`, #297),
+//! merge-base computed through the mirror and persisted on
+//! `ReviewTarget` (DAR SS2.1-2.2), then the atomic
+//! `ReviewStore::enqueue_review` (generation + queue write, #295).
+//! Nothing changed = no mirror work at all (AC7). The per-tick
+//! admission budget `max_reviews_per_tick` bounds admissions
+//! tick-wide and is checked BEFORE any git work (D10, AC6).
+//!
+//! Discovery NEVER touches the queue/state files directly and
+//! never fetches diffs or context (rate-limit discipline, D4).
+
+use tracing::{info, warn};
+
+use crate::daemon::orchestration::classify_error;
+use crate::github::pr::list_pull_requests;
+use crate::github::Client;
+use crate::infra::config::{AutoReviewConfig, Config};
+use crate::infra::error::{CaduceusError, CaduceusResult};
+
+use crate::repo::BareMirror;
+use crate::review::{RepositoryId, ReviewTarget};
+use crate::state::review::{ReviewEnqueueOutcome, ReviewStore};
+use crate::worktree::git_runner::GitRunner;
+
+// ---------------------------------------------------------------------------
+// Event constants + emission shape (DAR SS13, D2; fork-gate pattern)
+// ---------------------------------------------------------------------------
+
+/// DAR SS13 discovery event: a PR row passed eligibility (may be
+/// admitted this tick, budget permitting).
+pub const DISCOVERED_EVENT: &str = "review_discovered";
+/// DAR SS13 discovery event: `enqueue_review` inserted the target.
+pub const ADMITTED_EVENT: &str = "review_admitted";
+/// DAR SS5.1 skip event: draft PR with `draft_pull_requests: false`.
+pub const SKIPPED_DRAFT_EVENT: &str = "review_skipped_draft";
+/// DAR SS5.1 skip event: the exact head SHA is already active in the
+/// review queue or was already reviewed.
+pub const SKIPPED_ALREADY_COMPLETE_EVENT: &str = "review_skipped_already_complete";
+/// DAR SS5.1 poll event: the PR's head moved relative to a SHA the
+/// daemon held (active entry or `last_reviewed_head_sha`).
+pub const STALE_SHA_EVENT: &str = "review_stale_sha_observed";
+
+/// Emit `review_discovered` (D5 step: a row passed eligibility).
+fn emit_discovered(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = DISCOVERED_EVENT,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "PR revision discovered for review"
+    );
+}
+
+/// Emit `review_admitted` (D2: DAR SS13 assigns this event to
+/// discovery; fired only when `enqueue_review` returned `Inserted`).
+fn emit_admitted(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = ADMITTED_EVENT,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "PR revision admitted into the review queue"
+    );
+}
+
+/// Emit `review_skipped_draft` (DAR SS5.1).
+fn emit_skipped_draft(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = SKIPPED_DRAFT_EVENT,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "PR skipped: draft"
+    );
+}
+
+/// Emit `review_skipped_already_complete` (DAR SS5.1: dedup skip).
+fn emit_skipped_already_complete(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = SKIPPED_ALREADY_COMPLETE_EVENT,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "PR skipped: head SHA already queued or reviewed"
+    );
+}
+
+/// Emit `review_stale_sha_observed` (D6: the held SHA moved).
+fn emit_stale_sha(repo: &str, pr: u64, previous_sha: &str, observed_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = STALE_SHA_EVENT,
+        repo = repo,
+        pr = pr,
+        previous_sha = previous_sha,
+        observed_sha = observed_sha,
+        "PR head moved since the last held revision"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Core types (plan SS4.3 contract)
+// ---------------------------------------------------------------------------
+
+/// What discovery holds for one `(repo, pr)` (D6): the head SHAs of
+/// ACTIVE queue entries and the completed-review pointer.
+///
+/// Public so integration tests can build the dedup fixtures
+/// (`classify_discovery_row_for_tests`); no behaviour surface.
+#[derive(Clone, Debug)]
+pub struct HeldShas {
+    /// Active (`Queued`/`InProgress`) queue entries' head SHAs.
+    pub active: Vec<String>,
+    /// `ReviewState.last_reviewed_head_sha` of the completed review.
+    pub last_reviewed: Option<String>,
+}
+
+/// One row's verdict (D5). `Ineligible` and `Malformed` carry NO
+/// event; `SkipDraft` / `SkipFork` / `SkipAlreadyComplete` carry
+/// their SS13 events at the emit site.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RowAction {
+    /// Admit (subject to the tick-wide budget, D10).
+    Admit,
+    /// Draft + `draft_pull_requests: false` -> `review_skipped_draft`.
+    SkipDraft,
+    /// Fork gate failed -> existing `emit_fork_gate_skip`.
+    SkipFork { head_repo: Option<String> },
+    /// Dedup hit -> `review_skipped_already_complete`.
+    SkipAlreadyComplete,
+    /// Closed / merged - never admitted, NO event (DAR SS5.1).
+    Ineligible,
+    /// Unreadable wire row - log-only, NO event (DAR SS13 defines no
+    /// malformed-row event; mirrors `IssuePollDiagnostic::Malformed`).
+    Malformed { reason: String },
+}
+
+/// One row's decision (D5 + D6).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RowDecision {
+    pub action: RowAction,
+    /// `(previous_sha, observed_sha)` when the PR's held SHA moved (D6).
+    pub stale: Option<(String, String)>,
+    /// Observed head SHA when readable.
+    pub head_sha: String,
+    pub base_sha: String,
+    pub base_ref: String,
+}
+
+/// Tick-wide discovery counters (plan SS4.3; log at step end).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ReviewDiscoveryStats {
+    pub repos_polled: u32,
+    pub discovered: u32,
+    pub admitted: u32,
+    pub skipped_draft: u32,
+    pub skipped_fork: u32,
+    pub skipped_already_complete: u32,
+    pub ineligible: u32,
+    pub malformed: u32,
+    pub stale_observed: u32,
+    pub skipped_unavailable_sha: u32,
+    pub failed_admissions: u32,
+    pub failed_repos: u32,
+    pub budget_exhausted: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Pure eligibility classifier (Task 4, D5 - no I/O, no logging, never
+// panics on any wire shape; mirrors classify_fork's contract)
+// ---------------------------------------------------------------------------
+
+/// Classify one `/pulls` row through the D5 eligibility order:
+/// malformed -> closed/merged -> draft -> fork -> dedup ->
+/// stale-observe -> admit. Pure: no I/O, no logging, never panics.
+///
+/// Public via [`classify_discovery_row_for_tests`] (the integration
+/// seam, D12); production callers use this directly.
+pub(crate) fn classify_discovery_row(
+    row: &crate::github::pr::PullRequestDetail,
+    ar: &AutoReviewConfig,
+    held: &HeldShas,
+) -> RowDecision {
+    // 2. Malformed rows (D5 step 2): missing identity or SHA context.
+    let Some(_) = row.number else {
+        return malformed("missing number");
+    };
+    let Some(base) = row.base.as_ref() else {
+        return malformed("missing base");
+    };
+    let Some(base_sha) = base.sha.as_deref() else {
+        return malformed("missing base.sha");
+    };
+    let Some(base_ref) = base.ref_name.as_deref() else {
+        return malformed("missing base.ref");
+    };
+    let Some(head) = row.head.as_ref() else {
+        return malformed("missing head");
+    };
+    let Some(head_sha) = head.sha.as_deref() else {
+        return malformed("missing head.sha");
+    };
+    if head_sha.is_empty() || base_sha.is_empty() {
+        return malformed("empty SHA");
+    }
+
+    // 3. Closed / merged rows are never admitted - NO event (DAR SS5.1).
+    if row.state.as_deref() != Some("open") || row.merged == Some(true) {
+        return RowDecision {
+            action: RowAction::Ineligible,
+            stale: None,
+            head_sha: head_sha.to_string(),
+            base_sha: base_sha.to_string(),
+            base_ref: base_ref.to_string(),
+        };
+    }
+
+    // 4. Draft gate (DAR SS5.1): `review_skipped_draft` unless the
+    //    operator opted in.
+    if row.draft && !ar.draft_pull_requests {
+        return RowDecision {
+            action: RowAction::SkipDraft,
+            stale: None,
+            head_sha: head_sha.to_string(),
+            base_sha: base_sha.to_string(),
+            base_ref: base_ref.to_string(),
+        };
+    }
+
+    // 5. Fork gate (Phase-1 contract, #316): every non-SameRepo
+    //    verdict skips with the existing SS13 event; `head.repo: null`
+    //    (deleted head branch) lands here as `HeadRepoMissing`.
+    let fork = crate::github::fork_gate::classify_fork(row);
+    if !fork.passes() {
+        return RowDecision {
+            action: RowAction::SkipFork {
+                head_repo: fork.head_repo_identity().map(str::to_string),
+            },
+            stale: None,
+            head_sha: head_sha.to_string(),
+            base_sha: base_sha.to_string(),
+            base_ref: base_ref.to_string(),
+        };
+    }
+
+    // 6. Dedup: the exact `(repo, pr, head_sha)` is already active in
+    //    the queue or already reviewed -> `review_skipped_already_
+    //    complete` (DAR SS4.3 pointer + active-only dedup; history is
+    //    never consulted).
+    let already_held = held.active.iter().any(|sha| sha == head_sha)
+        || held.last_reviewed.as_deref() == Some(head_sha);
+    if already_held {
+        return RowDecision {
+            action: RowAction::SkipAlreadyComplete,
+            stale: None,
+            head_sha: head_sha.to_string(),
+            base_sha: base_sha.to_string(),
+            base_ref: base_ref.to_string(),
+        };
+    }
+
+    // 7. Stale observation (D6): ANY other held SHA differs from the
+    //    observed head -> emit once at the emit site and CONTINUE -
+    //    the observed head is itself genuinely new and admits now.
+    let stale = held
+        .active
+        .first()
+        .cloned()
+        .or_else(|| held.last_reviewed.clone())
+        .filter(|previous| previous != head_sha)
+        .map(|previous| (previous, head_sha.to_string()));
+
+    // 8. Admit (budget permitting at the caller, D10).
+    RowDecision {
+        action: RowAction::Admit,
+        stale,
+        head_sha: head_sha.to_string(),
+        base_sha: base_sha.to_string(),
+        base_ref: base_ref.to_string(),
+    }
+}
+
+fn malformed(reason: &str) -> RowDecision {
+    RowDecision {
+        action: RowAction::Malformed {
+            reason: reason.to_string(),
+        },
+        stale: None,
+        head_sha: String::new(),
+        base_sha: String::new(),
+        base_ref: String::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Admission (Task 5, D11)
+// ---------------------------------------------------------------------------
+
+/// One admission: fetch head SHA, fetch base SHA, compute + persist
+/// the merge base, enqueue atomically (D11). Git errors are per-target
+/// (caller logs + continues); store-write errors propagate as
+/// step-level (D9). Returns `Ok(true)` when the target was inserted,
+/// `Ok(false)` when a concurrent admission already held it or the
+/// SHAs were unavailable (D8).
+#[allow(clippy::too_many_arguments)] // plan D11 surface: fixed 8-arg admission contract
+pub(crate) async fn admit_target(
+    runner: &GitRunner,
+    mirror: &BareMirror,
+    review_store: &ReviewStore,
+    repository: &RepositoryId,
+    pull_request: u64,
+    head_sha: &str,
+    base_sha: &str,
+    base_ref: &str,
+) -> CaduceusResult<bool> {
+    // 2. SHA-anchored head fetch (D8: unavailable -> skip, no event;
+    //    #339 owns the skip routing).
+    mirror.fetch_sha(runner, head_sha).await?;
+    // 3. Base fetch - both objects are then guaranteed present
+    //    locally (D11: do NOT rely on the base-branch fetch having
+    //    landed the wire's base.sha).
+    mirror.fetch_sha(runner, base_sha).await?;
+    // 4. Merge base (DAR SS2.1). Unrelated histories fail as
+    //    `CaduceusError::Git` -> per-target log-and-skip (caller).
+    let merge_base = mirror.merge_base(runner, base_sha, head_sha).await?;
+    // 5. Build the full ReviewTarget (merge_base populated; validation
+    //    happens inside enqueue_review).
+    let target = ReviewTarget {
+        repository: repository.clone(),
+        pull_request,
+        head_sha: head_sha.to_string(),
+        base_sha: base_sha.to_string(),
+        base_ref: base_ref.to_string(),
+        merge_base,
+    };
+    // 6. Atomic generation + queue write (#295).
+    match review_store.enqueue_review(&target)? {
+        ReviewEnqueueOutcome::Inserted => Ok(true),
+        ReviewEnqueueOutcome::AlreadyPresent => Ok(false),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The discovery loop (Task 6, D5/D9/D10/D11/D12)
+// ---------------------------------------------------------------------------
+
+/// Step 5.5 of the tick: per-repo PR discovery + admission.
+///
+/// Returns `Err` ONLY for step-level failures (rate limit while
+/// listing; review-store write errors). Everything per-repo /
+/// per-row is logged + counted (D9).
+pub(crate) async fn poll_review_step(
+    repos: &[String],
+    client: &Client,
+    cfg: &Config,
+    review_store: &ReviewStore,
+    runner: &GitRunner,
+    resolve_remote: &dyn Fn(&str, &str) -> CaduceusResult<String>,
+) -> CaduceusResult<ReviewDiscoveryStats> {
+    let ar = match cfg.auto_review() {
+        Some(ar) => ar,
+        // Whole step gated on `auto_review.enabled` (D5 step 1).
+        None => return Ok(ReviewDiscoveryStats::default()),
+    };
+    if !ar.enabled {
+        return Ok(ReviewDiscoveryStats::default());
+    }
+
+    let budget = cfg.max_reviews_per_tick;
+    let mut stats = ReviewDiscoveryStats::default();
+    // Held SHAs read once per repo via one snapshot (D11/D9: a read
+    // path over the store, no direct file access).
+    let mut mirrors: std::collections::BTreeMap<String, BareMirror> =
+        std::collections::BTreeMap::new();
+
+    for repo in repos {
+        // Parse the `owner/repo` slug. Malformed slugs cannot happen
+        // for validated config / API discovery, but a safety net
+        // keeps the row classifier total.
+        let Some((owner, name)) = repo.split_once('/') else {
+            warn!(
+                target: "caduceus",
+                repo = repo,
+                "review discovery: malformed repo slug; skipping"
+            );
+            stats.failed_repos += 1;
+            continue;
+        };
+
+        let pulls = match list_pull_requests(client, owner, name).await {
+            Ok(pulls) => pulls,
+            // Per-REPO tier (D9): list errors log + count + continue.
+            // A global rate limit is a step-level condition - later
+            // repos would fail identically, so surface it (D9).
+            Err(err @ CaduceusError::RateLimited { .. }) => return Err(err),
+            Err(err) => {
+                warn!(
+                    target: "caduceus",
+                    error = %err,
+                    repo = repo,
+                    "review discovery: PR list failed; continuing to next repo"
+                );
+                stats.failed_repos += 1;
+                continue;
+            }
+        };
+        stats.repos_polled += 1;
+
+        for row in &pulls {
+            // Budget check BEFORE any per-row work so an exhausted
+            // budget does no git work (D10). Deferred candidates are
+            // re-discovered next tick - no `review_discovered` event
+            // for them.
+            if budget != 0 && stats.admitted >= budget {
+                stats.budget_exhausted = true;
+                break;
+            }
+
+            let Some(pr_number) = row.number else {
+                stats.malformed += 1;
+                continue;
+            };
+
+            // Held SHAs for this (repo, pr): active queue entries +
+            // the completed-review pointer (D6). Read per row through
+            // the store's public read API.
+            let held = read_held_shas(review_store, owner, name, pr_number)?;
+
+            let decision = classify_discovery_row(row, ar, &held);
+
+            // Emit the stale observation BEFORE the action event so
+            // the log reads chronologically (D6).
+            if let Some((previous, observed)) = &decision.stale {
+                emit_stale_sha(repo, pr_number, previous, observed);
+                stats.stale_observed += 1;
+            }
+
+            match decision.action {
+                RowAction::Admit => {
+                    emit_discovered(repo, pr_number, &decision.head_sha);
+                    stats.discovered += 1;
+
+                    // Lazy mirror bootstrap (D7): only when this repo
+                    // has at least one candidate that passed
+                    // eligibility + budget (AC7).
+                    let mirror = match mirrors.get(repo) {
+                        Some(m) => m,
+                        None => {
+                            let remote = match resolve_remote(owner, name) {
+                                Ok(remote) => remote,
+                                Err(err) => {
+                                    warn!(
+                                        target: "caduceus",
+                                        error = %err,
+                                        repo = repo,
+                                        "review discovery: remote resolve failed; skipping repo"
+                                    );
+                                    stats.failed_repos += 1;
+                                    break;
+                                }
+                            };
+                            match BareMirror::ensure(
+                                runner,
+                                cfg,
+                                owner,
+                                name,
+                                &remote,
+                                &decision.base_ref,
+                            )
+                            .await
+                            {
+                                Ok(m) => {
+                                    mirrors.insert(repo.to_string(), m);
+                                    mirrors.get(repo).expect("just inserted")
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        target: "caduceus",
+                                        error = %err,
+                                        repo = repo,
+                                        "review discovery: mirror ensure failed; skipping repo"
+                                    );
+                                    stats.failed_repos += 1;
+                                    break;
+                                }
+                            }
+                        }
+                    };
+
+                    let repository_id = RepositoryId {
+                        owner: owner.to_string(),
+                        repo: name.to_string(),
+                    };
+                    match admit_target(
+                        runner,
+                        mirror,
+                        review_store,
+                        &repository_id,
+                        pr_number,
+                        &decision.head_sha,
+                        &decision.base_sha,
+                        &decision.base_ref,
+                    )
+                    .await
+                    {
+                        Ok(true) => {
+                            emit_admitted(repo, pr_number, &decision.head_sha);
+                            stats.admitted += 1;
+                        }
+                        Ok(false) => {
+                            // A concurrent admission won the race or
+                            // the SHAs were unavailable (D8). Debug
+                            // log, no event.
+                            info!(
+                                target: "caduceus",
+                                repo = repo,
+                                pr = pr_number,
+                                "review discovery: target already present; skipping"
+                            );
+                        }
+                        Err(err) => {
+                            // Per-target git errors (incl.
+                            // HeadShaUnavailable, D8) log + count +
+                            // continue. Store-write errors propagate
+                            // as step-level (D9).
+                            let class = classify_error(&err);
+                            if matches!(
+                                class,
+                                crate::daemon::orchestration::FailureClass::Infrastructure
+                            ) && !matches!(err, CaduceusError::HeadShaUnavailable { .. })
+                            {
+                                return Err(err);
+                            }
+                            if matches!(err, CaduceusError::HeadShaUnavailable { .. }) {
+                                stats.skipped_unavailable_sha += 1;
+                                info!(
+                                    target: "caduceus",
+                                    repo = repo,
+                                    pr = pr_number,
+                                    "review discovery: head SHA unavailable; skipping (next poll retries)"
+                                );
+                            } else {
+                                warn!(
+                                    target: "caduceus",
+                                    error = %err,
+                                    repo = repo,
+                                    pr = pr_number,
+                                    "review discovery: admission failed; skipping target"
+                                );
+                                stats.failed_admissions += 1;
+                            }
+                        }
+                    }
+                }
+                RowAction::SkipDraft => {
+                    emit_skipped_draft(repo, pr_number, &decision.head_sha);
+                    stats.skipped_draft += 1;
+                }
+                RowAction::SkipFork { head_repo } => {
+                    crate::github::fork_gate::emit_fork_gate_skip(
+                        repo,
+                        pr_number,
+                        head_repo.as_deref(),
+                    );
+                    stats.skipped_fork += 1;
+                }
+                RowAction::SkipAlreadyComplete => {
+                    emit_skipped_already_complete(repo, pr_number, &decision.head_sha);
+                    stats.skipped_already_complete += 1;
+                }
+                RowAction::Ineligible => {
+                    stats.ineligible += 1;
+                }
+                RowAction::Malformed { reason } => {
+                    warn!(
+                        target: "caduceus",
+                        repo = repo,
+                        reason = reason,
+                        "review discovery: malformed PR row; skipping"
+                    );
+                    stats.malformed += 1;
+                }
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Read the held SHAs for one `(repo, pr)` (D6): active queue
+/// entries' head SHAs + `ReviewState.last_reviewed_head_sha`.
+/// Store-read errors propagate as step-level (D9).
+fn read_held_shas(
+    review_store: &ReviewStore,
+    owner: &str,
+    name: &str,
+    pr_number: u64,
+) -> CaduceusResult<HeldShas> {
+    let repository = RepositoryId {
+        owner: owner.to_string(),
+        repo: name.to_string(),
+    };
+    let snapshot = review_store.review_queue_snapshot()?;
+    let active: Vec<String> = snapshot
+        .entries
+        .values()
+        .filter(|entry| {
+            entry.phase.is_active()
+                && entry.target.repository.owner == repository.owner
+                && entry.target.repository.repo == repository.repo
+                && entry.target.pull_request == pr_number
+        })
+        .map(|entry| entry.target.head_sha.clone())
+        .collect();
+    let state = review_store.review_state(&repository, pr_number)?;
+    let last_reviewed = state.and_then(|s| s.last_reviewed_head_sha);
+    Ok(HeldShas {
+        active,
+        last_reviewed,
+    })
+}
+
+/// Public test seam (plan SS4.3, D12): mirrors
+/// `poll_awaiting_review_entries_for_tests`. Same body as
+/// `poll_review_step`.
+pub async fn poll_review_step_for_tests(
+    repos: &[String],
+    client: &Client,
+    cfg: &Config,
+    review_store: &ReviewStore,
+    runner: &GitRunner,
+    resolve_remote: &dyn Fn(&str, &str) -> CaduceusResult<String>,
+) -> CaduceusResult<ReviewDiscoveryStats> {
+    poll_review_step(repos, client, cfg, review_store, runner, resolve_remote).await
+}
+
+/// Public test seam (D12): the pure eligibility classifier. Same body
+/// as `classify_discovery_row`.
+pub fn classify_discovery_row_for_tests(
+    row: &crate::github::pr::PullRequestDetail,
+    ar: &AutoReviewConfig,
+    held: &HeldShas,
+) -> RowDecision {
+    classify_discovery_row(row, ar, held)
+}
+
+/// Public test seam (D12): the structured `review_discovered`
+/// emitter, for event-capture tests.
+pub fn emit_discovered_for_tests(repo: &str, pr: u64, head_sha: &str) {
+    emit_discovered(repo, pr, head_sha)
+}
+
+/// Public test seam (D12): one admission (fetch head SHA, fetch base
+/// SHA, merge base, atomic enqueue). Same body as `admit_target`.
+#[allow(clippy::too_many_arguments)]
+pub async fn admit_target_for_tests(
+    runner: &GitRunner,
+    mirror: &BareMirror,
+    review_store: &ReviewStore,
+    repository: &RepositoryId,
+    pull_request: u64,
+    head_sha: &str,
+    base_sha: &str,
+    base_ref: &str,
+) -> CaduceusResult<bool> {
+    admit_target(
+        runner,
+        mirror,
+        review_store,
+        repository,
+        pull_request,
+        head_sha,
+        base_sha,
+        base_ref,
+    )
+    .await
+}

--- a/src/daemon/tick/review_discovery.rs
+++ b/src/daemon/tick/review_discovery.rs
@@ -31,7 +31,6 @@
 
 use tracing::{info, warn};
 
-use crate::daemon::orchestration::classify_error;
 use crate::github::pr::list_pull_requests;
 use crate::github::Client;
 use crate::infra::config::{AutoReviewConfig, Config};
@@ -543,35 +542,40 @@ pub(crate) async fn poll_review_step(
                             );
                         }
                         Err(err) => {
-                            // Per-target git errors (incl.
-                            // HeadShaUnavailable, D8) log + count +
-                            // continue. Store-write errors propagate
-                            // as step-level (D9).
-                            let class = classify_error(&err);
-                            if matches!(
-                                class,
-                                crate::daemon::orchestration::FailureClass::Infrastructure
-                            ) && !matches!(err, CaduceusError::HeadShaUnavailable { .. })
-                            {
-                                return Err(err);
-                            }
-                            if matches!(err, CaduceusError::HeadShaUnavailable { .. }) {
-                                stats.skipped_unavailable_sha += 1;
-                                info!(
-                                    target: "caduceus",
-                                    repo = repo,
-                                    pr = pr_number,
-                                    "review discovery: head SHA unavailable; skipping (next poll retries)"
-                                );
-                            } else {
-                                warn!(
-                                    target: "caduceus",
-                                    error = %err,
-                                    repo = repo,
-                                    pr = pr_number,
-                                    "review discovery: admission failed; skipping target"
-                                );
-                                stats.failed_admissions += 1;
+                            // D9 per-row isolation: git errors from the
+                            // admission itself (mirror fetch, merge
+                            // base - including `HeadShaUnavailable`,
+                            // D8) log + count + continue. Only
+                            // store/state write errors (from
+                            // `enqueue_review`) and cancellation
+                            // propagate as step-level so the call
+                            // site can classify them.
+                            match err {
+                                CaduceusError::HeadShaUnavailable { .. } => {
+                                    stats.skipped_unavailable_sha += 1;
+                                    info!(
+                                        target: "caduceus",
+                                        repo = repo,
+                                        pr = pr_number,
+                                        "review discovery: head SHA unavailable; skipping (next poll retries)"
+                                    );
+                                }
+                                // Git transport / merge-base failure
+                                // for this target only (e.g. unrelated
+                                // histories): the next poll retries.
+                                CaduceusError::Git { .. } => {
+                                    warn!(
+                                        target: "caduceus",
+                                        error = %err,
+                                        repo = repo,
+                                        pr = pr_number,
+                                        "review discovery: admission failed; skipping target"
+                                    );
+                                    stats.failed_admissions += 1;
+                                }
+                                // Store/state write errors and
+                                // cancellation are step-level (D9).
+                                other => return Err(other),
                             }
                         }
                     }

--- a/src/repo/mirror.rs
+++ b/src/repo/mirror.rs
@@ -245,6 +245,43 @@ impl BareMirror {
         Ok(output.status == Some(0))
     }
 
+    /// Compute the merge base of two SHAs inside the mirror:
+    /// `git merge-base <base_sha> <head_sha>` (issue #312, D11 step 4).
+    /// This is the three-dot diff anchor captured once at admission and
+    /// persisted on `ReviewTarget` (DAR SS2.1-2.2). Both SHAs must
+    /// already be in the mirror's object store (`fetch_sha` first) -
+    /// unrelated histories (no common ancestor) fail as
+    /// [`CaduceusError::Git`].
+    pub async fn merge_base(
+        &self,
+        runner: &GitRunner,
+        base_sha: &str,
+        head_sha: &str,
+    ) -> CaduceusResult<String> {
+        let output = runner
+            .run_args(
+                "mirror-merge-base",
+                [
+                    "-C",
+                    &self.path.to_string_lossy(),
+                    "merge-base",
+                    base_sha,
+                    head_sha,
+                ],
+            )
+            .await?;
+        if output.cancelled {
+            return Err(CaduceusError::Cancelled);
+        }
+        if output.timed_out || output.status != Some(0) {
+            return Err(CaduceusError::Git {
+                operation: "mirror-merge-base",
+                stderr: output.stderr,
+            });
+        }
+        Ok(output.stdout.trim().to_string())
+    }
+
     /// Expose the mirror path.
     pub fn path(&self) -> &Path {
         &self.path

--- a/src/worktree/repository.rs
+++ b/src/worktree/repository.rs
@@ -245,12 +245,7 @@ pub fn parse_origin(remote_url: &str) -> CaduceusResult<(String, String)> {
 /// host. Public github.com → origin host must equal `github.com`.
 /// Enterprise → origin host must equal the api_base host verbatim.
 pub fn validate_origin_host(remote_url: &str, api_base: &str) -> CaduceusResult<()> {
-    let api_url = Url::parse(api_base)
-        .map_err(|err| CaduceusError::Config(format!("invalid api_base {api_base}: {err}")))?;
-    let api_host = api_url
-        .host_str()
-        .map(|h| h.to_ascii_lowercase())
-        .ok_or_else(|| CaduceusError::Config(format!("api_base has no host: {api_base}")))?;
+    let api_host = api_git_host(api_base)?;
     let origin_host = origin_host(remote_url)?;
     // The contract distinguishes two cases:
     //   1. Public github.com — api_base is the canonical
@@ -282,6 +277,40 @@ pub fn validate_origin_host(remote_url: &str, api_base: &str) -> CaduceusResult<
         });
     }
     Ok(())
+}
+
+/// Map the daemon's `api_base` to the git host its remotes must
+/// target: the single api-to-git host rule, shared by
+/// [`validate_origin_host`] and [`git_https_remote`] so the two
+/// cannot drift (issue #312, D7).
+///
+/// Public (`api.github.com` / `github.com`, the canonical default
+/// `https://api.github.com` URL) maps to `github.com`; enterprise
+/// maps to the api_base host verbatim (lowercased).
+pub fn api_git_host(api_base: &str) -> CaduceusResult<String> {
+    let api_url = Url::parse(api_base)
+        .map_err(|err| CaduceusError::Config(format!("invalid api_base {api_base}: {err}")))?;
+    let api_host = api_url
+        .host_str()
+        .map(|h| h.to_ascii_lowercase())
+        .ok_or_else(|| CaduceusError::Config(format!("api_base has no host: {api_base}")))?;
+    Ok(api_host)
+}
+
+/// Derive the https git remote URL for *owner/repo* from the
+/// daemon's `api_base` (issue #312, D7). Public
+/// (`api.github.com` / `github.com`) remotes target
+/// `https://github.com/{owner}/{repo}.git`; enterprise remotes
+/// target the api_base host verbatim. Auth rides the
+/// [`GitRunner`]'s `GIT_ASKPASS` credential-helper fd - no
+/// URL-embedded credentials.
+pub fn git_https_remote(api_base: &str, owner: &str, repo: &str) -> CaduceusResult<String> {
+    let api_host = api_git_host(api_base)?;
+    let is_public = api_host == "api.github.com"
+        || api_host == "github.com"
+        || api_base.trim_end_matches('/') == "https://api.github.com";
+    let git_host = if is_public { "github.com" } else { &api_host };
+    Ok(format!("https://{git_host}/{owner}/{repo}.git"))
 }
 
 /// Extract the host component of an origin URL. SSH forms

--- a/tests/daemon/review_discovery_test.rs
+++ b/tests/daemon/review_discovery_test.rs
@@ -1,0 +1,1384 @@
+//! In-tick PR discovery + admission tests (issue #312, plan Tasks 1/4/5/6/7).
+//!
+//! Coverage per DAR §15 and the issue's required-tests list:
+//!
+//! - Event-constant catalog pin + structured emission capture
+//!   (`serial_test::serial`: `tracing_core` caches callsite interest
+//!   process-wide, the #167 finding).
+//! - The pure eligibility classifier's §5.1 truth table: open,
+//!   draft (default + opted-in), closed, merged, fork, nullable
+//!   head repo, already-active / already-reviewed dedup,
+//!   stale-SHA observation, malformed rows, and the
+//!   draft-beats-fork ordering pin.
+//! - Admission against a real local git remote + `ReviewStore`:
+//!   merge-base capture (AC5), generation assignment + bump (AC4),
+//!   dedup, and unavailable-SHA skip.
+//! - The `poll_review_step` loop over wiremock: per-repo failure
+//!   isolation (AC2), rate-limit surfacing, malformed body,
+//!   admission budget (AC6), zero mirror work when nothing
+//!   changed (AC7), stale event + admission, pagination, and
+//!   wire-order admission.
+//! - Tick wiring: issues-before-pulls HTTP order (AC1), disabled /
+//!   dry-run skip, corrupt review store does not starve the drain
+//!   (AC3), and the D14 rate-limit observation regression.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use caduceus::config::{AutoReviewConfig, Config, LoadContext, RawConfig};
+use caduceus::daemon::tick::review_discovery::{
+    admit_target_for_tests, classify_discovery_row_for_tests, poll_review_step_for_tests,
+    ADMITTED_EVENT, DISCOVERED_EVENT, SKIPPED_ALREADY_COMPLETE_EVENT, SKIPPED_DRAFT_EVENT,
+    STALE_SHA_EVENT,
+};
+use caduceus::error::CaduceusError;
+use caduceus::github::fork_gate::FORK_SKIP_EVENT;
+use caduceus::github::{Client, HttpCache, PullRequestDetail};
+use caduceus::infra::logging::build_test_subscriber;
+use caduceus::meta::TickOutcome;
+use caduceus::orchestration::SystemClock;
+use caduceus::repo::BareMirror;
+use caduceus::review::{RepositoryId, ReviewState, ReviewTarget};
+use caduceus::scheduler::{DrainConfig, Pool};
+use caduceus::state::meta::MetaStore;
+use caduceus::state::review::{ReviewPhase, ReviewStore};
+use caduceus::worktree::GitRunner;
+use chrono::Utc;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// A `/pulls` row. `None` renders `"repo": null` (the deleted-head
+/// wire shape). Defaults: number 7, open, non-draft, SHAs `aaaa` /
+/// `bbbb`.
+fn pr_row(head_repo: Option<&str>, base_repo: Option<&str>) -> serde_json::Value {
+    let mut row = serde_json::json!({
+        "number": 7,
+        "title": "Discovery row",
+        "state": "open",
+        "draft": false,
+        "base": {"ref": "main", "sha": "aaaa"},
+        "head": {"ref": "feature-x", "sha": "bbbb"}
+    });
+    row["base"]["repo"] = base_repo
+        .map(|name| serde_json::json!({"full_name": name}))
+        .unwrap_or(serde_json::Value::Null);
+    row["head"]["repo"] = head_repo
+        .map(|name| serde_json::json!({"full_name": name}))
+        .unwrap_or(serde_json::Value::Null);
+    row
+}
+
+fn with_state(mut row: serde_json::Value, state: &str) -> serde_json::Value {
+    row["state"] = serde_json::json!(state);
+    row
+}
+
+fn with_draft(mut row: serde_json::Value, draft: bool) -> serde_json::Value {
+    row["draft"] = serde_json::json!(draft);
+    row
+}
+
+fn with_number(mut row: serde_json::Value, number: Option<u64>) -> serde_json::Value {
+    row["number"] = number
+        .map(|n| serde_json::json!(n))
+        .unwrap_or(serde_json::Value::Null);
+    row
+}
+
+fn with_head_sha(mut row: serde_json::Value, sha: &str) -> serde_json::Value {
+    row["head"]["sha"] = serde_json::json!(sha);
+    row
+}
+
+fn with_head_sha_absent(mut row: serde_json::Value) -> serde_json::Value {
+    if let Some(head) = row.get_mut("head").and_then(|h| h.as_object_mut()) {
+        head.remove("sha");
+    }
+    row
+}
+
+fn with_base_ref_absent(mut row: serde_json::Value) -> serde_json::Value {
+    if let Some(base) = row.get_mut("base").and_then(|b| b.as_object_mut()) {
+        base.remove("ref");
+    }
+    row
+}
+
+/// Decode a wire row into the typed model. A panic here means the
+/// fixture is not a valid `/pulls` row.
+fn decode(row: serde_json::Value) -> PullRequestDetail {
+    serde_json::from_value(row).expect("wire row decodes into PullRequestDetail")
+}
+
+fn ar_config(enabled: bool) -> AutoReviewConfig {
+    AutoReviewConfig {
+        enabled,
+        draft_pull_requests: false,
+    }
+}
+
+fn ar_config_drafts(enabled: bool, drafts: bool) -> AutoReviewConfig {
+    AutoReviewConfig {
+        enabled,
+        draft_pull_requests: drafts,
+    }
+}
+
+fn held_none() -> caduceus::daemon::tick::review_discovery::HeldShas {
+    caduceus::daemon::tick::review_discovery::HeldShas {
+        active: Vec::new(),
+        last_reviewed: None,
+    }
+}
+
+fn held(
+    active: &[&str],
+    last_reviewed: Option<&str>,
+) -> caduceus::daemon::tick::review_discovery::HeldShas {
+    caduceus::daemon::tick::review_discovery::HeldShas {
+        active: active.iter().map(|s| s.to_string()).collect(),
+        last_reviewed: last_reviewed.map(|s| s.to_string()),
+    }
+}
+
+/// Config with the `auto_review` block enabled and discovery pointed
+/// at the wiremock base. TrustedHost is fine here: only `from_raw`
+/// rejects the TrustedHost+enabled combination, and `test_defaults`
+/// bypasses `from_raw` (the documented escape hatch for tests).
+fn discovery_config(root: &Path, api_base: &str) -> Config {
+    let mut cfg = Config::test_defaults(root);
+    cfg.api_base = api_base.to_string();
+    cfg.watched_repos = vec!["owner/r".to_string()];
+    cfg.auto_review = Some(ar_config(true));
+    cfg
+}
+
+fn review_store(state_dir: &Path) -> ReviewStore {
+    ReviewStore::open(state_dir).expect("review store opens")
+}
+
+fn repo_id() -> RepositoryId {
+    RepositoryId {
+        owner: "owner".to_string(),
+        repo: "r".to_string(),
+    }
+}
+
+fn target(head_sha: &str, base_sha: &str, merge_base: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: repo_id(),
+        pull_request: 7,
+        head_sha: head_sha.to_string(),
+        base_sha: base_sha.to_string(),
+        base_ref: "main".to_string(),
+        merge_base: merge_base.to_string(),
+    }
+}
+
+/// Initialise a bare remote with `main` (commit A), a `feature`
+/// branch (commit B, child of A), and commit C (child of B, the
+/// branch tip). Returns `(A, B, C)`. B and C are non-ancestors of
+/// main, so deleting `feature` + gc prunes them (mirror_test.rs
+/// discipline).
+fn init_bare_remote_with_feature(path: &Path) -> (String, String, String) {
+    let run = |cmd: &mut Command| {
+        let output = cmd.output().expect("spawn command");
+        assert!(
+            output.status.success(),
+            "command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run(Command::new("git").arg("init").arg("--bare").arg(path));
+    run(Command::new("git")
+        .current_dir(path)
+        .args(["symbolic-ref", "HEAD", "refs/heads/main"]));
+    let tree = {
+        let output = Command::new("git")
+            .current_dir(path)
+            .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
+            .output()
+            .expect("hash-object");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    let commit = |message: &str, parent: Option<&str>| -> String {
+        let mut args = vec!["commit-tree".to_string(), tree.clone()];
+        if let Some(p) = parent {
+            args.push("-p".to_string());
+            args.push(p.to_string());
+        }
+        args.push("-m".to_string());
+        args.push(message.to_string());
+        let output = Command::new("git")
+            .current_dir(path)
+            .args(&args)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@example.com")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@example.com")
+            .output()
+            .expect("commit-tree");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    let commit_a = commit("base", None);
+    run(Command::new("git")
+        .current_dir(path)
+        .args(["update-ref", "refs/heads/main", &commit_a]));
+    let commit_b = commit("feature", Some(&commit_a));
+    let commit_c = commit("feature tip", Some(&commit_b));
+    run(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/feature",
+        &commit_c,
+    ]));
+    (commit_a, commit_b, commit_c)
+}
+
+struct MirrorFixture {
+    root: std::path::PathBuf,
+    runner: GitRunner,
+    mirror: BareMirror,
+    base_sha: String,
+    head_sha: String,
+}
+
+/// Local bare remote + mirror with `main` fetched; `feature` tip NOT
+/// fetched (mirrors production: `ensure` fetches the base branch
+/// only).
+async fn mirror_fixture(label: &str) -> MirrorFixture {
+    let root = tempdir(label);
+    let remote_dir = root.join("remote.git");
+    let (base_sha, head_sha, _tip) = init_bare_remote_with_feature(&remote_dir);
+    let remote_url = format!("file://{}", remote_dir.display());
+
+    let mut cfg = Config::test_defaults(&root);
+    cfg.repo_storage_root = root.join("repos");
+    cfg.git_timeout_seconds = 30;
+    let runner = GitRunner::new(&cfg);
+
+    let mirror = BareMirror::ensure(&runner, &cfg, "owner", "r", &remote_url, "main")
+        .await
+        .expect("ensure");
+
+    MirrorFixture {
+        root,
+        runner,
+        mirror,
+        base_sha,
+        head_sha,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task 1 — event constants + emission
+// ---------------------------------------------------------------------------
+
+#[test]
+fn event_constants_match_dar_13_catalog() {
+    assert_eq!(DISCOVERED_EVENT, "review_discovered");
+    assert_eq!(ADMITTED_EVENT, "review_admitted");
+    assert_eq!(SKIPPED_DRAFT_EVENT, "review_skipped_draft");
+    assert_eq!(
+        SKIPPED_ALREADY_COMPLETE_EVENT,
+        "review_skipped_already_complete"
+    );
+    assert_eq!(STALE_SHA_EVENT, "review_stale_sha_observed");
+    assert_eq!(FORK_SKIP_EVENT, "review_skipped_fork_unsupported");
+}
+
+/// Capture `emit_discovered` through the plan's serial +
+/// `tracing_appender::non_blocking` discipline (fork_gate_test.rs
+/// pattern).
+#[test]
+#[serial_test::serial]
+fn discovered_event_emits_structured_line() {
+    let root = tempdir("discovery-event");
+    let log_path = root.join("discovery.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        caduceus::daemon::tick::review_discovery::emit_discovered_for_tests("o/r", 7, "abc");
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        body.contains(&format!("\"event\":\"{DISCOVERED_EVENT}\"")),
+        "event name missing: {body}"
+    );
+    assert!(body.contains("\"repo\":\"o/r\""), "got: {body}");
+    assert!(body.contains("\"pr\":7"), "got: {body}");
+    assert!(body.contains("\"head_sha\":\"abc\""), "got: {body}");
+}
+
+// ---------------------------------------------------------------------------
+// Task 4 — pure eligibility classifier (DAR §5.1 truth table)
+// ---------------------------------------------------------------------------
+
+use caduceus::daemon::tick::review_discovery::RowAction;
+
+#[test]
+fn open_non_draft_new_sha_admits() {
+    let row = decode(pr_row(Some("owner/r"), Some("owner/r")));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert_eq!(decision.action, RowAction::Admit);
+    assert!(decision.stale.is_none());
+    assert_eq!(decision.head_sha, "bbbb");
+    assert_eq!(decision.base_sha, "aaaa");
+    assert_eq!(decision.base_ref, "main");
+}
+
+#[test]
+fn draft_skips_with_event_reason() {
+    let row = decode(with_draft(pr_row(Some("owner/r"), Some("owner/r")), true));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert_eq!(decision.action, RowAction::SkipDraft);
+}
+
+#[test]
+fn draft_admits_when_configured() {
+    let row = decode(with_draft(pr_row(Some("owner/r"), Some("owner/r")), true));
+    let decision =
+        classify_discovery_row_for_tests(&row, &ar_config_drafts(true, true), &held_none());
+    assert_eq!(decision.action, RowAction::Admit);
+}
+
+#[test]
+fn closed_is_ineligible_without_event() {
+    let row = decode(with_state(
+        pr_row(Some("owner/r"), Some("owner/r")),
+        "closed",
+    ));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert_eq!(decision.action, RowAction::Ineligible);
+}
+
+#[test]
+fn merged_is_ineligible_without_event() {
+    let mut row = with_state(pr_row(Some("owner/r"), Some("owner/r")), "open");
+    row["merged"] = serde_json::json!(true);
+    let decision = classify_discovery_row_for_tests(&decode(row), &ar_config(true), &held_none());
+    assert_eq!(decision.action, RowAction::Ineligible);
+}
+
+#[test]
+fn fork_skips_with_head_repo_identity() {
+    let row = decode(pr_row(Some("someone/else"), Some("owner/r")));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert_eq!(
+        decision.action,
+        RowAction::SkipFork {
+            head_repo: Some("someone/else".to_string())
+        }
+    );
+}
+
+#[test]
+fn null_head_repo_skips_with_none() {
+    // Deleted head branch: `head.repo: null` lands on the fork gate
+    // as `HeadRepoMissing` (fail closed) — the nullable-head-repo
+    // discovery fixture.
+    let row = decode(pr_row(None, Some("owner/r")));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert_eq!(decision.action, RowAction::SkipFork { head_repo: None });
+}
+
+#[test]
+fn already_reviewed_sha_skips() {
+    let row = decode(pr_row(Some("owner/r"), Some("owner/r")));
+    let decision =
+        classify_discovery_row_for_tests(&row, &ar_config(true), &held(&[], Some("bbbb")));
+    assert_eq!(decision.action, RowAction::SkipAlreadyComplete);
+}
+
+#[test]
+fn active_queue_sha_skips() {
+    let row = decode(pr_row(Some("owner/r"), Some("owner/r")));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held(&["bbbb"], None));
+    assert_eq!(decision.action, RowAction::SkipAlreadyComplete);
+}
+
+#[test]
+fn moved_head_reports_stale_and_admits() {
+    let row = decode(with_head_sha(
+        pr_row(Some("owner/r"), Some("owner/r")),
+        "cccc",
+    ));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held(&["bbbb"], None));
+    assert_eq!(decision.action, RowAction::Admit);
+    assert_eq!(
+        decision.stale,
+        Some(("bbbb".to_string(), "cccc".to_string()))
+    );
+}
+
+#[test]
+fn missing_number_is_malformed() {
+    let row = decode(with_number(pr_row(Some("owner/r"), Some("owner/r")), None));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert!(matches!(decision.action, RowAction::Malformed { .. }));
+}
+
+#[test]
+fn missing_head_sha_is_malformed() {
+    let row = decode(with_head_sha_absent(pr_row(
+        Some("owner/r"),
+        Some("owner/r"),
+    )));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert!(matches!(decision.action, RowAction::Malformed { .. }));
+}
+
+#[test]
+fn missing_base_sha_is_malformed() {
+    let row = decode(with_base_ref_absent(pr_row(
+        Some("owner/r"),
+        Some("owner/r"),
+    )));
+    // Remove the base ref: classifier must treat the row as
+    // malformed before any admission path.
+    assert!(matches!(
+        classify_discovery_row_for_tests(&row, &ar_config(true), &held_none()).action,
+        RowAction::Malformed { .. }
+    ));
+}
+
+#[test]
+fn missing_head_is_malformed() {
+    let mut row = pr_row(Some("owner/r"), Some("owner/r"));
+    row["head"] = serde_json::Value::Null;
+    let decision = classify_discovery_row_for_tests(&decode(row), &ar_config(true), &held_none());
+    assert!(matches!(decision.action, RowAction::Malformed { .. }));
+}
+
+#[test]
+fn eligibility_order_draft_beats_fork() {
+    // D5 ordering pin: the draft gate fires before the fork gate, so
+    // a draft fork row carries the draft skip, not the fork skip.
+    let row = decode(with_draft(
+        pr_row(Some("someone/else"), Some("owner/r")),
+        true,
+    ));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert_eq!(decision.action, RowAction::SkipDraft);
+}
+
+#[test]
+fn closed_beats_everything_including_malformed_base_repo() {
+    // Closed state is checked before the fork gate: a closed fork
+    // row is plain Ineligible (no event).
+    let row = decode(with_state(
+        pr_row(Some("someone/else"), Some("owner/r")),
+        "closed",
+    ));
+    let decision = classify_discovery_row_for_tests(&row, &ar_config(true), &held_none());
+    assert_eq!(decision.action, RowAction::Ineligible);
+}
+
+// ---------------------------------------------------------------------------
+// Task 5 — admission (local git + real ReviewStore)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn admit_persists_merge_base_and_assigns_generation() {
+    let f = mirror_fixture("admit-merge-base").await;
+    let store = review_store(&f.root.join("state"));
+
+    let inserted = admit_target_for_tests(
+        &f.runner,
+        &f.mirror,
+        &store,
+        &repo_id(),
+        7,
+        &f.head_sha,
+        &f.base_sha,
+        "main",
+    )
+    .await
+    .expect("admission succeeds");
+
+    assert!(inserted, "first admission inserts");
+    let queue = store.review_queue_snapshot().expect("snapshot");
+    assert_eq!(queue.entries.len(), 1, "exactly one queue entry");
+    let entry = queue.entries.values().next().expect("entry");
+    assert_eq!(entry.target.head_sha, f.head_sha);
+    assert_eq!(entry.target.base_sha, f.base_sha);
+    assert_eq!(
+        entry.target.merge_base, f.base_sha,
+        "AC5: merge base persisted"
+    );
+    assert_eq!(entry.review_generation, 1, "first generation");
+    assert_eq!(entry.phase, ReviewPhase::Queued);
+}
+
+#[tokio::test]
+async fn second_admission_of_new_sha_bumps_generation() {
+    let f = mirror_fixture("admit-generation").await;
+    let store = review_store(&f.root.join("state"));
+
+    admit_target_for_tests(
+        &f.runner,
+        &f.mirror,
+        &store,
+        &repo_id(),
+        7,
+        &f.head_sha,
+        &f.base_sha,
+        "main",
+    )
+    .await
+    .expect("first admission");
+
+    // Same (repo, pr, head): dedup keeps the queue at one entry.
+    let again = admit_target_for_tests(
+        &f.runner,
+        &f.mirror,
+        &store,
+        &repo_id(),
+        7,
+        &f.head_sha,
+        &f.base_sha,
+        "main",
+    )
+    .await
+    .expect("second admission of same target");
+    assert!(!again, "AC4: duplicate (repo, pr, head) not re-admitted");
+    let queue = store.review_queue_snapshot().expect("snapshot");
+    assert_eq!(queue.entries.len(), 1, "still one entry");
+    let generation = queue
+        .entries
+        .values()
+        .next()
+        .expect("entry")
+        .review_generation;
+
+    // A new head SHA on the same PR re-admits with a new generation
+    // (AC4). The base SHA is present in the mirror, so admitting it
+    // as a (synthetic) new head exercises the store's generation
+    // bookkeeping without another fixture commit.
+    let inserted = admit_target_for_tests(
+        &f.runner,
+        &f.mirror,
+        &store,
+        &repo_id(),
+        7,
+        &f.base_sha,
+        &f.base_sha,
+        "main",
+    )
+    .await
+    .expect("re-admission with new head SHA");
+    assert!(inserted, "new SHA after completion re-admits");
+    let queue = store.review_queue_snapshot().expect("snapshot");
+    let entry = queue
+        .entries
+        .values()
+        .find(|e| e.target.head_sha == f.base_sha)
+        .expect("new entry");
+    assert_eq!(
+        entry.review_generation,
+        generation + 1,
+        "AC4: generation bumped for the new head"
+    );
+}
+
+#[tokio::test]
+async fn unavailable_head_sha_is_skipped_not_admitted() {
+    let f = mirror_fixture("admit-unavailable").await;
+    let store = review_store(&f.root.join("state"));
+
+    // A SHA the remote never had (and the mirror cannot fetch).
+    let ghost = "1111111111111111111111111111111111111111";
+    let result = admit_target_for_tests(
+        &f.runner,
+        &f.mirror,
+        &store,
+        &repo_id(),
+        7,
+        ghost,
+        &f.base_sha,
+        "main",
+    )
+    .await;
+
+    match result {
+        // D8 contract: unavailable SHA surfaces as HeadShaUnavailable
+        // (discovery routes it to a log-and-skip; never enqueues).
+        Err(CaduceusError::HeadShaUnavailable { sha }) => {
+            assert_eq!(sha, ghost);
+        }
+        Ok(_) => panic!("unavailable SHA must not be admitted"),
+        Err(other) => panic!("expected HeadShaUnavailable, got: {other:?}"),
+    }
+    let queue = store.review_queue_snapshot().expect("snapshot");
+    assert!(
+        queue.entries.is_empty(),
+        "queue must be unchanged on unavailable SHA"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Task 6 — poll_review_step (wiremock + local git)
+// ---------------------------------------------------------------------------
+
+/// Discovery-loop harness: wiremock serves `/repos/owner/r/pulls`;
+/// the remote resolver points at a local bare `origin` so the lazy
+/// mirror bootstrap works hermetically.
+struct StepHarness {
+    cfg: Config,
+    server: MockServer,
+    store: ReviewStore,
+    remote_dir: std::path::PathBuf,
+    /// Real fixture SHAs: base (A, on main), mid (B), tip (C, the
+    /// feature-branch head the wire rows advertise). Discovery can
+    /// only admit SHAs the local remote actually serves.
+    base_sha: String,
+    mid_sha: String,
+    tip_sha: String,
+}
+
+impl StepHarness {
+    async fn start(label: &str) -> Self {
+        let root = tempdir(label);
+        let server = MockServer::start().await;
+        let mut cfg = discovery_config(&root, &server.uri());
+        cfg.repo_storage_root = root.join("repos");
+        cfg.git_timeout_seconds = 30;
+
+        let remote_dir = root.join("origin.git");
+        let (base_sha, mid_sha, tip_sha) = init_bare_remote_with_feature(&remote_dir);
+
+        let store = review_store(&root.join("state"));
+        StepHarness {
+            cfg,
+            server,
+            store,
+            remote_dir,
+            base_sha,
+            mid_sha,
+            tip_sha,
+        }
+    }
+
+    /// A wire row for `owner/{repo}` whose head SHA is the fixture's
+    /// real tip commit (fetchable from the local remote).
+    fn row(&self, repo: &str, pr: u64, head_sha: &str) -> serde_json::Value {
+        let mut row = pr_row(
+            Some(&format!("owner/{repo}")),
+            Some(&format!("owner/{repo}")),
+        );
+        row["number"] = serde_json::json!(pr);
+        row["head"]["sha"] = serde_json::json!(head_sha);
+        row["base"]["sha"] = serde_json::json!(self.base_sha);
+        row
+    }
+
+    fn client(&self) -> Client {
+        let cache = HttpCache::open(&self.cfg.state_dir).expect("cache opens");
+        Client::with_cache(&self.cfg, cache).expect("client builds")
+    }
+
+    fn remote_url(&self) -> String {
+        format!("file://{}", self.remote_dir.display())
+    }
+}
+
+fn pulls_row_open(pr: u64, head_sha: &str) -> serde_json::Value {
+    let mut row = pr_row(Some("owner/r"), Some("owner/r"));
+    row["number"] = serde_json::json!(pr);
+    row["head"]["sha"] = serde_json::json!(head_sha);
+    row
+}
+
+#[tokio::test]
+async fn per_repo_500_does_not_stop_later_repos() {
+    let h = StepHarness::start("iso-500").await;
+    // Repo A fails hard; repo B lists one new open PR.
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/a/pulls"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&h.server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/b/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!([h.row("b", 7, &h.tip_sha)])),
+        )
+        .mount(&h.server)
+        .await;
+
+    // B must resolve to the same local remote.
+    let remote_url = h.remote_url();
+    let stats = poll_review_step_for_tests(
+        &["owner/a".to_string(), "owner/b".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &move |owner: &str, repo: &str| {
+            let _ = (owner, repo);
+            Ok(remote_url.clone())
+        },
+    )
+    .await
+    .expect("step returns Ok despite repo A's 500 (AC2)");
+
+    assert_eq!(stats.failed_repos, 1, "repo A counted, not fatal");
+    assert_eq!(stats.repos_polled, 1, "repo B still polled");
+    assert_eq!(stats.admitted, 1, "repo B's PR admitted");
+    let queue = h.store.review_queue_snapshot().expect("snapshot");
+    assert_eq!(queue.entries.len(), 1, "repo B's entry queued");
+    let entry = queue.entries.values().next().expect("entry");
+    assert_eq!(entry.target.repository.owner, "owner");
+    assert_eq!(entry.target.repository.repo, "b");
+}
+
+#[tokio::test]
+async fn malformed_json_body_is_per_repo_continue() {
+    let h = StepHarness::start("iso-malformed").await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/a/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{\"not\":\"an array\"}"))
+        .mount(&h.server)
+        .await;
+
+    let stats = poll_review_step_for_tests(
+        &["owner/a".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &|_o, _r| Err(CaduceusError::Config("unused".to_string())),
+    )
+    .await
+    .expect("step returns Ok (per-repo tier)");
+
+    assert_eq!(stats.failed_repos, 1);
+    assert_eq!(stats.admitted, 0);
+}
+
+#[tokio::test]
+async fn rate_limit_surfaces_as_step_error() {
+    let h = StepHarness::start("rate-limit").await;
+    let reset_at_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 600;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/a/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("X-RateLimit-Remaining", "0")
+                .insert_header("X-RateLimit-Reset", reset_at_unix.to_string())
+                .insert_header("X-RateLimit-Limit", "5000")
+                .set_body_string("[]"),
+        )
+        .mount(&h.server)
+        .await;
+
+    let err = poll_review_step_for_tests(
+        &["owner/a".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &|_o, _r| Err(CaduceusError::Config("unused".to_string())),
+    )
+    .await
+    .expect_err("exhausted quota is a step-level error (D9)");
+
+    assert!(
+        matches!(err, CaduceusError::RateLimited { .. }),
+        "expected RateLimited, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn budget_caps_admissions_across_repos() {
+    let h = StepHarness::start("budget").await;
+    let mut cfg = h.cfg.clone();
+    cfg.max_reviews_per_tick = 1;
+    // Both repos list one open PR whose head is the fixture's real
+    // tip commit (fetchable), so the ONLY limiter is the budget.
+    for (slug, name) in [("owner/a", "a"), ("owner/b", "b")] {
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/{slug}/pulls")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!([h.row(name, 7, &h.tip_sha)])),
+            )
+            .mount(&h.server)
+            .await;
+    }
+
+    let remote_url = h.remote_url();
+    let stats = poll_review_step_for_tests(
+        &["owner/a".to_string(), "owner/b".to_string()],
+        &h.client(),
+        &cfg,
+        &h.store,
+        &GitRunner::new(&cfg),
+        &move |_o, _r| Ok(remote_url.clone()),
+    )
+    .await
+    .expect("budgeted step succeeds");
+
+    assert_eq!(stats.admitted, 1, "AC6: budget caps tick-wide admissions");
+    assert!(stats.budget_exhausted, "exhaustion flagged");
+    let queue = h.store.review_queue_snapshot().expect("snapshot");
+    assert_eq!(queue.entries.len(), 1, "only one entry enqueued");
+}
+
+#[tokio::test]
+async fn no_new_shas_means_no_mirror_and_no_writes() {
+    let h = StepHarness::start("no-new").await;
+    // Wire: one open PR whose head SHA is already held as reviewed.
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!([pulls_row_open(7, "bbbb")])),
+        )
+        .mount(&h.server)
+        .await;
+
+    // Seed the completed-review pointer: last_reviewed == wire head.
+    let store = &h.store;
+    let state = ReviewState::new(repo_id(), 7, 1);
+    store.save_review_state(&state).expect("seed");
+    let mut reviewed = ReviewState::new(repo_id(), 7, 1);
+    reviewed.last_reviewed_head_sha = Some("bbbb".to_string());
+    store.save_review_state(&reviewed).expect("seed reviewed");
+
+    let queue_before = store.review_queue_snapshot().expect("snapshot");
+
+    let stats = poll_review_step_for_tests(
+        &["owner/r".to_string()],
+        &h.client(),
+        &h.cfg,
+        store,
+        &GitRunner::new(&h.cfg),
+        &|_o, _r| {
+            Err(CaduceusError::Config(
+                "resolver must not be called".to_string(),
+            ))
+        },
+    )
+    .await
+    .expect("no-op step succeeds");
+
+    assert_eq!(stats.admitted, 0);
+    assert_eq!(stats.skipped_already_complete, 1);
+    assert!(
+        !h.cfg.repo_storage_root.join("mirrors").exists(),
+        "AC7: lazy mirror bootstrap must not run when nothing changed"
+    );
+    let queue_after = store.review_queue_snapshot().expect("snapshot");
+    assert_eq!(
+        queue_before.entries, queue_after.entries,
+        "queue untouched when nothing changed"
+    );
+}
+
+#[tokio::test]
+async fn stale_sha_event_then_admission() {
+    let h = StepHarness::start("stale").await;
+    // Active (Queued) entry for the old SHA (commit A, on main —
+    // fetchable, so the seed is a valid stored target); the wire
+    // reports the fixture's real tip commit C as the new head.
+    let old_target = target(&h.base_sha, &h.base_sha, &h.base_sha);
+    let outcome = h.store.enqueue_review(&old_target).expect("seed active");
+    assert!(matches!(
+        outcome,
+        caduceus::state::review::ReviewEnqueueOutcome::Inserted
+    ));
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!([h.row("r", 7, &h.tip_sha)])),
+        )
+        .mount(&h.server)
+        .await;
+
+    let remote_url = h.remote_url();
+    let stats = poll_review_step_for_tests(
+        &["owner/r".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &move |_o, _r| Ok(remote_url.clone()),
+    )
+    .await
+    .expect("stale path admits");
+
+    assert_eq!(stats.stale_observed, 1, "D6 stale observation");
+    assert_eq!(stats.admitted, 1, "new head admits");
+    let queue = h.store.review_queue_snapshot().expect("snapshot");
+    let fresh = queue
+        .entries
+        .values()
+        .find(|e| e.target.head_sha == h.tip_sha)
+        .expect("new-head entry");
+    assert_eq!(fresh.review_generation, 2, "generation advanced");
+}
+
+#[tokio::test]
+async fn pagination_follows_link_header() {
+    let h = StepHarness::start("pagination").await;
+    // Page 1 carries a `Link: rel="next"` pointing at page 2 on the
+    // mock's own URI (the MockGitHub::mount_paged shape, hand-rolled
+    // because StepHarness holds the raw MockServer). Both rows carry
+    // real fixture SHAs (tip C, mid B) so both admit.
+    let page2_url = format!("{}/repos/owner/r/pulls?page=2", h.server.uri());
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .and(wiremock::matchers::query_param_is_missing("page"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!([h.row("r", 7, &h.tip_sha)]))
+                .append_header("Link", format!("<{page2_url}>; rel=\"next\"")),
+        )
+        .mount(&h.server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .and(wiremock::matchers::query_param("page", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!([h.row("r", 8, &h.mid_sha)])),
+        )
+        .mount(&h.server)
+        .await;
+
+    let remote_url = h.remote_url();
+    let stats = poll_review_step_for_tests(
+        &["owner/r".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &move |_o, _r| Ok(remote_url.clone()),
+    )
+    .await
+    .expect("paginated listing works");
+
+    assert_eq!(stats.discovered, 2, "both pages classified");
+    assert_eq!(stats.admitted, 2, "both PRs admitted");
+}
+
+#[tokio::test]
+async fn admission_follows_wire_order() {
+    let h = StepHarness::start("wire-order").await;
+    let mut cfg = h.cfg.clone();
+    cfg.max_reviews_per_tick = 2;
+    // Wire order (GitHub sort=updated desc): PR 9 (tip C), PR 8 (mid
+    // B), PR 7 (base A). All three SHAs exist on the local remote, so
+    // fetchability never decides — wire order + budget do.
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            h.row("r", 9, &h.tip_sha),
+            h.row("r", 8, &h.mid_sha),
+            h.row("r", 7, &h.base_sha),
+        ])))
+        .mount(&h.server)
+        .await;
+
+    let remote_url = h.remote_url();
+    let stats = poll_review_step_for_tests(
+        &["owner/r".to_string()],
+        &h.client(),
+        &cfg,
+        &h.store,
+        &GitRunner::new(&cfg),
+        &move |_o, _r| Ok(remote_url.clone()),
+    )
+    .await
+    .expect("ordered admissions");
+
+    assert_eq!(stats.admitted, 2, "budget admits the first two wire rows");
+    assert!(stats.budget_exhausted, "third row deferred to next tick");
+    let queue = h.store.review_queue_snapshot().expect("snapshot");
+    let mut admitted_prs: Vec<u64> = queue
+        .entries
+        .values()
+        .map(|e| e.target.pull_request)
+        .collect();
+    admitted_prs.sort();
+    assert_eq!(
+        admitted_prs,
+        vec![8, 9],
+        "wire (list) order decides which rows win the budget"
+    );
+}
+
+#[tokio::test]
+async fn draft_pr_skips_with_event_and_no_admission() {
+    let h = StepHarness::start("draft-skip").await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([with_draft(
+                pulls_row_open(7, "bbbb"),
+                true
+            )])),
+        )
+        .mount(&h.server)
+        .await;
+
+    let stats = poll_review_step_for_tests(
+        &["owner/r".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &|_o, _r| Err(CaduceusError::Config("resolver must not run".to_string())),
+    )
+    .await
+    .expect("draft skip is not an error");
+
+    assert_eq!(stats.skipped_draft, 1);
+    assert_eq!(stats.admitted, 0);
+}
+
+#[tokio::test]
+async fn closed_pr_is_ineligible_never_admitted() {
+    let h = StepHarness::start("closed-skip").await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([with_state(
+                pulls_row_open(7, "bbbb"),
+                "closed"
+            )])),
+        )
+        .mount(&h.server)
+        .await;
+
+    let stats = poll_review_step_for_tests(
+        &["owner/r".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &|_o, _r| Err(CaduceusError::Config("resolver must not run".to_string())),
+    )
+    .await
+    .expect("closed rows are not errors");
+
+    assert_eq!(stats.ineligible, 1);
+    assert_eq!(stats.admitted, 0);
+    assert!(
+        h.store
+            .review_queue_snapshot()
+            .expect("snap")
+            .entries
+            .is_empty(),
+        "DAR §5.1: discovery-time closed PR never admitted"
+    );
+}
+
+#[tokio::test]
+async fn disabled_auto_review_makes_no_requests() {
+    let h = StepHarness::start("disabled").await;
+    let mut cfg = h.cfg.clone();
+    cfg.auto_review = Some(ar_config(false));
+
+    let stats = poll_review_step_for_tests(
+        &["owner/r".to_string()],
+        &h.client(),
+        &cfg,
+        &h.store,
+        &GitRunner::new(&cfg),
+        &|_o, _r| Err(CaduceusError::Config("resolver must not run".to_string())),
+    )
+    .await
+    .expect("disabled step is a no-op");
+
+    assert_eq!(
+        stats,
+        caduceus::daemon::tick::review_discovery::ReviewDiscoveryStats::default()
+    );
+    assert!(
+        h.server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "no HTTP request when auto_review disabled"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Task 7 — tick wiring (AC1/AC3), D14
+// ---------------------------------------------------------------------------
+
+fn tick_cfg(base: &Path, api_base: &str, auto_review: Option<AutoReviewConfig>) -> Config {
+    let raw = RawConfig {
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        state_dir: Some(base.join("state")),
+        workdir_base: Some(base.to_path_buf()),
+        watched_repos: Some(vec!["owner/r".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let ctx = LoadContext {
+        plugin_root: Some(base.to_path_buf()),
+        ..Default::default()
+    };
+    let mut cfg = Config::from_raw(raw, &ctx).expect("config");
+    cfg.api_base = api_base.to_string();
+    cfg.auto_review = auto_review;
+    cfg
+}
+
+async fn run_tick(
+    cfg: Config,
+    server: &MockServer,
+) -> caduceus::error::CaduceusResult<TickOutcome> {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(server)
+        .await;
+    let mut cfg = cfg;
+    cfg.api_base = server.uri();
+    let cache = HttpCache::open(&cfg.state_dir).expect("cache opens");
+    let client = Client::with_cache(&cfg, cache).expect("client builds");
+    let clock: Arc<dyn caduceus::orchestration::Clock> = Arc::new(SystemClock);
+    let git = GitRunner::new(&cfg);
+    let pool = Arc::new(
+        Pool::new(
+            cfg.worker_parallelism,
+            DrainConfig::from_seconds_and_ms(cfg.drain_timeout_seconds, cfg.backpressure_budget_ms),
+        )
+        .with_lease_store_dir(
+            cfg.state_dir.clone(),
+            std::time::Duration::from_secs(cfg.worker_lease_ttl_seconds),
+        ),
+    );
+    let services = caduceus::orchestration::Services::production(
+        &cfg,
+        clock,
+        Arc::new(client),
+        git,
+        Arc::clone(&pool),
+        Arc::new(caduceus::infra::disk::DiskPressureGuard::disabled()),
+    );
+    caduceus::tick::tick(cfg, services, pool, CancellationToken::new()).await
+}
+
+async fn request_paths(server: &MockServer) -> Vec<String> {
+    server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .map(|req| req.url.path().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn tick_polls_issues_then_pulls_in_order() {
+    let base = tempdir("tick-order");
+    let server = MockServer::start().await;
+    let mut cfg = tick_cfg(&base, &server.uri(), Some(ar_config(true)));
+    cfg.repo_storage_root = base.join("repos");
+    cfg.git_timeout_seconds = 30;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let outcome = run_tick(cfg, &server).await.expect("tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+
+    let paths = request_paths(&server).await;
+    let issues = paths
+        .iter()
+        .position(|p| p.contains("/issues"))
+        .expect("issues polled");
+    let pulls = paths
+        .iter()
+        .position(|p| p.ends_with("/pulls"))
+        .expect("pulls polled");
+    assert!(
+        issues < pulls,
+        "AC1: issues must be polled before pulls; got {paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn discovery_skipped_when_disabled_or_dry_run() {
+    // Disabled.
+    let base = tempdir("tick-disabled");
+    let server = MockServer::start().await;
+    let mut cfg = tick_cfg(&base, &server.uri(), Some(ar_config(false)));
+    cfg.repo_storage_root = base.join("repos");
+    run_tick(cfg.clone(), &server).await.expect("tick");
+    assert!(
+        !request_paths(&server)
+            .await
+            .iter()
+            .any(|p| p.ends_with("/pulls")),
+        "no /pulls request when disabled"
+    );
+
+    // Dry run.
+    let base = tempdir("tick-dryrun");
+    let server = MockServer::start().await;
+    let mut cfg = tick_cfg(&base, &server.uri(), Some(ar_config(true)));
+    cfg.dry_run = true;
+    cfg.repo_storage_root = base.join("repos");
+    run_tick(cfg, &server).await.expect("tick");
+    assert!(
+        !request_paths(&server)
+            .await
+            .iter()
+            .any(|p| p.ends_with("/pulls")),
+        "no /pulls request in dry run"
+    );
+}
+
+#[tokio::test]
+async fn corrupt_review_store_does_not_break_tick() {
+    let base = tempdir("tick-corrupt-store");
+    let server = MockServer::start().await;
+    let mut cfg = tick_cfg(&base, &server.uri(), Some(ar_config(true)));
+    cfg.repo_storage_root = base.join("repos");
+    cfg.git_timeout_seconds = 30;
+
+    // One queued issue so the drain has work to consider.
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "number": 1,
+                "title": "queued issue",
+                "state": "open",
+                "labels": [{"name": cfg.ticket_label_code.clone()}],
+                "updated_at": "2020-01-01T00:00:00Z",
+                "user": {"login": "octocat"}
+            }
+        ])))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    // Corrupt the review queue so the PR step's store open/read
+    // fails. The tick has not run yet, so the state directory must
+    // exist first (ReviewStore::open creates it lazily).
+    std::fs::create_dir_all(&cfg.state_dir).expect("state dir");
+    std::fs::write(cfg.state_dir.join("review_queue.json"), b"not valid json")
+        .expect("corrupt review queue");
+
+    let outcome = run_tick(cfg, &server).await.expect("tick still Ok (AC3)");
+    assert_eq!(outcome, TickOutcome::IdleEmpty, "drain still ran");
+}
+
+#[tokio::test]
+async fn pr_step_rate_limit_is_persisted_and_drain_runs() {
+    let base = tempdir("tick-pr-rate-limit");
+    let server = MockServer::start().await;
+    let mut cfg = tick_cfg(&base, &server.uri(), Some(ar_config(true)));
+    cfg.repo_storage_root = base.join("repos");
+    cfg.git_timeout_seconds = 30;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+    let reset_at_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 600;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/r/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("X-RateLimit-Remaining", "0")
+                .insert_header("X-RateLimit-Reset", reset_at_unix.to_string())
+                .insert_header("X-RateLimit-Limit", "5000")
+                .set_body_string("[]"),
+        )
+        .mount(&server)
+        .await;
+
+    let outcome = run_tick(cfg, &server).await.expect("tick returns Ok (AC3)");
+    assert_eq!(outcome, TickOutcome::IdleEmpty, "drain still ran");
+
+    // D14: the PR step's rate-limit observation is persisted for the
+    // next tick's cadence gate. The gate reads the same state_dir the
+    // tick used (cfg.state_dir == base/state).
+    let gate = caduceus::state::meta::CadenceGate::open(&base.join("state")).expect("gate opens");
+    let snap = gate.store().snapshot();
+    let obs = snap
+        .rate_limit
+        .expect("D14: PR-step rate limit persisted via last_error");
+    assert_eq!(obs.remaining, 0);
+}
+
+#[test]
+fn finish_tick_outcome_persists_rate_limit_from_last_error() {
+    let base = tempdir("d14-unit");
+    let state_dir = base.join("state").join("state");
+    let gate = caduceus::state::meta::CadenceGate::open(&state_dir).expect("gate opens");
+    let meta = MetaStore::open(&state_dir).expect("meta opens");
+    let now = Utc::now();
+    let err = CaduceusError::RateLimited {
+        reset_at: 600,
+        remaining: 0,
+        limit: Some(5000),
+    };
+
+    caduceus::daemon::tick::awaiting_review::finish_tick_outcome_for_tests(
+        &gate,
+        &meta,
+        now,
+        TickOutcome::IdleEmpty,
+        None,
+        Some(&err),
+    )
+    .expect("finish succeeds");
+
+    let snap = gate.store().snapshot();
+    let obs = snap
+        .rate_limit
+        .expect("D14: rate-limit observation persisted from last_error");
+    assert_eq!(obs.remaining, 0);
+    assert_eq!(
+        obs.reset_at.timestamp(),
+        now.timestamp() + 600,
+        "reset_at_unix = observed_at + reset_at"
+    );
+}

--- a/tests/daemon/review_discovery_test.rs
+++ b/tests/daemon/review_discovery_test.rs
@@ -253,6 +253,46 @@ struct MirrorFixture {
     head_sha: String,
 }
 
+/// Add an orphan commit (a second root, no parents) on
+/// `refs/heads/orphan` to the bare remote at `path`. The commit is
+/// fetchable (a branch tip), but has NO common ancestor with
+/// `main`, so `git merge-base main..orphan` fails — discovery
+/// surfaces that as `CaduceusError::Git` (the per-target git-error
+/// shape the D9 isolation tests need, distinct from
+/// `HeadShaUnavailable`).
+fn add_orphan_commit(path: &Path) -> String {
+    let run = |cmd: &mut Command| {
+        let output = cmd.output().expect("spawn command");
+        assert!(
+            output.status.success(),
+            "command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    let tree = {
+        let output = Command::new("git")
+            .current_dir(path)
+            .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
+            .output()
+            .expect("hash-object");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["commit-tree", &tree, "-m", "orphan root"])
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .output()
+        .expect("commit-tree");
+    let orphan = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    run(Command::new("git")
+        .current_dir(path)
+        .args(["update-ref", "refs/heads/orphan", &orphan]));
+    orphan
+}
+
 /// Local bare remote + mirror with `main` fetched; `feature` tip NOT
 /// fetched (mirrors production: `ensure` fetches the base branch
 /// only).
@@ -749,6 +789,66 @@ async fn per_repo_500_does_not_stop_later_repos() {
     let entry = queue.entries.values().next().expect("entry");
     assert_eq!(entry.target.repository.owner, "owner");
     assert_eq!(entry.target.repository.repo, "b");
+}
+
+#[tokio::test]
+async fn git_admission_failure_continues_to_later_repos() {
+    let h = StepHarness::start("iso-git").await;
+    // Repo A lists one open PR whose head is a FETCHABLE orphan
+    // commit (second root): fetch succeeds, but merge-base has no
+    // common ancestor and fails as `CaduceusError::Git` — the
+    // per-target git-error shape (NOT `HeadShaUnavailable`). Repo B
+    // lists one new open PR and must still admit (D9 per-target
+    // isolation; the old code aborted the whole step here).
+    let orphan = add_orphan_commit(&h.remote_dir);
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/a/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([h.row("a", 7, &orphan)])),
+        )
+        .mount(&h.server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/b/pulls"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!([h.row("b", 9, &h.tip_sha)])),
+        )
+        .mount(&h.server)
+        .await;
+
+    // Both repos resolve to the same local remote (which serves the
+    // orphan branch).
+    let remote_url = h.remote_url();
+    let stats = poll_review_step_for_tests(
+        &["owner/a".to_string(), "owner/b".to_string()],
+        &h.client(),
+        &h.cfg,
+        &h.store,
+        &GitRunner::new(&h.cfg),
+        &move |owner: &str, repo: &str| {
+            let _ = (owner, repo);
+            Ok(remote_url.clone())
+        },
+    )
+    .await
+    .expect("step returns Ok despite repo A's git admission failure (D9)");
+
+    assert_eq!(stats.failed_admissions, 1, "git error counted, not fatal");
+    assert_eq!(stats.admitted, 1, "repo B's PR still admitted");
+    assert_eq!(
+        stats.skipped_unavailable_sha, 0,
+        "the failure is Git, not HeadShaUnavailable"
+    );
+    let queue = h.store.review_queue_snapshot().expect("snapshot");
+    assert_eq!(queue.entries.len(), 1, "only repo B's entry queued");
+    let entry = queue.entries.values().next().expect("entry");
+    assert_eq!(entry.target.repository.owner, "owner");
+    assert_eq!(entry.target.repository.repo, "b");
+    assert_eq!(
+        entry.target.head_sha, h.tip_sha,
+        "repo B's head, not the orphan"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Tick-era review discovery for Auto Review (issue #312): a new
`review_discovery` tick step polls watched repos' pull requests, filters
rows through the pure eligibility classifier (open, non-draft, non-fork,
SHA not already held), and admits genuinely new head revisions into the
review queue.

- Admission is SHA-anchored: `fetch_sha` for head + base against the
  bare mirror, merge-base computed and persisted on the
  `ReviewTarget`, then the atomic `ReviewStore::enqueue_review`
  generation CAS.
- Per-repo failure isolation: one repo's PR-list failure logs and
  continues; a fatal PR-step error folds into the tick's `last_error`
  without starving the drain (non-fatal classification).
- `max_reviews_per_tick` admission budget (default
  `worker_parallelism x 4`) bounds tick-wide admissions.
- D14 fix: `finish_tick_outcome` now persists the rate-limit
  observation from `last_error` so a PR-step rate limit gates the next
  tick's cadence.
- Events: `review_discovered`, `review_admitted`,
  `review_skipped_draft`, `review_skipped_already_complete`,
  `review_stale_sha_observed` (plus existing fork-gate skip).
- No diffs or context are fetched when nothing changed (rate-limit
  discipline).

Closes #312

## Test plan

- `cargo fmt --check` clean
- `cargo clippy --locked --all-targets -- -D warnings` clean
- `cargo test --locked --all-targets` green (full suite, 0 failures)
- `cargo test --test review_discovery_test` 48/48 green
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py`
  188 passed

Tests cover: event-constant catalog + structured emission, the
eligibility truth table (open/draft/closed/merged/fork/null-head-repo,
dedup, stale-SHA, malformed rows, draft-beats-fork ordering), admission
against a real local git remote (merge-base capture, generation bump,
dedup, unavailable-SHA skip), the discovery loop over wiremock
(per-repo 500 isolation, rate-limit surfacing, malformed body, budget
cap, zero mirror work when nothing changed, stale event + admission,
pagination Link-header follow, wire-order admission), and tick wiring
(issues-before-pulls HTTP order, disabled/dry-run skip, corrupt review
store does not starve the drain, D14 rate-limit persistence).