### PR TITLE
feat(review): add resume-safe publication finalizer FSM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,6 +464,10 @@ name = "sticky_comment_publish_test"
 path = "tests/review/sticky_comment_publish_test.rs"
 
 [[test]]
+name = "finalizer_test"
+path = "tests/review/finalizer_test.rs"
+
+[[test]]
 name = "review_store_test"
 path = "tests/state/review_store_test.rs"
 

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -509,6 +509,8 @@ pub async fn tick(
     //      (AC2/AC3). Never returns early.
     let mut pr_step_error: Option<CaduceusError> = None;
     let ar_enabled = cfg.auto_review().map(|ar| ar.enabled).unwrap_or(false);
+    let mut review_store_open: Option<Result<crate::state::review::ReviewStore, CaduceusError>> =
+        None;
     if ar_enabled && !cfg.dry_run {
         let review_store = if use_sqlite {
             crate::state::review::ReviewStore::open_sqlite(&state_dir)
@@ -541,14 +543,58 @@ pub async fn tick(
                         pr_step_error = Some(err);
                     }
                 }
+                // Keep the open store for the 5.6 publication poll.
+                review_store_open = Some(Ok(review_store));
             }
             Err(err) => {
                 tracing::warn!(
                     error = %err,
                     "review store open failed; skipping PR discovery"
                 );
-                pr_step_error = Some(err);
+                review_store_open = Some(Err(err));
+                pr_step_error = review_store_open
+                    .as_mut()
+                    .and_then(|slot| slot.as_mut().err())
+                    .map(|e| {
+                        // Classify from the display form; the original
+                        // moves into the 5.6 match arm below.
+                        CaduceusError::Other(e.to_string())
+                    });
             }
+        }
+    }
+
+    // 5.6. Review publication finalization poll (issue #310, DAR
+    //      §9.1): resume-safe FSM for the sticky PR comment. Runs only
+    //      when `auto_review.enabled` (and not in dry run), after PR
+    //      discovery. Per-entry failures are logged + counted inside
+    //      the poll (isolation mirrors #312); the tick NEVER returns
+    //      early — the drain below always runs.
+    if ar_enabled && !cfg.dry_run {
+        match review_store_open {
+            Some(Ok(ref review_store)) => {
+                match review_finalize_step::poll_publication_step(&client, &cfg, review_store).await
+                {
+                    Ok(stats) => info!(?stats, "review publication finalize complete"),
+                    Err(err) => {
+                        let class = classify_error(&err);
+                        tracing::warn!(
+                            error = %err, ?class,
+                            "review publication poll failed; continuing to drain"
+                        );
+                        if pr_step_error.is_none() {
+                            pr_step_error = Some(err);
+                        }
+                    }
+                }
+            }
+            Some(Err(err)) => {
+                tracing::warn!(
+                    error = %err,
+                    "review store open failed; skipping publication finalize"
+                );
+            }
+            None => {}
         }
     }
 
@@ -827,6 +873,7 @@ pub mod awaiting_review;
 pub mod per_claim;
 pub mod resume;
 pub mod review_discovery;
+pub mod review_finalize_step;
 
 use self::awaiting_review::*;
 use self::per_claim::*;

--- a/src/daemon/tick/review_finalize_step.rs
+++ b/src/daemon/tick/review_finalize_step.rs
@@ -1,0 +1,107 @@
+//! In-tick review publication finalizer poll (issue #310, DAR §9.1).
+//!
+//! Step 5.6 of the tick pipeline (after PR discovery, before the issue
+//! drain): scan the review store for due finalizations
+//! ([`crate::state::review::ReviewStore::due_finalizations`]) and run
+//! the publication FSM ([`crate::review::finalize_review`]) for each.
+//!
+//! Isolation mirrors #312's discovery step: per-entry failures are
+//! logged + counted + skipped (one bad entry never aborts the poll);
+//! the step itself never returns `Err` for a per-entry condition and
+//! never aborts the tick. Dispatch routing / completion-driven wakeups
+//! remain #339's — this module only polls.
+
+use tracing::warn;
+
+use crate::infra::error::CaduceusResult;
+use crate::review::{finalize_review, FinalizeOutcome};
+use crate::state::review::ReviewStore;
+
+/// Tick-wide finalizer counters (logged at step end).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PublicationStats {
+    /// Entries the poll attempted to finalize.
+    pub attempted: u32,
+    /// Publications (created, updated, or idempotently confirmed).
+    pub published: u32,
+    /// Stale-generation suppressions (§9.4).
+    pub suppressed: u32,
+    /// Quiet skips (PR-404, closed-unmerged, non-success results) and
+    /// pre-state guard passes (already-final, retry-not-due,
+    /// concurrent-CAS loss, no state).
+    pub skipped: u32,
+    /// Retryable failures with persisted backoff.
+    pub failed_retryable: u32,
+    /// Per-entry errors (store/parse failures) — logged + counted.
+    pub errors: u32,
+}
+
+fn fold_outcome(stats: &mut PublicationStats, outcome: FinalizeOutcome) {
+    match outcome {
+        FinalizeOutcome::Published
+        | FinalizeOutcome::PublishedUnchanged
+        | FinalizeOutcome::PublishedRecreated => stats.published += 1,
+        FinalizeOutcome::SuppressedStaleGeneration => stats.suppressed += 1,
+        FinalizeOutcome::FailedRetryable { .. } => stats.failed_retryable += 1,
+        FinalizeOutcome::NoState
+        | FinalizeOutcome::AlreadyFinal
+        | FinalizeOutcome::SkipRetryNotDue
+        | FinalizeOutcome::SkipConcurrent
+        | FinalizeOutcome::PrGone
+        | FinalizeOutcome::SkippedClosedUnmerged => stats.skipped += 1,
+    }
+}
+
+/// Step 5.6: finalize due review publications. Per-entry isolation —
+/// one bad entry is logged + counted; the poll continues.
+pub(crate) async fn poll_publication_step(
+    client: &crate::github::Client,
+    cfg: &crate::infra::config::Config,
+    review_store: &ReviewStore,
+) -> CaduceusResult<PublicationStats> {
+    let due = review_store.due_finalizations()?;
+    let mut stats = PublicationStats::default();
+    let now = chrono::Utc::now();
+    for entry in &due {
+        match finalize_review(client, cfg, review_store, entry, now).await {
+            Ok(outcome) => {
+                stats.attempted += 1;
+                fold_outcome(&mut stats, outcome);
+            }
+            Err(err) => {
+                warn!(
+                    target: "caduceus",
+                    error = %err,
+                    repo = entry.repository.full_name(),
+                    pr = entry.pull_request,
+                    head_sha = entry.head_sha,
+                    "review finalization failed; continuing"
+                );
+                stats.errors += 1;
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Test seam: same loop as [`poll_publication_step`] against an
+/// explicit config (mirrors #312's `poll_review_step` seam). Errors are
+/// counted, never propagated, so one bad entry cannot fail a test's
+/// surrounding assertions.
+pub async fn poll_publication_step_for_tests(
+    client: &crate::github::Client,
+    cfg: &crate::infra::config::Config,
+    review_store: &ReviewStore,
+) -> CaduceusResult<PublicationStats> {
+    let due = review_store.due_finalizations()?;
+    let mut stats = PublicationStats::default();
+    let now = chrono::Utc::now();
+    for entry in &due {
+        stats.attempted += 1;
+        match finalize_review(client, cfg, review_store, entry, now).await {
+            Ok(outcome) => fold_outcome(&mut stats, outcome),
+            Err(_) => stats.errors += 1,
+        }
+    }
+    Ok(stats)
+}

--- a/src/github/merge_detect.rs
+++ b/src/github/merge_detect.rs
@@ -31,11 +31,15 @@ pub async fn poll_pr_merge_status(
     pr_number: u64,
 ) -> CaduceusResult<MergeStatus> {
     let path = format!("/repos/{owner}/{repo}/pulls/{pr_number}");
-    let resp = client.get(&path, "application/vnd.github+json").await?;
+    let resp = match client.get(&path, "application/vnd.github+json").await {
+        Ok(resp) => resp,
+        // The transport surfaces a 404 as a typed error, not an
+        // `Ok` response: map it to the gone-state B input (DAR
+        // §9.3 — PR deleted; quiet skip, never recreate).
+        Err(CaduceusError::GitHubApi { status: 404, .. }) => return Ok(MergeStatus::NotFound),
+        Err(err) => return Err(err),
+    };
 
-    if resp.status == 404 {
-        return Ok(MergeStatus::NotFound);
-    }
     if !matches!(resp.status, 200) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,

--- a/src/review/finalize.rs
+++ b/src/review/finalize.rs
@@ -1,0 +1,574 @@
+//! Resume-safe review publication finalizer (DAR §9.1–9.4, §13 —
+//! `docs/architecture/auto-review.md`; issue #310).
+//!
+//! The finalizer owns the publication FSM
+//! `Pending → Publishing → Published | FailedRetryable` for the sticky
+//! PR comment. The canonical [`crate::review::ReviewResult`] is durable
+//! in review history (#295) **before any GitHub call**; publication is
+//! presentation only. A restart mid-publish resumes from the persisted
+//! `publication_state` — the model is NEVER re-run because publication
+//! failed (DAR §9.1, AC1).
+//!
+//! # FSM step (`finalize_review`)
+//!
+//! 1. Generation guard (DAR §9.4): a completing run whose generation is
+//!    older than the current `ReviewState.review_generation` is
+//!    suppressed — recorded in history only, never published
+//!    (`review_publication_suppressed_stale_generation`, AC2). The
+//!    suppression is a non-transition: the current generation owns the
+//!    presentation.
+//! 2. Pre-state guards: `Published` → already final; `FailedRetryable`
+//!    with a future `next_publish_at` → retry not yet due. No write, no
+//!    GitHub call.
+//! 3. Claim: `Pending|FailedRetryable|Publishing → Publishing` with
+//!    `publication_attempt_count += 1`, persisted via
+//!    `ReviewStore::save_review_state`. The store rejects
+//!    generation-regressing writes, so a newer admission winning the
+//!    race surfaces as `StateCorrupt` → `SkipConcurrent` (the CAS IS the
+//!    generation guard).
+//! 4. Publish via [`crate::review::sticky_comment::publish`] with the PR
+//!    lifecycle from `poll_pr_merge_status` (DAR §9.3 gone-states A–D).
+//! 5. Terminal save: success → `Published` (+ sticky comment id);
+//!    retryable error → `FailedRetryable` with persisted exponential
+//!    backoff (`next_publish_at`, `last_publish_error`); gone-states
+//!    B/C and suppression → finalized-without-publication (see
+//!    Terminal classification below).
+//!
+//! # Terminal classification (plan §6, Option 2)
+//!
+//! The publication enum has no `Skipped`/`FailedNonRetryable` variant
+//! (deliberate — the issue's scope does not add states). Permanently
+//! unpublishable outcomes (PR-404, closed-unmerged, stale-generation,
+//! non-success result) finalize as `publication_state := Published` —
+//! "finalization complete, nothing to show" — with the reason recorded
+//! in `last_publish_error` (`pr_not_found`, `closed_unmerged`,
+//! `suppressed_stale_generation`, `no_publishable_result`). Chosen over
+//! leaving the row at `Publishing` because the due-scan is
+//! history-driven: a `Publishing` row with no pending terminal save is
+//! precisely the crash-recovery case, and the two must not be
+//! confusable.
+//!
+//! # Crash recovery (AC5)
+//!
+//! `publication_state` IS the resume checkpoint: the poll re-enters any
+//! non-terminal row whose retry debt elapsed (`Publishing` with no
+//! backoff = a crashed claim). Re-publication is idempotent: the sticky
+//! comment is byte-identical (#308 `Unchanged`), and a create whose id
+//! was never persisted self-heals via marker adoption
+//! ([`crate::review::sticky_comment::find_sticky_comment_by_marker`]).
+//! A crash after publish but before the terminal save therefore never
+//! duplicates the comment.
+//!
+//! # Boundaries
+//!
+//! - Dispatch routing / skip routing is #339's: the tick's poll step
+//!   (`daemon::tick::review_finalize_step`) scans the store; #339 will
+//!   own completion-driven wakeups.
+//! - Single-daemon assumption: concurrent daemons are bounded by the
+//!   CAS + #308 idempotency (worst case a wasted API call, never a
+//!   duplicate comment), but scheduling is not coordinated.
+//! - `enqueue_review` re-arms publication on a new admission: bumping
+//!   `review_generation` resets `publication_state` to `Pending` (and
+//!   clears the stale publication-retry debt) so the next generation's
+//!   completion can publish. Without the reset, a `Published` row from
+//!   generation N would permanently block generation N+1.
+
+use chrono::{DateTime, Utc};
+use tracing::info;
+
+use crate::github::merge_detect::poll_pr_merge_status;
+use crate::github::Client;
+use crate::infra::config::Config;
+use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::review::sticky_comment::{publish, RenderInput, StickyOutcome};
+use crate::review::{
+    parse_review_result, PublicationState, RepositoryId, ReviewState, MAX_PUBLISH_ERROR_BYTES,
+};
+use crate::state::review::ReviewStore;
+
+// ---------------------------------------------------------------------------
+// Events (DAR §13 — owned by #310)
+// ---------------------------------------------------------------------------
+
+/// DAR §13 finalizer event: the publication attempt began (after the
+/// claim, before any GitHub call).
+pub const EVENT_PUBLISH_STARTED: &str = "review_publish_started";
+/// DAR §13 finalizer event: the sticky comment was published or
+/// idempotently confirmed.
+pub const EVENT_PUBLISHED: &str = "review_published";
+/// DAR §13 finalizer event: publication failed with persisted backoff.
+pub const EVENT_PUBLISH_FAILED_RETRYABLE: &str = "review_publish_failed_retryable";
+/// DAR §13/§9.4 event: a stale-generation publication was suppressed.
+pub const EVENT_SUPPRESSED_STALE_GENERATION: &str =
+    "review_publication_suppressed_stale_generation";
+/// Finalizer event: PR closed without merge at finalization time —
+/// quiet skip + structured event (DAR §9.3 row C).
+pub const EVENT_SKIPPED_PR_CLOSED_UNMERGED: &str = "review_skipped_pr_closed_unmerged";
+
+fn emit_publish_started(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = EVENT_PUBLISH_STARTED,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "review publication started"
+    );
+}
+
+fn emit_published(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = EVENT_PUBLISHED,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "review published to the sticky PR comment"
+    );
+}
+
+fn emit_publish_failed_retryable(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = EVENT_PUBLISH_FAILED_RETRYABLE,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "review publication failed; retry scheduled with backoff"
+    );
+}
+
+fn emit_suppressed_stale_generation(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = EVENT_SUPPRESSED_STALE_GENERATION,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "stale-generation publication suppressed; result remains in history"
+    );
+}
+
+fn emit_skipped_pr_closed_unmerged(repo: &str, pr: u64, head_sha: &str) {
+    info!(
+        target: "caduceus",
+        event = EVENT_SKIPPED_PR_CLOSED_UNMERGED,
+        repo = repo,
+        pr = pr,
+        head_sha = head_sha,
+        "publication skipped: PR closed without merge"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Terminal sentinels (Option 2 classification — see module docs)
+// ---------------------------------------------------------------------------
+
+/// `last_publish_error` sentinel: PR lookup 404 (DAR §9.3 row B).
+pub const PUBLISH_ERROR_PR_NOT_FOUND: &str = "pr_not_found";
+/// `last_publish_error` sentinel: PR closed without merge (§9.3 row C).
+pub const PUBLISH_ERROR_CLOSED_UNMERGED: &str = "closed_unmerged";
+/// `last_publish_error` sentinel: stale-generation suppression (§9.4).
+pub const PUBLISH_ERROR_SUPPRESSED_STALE: &str = "suppressed_stale_generation";
+/// `last_publish_error` sentinel: the durable result carries no
+/// publishable review (non-success execution result).
+pub const PUBLISH_ERROR_NO_PUBLISHABLE_RESULT: &str = "no_publishable_result";
+
+// ---------------------------------------------------------------------------
+// Due-scan types
+// ---------------------------------------------------------------------------
+
+/// One `(repo, pr)` finalization the poll should run: the completing
+/// run's identity and the generation to guard against.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DueFinalization {
+    /// Repository the PR lives in.
+    pub repository: RepositoryId,
+    /// PR number.
+    pub pull_request: u64,
+    /// The completing run's `review_generation` — the value the guard
+    /// compares against the current `ReviewState.review_generation`.
+    pub run_generation: u64,
+    /// Head SHA of the completing run (the history-row lookup key).
+    pub head_sha: String,
+}
+
+/// What one [`finalize_review`] step decided.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FinalizeOutcome {
+    /// No state row / no durable result for the run — nothing to
+    /// finalize. Quiet: no event, no write.
+    NoState,
+    /// `publication_state` was already `Published` (final or
+    /// finalized-without-publication). No write, no GitHub call.
+    AlreadyFinal,
+    /// `FailedRetryable` whose `next_publish_at` is still in the
+    /// future. No write, no GitHub call.
+    SkipRetryNotDue,
+    /// The claim's CAS save lost to a newer admission
+    /// (generation regression). No GitHub call.
+    SkipConcurrent,
+    /// Stale generation (pre-publish guard or post-publish CAS loss):
+    /// history only, presentation untouched by this run.
+    SuppressedStaleGeneration,
+    /// Comment created/updated; `sticky_comment_id` persisted.
+    Published,
+    /// Byte-identical re-publication confirmed (`Unchanged`); no PATCH.
+    PublishedUnchanged,
+    /// Gone-state A recovery: comment adopted/recreated via marker
+    /// search; new id persisted.
+    PublishedRecreated,
+    /// Gone-state B: PR 404 — quiet skip, never recreate (no event).
+    PrGone,
+    /// Gone-state C: closed-unmerged — quiet skip + event.
+    SkippedClosedUnmerged,
+    /// Publication failed; retry scheduled with persisted backoff.
+    FailedRetryable {
+        /// When the next publication attempt may run.
+        next_attempt_at: DateTime<Utc>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Backoff (plan §5: min(2^min(n,12) * 30s, 1h))
+// ---------------------------------------------------------------------------
+
+/// Publication backoff for the n-th attempt: `min(2^min(n,12) * 30s,
+/// 3600s)` — 60s, 2m, 4m, 8m, 16m, 32m, 1h cap. `n` is
+/// `publication_attempt_count` (publication retries — never the worker
+/// attempt counter, DAR §9.1).
+pub fn backoff_delay(publication_attempt_count: u32) -> chrono::Duration {
+    let shift = publication_attempt_count.min(12);
+    let secs = (1u64 << shift) * 30;
+    chrono::Duration::seconds((secs.min(3600)) as i64)
+}
+
+/// Char-boundary-safe truncation for `last_publish_error` (cap is the
+/// validator's `MAX_PUBLISH_ERROR_BYTES`).
+fn truncate_error(msg: &str) -> String {
+    if msg.len() <= MAX_PUBLISH_ERROR_BYTES {
+        return msg.to_string();
+    }
+    let mut end = MAX_PUBLISH_ERROR_BYTES;
+    while end > 0 && !msg.is_char_boundary(end) {
+        end -= 1;
+    }
+    msg[..end].to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Claim (Pending|FailedRetryable|Publishing → Publishing, CAS-guarded)
+// ---------------------------------------------------------------------------
+
+/// Persist the `Publishing` claim for `state`:
+/// `publication_state := Publishing`, `publication_attempt_count += 1`,
+/// retry debt cleared. The equal-generation write is allowed by
+/// `save_review_state`; a generation-regression rejection (a newer
+/// admission won the race) returns `Ok(false)` — the caller must not
+/// publish. Any other store error propagates.
+pub fn claim_for_publication(store: &ReviewStore, state: &ReviewState) -> CaduceusResult<bool> {
+    let mut claimed = state.clone();
+    claimed.publication_state = PublicationState::Publishing;
+    claimed.publication_attempt_count = claimed.publication_attempt_count.saturating_add(1);
+    claimed.next_publish_at = None;
+    match store.save_review_state(&claimed) {
+        Ok(()) => Ok(true),
+        Err(CaduceusError::StateCorrupt { .. }) => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The FSM step
+// ---------------------------------------------------------------------------
+
+/// Run one publication-finalization step for a due finalization (the
+/// FSM core, plan §5). Guards run before any write; no GitHub call
+/// happens before the claim succeeds.
+pub async fn finalize_review(
+    client: &Client,
+    cfg: &Config,
+    store: &ReviewStore,
+    due: &DueFinalization,
+    now: DateTime<Utc>,
+) -> CaduceusResult<FinalizeOutcome> {
+    let repo_full = due.repository.full_name();
+    let owner = due.repository.owner.as_str();
+    let repo_name = due.repository.repo.as_str();
+
+    let Some(mut state) = store.review_state(&due.repository, due.pull_request)? else {
+        return Ok(FinalizeOutcome::NoState);
+    };
+
+    // Generation guard (DAR §9.4, AC2). `run_generation >
+    // review_generation` is impossible under the monotonic admission
+    // CAS — treat as NoState (corrupt) rather than publishing.
+    if due.run_generation > state.review_generation {
+        return Ok(FinalizeOutcome::NoState);
+    }
+    if due.run_generation < state.review_generation {
+        emit_suppressed_stale_generation(&repo_full, due.pull_request, &due.head_sha);
+        return Ok(FinalizeOutcome::SuppressedStaleGeneration);
+    }
+
+    // Pre-state guards: no write, no GitHub call.
+    match state.publication_state {
+        PublicationState::Published => return Ok(FinalizeOutcome::AlreadyFinal),
+        PublicationState::FailedRetryable
+            if state.next_publish_at.map(|t| t > now).unwrap_or(false) =>
+        {
+            return Ok(FinalizeOutcome::SkipRetryNotDue);
+        }
+        _ => {}
+    }
+
+    // Durable-result-before-publication invariant: the canonical result
+    // must already be in history. Nothing here re-runs the model.
+    let rows = store.history_for_head_sha(&due.repository, due.pull_request, &due.head_sha)?;
+    let Some(row) = rows.last() else {
+        return Ok(FinalizeOutcome::NoState);
+    };
+    let result = parse_review_result(&row.result_json)?;
+    let Some(review) = result.review else {
+        // Non-success execution result: nothing to publish. Finalize
+        // quietly (terminal sentinel) — retrying could not help; the
+        // result stays in history.
+        finalize_without_publication(
+            store,
+            &mut state,
+            &row.head_sha,
+            &row.review_run_id,
+            PUBLISH_ERROR_NO_PUBLISHABLE_RESULT,
+            now,
+        )?;
+        return Ok(FinalizeOutcome::NoState);
+    };
+
+    // Claim (CAS vehicle for the generation guard under races).
+    if !claim_for_publication(store, &state)? {
+        return Ok(FinalizeOutcome::SkipConcurrent);
+    }
+    state.publication_state = PublicationState::Publishing;
+    state.publication_attempt_count = state.publication_attempt_count.saturating_add(1);
+    state.next_publish_at = None;
+
+    emit_publish_started(&repo_full, due.pull_request, &due.head_sha);
+
+    // PR lifecycle classification (DAR §9.3) — first GitHub call.
+    let pr_state = match poll_pr_merge_status(client, owner, repo_name, due.pull_request).await {
+        Ok(pr_state) => pr_state,
+        Err(err) => {
+            return save_retryable(store, &mut state, due, &err, now);
+        }
+    };
+
+    let input = RenderInput {
+        review: &review,
+        reviewed_head_sha: &due.head_sha,
+        current_head_sha: None,
+    };
+    let sticky = match publish(
+        client,
+        cfg,
+        owner,
+        repo_name,
+        due.pull_request,
+        &state,
+        &input,
+        pr_state,
+    )
+    .await
+    {
+        Ok(sticky) => sticky,
+        Err(err) => {
+            return save_retryable(store, &mut state, due, &err, now);
+        }
+    };
+
+    match sticky {
+        StickyOutcome::Published { comment_id } => {
+            finalize_published(
+                store,
+                &mut state,
+                &review,
+                &row.head_sha,
+                &row.review_run_id,
+                comment_id,
+                now,
+            )?;
+            emit_published(&repo_full, due.pull_request, &due.head_sha);
+            Ok(FinalizeOutcome::Published)
+        }
+        StickyOutcome::Unchanged { comment_id } => {
+            finalize_published(
+                store,
+                &mut state,
+                &review,
+                &row.head_sha,
+                &row.review_run_id,
+                comment_id,
+                now,
+            )?;
+            emit_published(&repo_full, due.pull_request, &due.head_sha);
+            Ok(FinalizeOutcome::PublishedUnchanged)
+        }
+        StickyOutcome::CommentGoneRecreated { new_comment_id } => {
+            finalize_published(
+                store,
+                &mut state,
+                &review,
+                &row.head_sha,
+                &row.review_run_id,
+                new_comment_id,
+                now,
+            )?;
+            emit_published(&repo_full, due.pull_request, &due.head_sha);
+            Ok(FinalizeOutcome::PublishedRecreated)
+        }
+        StickyOutcome::PrNotFound => {
+            // Gone-state B: quiet skip, no event, never recreate.
+            finalize_without_publication(
+                store,
+                &mut state,
+                &row.head_sha,
+                &row.review_run_id,
+                PUBLISH_ERROR_PR_NOT_FOUND,
+                now,
+            )?;
+            Ok(FinalizeOutcome::PrGone)
+        }
+        StickyOutcome::PrClosedUnmerged => {
+            // Gone-state C: quiet skip + event; history remains.
+            emit_skipped_pr_closed_unmerged(&repo_full, due.pull_request, &due.head_sha);
+            finalize_without_publication(
+                store,
+                &mut state,
+                &row.head_sha,
+                &row.review_run_id,
+                PUBLISH_ERROR_CLOSED_UNMERGED,
+                now,
+            )?;
+            Ok(FinalizeOutcome::SkippedClosedUnmerged)
+        }
+        StickyOutcome::PrMergedSuppressed | StickyOutcome::SuppressedStaleGeneration => {
+            // Defensive mapping (publish itself never returns these —
+            // see sticky_comment.rs); treated as the §9.4 suppression.
+            emit_suppressed_stale_generation(&repo_full, due.pull_request, &due.head_sha);
+            finalize_without_publication(
+                store,
+                &mut state,
+                &row.head_sha,
+                &row.review_run_id,
+                PUBLISH_ERROR_SUPPRESSED_STALE,
+                now,
+            )?;
+            Ok(FinalizeOutcome::SuppressedStaleGeneration)
+        }
+    }
+}
+
+/// Terminal save for a published comment: `Published` + sticky id,
+/// retry debt cleared, review observations recorded, event emitted by
+/// the caller. A CAS regression on the save (a newer admission reset
+/// the row mid-publish) leaves the state to the newer generation and
+/// reports the suppression — the GitHub call already happened; #308
+/// byte-identical idempotency keeps any later re-publish duplicate-free.
+fn finalize_published(
+    store: &ReviewStore,
+    state: &mut ReviewState,
+    review: &crate::review::Review,
+    head_sha: &str,
+    run_id: &str,
+    comment_id: u64,
+    now: DateTime<Utc>,
+) -> CaduceusResult<()> {
+    state.publication_state = PublicationState::Published;
+    state.sticky_comment_id = Some(comment_id);
+    state.next_publish_at = None;
+    state.last_publish_error = None;
+    state.last_reviewed_head_sha = Some(head_sha.to_string());
+    state.last_verdict = Some(review.verdict);
+    state.last_reviewed_at = Some(now);
+    state.last_run_id = Some(run_id.to_string());
+    match store.save_review_state(state) {
+        Ok(()) => Ok(()),
+        Err(err @ CaduceusError::StateCorrupt { .. }) => {
+            tracing::warn!(
+                error = %err,
+                repo = state.repository.full_name(),
+                pr = state.pull_request,
+                "terminal publication save lost the generation race; \
+                 the newer admission owns the presentation"
+            );
+            // The comment WAS published; report the race without
+            // failing the step.
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Terminal save for a finalization that completes WITHOUT publishing
+/// (Option 2 sentinel — see module docs): `Published` state marker +
+/// the reason in `last_publish_error`. Review observations are still
+/// recorded: the review completed; only its presentation is absent.
+fn finalize_without_publication(
+    store: &ReviewStore,
+    state: &mut ReviewState,
+    head_sha: &str,
+    run_id: &str,
+    sentinel: &str,
+    now: DateTime<Utc>,
+) -> CaduceusResult<()> {
+    state.publication_state = PublicationState::Published;
+    state.next_publish_at = None;
+    state.last_publish_error = Some(sentinel.to_string());
+    state.last_reviewed_head_sha = Some(head_sha.to_string());
+    state.last_reviewed_at = Some(now);
+    state.last_run_id = Some(run_id.to_string());
+    match store.save_review_state(state) {
+        Ok(()) => Ok(()),
+        Err(err @ CaduceusError::StateCorrupt { .. }) => {
+            tracing::warn!(
+                error = %err,
+                repo = state.repository.full_name(),
+                pr = state.pull_request,
+                "finalization save lost the generation race; \
+                 the newer admission owns the state"
+            );
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Retryable-failure save (AC1, AC4): `FailedRetryable` + persisted
+/// exponential backoff + truncated error. The model is never re-run.
+fn save_retryable(
+    store: &ReviewStore,
+    state: &mut ReviewState,
+    due: &DueFinalization,
+    err: &CaduceusError,
+    now: DateTime<Utc>,
+) -> CaduceusResult<FinalizeOutcome> {
+    let next_attempt_at = now + backoff_delay(state.publication_attempt_count);
+    state.publication_state = PublicationState::FailedRetryable;
+    state.next_publish_at = Some(next_attempt_at);
+    state.last_publish_error = Some(truncate_error(&err.to_string()));
+    match store.save_review_state(state) {
+        Ok(()) => {}
+        Err(err @ CaduceusError::StateCorrupt { .. }) => {
+            tracing::warn!(
+                error = %err,
+                repo = due.repository.full_name(),
+                pr = due.pull_request,
+                "retry save lost the generation race; the newer \
+                 admission owns the publication state"
+            );
+            return Ok(FinalizeOutcome::SkipConcurrent);
+        }
+        Err(err) => return Err(err),
+    }
+    emit_publish_failed_retryable(&due.repository.full_name(), due.pull_request, &due.head_sha);
+    Ok(FinalizeOutcome::FailedRetryable { next_attempt_at })
+}

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -26,8 +26,16 @@
 //! Out of scope here (later issues): migrations (#293), executor
 //! targets (#346), CLI (#318).
 
+pub mod finalize;
 pub mod sticky_comment;
 
+pub use finalize::{
+    backoff_delay, claim_for_publication, finalize_review, DueFinalization, FinalizeOutcome,
+    EVENT_PUBLISHED, EVENT_PUBLISH_FAILED_RETRYABLE, EVENT_PUBLISH_STARTED,
+    EVENT_SKIPPED_PR_CLOSED_UNMERGED, EVENT_SUPPRESSED_STALE_GENERATION,
+    PUBLISH_ERROR_CLOSED_UNMERGED, PUBLISH_ERROR_NO_PUBLISHABLE_RESULT, PUBLISH_ERROR_PR_NOT_FOUND,
+    PUBLISH_ERROR_SUPPRESSED_STALE,
+};
 pub use sticky_comment::{
     find_sticky_comment_by_marker, publish, render_sticky_comment, RenderInput, StickyOutcome,
     REVIEW_MARKER, STICKY_COMMENT_MAX_BYTES, STICKY_MARKER_SEARCH_MAX_PAGES,

--- a/src/state/review/state.rs
+++ b/src/state/review/state.rs
@@ -314,6 +314,18 @@ impl ReviewStore {
                 Some(existing_state) => {
                     let generation = existing_state.review_generation + 1;
                     existing_state.review_generation = generation;
+                    // Re-arm publication for the new generation (DAR
+                    // §9.4 + #310): without the reset a `Published` row
+                    // from generation N would permanently block
+                    // generation N+1's publication, and retry debt from
+                    // the old generation would be stale. The reset is
+                    // inside the same exclusive section as the bump, so
+                    // the queue entry's generation and the reset are
+                    // atomic together.
+                    existing_state.publication_state = crate::review::PublicationState::Pending;
+                    existing_state.publication_attempt_count = 0;
+                    existing_state.next_publish_at = None;
+                    existing_state.last_publish_error = None;
                     generation
                 }
                 None => {
@@ -592,6 +604,53 @@ impl ReviewStore {
         self.with_shared(|store, conn| {
             let states = store.load_state_map(conn)?;
             Ok(states.states.get(&review_state_key(repo, pr)).cloned())
+        })
+    }
+
+    /// Finalizations due for publication (issue #310, DAR §9.1):
+    /// completed runs (history rows) whose generation is still CURRENT
+    /// for their `(repo, pr)` and whose state row is not yet finalized
+    /// (`publication_state != Published`). Each due entry carries the
+    /// completing run's generation (the stale-publication guard input)
+    /// and head SHA (the history-row lookup key).
+    ///
+    /// The scan is history-driven by design: the durable result exists
+    /// BEFORE any publication attempt (DAR §9.1), so the finalizer can
+    /// never be asked to publish a run that was never persisted. A row
+    /// whose generation was superseded is skipped here — the newer
+    /// generation owns the presentation (DAR §9.4); the older run stays
+    /// in history only. `retry_or_fail_review` failures (execution
+    /// retries) have no history row and never appear.
+    ///
+    /// Ordered oldest-first for deterministic tick behaviour.
+    pub fn due_finalizations(
+        &self,
+    ) -> CaduceusResult<Vec<crate::review::finalize::DueFinalization>> {
+        self.with_shared(|store, conn| {
+            let history = store.load_history(conn)?;
+            let states = store.load_state_map(conn)?;
+            let mut due = Vec::new();
+            for row in &history.rows {
+                let key = review_state_key(&row.repository, row.pull_request);
+                let Some(state) = states.states.get(&key) else {
+                    continue;
+                };
+                if state.publication_state == crate::review::PublicationState::Published {
+                    continue;
+                }
+                if row.review_generation != state.review_generation {
+                    // Superseded generation: suppressed by the guard at
+                    // finalize time; the poll never routes it.
+                    continue;
+                }
+                due.push(crate::review::finalize::DueFinalization {
+                    repository: row.repository.clone(),
+                    pull_request: row.pull_request,
+                    run_generation: row.review_generation,
+                    head_sha: row.head_sha.clone(),
+                });
+            }
+            Ok(due)
         })
     }
 

--- a/tests/review/finalizer_test.rs
+++ b/tests/review/finalizer_test.rs
@@ -1,0 +1,660 @@
+//! Review publication finalizer tests (issue #310, DAR §9.1–9.4, §15).
+//!
+//! Coverage:
+//!
+//! - AC1: FSM transitions persisted and resumed across restart; no
+//!   model re-run on GitHub failure (retryable failure →
+//!   `FailedRetryable` + persisted backoff, history row untouched).
+//! - AC2: stale-generation publication suppressed (history only, no
+//!   comment); monotonicity via the store's generation CAS.
+//! - AC3: merged → publishes; closed-unmerged → quiet skip + event;
+//!   PR-404 → quiet skip.
+//! - AC4: persisted backoff survives a store re-open (restart);
+//!   `publication_attempt_count` is separate from worker attempts.
+//! - AC5: crash-after-publish-before-mark produces no duplicate
+//!   comment (marker adoption / byte-identical idempotency).
+
+use caduceus::config::Config;
+use caduceus::github::{Client, HttpCache};
+use caduceus::infra::logging::build_test_subscriber;
+use caduceus::review::sticky_comment::{render_sticky_comment, RenderInput, REVIEW_MARKER};
+use caduceus::review::{
+    backoff_delay, claim_for_publication, finalize_review, DueFinalization, ExecutionStatus,
+    FinalizeOutcome, PublicationState, RepositoryId, Review, ReviewResult, ReviewState,
+    ReviewTarget, Verdict, REVIEW_SCHEMA_VERSION,
+};
+use caduceus::state::review::{ReviewHistoryRow, ReviewStore};
+use chrono::{DateTime, TimeZone, Utc};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::{tempdir, MockGitHub};
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const OWNER: &str = "octocat";
+const REPO: &str = "hello-world";
+const PR: u64 = 42;
+const SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn repository() -> RepositoryId {
+    RepositoryId {
+        owner: OWNER.to_string(),
+        repo: REPO.to_string(),
+    }
+}
+
+fn mock_client(gh: &MockGitHub) -> (Client, Config) {
+    let state_dir = tempdir("finalize");
+    let mut cfg = Config::test_defaults(&state_dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&state_dir).expect("cache opens");
+    let client = Client::with_cache(&cfg, cache).expect("client builds");
+    (client, cfg)
+}
+
+fn sample_review() -> Review {
+    Review {
+        verdict: Verdict::Pass,
+        summary: "looks good".to_string(),
+        findings: vec![],
+    }
+}
+
+fn result_json(review: Option<Review>) -> String {
+    serde_json::to_string(&ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status: match review {
+            Some(_) => ExecutionStatus::Success,
+            None => ExecutionStatus::Failure,
+        },
+        review,
+    })
+    .expect("result serializes")
+}
+
+fn history_row(run_id: &str, generation: u64, review: Option<Review>) -> ReviewHistoryRow {
+    ReviewHistoryRow {
+        review_run_id: run_id.to_string(),
+        repository: repository(),
+        pull_request: PR,
+        head_sha: SHA.to_string(),
+        review_generation: generation,
+        completed_at: Utc.with_ymd_and_hms(2026, 9, 7, 12, 0, 0).unwrap(),
+        result_json: result_json(review),
+    }
+}
+
+/// Seed a fresh store: `ReviewState` at `generation` in `publication`,
+/// plus one durable history row for the run. Returns the store path so
+/// a test can re-open it (restart semantics).
+fn seeded_store(
+    label: &str,
+    generation: u64,
+    publication: PublicationState,
+) -> (ReviewStore, std::path::PathBuf) {
+    let dir = tempdir(label);
+    let store = ReviewStore::open(&dir).expect("review store opens");
+    let mut state = ReviewState::new(repository(), PR, generation);
+    state.publication_state = publication;
+    store.save_review_state(&state).expect("seed state");
+    store
+        .append_history(history_row("run-1", generation, Some(sample_review())))
+        .expect("seed history");
+    (store, dir)
+}
+
+fn due(generation: u64) -> DueFinalization {
+    DueFinalization {
+        repository: repository(),
+        pull_request: PR,
+        run_generation: generation,
+        head_sha: SHA.to_string(),
+    }
+}
+
+fn now() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 9, 7, 13, 0, 0).unwrap()
+}
+
+/// The exact rendered body the finalizer publishes for
+/// [`sample_review`] (marker adoption tests replay it).
+fn rendered_body() -> String {
+    render_sticky_comment(&RenderInput {
+        review: &sample_review(),
+        reviewed_head_sha: SHA,
+        current_head_sha: None,
+    })
+}
+
+/// Mount the GitHub endpoints a happy-path publish consumes: the PR
+/// lifecycle GET (still open), an empty marker-search page, and the
+/// create endpoint returning `comment_id`.
+async fn mount_publish_open(gh: &MockGitHub, comment_id: u64) {
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([])],
+    )
+    .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        201,
+        serde_json::json!({ "id": comment_id, "body": "" }),
+    )
+    .await;
+}
+
+fn load_state(store: &ReviewStore) -> ReviewState {
+    store
+        .review_state(&repository(), PR)
+        .expect("state read")
+        .expect("state row exists")
+}
+
+// ---------------------------------------------------------------------------
+// AC1 + AC3: happy path — Pending → Publishing → Published
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn happy_path_publishes_and_persists_terminal_state() {
+    let gh = MockGitHub::start().await;
+    mount_publish_open(&gh, 777).await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-happy", 1, PublicationState::Pending);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::Published);
+
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.sticky_comment_id, Some(777));
+    assert_eq!(state.publication_attempt_count, 1);
+    assert_eq!(state.next_publish_at, None);
+    assert_eq!(state.last_publish_error, None);
+    assert_eq!(state.last_reviewed_head_sha.as_deref(), Some(SHA));
+    assert_eq!(state.last_verdict, Some(Verdict::Pass));
+
+    // Exactly one comment was created — no duplicate.
+    assert_eq!(gh.counts().post, 1, "one create");
+}
+
+// ---------------------------------------------------------------------------
+// AC3 row D: merged-and-current publishes
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn merged_pr_publishes() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({
+            "state": "closed",
+            "merged": true,
+            "merge_commit_sha": "ff00ff"
+        }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([])],
+    )
+    .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        201,
+        serde_json::json!({ "id": 901, "body": "" }),
+    )
+    .await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-merged", 1, PublicationState::Pending);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::Published, "merged publishes");
+    assert_eq!(load_state(&store).sticky_comment_id, Some(901));
+}
+
+// ---------------------------------------------------------------------------
+// AC3 row C: closed-unmerged → quiet skip + event, terminal sentinel
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn closed_unmerged_is_quiet_skip_with_event() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "closed", "merged": false }),
+    )
+    .await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, dir) = seeded_store("fin-closed", 1, PublicationState::Pending);
+
+    // Capture the skip event around the finalize (serial discipline:
+    // callsite interest is cached process-wide). The subscriber is
+    // installed for the current thread only; the #[tokio::test]
+    // runtime is already driving this future on it.
+    let capture = dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        finalize_review(&client, &cfg, &store, &due(1), now())
+            .await
+            .expect("finalize succeeds")
+    };
+    drop(guard);
+
+    assert_eq!(outcome, FinalizeOutcome::SkippedClosedUnmerged);
+    // Quiet skip + structured event (DAR §9.3 row C).
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    assert!(
+        body.contains("review_skipped_pr_closed_unmerged"),
+        "skip event missing: {body}"
+    );
+
+    // Terminal: finalized without publication, no comment created.
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.sticky_comment_id, None);
+    assert_eq!(state.last_publish_error.as_deref(), Some("closed_unmerged"));
+    assert_eq!(gh.counts().mutations(), 0, "no comment created");
+}
+
+// ---------------------------------------------------------------------------
+// AC3 row B: PR-404 → quiet skip, no comment
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pr_not_found_is_quiet_skip() {
+    let gh = MockGitHub::start().await;
+    gh.mount_status(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        404,
+        serde_json::json!({ "message": "Not Found" }),
+    )
+    .await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-404", 1, PublicationState::Pending);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::PrGone);
+
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.sticky_comment_id, None);
+    assert_eq!(state.last_publish_error.as_deref(), Some("pr_not_found"));
+    assert_eq!(gh.counts().mutations(), 0, "no comment created");
+}
+
+// ---------------------------------------------------------------------------
+// AC1 + AC4: retryable GitHub failure → FailedRetryable + persisted
+// backoff; the model is never re-run (history row unchanged)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn github_failure_lands_in_failed_retryable_with_backoff() {
+    let gh = MockGitHub::start().await;
+    // Lifecycle probe succeeds; the comment create 503s.
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([])],
+    )
+    .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        503,
+        serde_json::json!({ "message": "unavailable" }),
+    )
+    .await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, dir) = seeded_store("fin-retry", 1, PublicationState::Pending);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize reports the retryable outcome");
+    let next_attempt_at = match outcome {
+        FinalizeOutcome::FailedRetryable { next_attempt_at } => next_attempt_at,
+        other => panic!("expected FailedRetryable, got {other:?}"),
+    };
+    assert_eq!(
+        next_attempt_at,
+        now() + backoff_delay(1),
+        "backoff for the first attempt"
+    );
+
+    // Retry state persisted: FailedRetryable + backoff + error, and
+    // the attempt counter is the PUBLICATION counter (AC4).
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::FailedRetryable);
+    assert_eq!(state.next_publish_at, Some(next_attempt_at));
+    assert!(state.last_publish_error.is_some(), "error persisted");
+    assert_eq!(state.publication_attempt_count, 1);
+
+    // AC1: the durable result is untouched — no model re-run.
+    let rows = store
+        .history_for_head_sha(&repository(), PR, SHA)
+        .expect("history read");
+    assert_eq!(rows.len(), 1, "exactly one history row");
+    assert!(
+        rows[0].result_json.contains("looks good"),
+        "durable result unchanged"
+    );
+
+    // AC4: restart — re-open the store from disk; the backoff state
+    // survives.
+    let reopened = ReviewStore::open(&dir).expect("re-open");
+    let state = load_state(&reopened);
+    assert_eq!(state.publication_state, PublicationState::FailedRetryable);
+    assert_eq!(state.next_publish_at, Some(next_attempt_at));
+    assert_eq!(state.publication_attempt_count, 1);
+
+    // Before the backoff elapses the step skips without a GitHub call.
+    let gh2 = MockGitHub::start().await;
+    let (client2, cfg2) = mock_client(&gh2);
+    let outcome = finalize_review(&client2, &cfg2, &reopened, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::SkipRetryNotDue);
+    assert_eq!(gh2.counts().total(), 0, "no GitHub call while backoff runs");
+
+    // After the backoff elapses the publication is retried (still
+    // from the same durable result — never a model re-run).
+    let gh3 = MockGitHub::start().await;
+    mount_publish_open(&gh3, 778).await;
+    let (client3, cfg3) = mock_client(&gh3);
+    let later = now() + backoff_delay(1) + chrono::Duration::seconds(1);
+    let outcome = finalize_review(&client3, &cfg3, &reopened, &due(1), later)
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::Published);
+    let state = load_state(&reopened);
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.sticky_comment_id, Some(778));
+    assert_eq!(state.publication_attempt_count, 2, "retried once");
+}
+
+// ---------------------------------------------------------------------------
+// AC2: stale-generation suppression — history only, no comment
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stale_generation_is_suppressed_without_publishing() {
+    let gh = MockGitHub::start().await;
+    let (client, cfg) = mock_client(&gh);
+    // Current state generation 2 (a newer admission bumped it); the
+    // completing run finished under generation 1.
+    let (store, _dir) = seeded_store("fin-stale", 2, PublicationState::Pending);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::SuppressedStaleGeneration);
+
+    // No GitHub call at all; no state transition (non-transition).
+    assert_eq!(gh.counts().total(), 0, "no HTTP for a suppressed run");
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::Pending);
+    assert_eq!(state.publication_attempt_count, 0);
+
+    // History only (AC2): the durable result remains.
+    let rows = store
+        .history_for_head_sha(&repository(), PR, SHA)
+        .expect("history read");
+    assert_eq!(rows.len(), 1, "result stays in history");
+}
+
+// ---------------------------------------------------------------------------
+// AC2: concurrent admission — the stale run's claim loses the
+// generation CAS and publication never starts
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn concurrent_admission_suppresses_stale_publication() {
+    let gh = MockGitHub::start().await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-cas", 1, PublicationState::Pending);
+
+    // A newer admission bumps the generation after run-1 completed.
+    let target = ReviewTarget {
+        repository: repository(),
+        pull_request: PR,
+        head_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        base_sha: "cccccccccccccccccccccccccccccccccccccccc".to_string(),
+        base_ref: "main".to_string(),
+        merge_base: "dddddddddddddddddddddddddddddddddddddddd".to_string(),
+    };
+    store
+        .enqueue_review(&target)
+        .expect("second admission wins the race");
+    let current = load_state(&store);
+    assert_eq!(current.review_generation, 2, "generation bumped");
+
+    // The stale run's finalization is suppressed before any publish.
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::SuppressedStaleGeneration);
+    assert_eq!(gh.counts().total(), 0, "publish never called");
+
+    // Claim-level check: a generation-regressing save is rejected by
+    // the store CAS — `claim_for_publication` maps it to Ok(false).
+    let mut stale = current.clone();
+    stale.review_generation = 1;
+    let claimed = claim_for_publication(&store, &stale).expect("claim checks CAS");
+    assert!(!claimed, "regressing claim is rejected");
+}
+
+// ---------------------------------------------------------------------------
+// AC1 + AC5: crash recovery — `Publishing` claim resumes; the orphaned
+// comment is adopted via the marker, never duplicated
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn crashed_publishing_claim_resumes_and_publishes() {
+    let gh = MockGitHub::start().await;
+    // The crashed claim already created the comment whose id was
+    // never persisted: the marker search finds it and publish adopts
+    // it (byte-identical → Unchanged, no duplicate create).
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    let body = rendered_body();
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([serde_json::json!({
+            "id": 99,
+            "body": body,
+        })])],
+    )
+    .await;
+    gh.mount_status(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/issues/comments/99"),
+        200,
+        serde_json::json!({ "id": 99, "body": body }),
+    )
+    .await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-crash", 1, PublicationState::Publishing);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(
+        outcome,
+        FinalizeOutcome::PublishedUnchanged,
+        "adopted the orphaned marker comment (byte-identical)"
+    );
+
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.sticky_comment_id, Some(99));
+    assert_eq!(gh.counts().post, 0, "no duplicate create after crash");
+}
+
+#[tokio::test]
+async fn crash_after_publish_before_mark_never_duplicates() {
+    // Crash simulation: the claim is `Publishing` (id not persisted)
+    // and the marker comment ALREADY exists with an older body —
+    // publish must PATCH the adopted id, not create a second comment.
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([serde_json::json!({
+            "id": 55,
+            "body": format!("an older review body\n{REVIEW_MARKER}"),
+        })])],
+    )
+    .await;
+    gh.mount_status(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/issues/comments/55"),
+        200,
+        serde_json::json!({ "id": 55, "body": "an older review body" }),
+    )
+    .await;
+    gh.mount_status(
+        "PATCH",
+        &format!("/repos/{OWNER}/{REPO}/issues/comments/55"),
+        200,
+        serde_json::json!({ "id": 55, "body": rendered_body() }),
+    )
+    .await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-dup", 1, PublicationState::Publishing);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(
+        outcome,
+        FinalizeOutcome::Published,
+        "adopted id patched in place"
+    );
+
+    assert_eq!(gh.counts().post, 0, "never a second comment");
+    assert_eq!(gh.counts().patch, 1, "adopted id patched");
+    assert_eq!(load_state(&store).sticky_comment_id, Some(55));
+}
+
+// ---------------------------------------------------------------------------
+// Pre-state guards: already-final and missing state
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn already_final_skips_without_github_call() {
+    let gh = MockGitHub::start().await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-final", 1, PublicationState::Published);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::AlreadyFinal);
+    assert_eq!(gh.counts().total(), 0, "zero GitHub calls");
+}
+
+#[tokio::test]
+async fn missing_state_row_is_quiet_no_state() {
+    let gh = MockGitHub::start().await;
+    let (client, cfg) = mock_client(&gh);
+    let dir = tempdir("fin-nostate");
+    let store = ReviewStore::open(&dir).expect("store opens");
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::NoState);
+    assert_eq!(gh.counts().total(), 0, "zero GitHub calls");
+}
+
+// ---------------------------------------------------------------------------
+// AC1: non-success durable result finalizes quietly (never re-runs)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn failed_execution_result_finalizes_without_publication() {
+    let gh = MockGitHub::start().await;
+    let (client, cfg) = mock_client(&gh);
+    let dir = tempdir("fin-failed");
+    let store = ReviewStore::open(&dir).expect("store opens");
+    let mut state = ReviewState::new(repository(), PR, 1);
+    state.publication_state = PublicationState::Pending;
+    store.save_review_state(&state).expect("seed state");
+    store
+        .append_history(history_row("run-1", 1, None))
+        .expect("seed failed-run history");
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::NoState, "quiet finalize");
+    assert_eq!(gh.counts().total(), 0, "nothing published, no HTTP");
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(
+        state.last_publish_error.as_deref(),
+        Some("no_publishable_result")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Backoff schedule (AC4 helper contract)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backoff_schedule_is_exponential_with_one_hour_cap() {
+    assert_eq!(backoff_delay(1), chrono::Duration::seconds(60));
+    assert_eq!(backoff_delay(2), chrono::Duration::seconds(120));
+    assert_eq!(backoff_delay(3), chrono::Duration::seconds(240));
+    assert_eq!(backoff_delay(5), chrono::Duration::seconds(960));
+    assert_eq!(backoff_delay(6), chrono::Duration::seconds(1920));
+    // Cap: 2^7 * 30s = 3840s > 3600s → 1h; everything above stays 1h.
+    assert_eq!(backoff_delay(7), chrono::Duration::seconds(3600));
+    assert_eq!(backoff_delay(12), chrono::Duration::seconds(3600));
+    assert_eq!(backoff_delay(50), chrono::Duration::seconds(3600));
+}


### PR DESCRIPTION
Closes #310

## Summary

Implements the resume-safe review publication finalizer FSM (DAR §9.1–§9.4, spec: `docs/architecture/auto-review.md`):

- **FSM**: `Pending → Publishing → Published | FailedRetryable`, all states persisted atomically through `ReviewStore::save_review_state`. The canonical `ReviewResult` is durable in review history (#295) before any GitHub call — publication is presentation only; the model is NEVER re-run on a GitHub failure (AC1).
- **New module** `src/review/finalize.rs`: `finalize_review` FSM step, `due_finalizations` due-scan input, `claim_for_publication` CAS claim, `backoff_delay` (min(2^min(n,12)·30s, 1h)), DAR §13 events (`review_publish_started`, `review_published`, `review_publish_failed_retryable`, `review_publication_suppressed_stale_generation`, `review_skipped_pr_closed_unmerged`).
- **Monotonic publication guard** (DAR §9.4, AC2): a completing run whose `review_generation` is older than the current state row is suppressed — history only, no comment, non-transition. `enqueue_review` bumps the generation atomically with the queue insert, and now also re-arms publication (resets `Pending`/counters) so generation N+1 is not blocked by a `Published` row from generation N.
- **Retry state** (AC4): `publication_attempt_count` / `next_publish_at` / `last_publish_error` persisted; failures land in `FailedRetryable` with exponential backoff; the counter is publication-only, separate from worker attempts.
- **Gone-state policy** (DAR §9.3, AC3): PR-404 → quiet skip (`poll_pr_merge_status` now maps the transport's typed `GitHubApi{status:404}` error to `MergeStatus::NotFound` — previously dead-code, so PR-404 surfaced as a retryable error); closed-unmerged → quiet skip + event; merged → publishes subject to the generation guard. Comment-404 recovery rides #308's marker adoption.
- **Crash recovery** (AC5): `publication_state` IS the resume checkpoint (`Publishing` with no retry debt = crashed claim); #308's byte-identical idempotency + marker adoption prevent duplicate comments after a crash between publish and terminal mark.
- **Tick step 5.6** `src/daemon/tick/review_finalize_step.rs`: `poll_publication_step` + `_for_tests` seam, per-entry error isolation, registered after PR discovery in `src/daemon/tick/mod.rs`. Dispatch routing / completion wakeups remain #339's.

## Tests

`tests/review/finalizer_test.rs` (new binary, 14 tests) covers every DAR §15 finalization requirement: FSM happy path, merged/closed-unmerged/PR-404 paths, retryable failure + persisted backoff surviving a store re-open (restart), retry-due skip + retry-after-backoff success, stale-generation suppression, concurrent-admission CAS loss, crash recovery with marker adoption (no duplicate), crash-after-publish-before-mark (no duplicate), already-final/missing-state guards, non-success durable result (quiet finalize, never re-run), and the backoff schedule.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo test --locked --all-targets` — 533 passed, 0 failed
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — passed