### PR TITLE
feat(state): add review-claim stale reaper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,12 +468,20 @@ name = "finalizer_test"
 path = "tests/review/finalizer_test.rs"
 
 [[test]]
+name = "crash_recovery_test"
+path = "tests/review/crash_recovery_test.rs"
+
+[[test]]
 name = "review_store_test"
 path = "tests/state/review_store_test.rs"
 
 [[test]]
 name = "review_activation_test"
 path = "tests/state/review_activation_test.rs"
+
+[[test]]
+name = "review_reaper_test"
+path = "tests/state/review_reaper_test.rs"
 
 [[test]]
 name = "state_store_test"

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -396,6 +396,17 @@ pub async fn tick(
     )
     .await;
 
+    // 3.2b. Reap orphan REVIEW claims (issue #371): sibling pass over
+    // `review-claims/` with the same liveness rule as the issue
+    // reaper. The issue pass above never touches the review dir and
+    // this pass never touches `claims/` (sibling-queue invariant).
+    let _ = crate::state::queue::reap_stale_review_claims(
+        &state_dir,
+        services.clock.now(),
+        cfg.stale_run_hours,
+    )
+    .await;
+
     // 3.5. Reclaim stale, unclaimed worktrees (best-effort).
     if !cfg.worktree_gc_disabled {
         match DaemonLock::try_acquire(&state_dir) {

--- a/src/state/queue/reaper.rs
+++ b/src/state/queue/reaper.rs
@@ -10,6 +10,10 @@ use chrono::{DateTime, Utc};
 use fs2::FileExt;
 
 use crate::infra::error::{CaduceusError, CaduceusResult};
+use crate::state::review::{
+    review_queue_key, ReviewClaimFileBody, ReviewPhase, ReviewStore, REVIEW_CLAIMS_DIRNAME,
+    REVIEW_CLAIM_FILE_VERSION,
+};
 use crate::worker::supervisor::process_lifecycle::IDENTITY;
 
 /// Directory under `<state_dir>/claims` where malformed/future-stamped
@@ -381,6 +385,233 @@ pub(crate) async fn reap_one_stale_claim(
     // above already happened; the queue phase is left alone.
 
     // 4. Unlink the claim file. The state is already durable
+    //    by this point; a final unlink failure surfaces as a
+    //    reaper warning, not a fatal error.
+    let _ = fs::remove_file(claim_path);
+    Ok(())
+}
+
+/// Reap stale REVIEW claims and quarantine malformed/future-stamped
+/// ones. Sibling of [`reap_stale_claims`] for the review queue
+/// (issue #371): review claim files live under
+/// `<state_dir>/review-claims/` — deliberately separate from the
+/// issue `claims/` dir — so the issue reaper never parses a review
+/// body as an issue body. The liveness rule is identical
+/// (`IDENTITY.is_alive` + [`process_start_identity`] match + age
+/// cutoff); the only divergences are the body type
+/// ([`ReviewClaimFileBody`]) and the queue lookup key
+/// (`review_queue_key(&target)`).
+///
+/// The queue mutation is serialised by the review store's exclusive
+/// `review.lock` section, matching the issue reaper's `state.lock`
+/// discipline. Runs under the tick's `LeaderToken`.
+pub async fn reap_stale_review_claims(
+    state_dir: &Path,
+    now: DateTime<Utc>,
+    stale_run_hours: u64,
+) -> CaduceusResult<ReapReport> {
+    let claims_dir = state_dir.join(REVIEW_CLAIMS_DIRNAME);
+    let mut report = ReapReport::default();
+
+    // Nothing to do if the claims dir is missing — the daemon
+    // may be starting cold.
+    if !claims_dir.is_dir() {
+        return Ok(report);
+    }
+
+    let entries = match fs::read_dir(&claims_dir) {
+        Ok(rd) => rd,
+        Err(err) => {
+            return Err(CaduceusError::Queue {
+                context: "reap-review",
+                stderr: format!("read_dir {}: {err}", claims_dir.display()),
+            });
+        }
+    };
+
+    let age_cutoff = now - chrono::Duration::seconds(stale_run_hours.saturating_mul(3600) as i64);
+    let future_cutoff = now + chrono::Duration::seconds(FUTURE_TIMESTAMP_TOLERANCE_SECS);
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                report.errors.push(format!("read_dir: {err}"));
+                continue;
+            }
+        };
+        let path = entry.path();
+        // Reject symlinks, exactly like the issue reaper — never
+        // follow a link out of the review claims dir.
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(err) => {
+                report
+                    .errors
+                    .push(format!("symlink_metadata {}: {err}", path.display()));
+                continue;
+            }
+        };
+        if meta.file_type().is_symlink() {
+            report
+                .errors
+                .push(format!("refusing to act on symlink: {}", path.display()));
+            continue;
+        }
+        let file_name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        // The `corrupt/` subdir is reserved for quarantine
+        // outputs, not input — never act on it.
+        if file_name == CLAIMS_CORRUPT_DIRNAME {
+            continue;
+        }
+        if !file_name.ends_with(".claim") {
+            // Unknown file: report and leave untouched.
+            report.errors.push(format!(
+                "unknown file in review claims dir: {}",
+                path.display()
+            ));
+            continue;
+        }
+
+        let bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(err) => {
+                report
+                    .errors
+                    .push(format!("read {}: {err}", path.display()));
+                continue;
+            }
+        };
+        let body: ReviewClaimFileBody = match serde_json::from_slice(&bytes) {
+            Ok(b) => b,
+            Err(err) => {
+                let _ = quarantine_claim(
+                    &claims_dir,
+                    &path,
+                    &bytes,
+                    &format!("malformed JSON: {err}"),
+                );
+                report.quarantined += 1;
+                report.count += 1;
+                report
+                    .errors
+                    .push(format!("malformed {} → quarantined: {err}", path.display()));
+                continue;
+            }
+        };
+        if body.version != REVIEW_CLAIM_FILE_VERSION {
+            let _ = quarantine_claim(
+                &claims_dir,
+                &path,
+                &bytes,
+                &format!("unsupported claim version {}", body.version),
+            );
+            report.quarantined += 1;
+            report.count += 1;
+            report.errors.push(format!(
+                "version mismatch in {}: got {}, expected {}",
+                path.display(),
+                body.version,
+                REVIEW_CLAIM_FILE_VERSION
+            ));
+            continue;
+        }
+        if body.started_at > future_cutoff {
+            let _ = quarantine_claim(
+                &claims_dir,
+                &path,
+                &bytes,
+                &format!(
+                    "started_at {} is more than {FUTURE_TIMESTAMP_TOLERANCE_SECS}s in the future",
+                    body.started_at
+                ),
+            );
+            report.quarantined += 1;
+            report.count += 1;
+            report.errors.push(format!(
+                "future started_at in {}: {}",
+                path.display(),
+                body.started_at
+            ));
+            continue;
+        }
+        // Recent enough that the staleness rule does not
+        // apply — leave alone, regardless of process identity.
+        if body.started_at > age_cutoff {
+            continue;
+        }
+        // Old claim: only stale if the recorded process is
+        // dead OR the start identity has changed (pid reuse).
+        let recorded_pid_alive = IDENTITY.is_alive(body.pid as i32);
+        let recorded_start_matches =
+            process_start_identity(state_dir, body.pid) == body.process_start_identity;
+        if recorded_pid_alive && recorded_start_matches {
+            // Live worker — the claim is valid even if it
+            // has been running longer than the threshold.
+            continue;
+        }
+        // Stale. Reap.
+        match reap_one_stale_review_claim(&claims_dir, &path, &body, now).await {
+            Ok(()) => {
+                report.stale_reaped += 1;
+                report.count += 1;
+            }
+            Err(err) => {
+                report
+                    .errors
+                    .push(format!("stale reap failed for {}: {err}", path.display()));
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Reap a single stale review claim. The caller has already
+/// determined staleness; this is the per-file teardown. The queue
+/// revert mirrors `reap_one_stale_claim`: an `InProgress` entry is
+/// returned to `Queued` with `next_attempt_at = now` and `attempts`
+/// untouched (no retry-budget burn). For any other phase the claim
+/// is just residue — it is unlinked and the phase is left alone.
+///
+/// No worktree teardown here (issue #371, Decision 4): review
+/// worktrees are reclaimed by the step-3.5 `gc_review_worktrees`
+/// sweep (#297/#299), so the reaper stays `&Config`-free.
+async fn reap_one_stale_review_claim(
+    claims_dir: &Path,
+    claim_path: &Path,
+    body: &ReviewClaimFileBody,
+    now: DateTime<Utc>,
+) -> CaduceusResult<()> {
+    // 1. Find the queue entry. If no entry exists, the claim is
+    //    orphaned — there is nothing to revert. Unlink the
+    //    claim and return.
+    let parent = claims_dir.parent().unwrap_or(claims_dir);
+    let store = ReviewStore::open(parent)?;
+    let snapshot = store.review_queue_snapshot()?;
+    let key = review_queue_key(&body.target);
+    let entry = match snapshot.entries.get(&key) {
+        Some(e) => e,
+        None => {
+            // Orphaned claim with no queue entry. Unlink and
+            // continue.
+            let _ = fs::remove_file(claim_path);
+            return Ok(());
+        }
+    };
+
+    // 2. Update the queue. If the entry is `InProgress`, return
+    //    to `Queued` without incrementing attempts. For any
+    //    other phase, leave the phase alone (the entry is
+    //    already durable) — the claim file is just residue.
+    if entry.phase == ReviewPhase::InProgress {
+        store.revert_stale_claim_for_reap(&key, &body.run_id, now)?;
+    }
+
+    // 3. Unlink the claim file. The state is already durable
     //    by this point; a final unlink failure surfaces as a
     //    reaper warning, not a fatal error.
     let _ = fs::remove_file(claim_path);

--- a/src/state/review/claim.rs
+++ b/src/state/review/claim.rs
@@ -8,8 +8,9 @@
 //!   directories never mix;
 //! - the body's identity is a [`ReviewTarget`], not an `IssueKey`.
 //!
-//! The reaping of stale review claims is dispatch's problem
-//! (#312/#339); this change ships the acquire/release primitives.
+//! The reaping of stale review claims lives in the state reaper
+//! (`crate::state::queue::reap_stale_review_claims`, issue #371);
+//! this module ships the acquire/release primitives.
 
 use std::path::PathBuf;
 

--- a/src/state/review/state.rs
+++ b/src/state/review/state.rs
@@ -282,6 +282,36 @@ impl ReviewStore {
         self.with_shared(|store, conn| store.load_queue(conn))
     }
 
+    /// Reaper-only revert (issue #371): return an `InProgress` review
+    /// entry to `Queued` with `next_attempt_at = now` and `attempts`
+    /// deliberately UNCHANGED — the stale-claim reaper never burns
+    /// retry budget. The caller has already determined staleness;
+    /// this is the queue-mutation half of the orphan-claim reap.
+    /// Runs inside the store's exclusive section (`review.lock`
+    /// flock / `BEGIN IMMEDIATE`) so the mutation is serialised with
+    /// normal store operations. If no entry matches `key` the
+    /// persist is a no-op (the claim is orphan residue; the caller
+    /// unlinks it).
+    pub(crate) fn revert_stale_claim_for_reap(
+        &self,
+        key: &str,
+        run_id: &str,
+        now: DateTime<Utc>,
+    ) -> CaduceusResult<()> {
+        self.with_exclusive(|store, conn| {
+            let mut queue = store.load_queue(conn)?;
+            if let Some(e) = queue.entries.get_mut(key) {
+                e.phase = ReviewPhase::Queued;
+                e.last_run_id = None;
+                e.last_error = Some(format!("reaper: stale claim for run {run_id}"));
+                e.next_attempt_at = Some(now);
+                e.updated_at = now;
+            }
+            store.persist_queue(conn, &queue)?;
+            Ok(())
+        })
+    }
+
     /// Enqueue a new review target. Assigns
     /// `review_generation = current ReviewState generation + 1`
     /// (or 1 when none), upserts the `ReviewState` row's generation,

--- a/tests/review/crash_recovery_test.rs
+++ b/tests/review/crash_recovery_test.rs
@@ -1,0 +1,312 @@
+//! AC2 + AC3 — restart mid-run / mid-publish recovery (issue #314,
+//! DAR §14, §15).
+//!
+//! AC2 (container kill): a SIGKILL'd in-flight review run leaves a
+//! review claim file + an `InProgress` entry. Tick step 3.1
+//! (`oci_lifecycle::reconcile_installation`) + step 3.2
+//! (`reap_stale_claims` + `reap_stale_review_claims`, issue #371) are
+//! supposed to clear the orphan and return the entry to `Queued` so
+//! the next tick re-claims it (`src/daemon/tick/mod.rs:376`, `:392`).
+//! This test drives the SAME functions the tick calls — no stub of
+//! the recovery logic. The issue pass runs first (a no-op for review
+//! claims); the review pass clears `review-claims/`.
+//!
+//! NOTE (Honesty Clause provenance): `reconcile_installation` requires
+//! a live OCI engine (it runs `podman ps` against a labeled container
+//! set), so this test uses the plan's D3 fallback — the post-reconcile
+//! state is seeded (no OCI run row remains; the container is already
+//! gone) and ONLY the real reapers are driven. The AC ("no orphan
+//! claims after restart") is proven by asserting the reaper clears the
+//! orphan review claim. On main @ 472a88f the issue reaper only walked
+//! the ISSUE claims dir and this test FAILED — that failure was the
+//! Honesty-Clause evidence that drove issue #371; the fix is the
+//! sibling `reap_stale_review_claims` pass, and the test PASSES with
+//! it.
+//!
+//! AC3 (restart mid-publish): a crash after the sticky comment is
+//! posted but before `finalize_published` persists `Published` leaves
+//! the row at `Publishing`. Re-entry adopts the existing comment by
+//! marker (byte-identical idempotency, §9.2) — no duplicate comment —
+//! and reaches `Published`.
+
+use caduceus::config::Config;
+use caduceus::github::{Client, HttpCache};
+use caduceus::review::sticky_comment::{render_sticky_comment, RenderInput, REVIEW_MARKER};
+use caduceus::review::{
+    finalize_review, ExecutionStatus, FinalizeOutcome, PublicationState, RepositoryId, Review,
+    ReviewResult, ReviewState, ReviewTarget, Verdict, REVIEW_SCHEMA_VERSION,
+};
+use caduceus::state::review::{
+    review_claim_digest, review_queue_key, ReviewClaimFileBody, ReviewHistoryRow, ReviewPhase,
+    ReviewStore, REVIEW_CLAIM_FILE_VERSION,
+};
+use chrono::{Duration, Utc};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+use fixtures::{tempdir, MockGitHub};
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const OWNER: &str = "octocat";
+const REPO: &str = "hello-world";
+const PR: u64 = 42;
+const SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn repo() -> RepositoryId {
+    RepositoryId {
+        owner: OWNER.to_string(),
+        repo: REPO.to_string(),
+    }
+}
+
+fn target(sha: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: repo(),
+        pull_request: PR,
+        head_sha: sha.to_string(),
+        base_sha: "b".repeat(40),
+        base_ref: "main".to_string(),
+        merge_base: "m".repeat(40),
+    }
+}
+
+fn sample_review() -> Review {
+    Review {
+        verdict: Verdict::Pass,
+        summary: "looks good".to_string(),
+        findings: vec![],
+    }
+}
+
+fn result_json(review: Option<Review>) -> String {
+    serde_json::to_string(&ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status: match review {
+            Some(_) => ExecutionStatus::Success,
+            None => ExecutionStatus::Failure,
+        },
+        review,
+    })
+    .expect("result serializes")
+}
+
+fn history_row(run_id: &str, generation: u64, head_sha: &str) -> ReviewHistoryRow {
+    ReviewHistoryRow {
+        review_run_id: run_id.to_string(),
+        repository: repo(),
+        pull_request: PR,
+        head_sha: head_sha.to_string(),
+        review_generation: generation,
+        completed_at: Utc::now(),
+        result_json: result_json(Some(sample_review())),
+    }
+}
+
+fn mock_client(gh: &MockGitHub, dir: &std::path::Path) -> (Client, Config) {
+    let mut cfg = Config::test_defaults(dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(dir).expect("cache opens");
+    let client = Client::with_cache(&cfg, cache).expect("client builds");
+    (client, cfg)
+}
+
+// ---------------------------------------------------------------------------
+// AC2 — restart mid-run (container kill): the orphan review claim must
+// be reaped by the step 3.2 path
+// ---------------------------------------------------------------------------
+
+/// The AC2 recovery assertion. On main @ 472a88f this FAILED:
+/// `reap_stale_claims` never walked `review-claims/`
+/// (`src/state/queue/reaper.rs:59-64` reads `state_dir/claims/` only),
+/// so the orphan claim survived and the `InProgress` entry was never
+/// re-claimable. The failure was the Honesty-Clause evidence; the fix
+/// is the sibling `reap_stale_review_claims` pass (issue #371), which
+/// this test drives in the same order the tick does.
+#[tokio::test]
+async fn container_kill_then_restart_reaps_orphan_claim() {
+    let dir = tempdir("crash-mid-run");
+    let cfg = Config::test_defaults(&dir);
+    let store = ReviewStore::open(&dir).expect("open store");
+    let target = target(SHA);
+    store.enqueue_review(&target).expect("seed entry");
+
+    // The daemon claims the entry and the worker run starts (the
+    // container is created under the daemon's OCI identity).
+    let claimed = store
+        .acquire_next_review("run-1", std::process::id(), Utc::now())
+        .expect("acquire succeeds")
+        .expect("one eligible entry");
+    assert_eq!(claimed.entry.phase, ReviewPhase::InProgress);
+
+    // Container kill: the daemon dies with the run in flight. The
+    // claim file now records a dead process. A run that has been
+    // in-flight longer than `stale_run_hours` (1h in test defaults)
+    // is deterministically "stale" by the reaper's own rule; rewrite
+    // the claim's started_at to model that crash, with a dead pid and
+    // a mismatched process identity (the container-killed daemon).
+    let key = review_queue_key(&target);
+    let digest = review_claim_digest(&key);
+    let claim_path = dir.join("review-claims").join(format!("{digest}.claim"));
+    let stale_body = ReviewClaimFileBody {
+        version: REVIEW_CLAIM_FILE_VERSION,
+        target: target.clone(),
+        run_id: "run-1".to_string(),
+        // Definitively dead on Linux (pid_max is far smaller).
+        pid: 999_999_999,
+        // Never matches the live daemon's identity string.
+        process_start_identity: "container-killed-daemon".to_string(),
+        started_at: Utc::now() - Duration::hours(2),
+        worktree_path: None,
+    };
+    std::fs::write(
+        &claim_path,
+        serde_json::to_string(&stale_body).expect("serialize claim"),
+    )
+    .expect("write stale claim body");
+
+    // Restart: the tick runs step 3.1 (reconcile_installation — the
+    // post-reconcile state is already seeded: no OCI run row survives)
+    // and then step 3.2, the real stale-claim reapers — the issue pass
+    // first (a no-op for review claims), then the review pass, in the
+    // same order the tick calls them.
+    let report = caduceus::state::queue::reap_stale_claims(&dir, Utc::now(), cfg.stale_run_hours)
+        .await
+        .expect("reap succeeds");
+    let _ = caduceus::state::queue::reap_stale_review_claims(&dir, Utc::now(), cfg.stale_run_hours)
+        .await
+        .expect("review reap succeeds");
+
+    // AC2 assertion: no orphan review claim remains.
+    let orphan_claims = std::fs::read_dir(dir.join("review-claims"))
+        .expect("read review-claims dir")
+        .filter_map(Result::ok)
+        .count();
+    assert_eq!(
+        orphan_claims, 0,
+        "orphan review claim must be reaped on restart (reap report: {report:?})"
+    );
+
+    // And the entry is re-claimable: back to Queued.
+    let reopened = ReviewStore::open(&dir).expect("re-open store");
+    let queue = reopened.review_queue_snapshot().expect("load queue");
+    let entry = queue
+        .entries
+        .values()
+        .next()
+        .expect("entry survives the restart");
+    assert_eq!(
+        entry.phase,
+        ReviewPhase::Queued,
+        "InProgress review entry is re-queued after the orphan reap"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC3 — restart mid-publish: no duplicate comment; resume reaches
+// Published
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn restart_mid_publish_emits_no_duplicate_comment_and_reaches_published() {
+    let gh = MockGitHub::start().await;
+    // Crash-after-publish-before-mark: the comment was posted by the
+    // crashed run but the id was never persisted. The marker search
+    // finds it and publish adopts it (byte-identical → Unchanged → no
+    // duplicate create, no PATCH).
+    let rendered = render_sticky_comment(&RenderInput {
+        review: &sample_review(),
+        reviewed_head_sha: SHA,
+        current_head_sha: None,
+    });
+    assert!(
+        rendered.contains(REVIEW_MARKER),
+        "rendered sticky carries the automation marker"
+    );
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([serde_json::json!({
+            "id": 99,
+            "body": rendered,
+        })])],
+    )
+    .await;
+    gh.mount_status(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/issues/comments/99"),
+        200,
+        serde_json::json!({ "id": 99, "body": rendered }),
+    )
+    .await;
+
+    let dir = tempdir("crash-mid-publish");
+    let (client, cfg) = mock_client(&gh, &dir);
+    let store = ReviewStore::open(&dir).expect("open store");
+
+    // Seed the crash state: `Publishing` row (comment posted, id NOT
+    // persisted) + the durable history row the poll derives the due
+    // finalization from.
+    let mut state = ReviewState::new(repo(), PR, 1);
+    state.publication_state = PublicationState::Publishing;
+    store.save_review_state(&state).expect("seed state");
+    store
+        .append_history(history_row("run-1", 1, SHA))
+        .expect("seed history");
+
+    // The crashed run is due: the poll re-enters the non-terminal row.
+    let due = store.due_finalizations().expect("due scan");
+    assert_eq!(due.len(), 1, "the crashed Publishing row is due");
+    assert_eq!(due[0].head_sha, SHA);
+
+    // First re-entry: adopts the existing marker comment — Unchanged.
+    let outcome = finalize_review(&client, &cfg, &store, &due[0], Utc::now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(
+        outcome,
+        FinalizeOutcome::PublishedUnchanged,
+        "resumes without re-posting — got {outcome:?}"
+    );
+    assert_eq!(
+        gh.counts().post,
+        0,
+        "no duplicate comment — the existing marker comment was adopted"
+    );
+    let state = store
+        .review_state(&repo(), PR)
+        .expect("state read")
+        .expect("state row exists");
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.sticky_comment_id, Some(99));
+
+    // Restart: re-open the store; the row is final — nothing is due
+    // and a re-finalize is a no-op.
+    drop(store);
+    let reopened = ReviewStore::open(&dir).expect("re-open store");
+    assert!(
+        reopened.due_finalizations().expect("due scan").is_empty(),
+        "Published row is not due after restart"
+    );
+    let outcome = finalize_review(
+        &client,
+        &cfg,
+        &reopened,
+        &caduceus::review::DueFinalization {
+            repository: repo(),
+            pull_request: PR,
+            run_generation: 1,
+            head_sha: SHA.to_string(),
+        },
+        Utc::now(),
+    )
+    .await
+    .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::AlreadyFinal);
+    assert_eq!(gh.counts().post, 0, "still no duplicate after restart");
+}

--- a/tests/state/review_reaper_test.rs
+++ b/tests/state/review_reaper_test.rs
@@ -1,0 +1,269 @@
+//! Unit tests for the review-claim stale reaper (issue #371).
+//!
+//! `caduceus::state::queue::reap_stale_review_claims` is the sibling
+//! of the issue-claim reaper: identical liveness rule
+//! (`IDENTITY.is_alive` + `process_start_identity` match + age
+//! cutoff), identical symlink rejection / `corrupt/` subdir skip /
+//! non-`.claim` skip, and malformed/future-stamp quarantine into
+//! `review-claims/corrupt/`. The queue revert returns an
+//! `InProgress` entry to `Queued` with `next_attempt_at = now` and
+//! NEVER touches `attempts` (no retry-budget burn).
+//!
+//! Covered here: symlink skip, malformed-body quarantine,
+//! liveness-rule miss (a live pid is not reaped), and attempt-burn
+//! absence. The end-to-end restart assertion lives in
+//! `tests/review/crash_recovery_test.rs`.
+
+use caduceus::config::Config;
+use caduceus::review::{RepositoryId, ReviewTarget};
+use caduceus::state::review::{
+    review_claim_digest, review_queue_key, ReviewClaimFileBody, ReviewPhase, ReviewStore,
+    REVIEW_CLAIM_FILE_VERSION,
+};
+use chrono::{Duration, Utc};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+use fixtures::tempdir;
+
+const OWNER: &str = "octocat";
+const REPO: &str = "hello-world";
+const PR: u64 = 42;
+const SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn target() -> ReviewTarget {
+    ReviewTarget {
+        repository: RepositoryId {
+            owner: OWNER.to_string(),
+            repo: REPO.to_string(),
+        },
+        pull_request: PR,
+        head_sha: SHA.to_string(),
+        base_sha: "b".repeat(40),
+        base_ref: "main".to_string(),
+        merge_base: "m".repeat(40),
+    }
+}
+
+/// Seed an `InProgress` review entry through the real claim path
+/// (`enqueue_review` + `acquire_next_review`) and return the claim
+/// file path. The claim the store writes carries the LIVE test
+/// process's pid/identity and a recent `started_at`.
+fn seed_in_progress(dir: &std::path::Path) -> std::path::PathBuf {
+    let store = ReviewStore::open(dir).expect("open store");
+    store.enqueue_review(&target()).expect("seed entry");
+    let claimed = store
+        .acquire_next_review("run-1", std::process::id(), Utc::now())
+        .expect("acquire succeeds")
+        .expect("one eligible entry");
+    assert_eq!(claimed.entry.phase, ReviewPhase::InProgress);
+    let key = review_queue_key(&target());
+    let digest = review_claim_digest(&key);
+    dir.join("review-claims").join(format!("{digest}.claim"))
+}
+
+/// Overwrite a claim file with a deliberately stale body (dead pid,
+/// mismatched identity, `started_at` older than `stale_run_hours`).
+fn write_stale_claim(
+    dir: &std::path::Path,
+    claim_path: &std::path::Path,
+    run_id: &str,
+    started_at: chrono::DateTime<Utc>,
+) {
+    let body = ReviewClaimFileBody {
+        version: REVIEW_CLAIM_FILE_VERSION,
+        target: target(),
+        run_id: run_id.to_string(),
+        // Definitively dead on Linux (pid_max is far smaller).
+        pid: 999_999_999,
+        // Never matches the live daemon's identity string.
+        process_start_identity: "container-killed-daemon".to_string(),
+        started_at,
+        worktree_path: None,
+    };
+    std::fs::write(
+        claim_path,
+        serde_json::to_string(&body).expect("serialize claim"),
+    )
+    .expect("write stale claim");
+    let _ = dir;
+}
+
+fn entry_phase(dir: &std::path::Path) -> ReviewPhase {
+    let reopened = ReviewStore::open(dir).expect("re-open store");
+    let queue = reopened.review_queue_snapshot().expect("load queue");
+    queue.entries.values().next().expect("entry survives").phase
+}
+
+// ---------------------------------------------------------------------------
+// Symlink skip
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn symlink_in_review_claims_is_reported_and_never_followed() {
+    let dir = tempdir("review-reaper-symlink");
+    let cfg = Config::test_defaults(&dir);
+    let claim_path = seed_in_progress(&dir);
+
+    // A symlink inside `review-claims/` pointing at a stale-shaped
+    // body OUTSIDE the dir. Following it would reap an unrelated
+    // file; the reaper must report it and move on.
+    let outside = dir.join("outside-stale.claim");
+    write_stale_claim(&dir, &outside, "run-1", Utc::now() - Duration::hours(2));
+    let link = dir.join("review-claims").join("evil.claim");
+    std::os::unix::fs::symlink(&outside, &link).expect("create symlink");
+
+    let report =
+        caduceus::state::queue::reap_stale_review_claims(&dir, Utc::now(), cfg.stale_run_hours)
+            .await
+            .expect("reap succeeds");
+
+    assert_eq!(report.count, 0, "no claim file acted on: {report:?}");
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| e.contains("refusing to act on symlink")),
+        "symlink must be reported in errors: {report:?}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&link).is_ok(),
+        "symlink untouched"
+    );
+    assert!(claim_path.exists(), "recent live claim not reaped");
+    assert_eq!(entry_phase(&dir), ReviewPhase::InProgress);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed-body quarantine
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn malformed_review_claim_is_quarantined_not_reaped() {
+    let dir = tempdir("review-reaper-malformed");
+    let cfg = Config::test_defaults(&dir);
+    let claim_path = seed_in_progress(&dir);
+
+    std::fs::write(&claim_path, b"this is not json {").expect("write garbage claim");
+
+    let report =
+        caduceus::state::queue::reap_stale_review_claims(&dir, Utc::now(), cfg.stale_run_hours)
+            .await
+            .expect("reap succeeds");
+
+    assert_eq!(report.quarantined, 1, "{report:?}");
+    assert_eq!(report.count, 1, "{report:?}");
+    assert!(!claim_path.exists(), "original claim moved to corrupt/");
+    let corrupt = dir.join("review-claims").join("corrupt");
+    let artefacts: Vec<_> = std::fs::read_dir(&corrupt)
+        .expect("corrupt dir")
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(artefacts.len(), 1, "one quarantined artefact");
+    assert!(
+        artefacts[0]
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".corrupt"),
+        "quarantine suffix"
+    );
+
+    // Quarantine does NOT revert the phase — the claim is corrupt,
+    // not confirmed stale.
+    assert_eq!(entry_phase(&dir), ReviewPhase::InProgress);
+}
+
+// ---------------------------------------------------------------------------
+// Liveness-rule miss: a live pid is not reaped
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn live_pid_claim_is_not_reaped() {
+    let dir = tempdir("review-reaper-live");
+    let cfg = Config::test_defaults(&dir);
+    let claim_path = seed_in_progress(&dir);
+
+    // Age the claim (old `started_at`) while KEEPING the live test
+    // process's pid and the identity the store recorded. The age
+    // check passes, but the liveness rule must skip it: the recorded
+    // pid is alive and the start identity matches.
+    let body: ReviewClaimFileBody =
+        serde_json::from_str(&std::fs::read_to_string(&claim_path).expect("read claim"))
+            .expect("parse claim body");
+    let aged = ReviewClaimFileBody {
+        started_at: Utc::now() - Duration::hours(2),
+        ..body
+    };
+    std::fs::write(
+        &claim_path,
+        serde_json::to_string(&aged).expect("serialize"),
+    )
+    .expect("rewrite aged claim");
+
+    let report =
+        caduceus::state::queue::reap_stale_review_claims(&dir, Utc::now(), cfg.stale_run_hours)
+            .await
+            .expect("reap succeeds");
+
+    assert_eq!(
+        report.stale_reaped, 0,
+        "live pid must not be reaped: {report:?}"
+    );
+    assert!(claim_path.exists(), "claim untouched for a live worker");
+    assert_eq!(entry_phase(&dir), ReviewPhase::InProgress);
+}
+
+// ---------------------------------------------------------------------------
+// Attempt-burn absence: InProgress → Queued without touching attempts
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reaped_entry_returns_to_queued_without_burning_attempts() {
+    let dir = tempdir("review-reaper-attempts");
+    let cfg = Config::test_defaults(&dir);
+    let store = ReviewStore::open(&dir).expect("open store");
+    store.enqueue_review(&target()).expect("seed entry");
+
+    // Burn one attempt through the real API so the pre-reap value is
+    // non-zero: retry_or_fail moves InProgress → Queued with
+    // attempts = 1, then re-acquire claims it again (attempts stays 1).
+    let claimed = store
+        .acquire_next_review("run-1", std::process::id(), Utc::now())
+        .expect("acquire succeeds")
+        .expect("one eligible entry");
+    let phase = store
+        .retry_or_fail_review(claimed.claim, "simulated failure", 5)
+        .expect("retry succeeds");
+    assert_eq!(phase, ReviewPhase::Queued);
+    let claimed = store
+        .acquire_next_review(
+            "run-2",
+            std::process::id(),
+            Utc::now() + Duration::seconds(301),
+        )
+        .expect("re-acquire succeeds")
+        .expect("one eligible entry");
+    assert_eq!(claimed.entry.attempts, 1, "pre-reap attempts");
+
+    let key = review_queue_key(&target());
+    let digest = review_claim_digest(&key);
+    let claim_path = dir.join("review-claims").join(format!("{digest}.claim"));
+    write_stale_claim(&dir, &claim_path, "run-2", Utc::now() - Duration::hours(2));
+
+    let report =
+        caduceus::state::queue::reap_stale_review_claims(&dir, Utc::now(), cfg.stale_run_hours)
+            .await
+            .expect("reap succeeds");
+    assert_eq!(report.stale_reaped, 1, "{report:?}");
+    assert!(!claim_path.exists(), "orphan claim unlinked");
+
+    let reopened = ReviewStore::open(&dir).expect("re-open store");
+    let queue = reopened.review_queue_snapshot().expect("load queue");
+    let entry = queue.entries.values().next().expect("entry survives");
+    assert_eq!(entry.phase, ReviewPhase::Queued, "InProgress → Queued");
+    assert_eq!(entry.attempts, 1, "attempts NOT incremented by the reaper");
+    assert!(
+        entry.next_attempt_at.is_some(),
+        "re-claimable immediately (next_attempt_at = now)"
+    );
+}


### PR DESCRIPTION
Reap orphan REVIEW claims (`review-claims/`) on restart, matching the issue-claim reaper.

- Add sibling `reap_stale_review_claims` in `src/state/queue/reaper.rs`: same liveness rule (`IDENTITY.is_alive` + `process_start_identity` match + age cutoff), symlink rejection, `corrupt/` subdir skip, malformed/future-stamp quarantine into `review-claims/corrupt/`. Reverted entries return `InProgress → Queued` with `next_attempt_at = now` and `attempts` untouched (no retry-budget burn).
- Issue-claim reaping (`reap_stale_claims`) is byte-for-byte unchanged (sibling-queue invariant).
- Tick step 3.2 now calls both reapers.
- Regression test `container_kill_then_restart_reaps_orphan_claim` (issue #314 AC2 evidence) passes; four new reaper unit tests (symlink skip, malformed quarantine, live-pid liveness miss, attempt-burn absence).

Closes #371