### PR TITLE
test(review): verify claim uniqueness and crash recovery (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   uniqueness constraint. Known follow-up (owned by the Auto Review
   epic): `migrate-state --to-sqlite` does not carry the JSON review
   sidecar files across a backend switch. Closes #295.
+- **Review claim-uniqueness and crash-recovery verification.** New
+  integration tests prove the review pipeline's concurrency and
+  crash-recovery guarantees: single claim per `ReviewTarget` under
+  concurrent admission; container-kill recovery with no orphan review
+  claims (issue #371); restart-mid-publish with no duplicate comment;
+  out-of-order completion with stale-generation suppression; and
+  terminal paths (mutation violation / head-SHA gone / PR gone /
+  oversized diff) that survive restart without burning the worker
+  retry budget. Closes #314.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,6 +472,18 @@ name = "crash_recovery_test"
 path = "tests/review/crash_recovery_test.rs"
 
 [[test]]
+name = "claim_uniqueness_test"
+path = "tests/review/claim_uniqueness_test.rs"
+
+[[test]]
+name = "out_of_order_test"
+path = "tests/review/out_of_order_test.rs"
+
+[[test]]
+name = "terminal_paths_test"
+path = "tests/review/terminal_paths_test.rs"
+
+[[test]]
 name = "review_store_test"
 path = "tests/state/review_store_test.rs"
 

--- a/tests/review/claim_uniqueness_test.rs
+++ b/tests/review/claim_uniqueness_test.rs
@@ -1,0 +1,166 @@
+//! AC1 — claim uniqueness under concurrent admission (issue #314, DAR
+//! §14, §15).
+//!
+//! N workers racing `acquire_next_review` for the same `ReviewTarget`
+//! produce exactly one claim; losers return `None` and leave no partial
+//! claim file. The guarantee is `create_new(true)` (O_CREAT|O_EXCL —
+//! the OS-level uniqueness) plus one exclusive transaction
+//! (`src/state/review/state.rs::acquire_next_review`).
+//!
+//! DAR §14's "reviews and fixes share the pool without starvation" is
+//! NOT asserted here: the admission seam (`max_reviews_per_tick` +
+//! `pool.admit`) is only reachable through the full tick (step 6.5a),
+//! not through an in-process unit seam. Per the #314 plan (Task 1.1
+//! note), that coexistence is exercised by the end-to-end test (#322),
+//! not this binary. What IS proven here is the store-level claim
+//! uniqueness the AC names.
+
+use std::sync::Arc;
+
+use caduceus::review::{RepositoryId, ReviewTarget};
+use caduceus::state::review::{ReviewPhase, ReviewStore};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+use fixtures::tempdir;
+
+fn repo() -> RepositoryId {
+    RepositoryId {
+        owner: "octocat".to_string(),
+        repo: "hello-world".to_string(),
+    }
+}
+
+fn target(sha: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: repo(),
+        pull_request: 42,
+        head_sha: sha.to_string(),
+        base_sha: "b".repeat(40),
+        base_ref: "main".to_string(),
+        merge_base: "m".repeat(40),
+    }
+}
+
+/// Seed one `Queued` review entry through the real admission path.
+fn seed_entry(store: &ReviewStore, sha: &str) {
+    store
+        .enqueue_review(&target(sha))
+        .expect("seed entry through admission");
+}
+
+fn claim_file_count(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir.join("review-claims"))
+        .expect("read review-claims dir")
+        .filter_map(Result::ok)
+        .count()
+}
+
+#[tokio::test]
+async fn two_workers_racing_same_target_produces_exactly_one_claim() {
+    let dir = tempdir("claim-race");
+    let store = Arc::new(ReviewStore::open(&dir).expect("open store"));
+    seed_entry(&store, &"a".repeat(40));
+
+    // Race 4 acquire calls on the same store + same target. The
+    // `review.lock` flock serialises the exclusive sections, so the
+    // first caller wins; every later caller sees the claim file via
+    // `create_new` AlreadyExists and returns None (try-next-FIFO).
+    let mut handles = Vec::new();
+    for i in 0..4u32 {
+        let s = store.clone();
+        handles.push(tokio::spawn(async move {
+            s.acquire_next_review(&format!("run-{i}"), 1000 + i, chrono::Utc::now())
+        }));
+    }
+    let results: Vec<_> = futures_util::future::join_all(handles)
+        .await
+        .into_iter()
+        .map(|r| r.expect("task join").expect("acquire call"))
+        .collect();
+
+    let winners = results.iter().filter(|r| r.is_some()).count();
+    assert_eq!(winners, 1, "exactly one claim — got {winners}");
+
+    // The winner's run_id is the entry's last_run_id.
+    let queue = store.review_queue_snapshot().expect("load queue");
+    let entry = queue
+        .entries
+        .values()
+        .next()
+        .expect("entry exists after seed");
+    assert_eq!(entry.phase, ReviewPhase::InProgress);
+    let winner = results
+        .iter()
+        .find(|r| r.is_some())
+        .unwrap()
+        .as_ref()
+        .unwrap();
+    assert_eq!(
+        entry.last_run_id.as_deref(),
+        Some(winner.claim.run_id()),
+        "entry last_run_id matches the winner's claim"
+    );
+
+    // Exactly one claim file on disk; losers created none (create_new
+    // failure happens before any write).
+    assert_eq!(claim_file_count(&dir), 1, "exactly one claim file on disk");
+}
+
+#[tokio::test]
+async fn loser_requeues_cleanly_no_partial_claim_file() {
+    // Same setup, one target; the loser of the race leaves NO
+    // <digest>.claim file behind (create_new failed before write), and
+    // the loser's call is a clean None — not an error.
+    let dir = tempdir("claim-clean-loser");
+    let store = ReviewStore::open(&dir).expect("open store");
+    seed_entry(&store, &"c".repeat(40));
+
+    let w1 = store
+        .acquire_next_review("run-1", 1, chrono::Utc::now())
+        .unwrap();
+    let w2 = store
+        .acquire_next_review("run-2", 2, chrono::Utc::now())
+        .unwrap();
+    assert!(w1.is_some(), "first caller wins");
+    assert!(w2.is_none(), "second caller loses cleanly");
+
+    assert_eq!(
+        claim_file_count(&dir),
+        1,
+        "only the winner's claim file exists"
+    );
+}
+
+#[tokio::test]
+async fn many_targets_processed_within_parallelism_budget() {
+    // DAR §14: the admission budget bounds per-tick claims but never
+    // starves distinct targets. Seed K targets; each is claimable
+    // exactly once by `acquire_next_review`.
+    let dir = tempdir("claim-many");
+    let store = ReviewStore::open(&dir).expect("open store");
+    for k in 0..8u32 {
+        seed_entry(&store, &format!("a{k:040}"));
+    }
+    let mut claimed = 0;
+    for i in 0..8u32 {
+        if store
+            .acquire_next_review(&format!("run-{i}"), i, chrono::Utc::now())
+            .unwrap()
+            .is_some()
+        {
+            claimed += 1;
+        }
+    }
+    assert_eq!(claimed, 8, "all K distinct targets claimable");
+
+    // Each target claimed exactly once: all 8 are InProgress.
+    let queue = store.review_queue_snapshot().unwrap();
+    let in_progress = queue
+        .entries
+        .values()
+        .filter(|e| e.phase == ReviewPhase::InProgress)
+        .count();
+    assert_eq!(in_progress, 8);
+    assert_eq!(claim_file_count(&dir), 8, "one claim file per target");
+}

--- a/tests/review/out_of_order_test.rs
+++ b/tests/review/out_of_order_test.rs
@@ -1,0 +1,300 @@
+//! AC4 — out-of-order completion + stale-generation suppression
+//! (issue #314, DAR §9.4, §15).
+//!
+//! B admitted after A (higher `review_generation`), B finishes first →
+//! the sticky comment shows B; A's result persists in history only,
+//! and `review_publication_suppressed_stale_generation` is emitted for
+//! A. The suppression survives a restart (the state is durable).
+//!
+//! The ordering is FABRICATED by persist-then-bump (plan D4), not live
+//! timing: A completes and its result is in history at generation 1;
+//! B is admitted (generation bumps to 2) and completes; B finalizes
+//! first; A's finalization is driven with its generation-1
+//! `DueFinalization` and the §9.4 guard suppresses it.
+
+use caduceus::config::Config;
+use caduceus::github::{Client, HttpCache};
+use caduceus::infra::logging::build_test_subscriber;
+use caduceus::review::{
+    finalize_review, DueFinalization, ExecutionStatus, FinalizeOutcome, PublicationState,
+    RepositoryId, Review, ReviewResult, ReviewTarget, Verdict, REVIEW_SCHEMA_VERSION,
+};
+use caduceus::state::review::{ReviewHistoryRow, ReviewStore};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+use fixtures::{tempdir, MockGitHub};
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const OWNER: &str = "octocat";
+const REPO: &str = "hello-world";
+const PR: u64 = 42;
+const SHA_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn repo() -> RepositoryId {
+    RepositoryId {
+        owner: OWNER.to_string(),
+        repo: REPO.to_string(),
+    }
+}
+
+fn target(sha: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: repo(),
+        pull_request: PR,
+        head_sha: sha.to_string(),
+        base_sha: "b".repeat(40),
+        base_ref: "main".to_string(),
+        merge_base: "m".repeat(40),
+    }
+}
+
+fn sample_review() -> Review {
+    Review {
+        verdict: Verdict::Pass,
+        summary: "looks good".to_string(),
+        findings: vec![],
+    }
+}
+
+fn history_row(run_id: &str, generation: u64, head_sha: &str) -> ReviewHistoryRow {
+    ReviewHistoryRow {
+        review_run_id: run_id.to_string(),
+        repository: repo(),
+        pull_request: PR,
+        head_sha: head_sha.to_string(),
+        review_generation: generation,
+        completed_at: chrono::Utc::now(),
+        result_json: serde_json::to_string(&ReviewResult {
+            schema_version: REVIEW_SCHEMA_VERSION,
+            status: ExecutionStatus::Success,
+            review: Some(sample_review()),
+        })
+        .expect("result serializes"),
+    }
+}
+
+/// Seed the full A-then-B completion story and return the store.
+/// A runs at generation 1 and completes (history row); B is admitted
+/// (generation bumps to 2), runs and completes. Both queue entries end
+/// `Done`; the state row is at generation 2, `Pending` (re-armed by
+/// B's admission).
+fn seeded_ooo_store(dir: &std::path::Path) -> ReviewStore {
+    let store = ReviewStore::open(dir).expect("open store");
+
+    // A: admit (gen 1) → claim → history → Done.
+    store.enqueue_review(&target(SHA_A)).expect("admit A");
+    let claimed_a = store
+        .acquire_next_review("run-a", 1, chrono::Utc::now())
+        .expect("acquire A")
+        .expect("A claimable");
+    assert_eq!(claimed_a.entry.review_generation, 1, "A runs at gen 1");
+    store
+        .append_history(history_row("run-a", 1, SHA_A))
+        .expect("A result persisted");
+    store.complete_review(claimed_a.claim).expect("A completes");
+
+    // B: admit (bumps to gen 2) → claim → history → Done.
+    store.enqueue_review(&target(SHA_B)).expect("admit B");
+    let claimed_b = store
+        .acquire_next_review("run-b", 2, chrono::Utc::now())
+        .expect("acquire B")
+        .expect("B claimable");
+    assert_eq!(claimed_b.entry.review_generation, 2, "B runs at gen 2");
+    store
+        .append_history(history_row("run-b", 2, SHA_B))
+        .expect("B result persisted");
+    store.complete_review(claimed_b.claim).expect("B completes");
+
+    let state = store
+        .review_state(&repo(), PR)
+        .expect("state read")
+        .expect("state row exists");
+    assert_eq!(state.review_generation, 2);
+    assert_eq!(state.publication_state, PublicationState::Pending);
+    store
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn b_before_a_leaves_sticky_b_and_suppresses_a() {
+    let dir = tempdir("ooo");
+    let gh = MockGitHub::start().await;
+    // B's publication path: PR open, empty marker page, create → id 777.
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([])],
+    )
+    .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        201,
+        serde_json::json!({ "id": 777, "body": "" }),
+    )
+    .await;
+    let mut cfg = Config::test_defaults(&dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&dir).expect("cache opens");
+    let client = Client::with_cache(&cfg, cache).expect("client builds");
+    let store = seeded_ooo_store(&dir);
+
+    // Capture the suppression event around A's finalization (serial
+    // discipline: the traced callsite interest is cached process-wide).
+    let capture = dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    // Both finalizes run under the subscriber: B publishes first (the
+    // due-scan routes only B — A's generation is already superseded),
+    // then A's stale DueFinalization is suppressed by the §9.4 guard.
+    let out_b;
+    let out_a;
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let due = store.due_finalizations().expect("due scan");
+        assert_eq!(due.len(), 1, "only B is due — A is superseded");
+        assert_eq!(due[0].head_sha, SHA_B);
+        out_b = finalize_review(&client, &cfg, &store, &due[0], chrono::Utc::now())
+            .await
+            .expect("B finalizes");
+        assert_eq!(out_b, FinalizeOutcome::Published, "B publishes");
+        assert_eq!(gh.counts().post, 1, "one comment — for B");
+
+        out_a = finalize_review(
+            &client,
+            &cfg,
+            &store,
+            &DueFinalization {
+                repository: repo(),
+                pull_request: PR,
+                run_generation: 1,
+                head_sha: SHA_A.to_string(),
+            },
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("A finalizes");
+    }
+    drop(appender_guard);
+
+    assert_eq!(
+        out_a,
+        FinalizeOutcome::SuppressedStaleGeneration,
+        "A suppressed — got {out_a:?}"
+    );
+    assert_eq!(
+        gh.counts().post,
+        1,
+        "no second comment for A — sticky still shows B"
+    );
+
+    // Event emitted for A.
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    assert!(
+        body.contains("review_publication_suppressed_stale_generation"),
+        "suppression event missing: {body}"
+    );
+
+    // History has both; the current pointer shows B.
+    let history = store
+        .history_for_pull_request(&repo(), PR)
+        .expect("history read");
+    assert_eq!(history.len(), 2, "A and B both in history");
+    let state = store
+        .review_state(&repo(), PR)
+        .expect("state read")
+        .expect("state row exists");
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(
+        state.last_reviewed_head_sha.as_deref(),
+        Some(SHA_B),
+        "sticky/current pointer shows B, not A"
+    );
+    assert_eq!(state.sticky_comment_id, Some(777));
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn stale_generation_suppression_survives_restart() {
+    let dir = tempdir("ooo-restart");
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([])],
+    )
+    .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        201,
+        serde_json::json!({ "id": 778, "body": "" }),
+    )
+    .await;
+    let mut cfg = Config::test_defaults(&dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&dir).expect("cache opens");
+    let client = Client::with_cache(&cfg, cache).expect("client builds");
+    let store = seeded_ooo_store(&dir);
+
+    // B publishes; A is suppressed.
+    let due = store.due_finalizations().expect("due scan");
+    assert_eq!(due.len(), 1);
+    let out_b = finalize_review(&client, &cfg, &store, &due[0], chrono::Utc::now())
+        .await
+        .expect("B finalizes");
+    assert_eq!(out_b, FinalizeOutcome::Published);
+    let out_a = finalize_review(
+        &client,
+        &cfg,
+        &store,
+        &DueFinalization {
+            repository: repo(),
+            pull_request: PR,
+            run_generation: 1,
+            head_sha: SHA_A.to_string(),
+        },
+        chrono::Utc::now(),
+    )
+    .await
+    .expect("A finalizes");
+    assert_eq!(out_a, FinalizeOutcome::SuppressedStaleGeneration);
+
+    // Restart: drop the handle and re-open. The suppression is durable
+    // — A is NOT re-due, B is Published.
+    drop(store);
+    let reopened = ReviewStore::open(&dir).expect("re-open store");
+    let due = reopened.due_finalizations().expect("due scan");
+    assert!(
+        due.is_empty(),
+        "suppression persisted across restart — nothing due"
+    );
+    let state = reopened
+        .review_state(&repo(), PR)
+        .expect("state read")
+        .expect("state row exists");
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.last_reviewed_head_sha.as_deref(), Some(SHA_B));
+    assert_eq!(state.sticky_comment_id, Some(778));
+    assert_eq!(gh.counts().post, 1, "exactly one comment across restart");
+}

--- a/tests/review/terminal_paths_test.rs
+++ b/tests/review/terminal_paths_test.rs
@@ -1,0 +1,280 @@
+//! AC5 — terminal paths survive restart without retry-budget burn
+//! (issue #314, DAR §8.1, §14, §15).
+//!
+//! The four non-retry end states of the review router
+//! (`src/daemon/tick/per_review.rs::handle_review_infra_or_retry`):
+//!
+//! | Condition | Route | Budget |
+//! |---|---|---|
+//! | Mutation violation (`ReviewSourceMutation`) | `NeedsAttention` (worktree KEPT) | NOT burned |
+//! | Head SHA gone (`HeadShaUnavailable`) | `Skipped` (quiet skip) | NOT burned |
+//! | PR gone (`ReviewGone`) | `Skipped` (quiet skip) | NOT burned |
+//! | Oversized diff | direct `finish_skip` (prompt-builder seam) | NOT burned |
+//!
+//! Each test drives the REAL router seam
+//! (`handle_review_infra_or_retry_for_tests`) with a freshly-claimed
+//! entry and asserts: correct terminal phase, `attempts` unchanged,
+//! the right structured event, and — via a store re-open — that the
+//! terminal state survives restart (so a restart never re-burns the
+//! budget).
+
+use std::sync::Arc;
+
+use caduceus::config::Config;
+use caduceus::daemon::orchestration::{classify_error, ReviewRunGuard};
+use caduceus::daemon::tick::per_review::handle_review_infra_or_retry_for_tests;
+use caduceus::infra::error::CaduceusError;
+use caduceus::infra::logging::build_test_subscriber;
+use caduceus::review::{RepositoryId, ReviewTarget};
+use caduceus::state::meta::TickOutcome;
+use caduceus::state::review::{
+    review_claim_digest, review_queue_key, ClaimedReview, ReviewPhase, ReviewStore,
+};
+use caduceus::worktree::GitRunner;
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+use fixtures::tempdir;
+
+const OWNER: &str = "octocat";
+const REPO: &str = "hello-world";
+const PR: u64 = 42;
+
+fn repo() -> RepositoryId {
+    RepositoryId {
+        owner: OWNER.to_string(),
+        repo: REPO.to_string(),
+    }
+}
+
+fn target(sha: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: repo(),
+        pull_request: PR,
+        head_sha: sha.to_string(),
+        base_sha: "b".repeat(40),
+        base_ref: "main".to_string(),
+        merge_base: "m".repeat(40),
+    }
+}
+
+/// Seed a fresh store with one claimed `InProgress` entry (attempts 0)
+/// and return the store + the claim.
+fn seed_claimed(dir: &std::path::Path) -> (ReviewStore, ClaimedReview) {
+    let store = ReviewStore::open(dir).expect("open store");
+    store
+        .enqueue_review(&target(&"a".repeat(40)))
+        .expect("seed");
+    let claimed = store
+        .acquire_next_review("run-terminal", std::process::id(), chrono::Utc::now())
+        .expect("acquire succeeds")
+        .expect("entry claimable");
+    assert_eq!(claimed.entry.attempts, 0);
+    (store, claimed)
+}
+
+fn guard_for(cfg: &Config, store: Arc<ReviewStore>, claimed: &ClaimedReview) -> ReviewRunGuard {
+    ReviewRunGuard::new(
+        claimed.claim.clone(),
+        store,
+        cfg.state_dir.join("processor.log"),
+        claimed.entry.target.clone(),
+        GitRunner::new(cfg),
+    )
+}
+
+/// Assert the terminal phase + no-burn + event, given the router
+/// inputs. Re-opens the store afterwards to prove the terminal state
+/// survives restart.
+async fn assert_terminal_route(
+    label: &str,
+    err: CaduceusError,
+    expected_phase: ReviewPhase,
+    expected_event: &str,
+) {
+    let dir = tempdir(label);
+    let cfg = Config::test_defaults(&dir);
+    let (store, claimed) = seed_claimed(&dir);
+    let store = Arc::new(store);
+    let class = classify_error(&err);
+
+    let capture = dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let mut guard = guard_for(&cfg, Arc::clone(&store), &claimed);
+        handle_review_infra_or_retry_for_tests(cfg.clone(), &mut guard, &err, class)
+            .await
+            .expect("router succeeds")
+    };
+    drop(appender_guard);
+
+    // Expected outcome class: terminal → Failed; quiet skip → Processed.
+    let expected_outcome = if expected_phase == ReviewPhase::NeedsAttention {
+        TickOutcome::Failed
+    } else {
+        TickOutcome::Processed
+    };
+    assert_eq!(outcome, expected_outcome, "tick outcome for {label}");
+
+    let queue = store.review_queue_snapshot().expect("load queue");
+    let entry = queue.entries.values().next().expect("entry exists").clone();
+    assert_eq!(entry.phase, expected_phase, "terminal phase for {label}");
+    assert_eq!(entry.attempts, 0, "no retry-budget burn for {label}");
+    assert_eq!(
+        entry.last_run_id, None,
+        "claim released on the terminal route for {label}"
+    );
+
+    // The claim file is gone (the terminal transition unlinked it).
+    let digest = review_claim_digest(&review_queue_key(&target(&"a".repeat(40))));
+    assert!(
+        !dir.join("review-claims")
+            .join(format!("{digest}.claim"))
+            .exists(),
+        "no claim file after {label}"
+    );
+
+    // Structured event emitted.
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    assert!(
+        body.contains(expected_event),
+        "expected event {expected_event} for {label}, got: {body}"
+    );
+
+    // Restart: terminal state is durable — the entry is NOT re-queued
+    // and the budget is not re-burned by a restart.
+    drop(store);
+    let reopened = ReviewStore::open(&dir).expect("re-open store");
+    let entry = reopened
+        .review_queue_snapshot()
+        .expect("load queue")
+        .entries
+        .values()
+        .next()
+        .expect("entry survives restart")
+        .clone();
+    assert_eq!(
+        entry.phase, expected_phase,
+        "terminal state persisted for {label}"
+    );
+    assert_eq!(
+        entry.attempts, 0,
+        "restart did not re-burn the budget for {label}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Terminal route: mutation violation → NeedsAttention (worktree KEPT)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn mutation_violation_is_terminal_needs_attention_no_burn() {
+    assert_terminal_route(
+        "terminal-mutation",
+        CaduceusError::ReviewSourceMutation {
+            worktree_path: "/state/review-worktrees/run-terminal".into(),
+            detail: "tracked files modified: src/main.rs".to_string(),
+        },
+        ReviewPhase::NeedsAttention,
+        "review_mutation_violation",
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Quiet-skip routes: head SHA gone / PR gone → Skipped
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn head_sha_unavailable_is_skip_no_burn() {
+    assert_terminal_route(
+        "terminal-headsha",
+        CaduceusError::HeadShaUnavailable {
+            sha: "a".repeat(40),
+        },
+        ReviewPhase::Skipped,
+        "review_skipped_head_sha_unavailable",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn pr_gone_is_skip_no_burn() {
+    assert_terminal_route(
+        "terminal-prgone",
+        CaduceusError::ReviewGone {
+            reason: "pr_not_found".to_string(),
+        },
+        ReviewPhase::Skipped,
+        "review_skipped_pr_gone",
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Oversized diff: direct finish_skip (the prompt-builder seam; the
+// route never enters handle_review_infra_or_retry — per_review.rs:442)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn oversized_diff_is_skip_no_burn() {
+    let dir = tempdir("terminal-oversized");
+    let cfg = Config::test_defaults(&dir);
+    let (store, claimed) = seed_claimed(&dir);
+    let store = Arc::new(store);
+
+    // Mirror run_review_claim step 6: emit the DAR §13 event, then
+    // finish_skip directly (no error, no retry path).
+    let capture = dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        caduceus::worker::review_prompt::emit_oversized_pr_skip(
+            &repo().full_name(),
+            PR,
+            &"a".repeat(40),
+            2_000_000,
+            1_000_000,
+        );
+        let mut guard = guard_for(&cfg, Arc::clone(&store), &claimed);
+        guard
+            .finish_skip("oversized review diff (deterministically unreviewable)")
+            .await
+            .expect("skip succeeds");
+    }
+    drop(appender_guard);
+
+    let entry = store
+        .review_queue_snapshot()
+        .expect("load queue")
+        .entries
+        .values()
+        .next()
+        .expect("entry exists")
+        .clone();
+    assert_eq!(entry.phase, ReviewPhase::Skipped);
+    assert_eq!(entry.attempts, 0, "oversized skip never burns the budget");
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    assert!(
+        body.contains("review_skipped_oversized_pr"),
+        "oversized event missing: {body}"
+    );
+}


### PR DESCRIPTION
TEST-FIRST verification of issue #314: the review pipeline's claim-uniqueness and crash-recovery guarantees, per `docs/architecture/auto-review.md` §9.4/§14/§15.

## What this PR adds

Four integration test binaries (all registered in Cargo.toml, no new production code):

| Binary | AC | What it proves |
|---|---|---|
| `tests/review/claim_uniqueness_test.rs` | AC1 | one claim per `ReviewTarget` under concurrent admission (`create_new(true)` + exclusive tx); losers re-queue cleanly with no partial claim file |
| `tests/review/crash_recovery_test.rs` | AC2+AC3 | container-kill → step 3.2 reaps the orphan review claim, entry back to `Queued`; restart-mid-publish adopts the existing marker comment (no duplicate POST) and reaches `Published` |
| `tests/review/out_of_order_test.rs` | AC4 | B-finishes-first: sticky shows B, A in history only, `review_publication_suppressed_stale_generation` for A; suppression survives restart |
| `tests/review/terminal_paths_test.rs` | AC5 | mutation → NeedsAttention, HeadSha/PR-gone/oversized → quiet skip; none burn the retry budget; terminal state survives restart |

`crash_recovery_test.rs` itself landed earlier with the #371 reaper fix (PR #372, a60575b) — it was the Honesty-Clause regression test that exposed the missing `review-claims/` reaping; it now passes on main. This PR contributes the other three binaries, the Cargo.toml registrations, and the CHANGELOG entry.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo test --locked --all-targets` (hermetic skips) — 2808 tests / 190 binaries pass, 0 failures
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 200 passed

## Deviations from the plan (documented per the plan-first contract)

1. AC2 harness uses the plan's D3 fallback: `reconcile_installation` needs a live OCI engine, so the test seeds post-reconcile state and drives the real reapers (`reap_stale_claims` + `reap_stale_review_claims`) — the same functions the tick calls at step 3.2.
2. Pool-sharing coexistence sub-test (DAR §14) dropped: the admission seam (`max_reviews_per_tick` + `pool.admit`) is only reachable through the full tick; per plan Task 1.1, exercised by the E2E test (#322). Claim uniqueness itself is proven at the store seam.
3. Troubleshooting doc delivered to the GitHub wiki Troubleshooting page (`## Recovery semantics` section, pushed as caduceus.wiki 4d38075) per plan D6 — no in-repo doc change.
4. Full-gate runs at default test threads hit pre-existing load flakes in unrelated binaries (ETXTBSY exec races in `oci_provenance_test`, identity/probe races in `review_reaper_test`/`readiness_test`). Reproduced identically on base a60575b with this diff stashed; the gate was verified with `--test-threads=8` (all targets, all tests).

Closes #314