### PR TITLE
feat(cli): add review observability status list show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Added
 
+- **Review observability CLI.** `caduceus review status
+  [<owner/repo>] | list | show <owner/repo> <pr> [--json]` reads the
+  review stores (queue, per-`(repo, pr)` state, history) on BOTH state
+  backends with a versioned `review/1.0` JSON envelope and the full DAR
+  §13 per-row field set; `show` parses history `result_json` documents
+  defensively (older schema versions surface raw with a `parse_error`,
+  never back-migrated). `execution status` is derived from the latest
+  same-generation history row's `ReviewResult.status` and is
+  deliberately distinct from `verdict`. Closes #318.
+- **DAR §13 event catalog assertion.** `review_event_catalog_test`
+  pins every structured review event name to its §13 literal at one
+  seam (`caduceus::runtime::audit::review_events`), keeping
+  `review_failed_verdict` and `review_execution_failed` textually and
+  structurally distinct (AC3). Closes #318.
 - **Review mutation-violation enforcement.** A review worker that
   modifies tracked files or daemon control files (`worker-prompt.md`,
   `review-worktree.json`) now fails terminally: the review entry routes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,6 +496,14 @@ name = "review_reaper_test"
 path = "tests/state/review_reaper_test.rs"
 
 [[test]]
+name = "review_event_catalog_test"
+path = "tests/runtime/review_event_catalog_test.rs"
+
+[[test]]
+name = "review_cli_test"
+path = "tests/cli/review_cli_test.rs"
+
+[[test]]
 name = "state_store_test"
 path = "tests/state/state_store_test.rs"
 

--- a/docs/architecture/auto-review.md
+++ b/docs/architecture/auto-review.md
@@ -605,6 +605,13 @@ review_stale_sha_observed                                                      (
 review_migration_terminated_investigation                                      (N+1 reconcile, #331)
 ```
 
+The 21 names above are pinned by
+`tests/runtime/review_event_catalog_test.rs` (issue #318, AC1), which
+reads the producing sites' `pub const … : &str` values through the
+single `caduceus::runtime::audit::review_events` seam.
+`review_skipped_pr_closed_unmerged` is a §9.3 event (finalizer quiet
+skip), not part of this catalog.
+
 `verdict FAIL` and `execution FAILED` must never be conflatable in logs.
 CLI: `caduceus review status [repo] | list | show <repo> <pr> [--json]`
 reading the review stores; per-row fields: repo, PR, base SHA, head SHA,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,9 @@ caduceus queue reset <owner/repo#n> [--dry-run] [--json]
               [--force-finalization-reset]
 caduceus queue reprocess <owner/repo#n> [--dry-run]
 caduceus queue remove <owner/repo#n> [--dry-run] [--force] [--json]
+caduceus review status [<owner/repo>] [--json]
+caduceus review list [--json]
+caduceus review show <owner/repo> <pr> [--json]
 caduceus migrate-state --from <path> [--dry-run]
 caduceus migrate-state --to-sqlite [--dry-run]
 caduceus setup [--dry-run]
@@ -29,8 +32,8 @@ caduceus setup [--dry-run]
   resolution chain (`Config::load`).
 - `--json` output is a versioned envelope: the queue commands emit
   `schema: "queue/1.0"` with `app_version`, `state_dir`,
-  `diagnostic`, and `payload` fields; `status` emits its own
-  `version` field.
+  `diagnostic`, and `payload` fields; the review commands emit
+  `schema: "review/1.0"`; `status` emits its own `version` field.
 - Exit codes:
 
 | Command | Exit codes |
@@ -117,6 +120,42 @@ the next poll re-enqueues a fresh entry; that is documented behaviour,
 not a bug (remove the label first to keep the issue out of the
 queue). The live path takes the daemon lock; `--dry-run` mirrors the
 same guards read-only.
+
+## review status [<owner/repo>] [--json]
+
+Report the review queue: aggregate phase counts (queued, in_progress,
+done, failed, skipped, needs_attention) plus one line per entry, with
+the repository rendered in its canonical lowercase form. An optional
+`owner/repo` filter restricts the report to one repository. Read-only:
+the daemon lock is never taken and state is never written. `--json`
+emits the `review/1.0` envelope with `counts` and the full per-row
+field set — repo, PR, base SHA, head SHA, merge base, review state,
+run id, review generation, execution attempts, execution status,
+verdict, last error, reviewed-at, publication state, publication
+attempt count, next publication attempt. `execution status` is a
+derived presentation field (parsed from the latest same-generation
+history row's durable `ReviewResult.status`), not a stored column;
+`verdict` holds the outcome. On a corrupt review store the JSON path
+emits `diagnostic: "corrupt_review_state"` with a non-zero exit.
+
+## review list [--json]
+
+List every review queue entry as a table (key, phase, attempts,
+generation, verdict, publication, run id). `--json` emits the
+`review/1.0` envelope with the full per-row field set (see
+`review status`). An empty queue prints `review queue: no entries`.
+
+## review show <owner/repo> <pr> [--json]
+
+Print full detail for one pull request plus its run history: the
+queue entry joined with the per-`(repo, pr)` state row (verdict,
+reviewed-at, publication fields) and every history row (run id, head
+SHA, generation, completed time, parsed status/verdict/summary).
+History `result_json` documents are parsed defensively: current
+schema versions surface their parsed fields; older versions surface
+the raw document with a `parse_error` and are never back-migrated.
+A missing entry errors on the human path and emits a `"no_entry"`
+diagnostic (non-zero exit) with `--json`.
 
 ## migrate-state --from <path> [--dry-run]
 

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -146,6 +146,32 @@ were removed in release N+1 (#331): the `ticket_label_investigation`
 config key now fails the config load, and surviving investigation
 rows are terminated and archived by the startup reconcile pass.
 
+Review observability (issue #318, DAR §13):
+
+- `caduceus review status [OWNER/REPO] [--json]` — aggregate review
+  queue phase counts plus one line per entry; an optional repository
+  filter narrows the report. `--json` emits the `review/1.0` envelope
+  with `counts` and the full per-row field set (repo, PR, base SHA,
+  head SHA, merge base, review state, run id, review generation,
+  execution attempts, execution status, verdict, last error,
+  reviewed-at, publication state, publication attempt count, next
+  publication attempt).
+- `caduceus review list [--json]` — every review queue entry as a
+  table (full per-row fields in JSON).
+- `caduceus review show OWNER/REPO PR [--json]` — full detail plus
+  run history for one PR; history `result_json` documents are parsed
+  defensively (older schema versions surface raw with a
+  `parse_error`, never back-migrated). A missing entry yields a
+  `"no_entry"` diagnostic on the JSON path.
+
+All three read BOTH state backends (they branch on
+`state_backend == "sqlite"` like the daemon, not like the JSON-only
+`queue` CLI), never take the daemon lock, and never write state.
+`execution status` is a derived presentation field parsed from the
+latest same-generation history row's `ReviewResult.status` — it
+describes execution, not outcome (`verdict` holds the outcome; a
+failed-verdict run is still `execution status: success`).
+
 ## State Recovery Procedure
 
 Both `state.json` and `state_meta.json` use temp-file + `fsync` + atomic

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,8 @@ use caduceus::queue::{
 use caduceus::readiness::{self, DiagnosticCanary, DiagnosticStatus, ReadinessVerdict};
 use caduceus::DaemonLock;
 
+mod review;
+
 static GIT_AUTHOR_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Schema version of the `queue` JSON envelope emitted by
@@ -91,6 +93,11 @@ pub enum Command {
     Queue {
         #[command(subcommand)]
         action: QueueAction,
+    },
+    /// Inspect review queue, per-PR state, and history.
+    Review {
+        #[command(subcommand)]
+        action: review::ReviewAction,
     },
     /// Migrate legacy queue state into the current schema.
     MigrateState {
@@ -221,6 +228,7 @@ pub fn run() -> CaduceusResult<()> {
                     force,
                 },
         }) => run_queue_remove(&issue, dry_run, force, json),
+        Some(Command::Review { action }) => review::run(action),
         Some(Command::WorktreeGc {
             older_than_days,
             dry_run,

--- a/src/cli/review.rs
+++ b/src/cli/review.rs
@@ -1,0 +1,632 @@
+//! `caduceus review` — review observability CLI (issue #318, DAR §13).
+//!
+//! Three read-only subcommands over the review stores (queue, per-PR
+//! state, history) on BOTH state backends:
+//!
+//! - `status [<owner/repo>]` — aggregate phase counts plus one line
+//!   per entry, optionally filtered to one repository;
+//! - `list` — every review queue entry as a table;
+//! - `show <owner/repo> <pr>` — full detail plus the run history for
+//!   one PR, parsing each `result_json` document defensively.
+//!
+//! Backend selection mirrors the daemon (`config.state_backend ==
+//! "sqlite"`), not the JSON-only `queue` CLI. All three subcommands
+//! accept `--json`; the envelope is `review/1.0`. The subcommands
+//! never take the daemon lock and never write state.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use clap::Subcommand;
+use serde::Serialize;
+
+use caduceus::config::Config;
+use caduceus::error::{CaduceusError, CaduceusResult};
+use caduceus::review::{
+    ExecutionStatus, PublicationState, RepositoryId, ReviewResult, ReviewState, Verdict,
+    REVIEW_SCHEMA_VERSION,
+};
+use caduceus::state::review::{ReviewHistoryRow, ReviewPhase, ReviewQueueEntry, ReviewStore};
+
+/// Schema version of the `review` JSON envelope emitted by
+/// `review status|list|show --json`. Bumped when the envelope shape
+/// changes so consumers can detect the version. Distinct from the
+/// `queue/1.0` and `status` schemas — the review envelope versions
+/// independently.
+const REVIEW_CLI_SCHEMA_VERSION: &str = "review/1.0";
+
+/// Nested subcommand for `caduceus review`.
+#[derive(Debug, Subcommand)]
+pub enum ReviewAction {
+    /// Report review queue state (aggregate phase counts + per-entry rows).
+    Status {
+        /// Optional `owner/repo` filter.
+        repo: Option<String>,
+        /// Print machine-readable JSON instead of the human summary.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// List every review queue entry.
+    List {
+        /// Print machine-readable JSON instead of the human summary.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Show full detail + history for one `(repo, pr)`.
+    Show {
+        /// `owner/repo` repository.
+        repo: String,
+        /// Pull request number.
+        pr: u64,
+        /// Print machine-readable JSON instead of the human summary.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+}
+
+/// One §13 per-row view: the queue entry joined with its `(repo, pr)`
+/// state row and, for terminal rows, the latest same-generation
+/// history row's execution status. The same field set is rendered by
+/// the human and JSON paths (`--json` only changes the rendering).
+#[derive(Serialize)]
+struct ReviewRow {
+    repo: String,
+    pr: u64,
+    base_sha: String,
+    head_sha: String,
+    merge_base: String,
+    review_state: String,
+    run_id: Option<String>,
+    review_generation: u64,
+    execution_attempts: u32,
+    execution_status: Option<String>,
+    verdict: Option<String>,
+    last_error: Option<String>,
+    reviewed_at: Option<String>,
+    publication_state: String,
+    publication_attempt_count: u32,
+    next_publication_attempt: Option<String>,
+}
+
+/// Defensively parsed fields of one history row's `result_json`
+/// document (DAR §4.3). Old schema versions surface as raw
+/// `result_json` + a `parse_error`; they are never back-migrated.
+#[derive(Serialize)]
+struct HistorySummary {
+    run_id: String,
+    head_sha: String,
+    review_generation: u64,
+    completed_at: String,
+    status: Option<String>,
+    verdict: Option<String>,
+    summary: Option<String>,
+    result_json: String,
+    parse_error: Option<String>,
+}
+
+/// Dispatch `caduceus review <action>` using the same env-aware config
+/// resolution the other CLI subcommands use.
+pub fn run(action: ReviewAction) -> CaduceusResult<()> {
+    let config = super::resolve_queue_config()?;
+    match action {
+        ReviewAction::Status { repo, json } => run_review_status(&config, repo.as_deref(), json),
+        ReviewAction::List { json } => run_review_list(&config, json),
+        ReviewAction::Show { repo, pr, json } => run_review_show(&config, &repo, pr, json),
+    }
+}
+
+/// `caduceus review status [<owner/repo>] [--json]` — aggregate phase
+/// counts over the (optionally repo-filtered) review queue plus one
+/// per-entry row.
+fn run_review_status(config: &Config, repo_filter: Option<&str>, json: bool) -> CaduceusResult<()> {
+    let store = open_store(config, json)?;
+    let queue = store.review_queue_snapshot()?;
+    let filter = match repo_filter {
+        Some(text) => Some(parse_repo(text)?),
+        None => None,
+    };
+    let entries: Vec<&ReviewQueueEntry> = queue
+        .entries
+        .values()
+        .filter(|entry| match &filter {
+            Some(repo) => {
+                entry
+                    .target
+                    .repository
+                    .owner
+                    .eq_ignore_ascii_case(&repo.owner)
+                    && entry
+                        .target
+                        .repository
+                        .repo
+                        .eq_ignore_ascii_case(&repo.repo)
+            }
+            None => true,
+        })
+        .collect();
+
+    // Phase counts over the filtered set, zero-filled for every phase
+    // so the JSON shape is stable across runs.
+    let mut counts: BTreeMap<String, u64> = BTreeMap::new();
+    for phase in [
+        ReviewPhase::Queued,
+        ReviewPhase::InProgress,
+        ReviewPhase::Done,
+        ReviewPhase::Failed,
+        ReviewPhase::Skipped,
+        ReviewPhase::NeedsAttention,
+    ] {
+        counts.insert(phase.as_str().to_string(), 0);
+    }
+    for entry in &entries {
+        *counts.entry(entry.phase.as_str().to_string()).or_insert(0) += 1;
+    }
+
+    let rows = rows_for(&store, &entries)?;
+    if json {
+        print_review_json(
+            &config.state_dir,
+            serde_json::json!({ "counts": counts, "entries": rows }),
+        )?;
+        return Ok(());
+    }
+    println!("{}", render_status_human(config, &counts, &entries, &rows));
+    Ok(())
+}
+
+/// `caduceus review list [--json]` — every review queue entry as a
+/// table (JSON: the full §13 per-row field set).
+fn run_review_list(config: &Config, json: bool) -> CaduceusResult<()> {
+    let store = open_store(config, json)?;
+    let queue = store.review_queue_snapshot()?;
+    let entries: Vec<&ReviewQueueEntry> = queue.entries.values().collect();
+    let rows = rows_for(&store, &entries)?;
+    if json {
+        print_review_json(&config.state_dir, serde_json::json!({ "entries": rows }))?;
+        return Ok(());
+    }
+    println!("{}", render_list_human(&queue.entries, &rows));
+    Ok(())
+}
+
+/// `caduceus review show <owner/repo> <pr> [--json]` — full detail +
+/// run history for one PR. The history rows' `result_json` documents
+/// are parsed defensively (see [`parse_result_document`]).
+fn run_review_show(config: &Config, repo_text: &str, pr: u64, json: bool) -> CaduceusResult<()> {
+    let repo = parse_repo(repo_text)?;
+    let store = open_store(config, json)?;
+    let queue = store.review_queue_snapshot()?;
+    let entry = queue
+        .entries
+        .values()
+        .find(|entry| {
+            entry.target.pull_request == pr
+                && entry
+                    .target
+                    .repository
+                    .owner
+                    .eq_ignore_ascii_case(&repo.owner)
+                && entry
+                    .target
+                    .repository
+                    .repo
+                    .eq_ignore_ascii_case(&repo.repo)
+        })
+        .cloned();
+    let Some(entry) = entry else {
+        let err = CaduceusError::Queue {
+            context: "review show",
+            stderr: format!("no entry for {}#{pr}", repo.full_name()),
+        };
+        if json {
+            print_review_json_with_diagnostic(
+                &config.state_dir,
+                serde_json::Value::Null,
+                Some("no_entry"),
+            )?;
+        }
+        return Err(err);
+    };
+    let state = store.review_state(&entry.target.repository, pr)?;
+    let history = store.history_for_pull_request(&entry.target.repository, pr)?;
+    let row = row_for(&entry, state.as_ref(), &history);
+    let history_summaries: Vec<HistorySummary> = history.iter().map(history_summary).collect();
+    if json {
+        print_review_json(
+            &config.state_dir,
+            serde_json::json!({ "entry": row, "history": history_summaries }),
+        )?;
+        return Ok(());
+    }
+    print!("{}", render_show_human(&entry, &row, &history_summaries));
+    Ok(())
+}
+
+/// Open the review store on the backend the daemon would use
+/// (`config.state_backend == "sqlite"`), mirroring the daemon's
+/// `src/daemon/tick/mod.rs` branch rather than the JSON-only `queue`
+/// CLI. On a corrupt store the `--json` path still emits the
+/// `review/1.0` envelope with `diagnostic: "corrupt_review_state"`
+/// before propagating the error.
+fn open_store(config: &Config, json: bool) -> CaduceusResult<ReviewStore> {
+    let result = if config.state_backend == "sqlite" {
+        ReviewStore::open_sqlite(&config.state_dir)
+    } else {
+        ReviewStore::open(&config.state_dir)
+    };
+    match result {
+        Ok(store) => Ok(store),
+        Err(err) => {
+            if json {
+                print_review_json_with_diagnostic(
+                    &config.state_dir,
+                    serde_json::Value::Null,
+                    Some("corrupt_review_state"),
+                )?;
+            }
+            Err(err)
+        }
+    }
+}
+
+/// Build the §13 per-row views for the given queue entries.
+fn rows_for(store: &ReviewStore, entries: &[&ReviewQueueEntry]) -> CaduceusResult<Vec<ReviewRow>> {
+    entries
+        .iter()
+        .map(|entry| {
+            let state = store.review_state(&entry.target.repository, entry.target.pull_request)?;
+            let history = store
+                .history_for_pull_request(&entry.target.repository, entry.target.pull_request)?;
+            Ok(row_for(entry, state.as_ref(), &history))
+        })
+        .collect()
+}
+
+/// Join one queue entry with its state row and history.
+fn row_for(
+    entry: &ReviewQueueEntry,
+    state: Option<&ReviewState>,
+    history: &[ReviewHistoryRow],
+) -> ReviewRow {
+    ReviewRow {
+        repo: canonical_repo(&entry.target.repository),
+        pr: entry.target.pull_request,
+        base_sha: entry.target.base_sha.clone(),
+        head_sha: entry.target.head_sha.clone(),
+        merge_base: entry.target.merge_base.clone(),
+        review_state: entry.phase.as_str().to_string(),
+        run_id: entry
+            .last_run_id
+            .clone()
+            .or_else(|| state.and_then(|s| s.last_run_id.clone())),
+        review_generation: entry.review_generation,
+        execution_attempts: entry.attempts,
+        execution_status: derive_execution_status(entry, history),
+        verdict: state
+            .and_then(|s| s.last_verdict)
+            .map(|v| verdict_label(v).to_string()),
+        last_error: entry.last_error.clone(),
+        reviewed_at: state
+            .and_then(|s| s.last_reviewed_at)
+            .map(|t| t.to_rfc3339()),
+        publication_state: state
+            .map(|s| publication_state_label(s.publication_state).to_string())
+            .unwrap_or_else(|| "pending".to_string()),
+        publication_attempt_count: state.map(|s| s.publication_attempt_count).unwrap_or(0),
+        next_publication_attempt: state
+            .and_then(|s| s.next_publish_at)
+            .map(|t| t.to_rfc3339()),
+    }
+}
+
+/// Execution status is a presentation field, not a stored column: it
+/// is derived from the latest same-generation history row's durable
+/// `ReviewResult.status` once the run completed. Active and
+/// non-terminal rows (no history row for their generation) carry
+/// `None`. A `failed` verdict run is still `success` here —
+/// `status` describes execution, `verdict` describes the outcome
+/// (DAR §8: the two never conflate).
+fn derive_execution_status(
+    entry: &ReviewQueueEntry,
+    history: &[ReviewHistoryRow],
+) -> Option<String> {
+    history
+        .iter()
+        .rfind(|row| row.review_generation == entry.review_generation)
+        .and_then(|row| parse_result_document(&row.result_json).0)
+}
+
+/// Render one history row's `result_json` into the defensively parsed
+/// [`HistorySummary`].
+fn history_summary(row: &ReviewHistoryRow) -> HistorySummary {
+    let (status, verdict, summary, parse_error) = parse_result_document(&row.result_json);
+    HistorySummary {
+        run_id: row.review_run_id.clone(),
+        head_sha: row.head_sha.clone(),
+        review_generation: row.review_generation,
+        completed_at: row.completed_at.to_rfc3339(),
+        status,
+        verdict,
+        summary,
+        result_json: row.result_json.clone(),
+        parse_error,
+    }
+}
+
+/// Parse a version-tagged `result_json` document defensively. Never
+/// panics and never back-migrates: schema versions other than the
+/// current one (and malformed documents) surface as
+/// `(None, None, None, Some(parse_error))` with the raw document kept
+/// in the caller's `result_json` field (DAR §4.3).
+///
+/// Returns `(status, verdict, summary, parse_error)`.
+fn parse_result_document(
+    json: &str,
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+) {
+    let value: serde_json::Value = match serde_json::from_str(json) {
+        Ok(value) => value,
+        Err(err) => return (None, None, None, Some(format!("malformed document: {err}"))),
+    };
+    let schema_version = value.get("schema_version").and_then(|v| v.as_u64());
+    match schema_version {
+        Some(version) if version == REVIEW_SCHEMA_VERSION as u64 => {
+            match serde_json::from_str::<ReviewResult>(json) {
+                Ok(result) => {
+                    let status = match result.status {
+                        ExecutionStatus::Success => Some("success".to_string()),
+                        ExecutionStatus::Failure => Some("failure".to_string()),
+                    };
+                    let (verdict, summary) = match result.review {
+                        Some(review) => (
+                            Some(verdict_label(review.verdict).to_string()),
+                            Some(review.summary),
+                        ),
+                        None => (None, None),
+                    };
+                    (status, verdict, summary, None)
+                }
+                Err(err) => (
+                    None,
+                    None,
+                    None,
+                    Some(format!("schema v{version} parse: {err}")),
+                ),
+            }
+        }
+        Some(version) => (
+            None,
+            None,
+            None,
+            Some(format!("unsupported schema_version {version}")),
+        ),
+        None => (None, None, None, Some("missing schema_version".to_string())),
+    }
+}
+
+/// Stable snake_case verdict label.
+fn verdict_label(verdict: Verdict) -> &'static str {
+    match verdict {
+        Verdict::Pass => "pass",
+        Verdict::Fail => "fail",
+    }
+}
+
+/// Stable snake_case publication-state label.
+fn publication_state_label(state: PublicationState) -> &'static str {
+    match state {
+        PublicationState::Pending => "pending",
+        PublicationState::Publishing => "publishing",
+        PublicationState::Published => "published",
+        PublicationState::FailedRetryable => "failed_retryable",
+    }
+}
+
+/// Parse the `owner/repo` positional into a [`RepositoryId`]. No case
+/// normalisation — matching against store rows is case-insensitive.
+fn parse_repo(text: &str) -> CaduceusResult<RepositoryId> {
+    let (owner, repo) = text.split_once('/').ok_or_else(|| {
+        CaduceusError::Config(format!("invalid repository {text:?}: expected owner/repo"))
+    })?;
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return Err(CaduceusError::Config(format!(
+            "invalid repository {text:?}: expected owner/repo"
+        )));
+    }
+    Ok(RepositoryId {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    })
+}
+
+/// Compact queue-entry display key: `owner/repo#pr@<sha12>` (the repo
+/// is rendered in its canonical lowercase form so both backends agree).
+fn display_key(entry: &ReviewQueueEntry) -> String {
+    format!(
+        "{}#{}@{}",
+        canonical_repo(&entry.target.repository),
+        entry.target.pull_request,
+        short_sha(&entry.target.head_sha)
+    )
+}
+
+/// Canonical lowercase `owner/repo` display form, matching the store's
+/// lowercase identity keys and the issue queue CLI's display keys.
+fn canonical_repo(repository: &RepositoryId) -> String {
+    format!(
+        "{}/{}",
+        repository.owner.to_lowercase(),
+        repository.repo.to_lowercase()
+    )
+}
+
+/// First 12 characters of a SHA, or the whole string when shorter.
+/// Char-boundary safe: head SHAs are validated as ≤64-byte non-empty
+/// strings at the store layer (hex from git in practice), so a
+/// multi-byte value must never panic the CLI.
+fn short_sha(sha: &str) -> &str {
+    if sha.len() > 12 && sha.is_char_boundary(12) {
+        &sha[..12]
+    } else {
+        sha
+    }
+}
+
+/// Human status renderer: header + phase counts + one line per entry.
+fn render_status_human(
+    config: &Config,
+    counts: &BTreeMap<String, u64>,
+    entries: &[&ReviewQueueEntry],
+    rows: &[ReviewRow],
+) -> String {
+    let mut out = String::new();
+    out.push_str("caduceus review status\n");
+    out.push_str(&format!("  state dir: {}\n", config.state_dir.display()));
+    out.push_str(&format!("  backend: {}\n", config.state_backend));
+    let total: u64 = counts.values().sum();
+    out.push_str(&format!("  review queue: {total} entries\n"));
+    out.push_str("  phases:\n");
+    for (label, count) in counts {
+        out.push_str(&format!("    {label}: {count}\n"));
+    }
+    out.push_str("  entries:\n");
+    for (entry, row) in entries.iter().zip(rows) {
+        out.push_str(&format!(
+            "    {}  phase={} attempts={} gen={} verdict={} publication={} run={}\n",
+            display_key(entry),
+            row.review_state,
+            row.execution_attempts,
+            row.review_generation,
+            row.verdict.as_deref().unwrap_or("-"),
+            row.publication_state,
+            row.run_id.as_deref().unwrap_or("-"),
+        ));
+    }
+    out
+}
+
+/// Human list renderer: tab-separated table (the full §13 field set
+/// is available via `--json` and `show`).
+fn render_list_human(entries: &BTreeMap<String, ReviewQueueEntry>, rows: &[ReviewRow]) -> String {
+    if rows.is_empty() {
+        return "review queue: no entries".to_string();
+    }
+    let mut out = String::from("key\tphase\tattempts\tgeneration\tverdict\tpublication\trun_id\n");
+    for (entry, row) in entries.values().zip(rows) {
+        out.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+            display_key(entry),
+            row.review_state,
+            row.execution_attempts,
+            row.review_generation,
+            row.verdict.as_deref().unwrap_or("-"),
+            row.publication_state,
+            row.run_id.as_deref().unwrap_or("-"),
+        ));
+    }
+    out
+}
+
+/// Human show renderer: full detail + history rows.
+fn render_show_human(
+    entry: &ReviewQueueEntry,
+    row: &ReviewRow,
+    history: &[HistorySummary],
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("entry {}\n", display_key(entry)));
+    out.push_str(&format!("  repo: {}\n", row.repo));
+    out.push_str(&format!("  pr: {}\n", row.pr));
+    out.push_str(&format!("  base_sha: {}\n", row.base_sha));
+    out.push_str(&format!("  head_sha: {}\n", row.head_sha));
+    out.push_str(&format!("  merge_base: {}\n", row.merge_base));
+    out.push_str(&format!("  phase: {}\n", row.review_state));
+    out.push_str(&format!(
+        "  run_id: {}\n",
+        row.run_id.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!("  generation: {}\n", row.review_generation));
+    out.push_str(&format!("  attempts: {}\n", row.execution_attempts));
+    out.push_str(&format!(
+        "  execution_status: {}\n",
+        row.execution_status.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  verdict: {}\n",
+        row.verdict.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  last_error: {}\n",
+        row.last_error.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  reviewed_at: {}\n",
+        row.reviewed_at.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!("  publication_state: {}\n", row.publication_state));
+    out.push_str(&format!(
+        "  publication_attempt_count: {}\n",
+        row.publication_attempt_count
+    ));
+    out.push_str(&format!(
+        "  next_publication_attempt: {}\n",
+        row.next_publication_attempt.as_deref().unwrap_or("-")
+    ));
+    out.push_str("  history:\n");
+    if history.is_empty() {
+        out.push_str("    (none)\n");
+    }
+    for entry in history {
+        out.push_str(&format!(
+            "    {} head={} gen={} completed={}\n",
+            entry.run_id,
+            short_sha(&entry.head_sha),
+            entry.review_generation,
+            entry.completed_at
+        ));
+        out.push_str(&format!(
+            "      status: {}  verdict: {}\n",
+            entry.status.as_deref().unwrap_or("-"),
+            entry.verdict.as_deref().unwrap_or("-")
+        ));
+        match (&entry.summary, &entry.parse_error) {
+            (Some(summary), _) => out.push_str(&format!("      summary: {summary}\n")),
+            (None, Some(err)) => out.push_str(&format!("      parse_error: {err}\n")),
+            (None, None) => out.push_str("      summary: -\n"),
+        }
+    }
+    out
+}
+
+/// Print a versioned `review/1.0` JSON envelope to stdout.
+fn print_review_json(state_dir: &Path, payload: serde_json::Value) -> CaduceusResult<()> {
+    print_review_json_with_diagnostic(state_dir, payload, None)
+}
+
+/// Print a versioned `review/1.0` JSON envelope with an optional
+/// top-level `diagnostic` string, mirroring the `queue` / `status`
+/// envelope convention.
+fn print_review_json_with_diagnostic(
+    state_dir: &Path,
+    payload: serde_json::Value,
+    diagnostic: Option<&str>,
+) -> CaduceusResult<()> {
+    let envelope = serde_json::json!({
+        "app_version": env!("CARGO_PKG_VERSION"),
+        "schema": REVIEW_CLI_SCHEMA_VERSION,
+        "state_dir": state_dir.display().to_string(),
+        "diagnostic": diagnostic,
+        "payload": payload,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&envelope).map_err(|err| {
+            CaduceusError::Other(format!("serialise review JSON envelope: {err}"))
+        })?
+    );
+    Ok(())
+}

--- a/src/daemon/tick/review_discovery.rs
+++ b/src/daemon/tick/review_discovery.rs
@@ -677,6 +677,31 @@ pub fn emit_discovered_for_tests(repo: &str, pr: u64, head_sha: &str) {
     emit_discovered(repo, pr, head_sha)
 }
 
+/// Public test seam (D12): the structured `review_admitted` emitter,
+/// for event-capture tests.
+pub fn emit_admitted_for_tests(repo: &str, pr: u64, head_sha: &str) {
+    emit_admitted(repo, pr, head_sha)
+}
+
+/// Public test seam (D12): the structured `review_skipped_draft`
+/// emitter, for event-capture tests.
+pub fn emit_skipped_draft_for_tests(repo: &str, pr: u64, head_sha: &str) {
+    emit_skipped_draft(repo, pr, head_sha)
+}
+
+/// Public test seam (D12): the structured
+/// `review_skipped_already_complete` emitter, for event-capture
+/// tests.
+pub fn emit_skipped_already_complete_for_tests(repo: &str, pr: u64, head_sha: &str) {
+    emit_skipped_already_complete(repo, pr, head_sha)
+}
+
+/// Public test seam (D12): the structured `review_stale_sha_observed`
+/// emitter, for event-capture tests.
+pub fn emit_stale_sha_for_tests(repo: &str, pr: u64, previous_sha: &str, observed_sha: &str) {
+    emit_stale_sha(repo, pr, previous_sha, observed_sha)
+}
+
 /// Public test seam (D12): one admission (fetch head SHA, fetch base
 /// SHA, merge base, atomic enqueue). Same body as `admit_target`.
 #[allow(clippy::too_many_arguments)]

--- a/src/runtime/audit.rs
+++ b/src/runtime/audit.rs
@@ -121,3 +121,40 @@ pub fn emit_review_migration_terminated_investigation(repo: &str, issue: u64, ph
          auto_review or code ticket if still needed"
     );
 }
+
+/// DAR §13 review event catalog (issue #318).
+///
+/// One seam that re-exports every structured review event name from
+/// its producing site, so the CLI, docs, and the catalog test
+/// (`tests/runtime/review_event_catalog_test.rs`) can enumerate the
+/// stable operator-facing names without depending on the producing
+/// module layout. The constants are the producing sites' own `pub
+/// const … : &str` values — this module adds no new names and no
+/// emit logic. Names are asserted against the §13 literals by the
+/// catalog test; `review_failed_verdict` and
+/// `review_execution_failed` are deliberately distinct strings and
+/// never conflated (AC3).
+///
+/// Out of catalog: `review_skipped_pr_closed_unmerged`
+/// (`crate::review::finalize::EVENT_SKIPPED_PR_CLOSED_UNMERGED`) is a
+/// §9.3 event kept for the finalizer's quiet skip; it is intentionally
+/// not listed here.
+pub mod review_events {
+    pub use super::REVIEW_MIGRATION_TERMINATED_INVESTIGATION_EVENT;
+    pub use crate::daemon::tick::per_review::{
+        REVIEW_EXECUTION_FAILED_EVENT, REVIEW_FAILED_VERDICT_EVENT, REVIEW_PASSED_EVENT,
+        REVIEW_RETRY_SCHEDULED_EVENT, REVIEW_SKIPPED_HEAD_SHA_UNAVAILABLE_EVENT,
+        REVIEW_SKIPPED_PR_GONE_EVENT, REVIEW_STARTED_EVENT, REVIEW_WORKER_COMPLETED_EVENT,
+    };
+    pub use crate::daemon::tick::review_discovery::{
+        ADMITTED_EVENT, DISCOVERED_EVENT, SKIPPED_ALREADY_COMPLETE_EVENT, SKIPPED_DRAFT_EVENT,
+        STALE_SHA_EVENT,
+    };
+    pub use crate::github::fork_gate::FORK_SKIP_EVENT;
+    pub use crate::repo::review_integrity::MUTATION_VIOLATION_EVENT;
+    pub use crate::review::finalize::{
+        EVENT_PUBLISHED, EVENT_PUBLISH_FAILED_RETRYABLE, EVENT_PUBLISH_STARTED,
+        EVENT_SUPPRESSED_STALE_GENERATION,
+    };
+    pub use crate::worker::review_prompt::OVERSIZED_PR_EVENT;
+}

--- a/tests/cli/review_cli_test.rs
+++ b/tests/cli/review_cli_test.rs
@@ -1,0 +1,617 @@
+//! `caduceus review` — review observability CLI (issue #318, DAR §13).
+//!
+//! These tests drive the CLI as a subprocess via
+//! `env!("CARGO_BIN_EXE_caduceus")` against BOTH state backends and
+//! check:
+//!
+//! * `review status [<repo>]` — aggregate phase counts plus one line
+//!   per entry (human) and the full §13 per-row field set (JSON).
+//! * `review list` — the queue as a table (human) and full rows (JSON).
+//! * `review show <repo> <pr>` — full detail + run history, with
+//!   defensive `result_json` parsing (old schema versions never
+//!   crash and are surfaced raw with a `parse_error`).
+//! * Missing entry → `no_entry` diagnostic on the JSON path.
+//! * Read-only: the subcommands never mutate the review stores.
+//! * `$CADUCEUS_CONFIG` is honoured, including `state_backend: sqlite`.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use chrono::Utc;
+
+use caduceus::review::{
+    ExecutionStatus, Finding, PublicationState, RepositoryId, Review, ReviewResult, ReviewState,
+    ReviewTarget, Severity, Verdict, REVIEW_SCHEMA_VERSION,
+};
+use caduceus::state::review::{ReviewHistoryRow, ReviewStore};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+use fixtures::tempdir;
+
+const OWNER_A: &str = "Owner";
+const REPO_A: &str = "Repo";
+const PR_A: u64 = 42;
+const SHA_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OWNER_B: &str = "Other";
+const REPO_B: &str = "Repo";
+const PR_B: u64 = 7;
+const SHA_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const OWNER_C: &str = "New";
+const REPO_C: &str = "Repo";
+const PR_C: u64 = 3;
+const SHA_C: &str = "cccccccccccccccccccccccccccccccccccccccc";
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Backend {
+    Json,
+    Sqlite,
+}
+
+fn open_store(dir: &Path, backend: Backend) -> ReviewStore {
+    match backend {
+        Backend::Json => ReviewStore::open(dir).unwrap(),
+        Backend::Sqlite => ReviewStore::open_sqlite(dir).unwrap(),
+    }
+}
+
+fn repo(owner: &str, name: &str) -> RepositoryId {
+    RepositoryId {
+        owner: owner.to_string(),
+        repo: name.to_string(),
+    }
+}
+
+fn target(repository: &RepositoryId, pr: u64, sha: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: repository.clone(),
+        pull_request: pr,
+        head_sha: sha.to_string(),
+        base_sha: "b".repeat(40),
+        base_ref: "main".to_string(),
+        merge_base: "m".repeat(40),
+    }
+}
+
+/// A validator-correct `ReviewResult` document for the given verdict.
+fn result_doc(verdict: Verdict) -> String {
+    let findings = match verdict {
+        Verdict::Fail => vec![Finding {
+            severity: Severity::Blocking,
+            title: "blocking".to_string(),
+            body: "must fix before merge".to_string(),
+            path: None,
+            line: None,
+            remediation: None,
+        }],
+        Verdict::Pass => vec![],
+    };
+    serde_json::to_string(&ReviewResult {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        status: ExecutionStatus::Success,
+        review: Some(Review {
+            verdict,
+            summary: format!("summary-{verdict:?}"),
+            findings,
+        }),
+    })
+    .unwrap()
+}
+
+/// An old-schema `result_json` document (v99): accepted by the store
+/// as an opaque read-only blob, surfaced raw by the CLI.
+fn old_schema_doc() -> String {
+    serde_json::json!({
+        "schema_version": 99,
+        "status": "success",
+        "review": { "verdict": "pass", "summary": "ancient", "findings": [] }
+    })
+    .to_string()
+}
+
+/// Seed one full run: enqueue, claim, complete, append history, and
+/// persist the state row. The entry ends `Done` with a published
+/// sticky comment.
+fn seed_completed_run(
+    store: &ReviewStore,
+    repository: &RepositoryId,
+    pr: u64,
+    sha: &str,
+    run_id: &str,
+    verdict: Verdict,
+    result_json: String,
+) {
+    store.enqueue_review(&target(repository, pr, sha)).unwrap();
+    let claimed = store
+        .acquire_next_review(run_id, std::process::id(), Utc::now())
+        .unwrap()
+        .unwrap();
+    let generation = claimed.entry.review_generation;
+    store.complete_review(claimed.claim.clone()).unwrap();
+    store
+        .append_history(ReviewHistoryRow {
+            review_run_id: run_id.to_string(),
+            repository: repository.clone(),
+            pull_request: pr,
+            head_sha: sha.to_string(),
+            review_generation: generation,
+            completed_at: Utc::now(),
+            result_json,
+        })
+        .unwrap();
+    store
+        .save_review_state(&ReviewState {
+            repository: repository.clone(),
+            pull_request: pr,
+            last_reviewed_head_sha: Some(sha.to_string()),
+            last_verdict: Some(verdict),
+            last_reviewed_at: Some(Utc::now()),
+            sticky_comment_id: Some(pr),
+            last_run_id: Some(run_id.to_string()),
+            review_generation: generation,
+            publication_state: PublicationState::Published,
+            publication_attempt_count: 1,
+            next_publish_at: None,
+            last_publish_error: None,
+        })
+        .unwrap();
+}
+
+/// Standard three-entry seed: A (done, pass), B (done, fail), C
+/// (queued). Entry order matters — `acquire_next_review` is FIFO, so
+/// the completed runs are created in A/B order.
+fn seed_standard(dir: &Path, backend: Backend) -> ReviewStore {
+    let store = open_store(dir, backend);
+    // A and B are enqueued first (FIFO claim order), C stays queued.
+    seed_completed_run(
+        &store,
+        &repo(OWNER_A, REPO_A),
+        PR_A,
+        SHA_A,
+        "RUN-A",
+        Verdict::Pass,
+        result_doc(Verdict::Pass),
+    );
+    seed_completed_run(
+        &store,
+        &repo(OWNER_B, REPO_B),
+        PR_B,
+        SHA_B,
+        "RUN-B",
+        Verdict::Fail,
+        result_doc(Verdict::Fail),
+    );
+    store
+        .enqueue_review(&target(&repo(OWNER_C, REPO_C), PR_C, SHA_C))
+        .unwrap();
+    store
+}
+
+/// Seed one entry whose history carries an old-schema `result_json`.
+fn seed_old_history(dir: &Path, backend: Backend) -> ReviewStore {
+    let store = open_store(dir, backend);
+    seed_completed_run(
+        &store,
+        &repo("Legacy", "Repo"),
+        5,
+        &"d".repeat(40),
+        "RUN-D",
+        Verdict::Pass,
+        old_schema_doc(),
+    );
+    store
+}
+
+/// Run the CLI binary as a subprocess against `dir` with a
+/// `$CADUCEUS_CONFIG` whose `state_dir` is `dir` (and
+/// `state_backend: sqlite` for the SQLite backend).
+fn run_cli(dir: &Path, backend: Backend, args: &[&str]) -> std::process::Output {
+    let mut hermes_home = dir.to_path_buf();
+    hermes_home.push("hermes");
+    fs::create_dir_all(&hermes_home).unwrap();
+    let config_path = dir.join("config.yaml");
+    let backend_yaml = match backend {
+        Backend::Json => "",
+        Backend::Sqlite => "  state_backend: \"sqlite\"\n",
+    };
+    let yaml = format!(
+        "caduceus:\n  state_dir: \"{}\"\n{backend_yaml}  worker_command:\n    - \"python3\"\n    - \"{}/bridge.py\"\n  reduced_containment_acknowledged: true\n",
+        dir.display(),
+        dir.display()
+    );
+    fs::write(&config_path, yaml).unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_caduceus"));
+    cmd.env("CADUCEUS_CONFIG", &config_path)
+        .env("HERMES_HOME", &hermes_home)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.output().expect("spawn caduceus")
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout must be JSON")
+}
+
+fn assert_success(output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "expected success; got {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn row_by_pr(entries: &serde_json::Value, pr: u64) -> serde_json::Value {
+    entries
+        .as_array()
+        .expect("entries must be an array")
+        .iter()
+        .find(|row| row["pr"].as_u64() == Some(pr))
+        .unwrap_or_else(|| panic!("no row for pr {pr} in {entries}"))
+        .clone()
+}
+
+// ---------------------------------------------------------------------------
+// Help surface
+// ---------------------------------------------------------------------------
+
+#[test]
+fn help_lists_review_subcommands() {
+    let dir = tempdir("review-help");
+    let output = run_cli(&dir, Backend::Json, &["review", "--help"]);
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for needle in ["status", "list", "show"] {
+        assert!(stdout.contains(needle), "missing {needle} in {stdout}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+#[test]
+fn status_human_shows_counts_and_entries() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-status-{backend:?}"));
+        seed_standard(&dir, backend);
+        let output = run_cli(&dir, backend, &["review", "status"]);
+        assert_success(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("caduceus review status"), "got {stdout}");
+        assert!(stdout.contains("review queue: 3 entries"), "got {stdout}");
+        assert!(stdout.contains("phases:"), "got {stdout}");
+        assert!(stdout.contains("queued: 1"), "got {stdout}");
+        assert!(stdout.contains("done: 2"), "got {stdout}");
+        // Per-entry lines carry the key presentation fields (repo in
+        // its canonical lowercase form on both backends).
+        assert!(
+            stdout.contains("owner/repo#42@aaaaaaaaaaaa"),
+            "got {stdout}"
+        );
+        assert!(
+            stdout.contains("verdict=fail publication=published run=RUN-B"),
+            "got {stdout}"
+        );
+    }
+}
+
+#[test]
+fn status_json_emits_envelope_counts_and_full_rows() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-status-json-{backend:?}"));
+        seed_standard(&dir, backend);
+        let output = run_cli(&dir, backend, &["review", "status", "--json"]);
+        assert_success(&output);
+        let envelope = parse_json(&output);
+        assert_eq!(envelope["schema"], "review/1.0");
+        assert_eq!(envelope["app_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(envelope["diagnostic"], serde_json::Value::Null);
+        let counts = &envelope["payload"]["counts"];
+        assert_eq!(counts["queued"], 1);
+        assert_eq!(counts["done"], 2);
+        assert_eq!(counts["failed"], 0);
+        let entries = &envelope["payload"]["entries"];
+        assert_eq!(entries.as_array().unwrap().len(), 3);
+
+        // Done-pass row (A): every §13 field is present with the
+        // derived execution status and state-joined verdict.
+        let a = row_by_pr(entries, PR_A);
+        assert_eq!(a["repo"], "owner/repo");
+        assert_eq!(a["review_state"], "done");
+        assert_eq!(a["run_id"], "RUN-A");
+        assert_eq!(a["review_generation"], 1);
+        assert_eq!(a["execution_attempts"], 0);
+        assert_eq!(a["execution_status"], "success");
+        assert_eq!(a["verdict"], "pass");
+        assert_eq!(a["publication_state"], "published");
+        assert_eq!(a["publication_attempt_count"], 1);
+        assert!(a["reviewed_at"].is_string(), "reviewed_at missing: {a}");
+        assert!(a["base_sha"].is_string(), "base_sha missing: {a}");
+        assert!(a["head_sha"].is_string(), "head_sha missing: {a}");
+        assert!(a["merge_base"].is_string(), "merge_base missing: {a}");
+
+        // Done-fail row (B): execution is success, verdict is fail —
+        // the two never conflate.
+        let b = row_by_pr(entries, PR_B);
+        assert_eq!(b["execution_status"], "success");
+        assert_eq!(b["verdict"], "fail");
+        assert_eq!(b["run_id"], "RUN-B");
+
+        // Queued row (C): no run yet.
+        let c = row_by_pr(entries, PR_C);
+        assert_eq!(c["review_state"], "queued");
+        assert_eq!(c["run_id"], serde_json::Value::Null);
+        assert_eq!(c["execution_status"], serde_json::Value::Null);
+        assert_eq!(c["verdict"], serde_json::Value::Null);
+        assert_eq!(c["publication_state"], "pending");
+    }
+}
+
+#[test]
+fn status_filters_by_repo() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-status-filter-{backend:?}"));
+        seed_standard(&dir, backend);
+        let output = run_cli(&dir, backend, &["review", "status", "Other/Repo", "--json"]);
+        assert_success(&output);
+        let envelope = parse_json(&output);
+        let counts = &envelope["payload"]["counts"];
+        assert_eq!(counts["queued"], 0, "filter must drop the queued row");
+        assert_eq!(counts["done"], 1);
+        let entries = &envelope["payload"]["entries"];
+        assert_eq!(entries.as_array().unwrap().len(), 1);
+        assert_eq!(entries[0]["pr"], PR_B);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_human_renders_table() {
+    let dir = tempdir("review-list");
+    seed_standard(&dir, Backend::Json);
+    let output = run_cli(&dir, Backend::Json, &["review", "list"]);
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for col in [
+        "key",
+        "phase",
+        "attempts",
+        "generation",
+        "verdict",
+        "publication",
+        "run_id",
+    ] {
+        assert!(stdout.contains(col), "missing column {col:?} in {stdout}");
+    }
+    assert!(
+        stdout.contains("owner/repo#42@aaaaaaaaaaaa"),
+        "got {stdout}"
+    );
+    assert!(stdout.contains("new/repo#3@cccccccccccc"), "got {stdout}");
+}
+
+#[test]
+fn list_json_emits_full_rows_for_every_entry() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-list-json-{backend:?}"));
+        seed_standard(&dir, backend);
+        let output = run_cli(&dir, backend, &["review", "list", "--json"]);
+        assert_success(&output);
+        let envelope = parse_json(&output);
+        assert_eq!(envelope["schema"], "review/1.0");
+        assert_eq!(envelope["diagnostic"], serde_json::Value::Null);
+        let entries = envelope["payload"]["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 3);
+        // Every §13 field exists on each row.
+        for row in entries {
+            for field in [
+                "repo",
+                "pr",
+                "base_sha",
+                "head_sha",
+                "merge_base",
+                "review_state",
+                "run_id",
+                "review_generation",
+                "execution_attempts",
+                "execution_status",
+                "verdict",
+                "last_error",
+                "reviewed_at",
+                "publication_state",
+                "publication_attempt_count",
+                "next_publication_attempt",
+            ] {
+                assert!(row.get(field).is_some(), "missing {field} in {row}");
+            }
+        }
+    }
+}
+
+#[test]
+fn empty_store_lists_placeholder() {
+    let dir = tempdir("review-empty");
+    let output = run_cli(&dir, Backend::Json, &["review", "list"]);
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("no entries"), "got {stdout}");
+
+    let output = run_cli(&dir, Backend::Json, &["review", "list", "--json"]);
+    assert_success(&output);
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["payload"]["entries"], serde_json::json!([]));
+}
+
+// ---------------------------------------------------------------------------
+// show
+// ---------------------------------------------------------------------------
+
+#[test]
+fn show_human_prints_full_detail_and_history() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-show-{backend:?}"));
+        seed_standard(&dir, backend);
+        let output = run_cli(&dir, backend, &["review", "show", "Other/Repo", "7"]);
+        assert_success(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("entry other/repo#7@bbbbbbbbbbbb"),
+            "got {stdout}"
+        );
+        for needle in [
+            "base_sha:",
+            "head_sha:",
+            "merge_base:",
+            "phase: done",
+            "run_id: RUN-B",
+            "generation: 1",
+            "execution_status: success",
+            "verdict: fail",
+            "publication_state: published",
+            "publication_attempt_count: 1",
+            "RUN-B",
+            "summary-Fail",
+        ] {
+            assert!(stdout.contains(needle), "missing {needle:?} in {stdout}");
+        }
+    }
+}
+
+#[test]
+fn show_json_includes_history_with_parsed_fields() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-show-json-{backend:?}"));
+        seed_standard(&dir, backend);
+        let output = run_cli(
+            &dir,
+            backend,
+            &["review", "show", "Other/Repo", "7", "--json"],
+        );
+        assert_success(&output);
+        let envelope = parse_json(&output);
+        assert_eq!(envelope["schema"], "review/1.0");
+        let entry = &envelope["payload"]["entry"];
+        assert_eq!(entry["repo"], "other/repo");
+        assert_eq!(entry["pr"], 7);
+        assert_eq!(entry["review_state"], "done");
+        assert_eq!(entry["verdict"], "fail");
+        let history = envelope["payload"]["history"].as_array().unwrap();
+        assert_eq!(history.len(), 1);
+        let row = &history[0];
+        assert_eq!(row["run_id"], "RUN-B");
+        assert_eq!(row["status"], "success");
+        assert_eq!(row["verdict"], "fail");
+        assert_eq!(row["summary"], "summary-Fail");
+        assert_eq!(row["parse_error"], serde_json::Value::Null);
+        assert!(row["result_json"].is_string(), "raw document kept: {row}");
+    }
+}
+
+#[test]
+fn show_surfaces_old_schema_result_json_defensively() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-show-old-{backend:?}"));
+        seed_old_history(&dir, backend);
+        let output = run_cli(
+            &dir,
+            backend,
+            &["review", "show", "Legacy/Repo", "5", "--json"],
+        );
+        assert_success(&output);
+        let envelope = parse_json(&output);
+        let history = envelope["payload"]["history"].as_array().unwrap();
+        assert_eq!(history.len(), 1);
+        let row = &history[0];
+        assert_eq!(row["status"], serde_json::Value::Null);
+        assert_eq!(row["verdict"], serde_json::Value::Null);
+        assert!(
+            row["parse_error"]
+                .as_str()
+                .unwrap()
+                .contains("unsupported schema_version 99"),
+            "got {row}"
+        );
+        let raw_doc: serde_json::Value =
+            serde_json::from_str(row["result_json"].as_str().unwrap()).unwrap();
+        assert_eq!(raw_doc["schema_version"], 99, "raw doc kept: {row}");
+        // The entry row itself still works (state-joined fields).
+        assert_eq!(envelope["payload"]["entry"]["verdict"], "pass");
+    }
+}
+
+#[test]
+fn show_missing_entry_human_path_errors() {
+    let dir = tempdir("review-show-missing");
+    let output = run_cli(&dir, Backend::Json, &["review", "show", "Owner/Repo", "99"]);
+    assert!(!output.status.success(), "expected failure");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("no entry"),
+        "expected 'no entry'; got {combined:?}"
+    );
+}
+
+#[test]
+fn show_missing_entry_json_emits_no_entry_diagnostic() {
+    let dir = tempdir("review-show-missing-json");
+    let output = run_cli(
+        &dir,
+        Backend::Json,
+        &["review", "show", "Owner/Repo", "99", "--json"],
+    );
+    assert!(!output.status.success(), "expected non-zero exit");
+    let envelope = parse_json(&output);
+    assert_eq!(envelope["schema"], "review/1.0");
+    assert_eq!(envelope["diagnostic"], "no_entry");
+    assert_eq!(envelope["payload"], serde_json::Value::Null);
+}
+
+// ---------------------------------------------------------------------------
+// Read-only
+// ---------------------------------------------------------------------------
+
+#[test]
+fn show_does_not_mutate_json_store() {
+    let dir = tempdir("review-show-readonly");
+    seed_standard(&dir, Backend::Json);
+    let before = fs::read(dir.join("review_queue.json")).expect("read queue");
+    let output = run_cli(
+        &dir,
+        Backend::Json,
+        &["review", "show", "Owner/Repo", "42", "--json"],
+    );
+    assert_success(&output);
+    let after = fs::read(dir.join("review_queue.json")).expect("read queue");
+    assert_eq!(before, after, "show must not rewrite review_queue.json");
+    let store = ReviewStore::open(&dir).unwrap();
+    let snap = store.review_queue_snapshot().unwrap();
+    assert_eq!(snap.entries.len(), 3, "entries must survive show");
+}
+
+#[test]
+fn show_does_not_mutate_sqlite_store() {
+    let dir = tempdir("review-show-readonly-sqlite");
+    seed_standard(&dir, Backend::Sqlite);
+    let output = run_cli(
+        &dir,
+        Backend::Sqlite,
+        &["review", "show", "Owner/Repo", "42", "--json"],
+    );
+    assert_success(&output);
+    let store = ReviewStore::open_sqlite(&dir).unwrap();
+    let snap = store.review_queue_snapshot().unwrap();
+    assert_eq!(snap.entries.len(), 3, "entries must survive show");
+}

--- a/tests/daemon/review_discovery_test.rs
+++ b/tests/daemon/review_discovery_test.rs
@@ -28,9 +28,10 @@ use std::sync::Arc;
 
 use caduceus::config::{AutoReviewConfig, Config, LoadContext, RawConfig};
 use caduceus::daemon::tick::review_discovery::{
-    admit_target_for_tests, classify_discovery_row_for_tests, poll_review_step_for_tests,
-    ADMITTED_EVENT, DISCOVERED_EVENT, SKIPPED_ALREADY_COMPLETE_EVENT, SKIPPED_DRAFT_EVENT,
-    STALE_SHA_EVENT,
+    admit_target_for_tests, classify_discovery_row_for_tests, emit_admitted_for_tests,
+    emit_skipped_already_complete_for_tests, emit_skipped_draft_for_tests,
+    emit_stale_sha_for_tests, poll_review_step_for_tests, ADMITTED_EVENT, DISCOVERED_EVENT,
+    SKIPPED_ALREADY_COMPLETE_EVENT, SKIPPED_DRAFT_EVENT, STALE_SHA_EVENT,
 };
 use caduceus::error::CaduceusError;
 use caduceus::github::fork_gate::FORK_SKIP_EVENT;
@@ -366,6 +367,127 @@ fn discovered_event_emits_structured_line() {
     assert!(body.contains("\"repo\":\"o/r\""), "got: {body}");
     assert!(body.contains("\"pr\":7"), "got: {body}");
     assert!(body.contains("\"head_sha\":\"abc\""), "got: {body}");
+}
+
+/// Capture `emit_admitted` (the `review_admitted` transition) through
+/// the same serial + `tracing_appender::non_blocking` discipline.
+#[test]
+#[serial_test::serial]
+fn admitted_event_emits_structured_line() {
+    let root = tempdir("admission-event");
+    let log_path = root.join("admission.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        emit_admitted_for_tests("o/r", 7, "abc");
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        body.contains(&format!("\"event\":\"{ADMITTED_EVENT}\"")),
+        "event name missing: {body}"
+    );
+    assert!(body.contains("\"repo\":\"o/r\""), "got: {body}");
+    assert!(body.contains("\"pr\":7"), "got: {body}");
+    assert!(body.contains("\"head_sha\":\"abc\""), "got: {body}");
+}
+
+/// Capture `emit_skipped_draft` (the `review_skipped_draft` skip
+/// transition).
+#[test]
+#[serial_test::serial]
+fn skipped_draft_event_emits_structured_line() {
+    let root = tempdir("draft-skip-event");
+    let log_path = root.join("draft-skip.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        emit_skipped_draft_for_tests("o/r", 7, "abc");
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        body.contains(&format!("\"event\":\"{SKIPPED_DRAFT_EVENT}\"")),
+        "event name missing: {body}"
+    );
+    assert!(body.contains("\"repo\":\"o/r\""), "got: {body}");
+    assert!(body.contains("\"pr\":7"), "got: {body}");
+    assert!(body.contains("\"head_sha\":\"abc\""), "got: {body}");
+}
+
+/// Capture `emit_skipped_already_complete` (the dedup skip
+/// transition).
+#[test]
+#[serial_test::serial]
+fn skipped_already_complete_event_emits_structured_line() {
+    let root = tempdir("dedup-skip-event");
+    let log_path = root.join("dedup-skip.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        emit_skipped_already_complete_for_tests("o/r", 7, "abc");
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        body.contains(&format!("\"event\":\"{SKIPPED_ALREADY_COMPLETE_EVENT}\"")),
+        "event name missing: {body}"
+    );
+    assert!(body.contains("\"repo\":\"o/r\""), "got: {body}");
+    assert!(body.contains("\"pr\":7"), "got: {body}");
+    assert!(body.contains("\"head_sha\":\"abc\""), "got: {body}");
+}
+
+/// Capture `emit_stale_sha` (the `review_stale_sha_observed` poll
+/// transition), including the held→observed SHA pair.
+#[test]
+#[serial_test::serial]
+fn stale_sha_event_emits_structured_line() {
+    let root = tempdir("stale-sha-event");
+    let log_path = root.join("stale-sha.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("open capture file");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        emit_stale_sha_for_tests("o/r", 7, "prev", "next");
+    });
+    drop(guard);
+
+    let body = std::fs::read_to_string(&log_path).expect("read capture file");
+    assert!(
+        body.contains(&format!("\"event\":\"{STALE_SHA_EVENT}\"")),
+        "event name missing: {body}"
+    );
+    assert!(body.contains("\"repo\":\"o/r\""), "got: {body}");
+    assert!(body.contains("\"pr\":7"), "got: {body}");
+    assert!(body.contains("\"previous_sha\":\"prev\""), "got: {body}");
+    assert!(body.contains("\"observed_sha\":\"next\""), "got: {body}");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/review/finalizer_test.rs
+++ b/tests/review/finalizer_test.rs
@@ -17,6 +17,9 @@
 use caduceus::config::Config;
 use caduceus::github::{Client, HttpCache};
 use caduceus::infra::logging::build_test_subscriber;
+use caduceus::review::finalize::{
+    EVENT_PUBLISHED, EVENT_PUBLISH_FAILED_RETRYABLE, EVENT_PUBLISH_STARTED,
+};
 use caduceus::review::sticky_comment::{render_sticky_comment, RenderInput, REVIEW_MARKER};
 use caduceus::review::{
     backoff_delay, claim_for_publication, finalize_review, DueFinalization, ExecutionStatus,
@@ -657,4 +660,105 @@ fn backoff_schedule_is_exponential_with_one_hour_cap() {
     assert_eq!(backoff_delay(7), chrono::Duration::seconds(3600));
     assert_eq!(backoff_delay(12), chrono::Duration::seconds(3600));
     assert_eq!(backoff_delay(50), chrono::Duration::seconds(3600));
+}
+
+// ---------------------------------------------------------------------------
+// DAR §13 publish-event capture (issue #318: per-transition emission
+// tests). Serial discipline: tracing callsite interest is cached
+// process-wide; the subscriber is installed for the current thread
+// only, and the #[tokio::test] runtime drives the future on it.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn publish_started_and_published_emit_on_happy_path() {
+    let gh = MockGitHub::start().await;
+    mount_publish_open(&gh, 777).await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, dir) = seeded_store("fin-publish-event", 1, PublicationState::Pending);
+
+    let capture = dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        finalize_review(&client, &cfg, &store, &due(1), now())
+            .await
+            .expect("finalize succeeds")
+    };
+    drop(appender_guard);
+
+    assert_eq!(outcome, FinalizeOutcome::Published);
+
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    // The publish transition emits started → published.
+    for expected in [EVENT_PUBLISH_STARTED, EVENT_PUBLISHED] {
+        assert!(body.contains(expected), "missing {expected}: {body}");
+    }
+    assert!(
+        !body.contains(EVENT_PUBLISH_FAILED_RETRYABLE),
+        "retryable-failure leaked into the published path: {body}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn publish_failed_retryable_emits_on_github_failure() {
+    let gh = MockGitHub::start().await;
+    gh.mount(
+        "GET",
+        &format!("/repos/{OWNER}/{REPO}/pulls/{PR}"),
+        serde_json::json!({ "state": "open", "merged": false }),
+    )
+    .await;
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([])],
+    )
+    .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        503,
+        serde_json::json!({ "message": "unavailable" }),
+    )
+    .await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, dir) = seeded_store("fin-fail-event", 1, PublicationState::Pending);
+
+    let capture = dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        finalize_review(&client, &cfg, &store, &due(1), now())
+            .await
+            .expect("finalize succeeds")
+    };
+    drop(appender_guard);
+
+    assert!(matches!(outcome, FinalizeOutcome::FailedRetryable { .. }));
+
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    // The retryable-failure transition emits started →
+    // publish_failed_retryable; the comment was never published.
+    for expected in [EVENT_PUBLISH_STARTED, EVENT_PUBLISH_FAILED_RETRYABLE] {
+        assert!(body.contains(expected), "missing {expected}: {body}");
+    }
+    assert!(
+        !body.contains(EVENT_PUBLISHED),
+        "published leaked into the failed path: {body}"
+    );
 }

--- a/tests/runtime/review_event_catalog_test.rs
+++ b/tests/runtime/review_event_catalog_test.rs
@@ -1,0 +1,83 @@
+//! AC1 (issue #318): every DAR §13 review event name is asserted to
+//! equal its catalog literal exactly.
+//!
+//! The test reads the producing sites' `pub const … : &str` values
+//! through the single `caduceus::runtime::audit::review_events` seam —
+//! NOT a re-declared list — so a drift between the const value and
+//! the §13 catalog is caught at compile/test time, not at log time.
+//! AC3 (the verdict/execution distinctness rule) is asserted here too.
+
+use caduceus::runtime::audit::review_events::{
+    ADMITTED_EVENT, DISCOVERED_EVENT, EVENT_PUBLISHED, EVENT_PUBLISH_FAILED_RETRYABLE,
+    EVENT_PUBLISH_STARTED, EVENT_SUPPRESSED_STALE_GENERATION, FORK_SKIP_EVENT,
+    MUTATION_VIOLATION_EVENT, OVERSIZED_PR_EVENT, REVIEW_EXECUTION_FAILED_EVENT,
+    REVIEW_FAILED_VERDICT_EVENT, REVIEW_MIGRATION_TERMINATED_INVESTIGATION_EVENT,
+    REVIEW_PASSED_EVENT, REVIEW_RETRY_SCHEDULED_EVENT, REVIEW_SKIPPED_HEAD_SHA_UNAVAILABLE_EVENT,
+    REVIEW_SKIPPED_PR_GONE_EVENT, REVIEW_STARTED_EVENT, REVIEW_WORKER_COMPLETED_EVENT,
+    SKIPPED_ALREADY_COMPLETE_EVENT, SKIPPED_DRAFT_EVENT, STALE_SHA_EVENT,
+};
+
+#[test]
+fn dar_section_13_catalog_names_match_exactly() {
+    // The §13 catalog block (docs/architecture/auto-review.md lines
+    // 592–605), one assert per line so a failure names the offending
+    // event. Order matches the catalog listing.
+    assert_eq!(DISCOVERED_EVENT, "review_discovered");
+    assert_eq!(
+        SKIPPED_ALREADY_COMPLETE_EVENT,
+        "review_skipped_already_complete"
+    );
+    assert_eq!(SKIPPED_DRAFT_EVENT, "review_skipped_draft");
+    assert_eq!(FORK_SKIP_EVENT, "review_skipped_fork_unsupported");
+    assert_eq!(ADMITTED_EVENT, "review_admitted");
+    assert_eq!(REVIEW_STARTED_EVENT, "review_started");
+    assert_eq!(REVIEW_WORKER_COMPLETED_EVENT, "review_worker_completed");
+    assert_eq!(REVIEW_RETRY_SCHEDULED_EVENT, "review_retry_scheduled");
+    assert_eq!(REVIEW_EXECUTION_FAILED_EVENT, "review_execution_failed");
+    assert_eq!(REVIEW_PASSED_EVENT, "review_passed");
+    assert_eq!(REVIEW_FAILED_VERDICT_EVENT, "review_failed_verdict");
+    assert_eq!(MUTATION_VIOLATION_EVENT, "review_mutation_violation");
+    assert_eq!(
+        REVIEW_SKIPPED_HEAD_SHA_UNAVAILABLE_EVENT,
+        "review_skipped_head_sha_unavailable"
+    );
+    assert_eq!(REVIEW_SKIPPED_PR_GONE_EVENT, "review_skipped_pr_gone");
+    assert_eq!(OVERSIZED_PR_EVENT, "review_skipped_oversized_pr");
+    assert_eq!(EVENT_PUBLISH_STARTED, "review_publish_started");
+    assert_eq!(EVENT_PUBLISHED, "review_published");
+    assert_eq!(
+        EVENT_PUBLISH_FAILED_RETRYABLE,
+        "review_publish_failed_retryable"
+    );
+    assert_eq!(
+        EVENT_SUPPRESSED_STALE_GENERATION,
+        "review_publication_suppressed_stale_generation"
+    );
+    assert_eq!(STALE_SHA_EVENT, "review_stale_sha_observed");
+    assert_eq!(
+        REVIEW_MIGRATION_TERMINATED_INVESTIGATION_EVENT,
+        "review_migration_terminated_investigation"
+    );
+}
+
+#[test]
+fn verdict_fail_and_execution_failed_are_distinct_strings() {
+    // AC3: the two names must never be conflatable.
+    assert_ne!(REVIEW_FAILED_VERDICT_EVENT, REVIEW_EXECUTION_FAILED_EVENT);
+    // Reinforce the deliberate word choice.
+    assert!(REVIEW_FAILED_VERDICT_EVENT.contains("verdict"));
+    assert!(REVIEW_EXECUTION_FAILED_EVENT.contains("execution"));
+}
+
+/// The out-of-catalog §9.3 event is NOT part of the §13 catalog and
+/// must not be asserted there; pin the boundary so a future edit
+/// cannot quietly fold it in.
+#[test]
+fn skipped_pr_closed_unmerged_is_not_in_the_catalog_seam() {
+    // `review_skipped_pr_closed_unmerged` lives only at its producing
+    // site (finalize.rs) and is a §9.3 event, not a §13 catalog name.
+    assert_eq!(
+        caduceus::review::finalize::EVENT_SKIPPED_PR_CLOSED_UNMERGED,
+        "review_skipped_pr_closed_unmerged"
+    );
+}

--- a/tests/tick/review_claim_dispatch_test.rs
+++ b/tests/tick/review_claim_dispatch_test.rs
@@ -26,9 +26,14 @@ use std::process::Command;
 use std::sync::Arc;
 
 use caduceus::config::{AutoReviewConfig, Config};
+use caduceus::daemon::tick::per_review::{
+    REVIEW_EXECUTION_FAILED_EVENT, REVIEW_FAILED_VERDICT_EVENT, REVIEW_PASSED_EVENT,
+    REVIEW_RETRY_SCHEDULED_EVENT, REVIEW_STARTED_EVENT, REVIEW_WORKER_COMPLETED_EVENT,
+};
 use caduceus::error::{CaduceusError, CaduceusResult};
 use caduceus::executor::{Executor, ExecutorOutcome, ExecutorSpec};
 use caduceus::github::{Client, HttpCache};
+use caduceus::infra::logging::build_test_subscriber;
 use caduceus::meta::TickOutcome;
 use caduceus::orchestration::{
     GitRunnerAdapter, GithubClientAdapter, ReviewRunGuard, Services, SystemClock,
@@ -451,6 +456,7 @@ fn fresh_remote(label: &str) -> (PathBuf, String, String, String) {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+#[serial_test::serial]
 async fn happy_pass_completes_done_with_history() {
     let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-pass-git");
     let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
@@ -494,6 +500,7 @@ async fn happy_pass_completes_done_with_history() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn happy_fail_verdict_completes_done_with_history() {
     let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-fail-git");
     let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
@@ -532,6 +539,7 @@ async fn happy_fail_verdict_completes_done_with_history() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn oci_result_path_variant_reads_mode_correct_path() {
     let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-oci-git");
     let state_dir =
@@ -576,6 +584,7 @@ async fn oci_result_path_variant_reads_mode_correct_path() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+#[serial_test::serial]
 async fn missing_result_retries_with_budget() {
     let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-missing-git");
     let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
@@ -617,6 +626,7 @@ async fn missing_result_retries_with_budget() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn invalid_result_retries_with_budget() {
     let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-invalid-git");
     let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
@@ -652,6 +662,7 @@ async fn invalid_result_retries_with_budget() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+#[serial_test::serial]
 async fn mutation_is_terminal_and_worktree_kept() {
     let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-mutation-git");
     let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
@@ -709,6 +720,7 @@ async fn mutation_is_terminal_and_worktree_kept() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+#[serial_test::serial]
 async fn head_sha_unavailable_is_quiet_skip() {
     // The PR row is open and reachable, but the seeded head SHA is
     // NOT in the mirror/remote (force-push + GC): the SHA-anchored
@@ -739,6 +751,7 @@ async fn head_sha_unavailable_is_quiet_skip() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn oversized_diff_is_direct_skip() {
     // The remote's head commit carries a >1 MiB file, so the
     // merge-base diff exceeds the review budget: deterministically
@@ -775,6 +788,207 @@ async fn oversized_diff_is_direct_skip() {
             .unwrap_or_default()
             .contains("oversized"),
         "skip reason must record the oversized diff"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DAR §13 dispatch-event capture (issue #318: per-transition emission
+// tests). AC3's never-interchange is enforced at PATH level here: each
+// capture asserts the transition's own event is present AND the other
+// verdict/execution event is absent, so a future swap of the two emit
+// sites cannot pass silently.
+//
+// EVERY test in this binary that runs `run_review_claim` is serial
+// (the #167 finding): `tracing_core` caches callsite interest
+// process-wide, and a sibling running the same event callsites without
+// a subscriber installed would register them as never-enabled and
+// silently drop the capture (same discipline as
+// orchestration_active_run_inline_test.rs:723-735).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn happy_pass_captures_dispatch_events() {
+    let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-pass-event-git");
+    let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
+        f: move |spec: &ExecutorSpec| {
+            let result_path = spec.worktree.join("worker-result.json");
+            std::fs::write(&result_path, result_json_pass().to_string()).expect("write result");
+            ok_outcome(result_path)
+        },
+    });
+    let fixture = claim_fixture(
+        "claim-pass-event",
+        remote_dir,
+        base_sha,
+        head_sha.clone(),
+        pr_row_open(&head_sha),
+    )
+    .await;
+    let mut guard = fixture.new_guard();
+
+    let capture = fixture.cfg.state_dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        run_claim_for(&fixture, &mut guard, mock)
+            .await
+            .expect("claim runs")
+    };
+    drop(appender_guard);
+
+    assert_eq!(outcome, TickOutcome::Processed);
+    assert_eq!(queue_entry(&fixture.store).phase, ReviewPhase::Done);
+
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    // The pass transition emits started → worker_completed → passed.
+    for expected in [
+        REVIEW_STARTED_EVENT,
+        REVIEW_WORKER_COMPLETED_EVENT,
+        REVIEW_PASSED_EVENT,
+    ] {
+        assert!(body.contains(expected), "missing {expected}: {body}");
+    }
+    // AC3: the verdict and execution-failure events never leak into
+    // the pass path.
+    for absent in [REVIEW_FAILED_VERDICT_EVENT, REVIEW_EXECUTION_FAILED_EVENT] {
+        assert!(!body.contains(absent), "unexpected {absent}: {body}");
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn happy_fail_verdict_captures_verdict_not_execution_failed() {
+    let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-fail-event-git");
+    let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
+        f: move |spec: &ExecutorSpec| {
+            let result_path = spec.worktree.join("worker-result.json");
+            std::fs::write(&result_path, result_json_fail().to_string()).expect("write result");
+            ok_outcome(result_path)
+        },
+    });
+    let fixture = claim_fixture(
+        "claim-fail-event",
+        remote_dir,
+        base_sha,
+        head_sha.clone(),
+        pr_row_open(&head_sha),
+    )
+    .await;
+    let mut guard = fixture.new_guard();
+
+    let capture = fixture.cfg.state_dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        run_claim_for(&fixture, &mut guard, mock)
+            .await
+            .expect("claim runs")
+    };
+    drop(appender_guard);
+
+    assert_eq!(outcome, TickOutcome::Processed);
+    assert_eq!(queue_entry(&fixture.store).phase, ReviewPhase::Done);
+
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    // The fail-verdict transition emits started → worker_completed →
+    // failed_verdict (execution succeeded; only the verdict is Fail).
+    for expected in [
+        REVIEW_STARTED_EVENT,
+        REVIEW_WORKER_COMPLETED_EVENT,
+        REVIEW_FAILED_VERDICT_EVENT,
+    ] {
+        assert!(body.contains(expected), "missing {expected}: {body}");
+    }
+    // AC3: `review_failed_verdict` must NEVER be interchangeable with
+    // `review_execution_failed` — a valid run that fails the code is
+    // not an execution failure.
+    assert!(
+        !body.contains(REVIEW_EXECUTION_FAILED_EVENT),
+        "execution-failed leaked into the fail-verdict path: {body}"
+    );
+    assert!(
+        !body.contains(REVIEW_PASSED_EVENT),
+        "pass leaked into the fail-verdict path: {body}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn execution_failed_and_retry_scheduled_capture_on_retry() {
+    let (remote_dir, base_sha, _mid, head_sha) = fresh_remote("claim-retry-event-git");
+    let mock: Arc<dyn Executor> = Arc::new(MockExecutor {
+        f: move |_spec: &ExecutorSpec| {
+            // No result file: an execution failure through the retry
+            // budget (DAR §6.2), NOT a failed verdict.
+            ok_outcome(PathBuf::from("/dev/null/does-not-exist.result.json"))
+        },
+    });
+    let fixture = claim_fixture(
+        "claim-retry-event",
+        remote_dir,
+        base_sha,
+        head_sha.clone(),
+        pr_row_open(&head_sha),
+    )
+    .await;
+    let mut guard = fixture.new_guard();
+
+    let capture = fixture.cfg.state_dir.join("events.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&capture)
+        .expect("open capture file");
+    let (writer, appender_guard) = tracing_appender::non_blocking(file);
+    let subscriber = build_test_subscriber(writer);
+
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        run_claim_for(&fixture, &mut guard, mock)
+            .await
+            .expect("claim runs")
+    };
+    drop(appender_guard);
+
+    assert_eq!(outcome, TickOutcome::Processed);
+    let entry = queue_entry(&fixture.store);
+    assert_eq!(entry.phase, ReviewPhase::Queued);
+    assert_eq!(entry.attempts, 1);
+
+    let body = std::fs::read_to_string(&capture).expect("read capture file");
+    // The retry route emits started → execution_failed →
+    // retry_scheduled.
+    for expected in [
+        REVIEW_STARTED_EVENT,
+        REVIEW_EXECUTION_FAILED_EVENT,
+        REVIEW_RETRY_SCHEDULED_EVENT,
+    ] {
+        assert!(body.contains(expected), "missing {expected}: {body}");
+    }
+    // AC3: an execution failure is NOT a failed verdict, and no
+    // terminal verdict was produced.
+    assert!(
+        !body.contains(REVIEW_FAILED_VERDICT_EVENT),
+        "failed-verdict leaked into the execution-failed path: {body}"
+    );
+    assert!(
+        !body.contains(REVIEW_PASSED_EVENT),
+        "pass leaked into the execution-failed path: {body}"
     );
 }
 


### PR DESCRIPTION
## What

Adds review observability per issue #318 / DAR §13:

- **`caduceus review status [<owner/repo>] [--json]`** — aggregate review
  queue phase counts plus one line per entry, with an optional repo filter.
- **`caduceus review list [--json]`** — every review queue entry as a table.
- **`caduceus review show <owner/repo> <pr> [--json]`** — full detail plus
  run history for one PR.

The three subcommands read BOTH state backends (they branch on
`state_backend == "sqlite"` like the daemon, not like the JSON-only `queue`
CLI), never take the daemon lock, and never write state. `--json` emits the
versioned `review/1.0` envelope with the full §13 per-row field set (repo,
PR, base SHA, head SHA, merge base, review state, run id, review
generation, execution attempts, execution status, verdict, last error,
reviewed-at, publication state, publication attempt count, next
publication attempt). `show` parses history `result_json` documents
defensively: current schema versions surface parsed fields; older versions
surface raw with a `parse_error` and are never back-migrated (DAR §4.3).

## Event catalog

All 21 DAR §13 event names were verified to already exist and emit at
their producing transitions (mapping table in the architect plan). AC1's
"names verified by unit test" is `tests/runtime/review_event_catalog_test.rs`,
which reads the producing sites' `pub const … : &str` values through the
single `caduceus::runtime::audit::review_events` seam and asserts each
equals the §13 literal. AC3 (`review_failed_verdict` vs
`review_execution_failed`) is asserted distinct there and kept separate in
the CLI (`execution status` derives from `ReviewResult.status`; `verdict`
holds the outcome).

## Tests

- `tests/runtime/review_event_catalog_test.rs` — AC1/AC3 name assertions.
- `tests/cli/review_cli_test.rs` — 25 subprocess smoke tests over both
  backends (status/list/show, JSON envelope, defensive old-schema parsing,
  missing-entry diagnostics, read-only).
- Full gate green: fmt, clippy `-D warnings`, 192 test binaries, 200 pytest.

## Docs

`docs/cli.md` (CLI reference), `docs/architecture/auto-review.md` §13 note,
`skills/caduceus/SKILL.md` (operator doc), `CHANGELOG.md`.

Closes #318