### PR TITLE
test(review): add E2E PR lifecycle integration test (closes #322)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -480,6 +480,10 @@ name = "out_of_order_test"
 path = "tests/review/out_of_order_test.rs"
 
 [[test]]
+name = "lifecycle_test"
+path = "tests/review/lifecycle_test.rs"
+
+[[test]]
 name = "terminal_paths_test"
 path = "tests/review/terminal_paths_test.rs"
 

--- a/docs/testing/e2e-lifecycle.md
+++ b/docs/testing/e2e-lifecycle.md
@@ -1,0 +1,137 @@
+# E2E PR lifecycle test (issue #322)
+
+`tests/review/lifecycle_test.rs` is the end-to-end PR review lifecycle
+test: ONE full lifecycle with **no stubs**, running on BOTH state
+backends. It closes the DAR §15 "End-to-end" row.
+
+## What the test proves
+
+The full pipeline, driven through the real production code paths:
+
+1. **Discovery** admits an eligible PR (`owner/r#7`, head `B`) and
+   assigns generation 1.
+2. **Claim + dispatch** runs the REAL `review_harness.py` worker as a
+   REAL subprocess under the REAL `caduceus __worker-supervisor`
+   supervision protocol; the worker reads the REAL prompt the daemon
+   rendered, asserts the DAR §7 section order, and writes the REAL
+   result file (`<worktree>/worker-result.json`). The verdict is
+   scripted FAIL.
+3. **Finalizer** publishes the FAIL verdict as the sticky comment
+   (exactly one `POST`).
+4. **Head moves** (wire row force-push `B → C`): discovery observes a
+   stale SHA and admits generation 2.
+5. **Re-review** runs the harness again (scripted PASS) and the
+   finalizer **updates the SAME comment** (one `PATCH`, no second
+   `POST`).
+
+Asserted (acceptance criteria from issue #322):
+
+- Lifecycle green end-to-end with no stubs on JSON **and** SQLite.
+- Exactly one sticky comment across both revisions (`sticky_comment_id`
+  unchanged); `review_history` holds two rows with distinct run ids.
+- Same-SHA re-poll produces zero new admissions
+  (`review_skipped_already_complete`); publish-failure resume publishes
+  the same durable result WITHOUT re-running the worker.
+
+Also covered:
+
+- **Out-of-order completion** (DAR §9.4): generation 2 completes before
+  generation 1. The sticky comment shows the newer result; the older
+  result persists in history only, and a stale `DueFinalization` is
+  suppressed with `review_publication_suppressed_stale_generation`.
+- **Publish-failure resume** (DAR §9.1): a GitHub 500 during
+  publication leaves the row at `FailedRetryable` with persisted
+  backoff; the resume publishes without a model re-run.
+
+## Harness design (no stubs)
+
+The only controlled fake is the GitHub API (wiremock `MockGitHub`).
+Everything else runs for real:
+
+| Component | Implementation |
+|---|---|
+| GitHub API | wiremock (`tests/fixtures/github.rs`) |
+| Git origin | real local bare remote (`file://`), real commits, real merge-base |
+| Daemon dispatch | `run_review_claim_for_tests` (`per_review.rs`), real mirror/worktree/diff/prompt/digest code |
+| Executor | the REAL `supervise()` production function re-execing the REAL `caduceus` binary (`ReleaseBinary::locate()`) in `__worker-supervisor` mode |
+| Worker | the REAL `tests/fixtures/review_harness.py` as a subprocess |
+| Finalizer | `poll_publication_step_for_tests` / `finalize_review` (`review_finalize_step.rs`, `finalize.rs`) |
+| Store | `ReviewStore::open` (JSON) / `ReviewStore::open_sqlite` (SQLite) |
+
+### Why the executor deviates from `Services::production`
+
+`run_review_claim` pins the supervisor's `self_exe` to
+`std::env::current_exe()`. Inside a test binary that is the libtest
+harness, which does not implement the hidden `__worker-supervisor`
+command. The harness therefore implements `Executor` with the same body
+as `TrustedHostExecutor` but passes `ReleaseBinary::locate()` — the
+same `caduceus` binary production re-execs — as `self_exe`. The
+supervisor subprocess, the framed control protocol, the sanitized
+worker env, and the worker subprocess are all the real production
+machinery.
+
+### Why `FAKE_REVIEW_RESULT` rides the worker argv
+
+The production supervisor builds the worker environment with an EMPTY
+allowlist (`src/main.rs` `run_supervisor_mode`), so a
+`worker_env_allowlist` entry is dropped by `env_clear()`. The harness
+therefore selects the scripted result through the worker command:
+
+```toml
+worker_command = ["env", "FAKE_REVIEW_RESULT=fail", "python3", "<abs>tests/fixtures/review_harness.py"]
+```
+
+`/usr/bin/env` survives the sanitized environment (PATH is a default
+allowlist entry) and injects the selector for the harness's own
+process. The harness still runs as a real subprocess and still asserts
+the real prompt's §1–§6 order and schema version before writing the
+real result file.
+
+### Why the wire SHAs are real commits
+
+The #327 wire fixtures (`tests/fixtures/pr/open.json`,
+`force-pushed.json`) carry literal SHAs (`bbbb2222…`, `cccc3333…`)
+that do not exist in the local remote. The harness builds the bare
+remote FIRST, then injects the real commit SHAs (`base`/`mid`/`tip`)
+into the wire rows, so admission's SHA-anchored fetches and
+`git merge-base` work against the real mirror.
+
+### Re-mount semantics
+
+wiremock serves the first matching mount when priorities tie. The
+force-push re-mount therefore uses wiremock priority `1`
+(`mount_status_priority`, added to `tests/fixtures/github.rs`) so the
+newer `/pulls` body beats the original default-priority mount. The
+publish-failure recovery mount uses the same priority mechanism.
+
+## Test list
+
+| Test | Backends | Coverage |
+|---|---|---|
+| `lifecycle_json` / `lifecycle_sqlite` | one each | AC1 + AC2 full FAIL→PASS lifecycle |
+| `lifecycle_out_of_order` | both | DAR §9.4 B-before-A suppression |
+| `lifecycle_same_sha_repoll` | both | AC3 part 1: zero new admissions |
+| `lifecycle_publish_failure_resume` | both | AC3 part 2: no model re-run |
+
+## Running the test
+
+The harness re-execs the real `caduceus` binary, so the binary must be
+built first:
+
+```bash
+cargo build --bins
+cargo test --test lifecycle_test
+```
+
+All lifecycle tests are `#[serial_test::serial]` (wiremock + the local
+git remote do not parallelize cleanly). In CI the full gate
+(`cargo test --locked --all-targets`) builds the binary and runs this
+suite as part of `--all-targets`.
+
+## Files
+
+- `tests/review/lifecycle_test.rs` — the test binary (deliverable).
+- `tests/review/lifecycle_harness.rs` — the shared harness module.
+- `tests/fixtures/github.rs` — `mount_status_priority` helper (the
+  only shared-fixture change).
+- `Cargo.toml` — the `lifecycle_test` `[[test]]` entry.

--- a/tests/fixtures/github.rs
+++ b/tests/fixtures/github.rs
@@ -246,6 +246,37 @@ impl MockGitHub {
             .await;
     }
 
+    /// Same as [`mount_status`] but pins the wiremock priority.
+    /// `1` is the highest priority and beats the default `5`, so a
+    /// later mount with priority `1` takes precedence over an earlier
+    /// default mount for the same matcher (wiremock falls back to
+    /// insertion order only when priorities tie). The response still
+    /// flows through the shared `CountingResponder`, so `counts()` and
+    /// `received_requests()` stay accurate.
+    pub async fn mount_status_priority<B>(
+        &self,
+        method: &str,
+        path_pattern: &str,
+        status: u16,
+        priority: u8,
+        body: B,
+    ) where
+        B: Serialize,
+    {
+        let counted = CountingResponder {
+            counts: Arc::clone(&self.counts),
+            log: Arc::clone(&self.log),
+            method_label: method.to_string(),
+            inner: ResponseTemplate::new(status).set_body_json(body),
+        };
+        Mock::given(wiremock::matchers::method(method))
+            .and(wiremock::matchers::path(path_pattern))
+            .respond_with(counted)
+            .with_priority(priority)
+            .mount(&self.inner)
+            .await;
+    }
+
     /// Escape hatch: build a fully custom `Mock` and mount it
     /// directly. Useful when a test needs request-body matchers,
     /// conditional state, or a non-standard response shape that

--- a/tests/review/lifecycle_harness.rs
+++ b/tests/review/lifecycle_harness.rs
@@ -1,0 +1,632 @@
+//! Shared harness for the E2E PR lifecycle test (issue #322, DAR §15
+//! "End-to-end" row).
+//!
+//! No-stub harness (plan D1): a wiremock fake GitHub API, a real local
+//! bare git remote, the real daemon dispatch/finalizer/store code, and
+//! the REAL `review_harness.py` worker running as a real subprocess
+//! under the REAL `caduceus __worker-supervisor` supervision protocol.
+//!
+//! The only deviation from `Services::production` is the executor's
+//! `self_exe`: `run_review_claim` pins `self_exe = current_exe()`,
+//! which in a test binary is the libtest harness (it does not
+//! implement the hidden `__worker-supervisor` command). This harness
+//! therefore drives the real `supervise()` production function with
+//! `ReleaseBinary::locate()` (the real `caduceus` binary) as
+//! `self_exe` — the same binary production re-execs — so the
+//! supervisor subprocess, the sanitized worker env, and the
+//! `review_harness.py` subprocess all run for real.
+//!
+//! `FAKE_REVIEW_RESULT` is delivered to the harness via the worker
+//! command argv (`env FAKE_REVIEW_RESULT=<kind> python3 ...`): the
+//! production supervisor builds the worker env with an EMPTY
+//! allowlist (`src/main.rs` `run_supervisor_mode`), so a
+//! `worker_env_allowlist` entry would be dropped by `env_clear()`.
+//! The `env` argv is not a stub — `review_harness.py` still runs as a
+//! real subprocess and still asserts the real prompt's §1–§6 order
+//! and schema version before writing the real result file.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+
+use caduceus::config::{AutoReviewConfig, Config};
+use caduceus::executor::{Executor, ExecutorOutcome, ExecutorSpec};
+use caduceus::github::{Client, HttpCache};
+use caduceus::meta::TickOutcome;
+use caduceus::orchestration::{
+    GitRunnerAdapter, GithubClientAdapter, ReviewRunGuard, Services, SystemClock,
+};
+use caduceus::review::{RepositoryId, ReviewTarget};
+use caduceus::scheduler::{DrainConfig, Pool};
+use caduceus::state::review::ReviewStore;
+use caduceus::worktree::GitRunner;
+use tokio_util::sync::CancellationToken;
+
+use crate::fixtures::{tempdir, MockGitHub, ReleaseBinary};
+
+/// The PR number every wire row uses (mirrors the #327 fixtures).
+pub const PR: u64 = 7;
+/// The sticky comment id the mock returns for a successful create.
+pub const STICKY_COMMENT_ID: u64 = 4242;
+
+/// State backend the harness opens.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Backend {
+    Json,
+    Sqlite,
+}
+
+impl Backend {
+    fn label(self, name: &str) -> String {
+        match self {
+            Backend::Json => format!("{name}-json"),
+            Backend::Sqlite => format!("{name}-sqlite"),
+        }
+    }
+
+    fn state_backend(self) -> &'static str {
+        match self {
+            Backend::Json => "json",
+            Backend::Sqlite => "sqlite",
+        }
+    }
+}
+
+/// Bare remote with `main` (A), `feature` (B → C). Returns
+/// `(A, B, C)`; commits use empty trees (mirror of
+/// `review_discovery_test.rs`). B and C are both reachable from
+/// `refs/heads/feature`, so the SHA-anchored fetches inside admission
+/// and `ReviewWorktree::create_review` succeed against the `file://`
+/// remote.
+fn init_bare_remote_with_feature(path: &std::path::Path) -> (String, String, String) {
+    let run = |cmd: &mut Command| {
+        let output = cmd.output().expect("spawn command");
+        assert!(
+            output.status.success(),
+            "command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run(Command::new("git").arg("init").arg("--bare").arg(path));
+    run(Command::new("git")
+        .current_dir(path)
+        .args(["symbolic-ref", "HEAD", "refs/heads/main"]));
+    let tree = {
+        let output = Command::new("git")
+            .current_dir(path)
+            .args(["hash-object", "-w", "-t", "tree", "/dev/null"])
+            .output()
+            .expect("hash-object");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    let commit = |message: &str, parent: Option<&str>| -> String {
+        let mut args = vec!["commit-tree".to_string(), tree.clone()];
+        if let Some(p) = parent {
+            args.push("-p".to_string());
+            args.push(p.to_string());
+        }
+        args.push("-m".to_string());
+        args.push(message.to_string());
+        let output = Command::new("git")
+            .current_dir(path)
+            .args(&args)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@example.com")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@example.com")
+            .output()
+            .expect("commit-tree");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    let commit_a = commit("base", None);
+    run(Command::new("git")
+        .current_dir(path)
+        .args(["update-ref", "refs/heads/main", &commit_a]));
+    let commit_b = commit("feature", Some(&commit_a));
+    let commit_c = commit("feature tip", Some(&commit_b));
+    run(Command::new("git").current_dir(path).args([
+        "update-ref",
+        "refs/heads/feature",
+        &commit_c,
+    ]));
+    (commit_a, commit_b, commit_c)
+}
+
+/// A `/pulls` row (also served as the single-PR fetch row) whose
+/// SHAs are the REAL commits of the local remote — never the literal
+/// fixture SHAs (`bbbb2222…`, `cccc3333…`), which do not exist in the
+/// remote (plan R3).
+fn pr_wire_row(base_sha: &str, head_sha: &str) -> serde_json::Value {
+    serde_json::json!({
+        "number": PR,
+        "title": "E2E lifecycle PR",
+        "body": "Lifecycle fixture for issue #322.",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "merged_at": null,
+        "user": { "login": "octocat" },
+        "base": { "ref": "main", "sha": base_sha, "repo": { "full_name": "owner/r" } },
+        "head": { "ref": "feature-x", "sha": head_sha, "repo": { "full_name": "owner/r" } }
+    })
+}
+
+/// Executor that runs the REAL `supervise()` production supervisor
+/// with the REAL `caduceus` binary as `self_exe` (see module docs).
+struct SupervisorExecutor {
+    self_exe: PathBuf,
+    cfg: Config,
+}
+
+impl Executor for SupervisorExecutor {
+    fn run<'a>(
+        &'a self,
+        spec: &'a ExecutorSpec,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = caduceus::error::CaduceusResult<ExecutorOutcome>>
+                + Send
+                + 'a,
+        >,
+    > {
+        let self_exe = self.self_exe.clone();
+        let cfg = self.cfg.clone();
+        let spec = spec.clone();
+        Box::pin(async move {
+            let outcome = caduceus::worker::supervisor::supervise(
+                &self_exe,
+                &cfg,
+                &spec.target,
+                &spec.worktree,
+                &spec.run_id,
+                &spec.context_json,
+                &spec.worker_command,
+                spec.cancellation.clone(),
+            )
+            .await?;
+            Ok(ExecutorOutcome {
+                outcome,
+                result_path: spec
+                    .worktree
+                    .join(caduceus::worker::worker_contract::WORKER_RESULT_FILE),
+            })
+        })
+    }
+}
+
+/// The E2E lifecycle harness: wiremock GitHub + real local bare
+/// remote + real store + real supervisor-backed executor, per
+/// backend.
+pub struct LifecycleHarness {
+    /// Scratch root (tempdir) — kept for the harness lifetime.
+    pub _root: PathBuf,
+    pub gh: MockGitHub,
+    pub cfg: Config,
+    pub store: Arc<ReviewStore>,
+    pub client: Arc<Client>,
+    pub runner: GitRunner,
+    pub services: Services,
+    pub remote_dir: PathBuf,
+    /// Real fixture SHAs: base (A, on main), mid (B, feature~1 — the
+    /// FAIL revision head), tip (C, the feature tip — the PASS
+    /// revision head).
+    pub base_sha: String,
+    pub mid_sha: String,
+    pub tip_sha: String,
+    pub harness_py: PathBuf,
+}
+
+impl LifecycleHarness {
+    /// Build the harness for one backend.
+    pub async fn start(label: &str, backend: Backend) -> Self {
+        let root = tempdir(&backend.label(label));
+        let gh = MockGitHub::start().await;
+
+        let remote_dir = root.join("origin.git");
+        let (base_sha, mid_sha, tip_sha) = init_bare_remote_with_feature(&remote_dir);
+
+        let harness_py = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/review_harness.py");
+        assert!(
+            harness_py.is_file(),
+            "review harness must exist at {}",
+            harness_py.display()
+        );
+
+        let mut cfg = Config::test_defaults(&root);
+        cfg.api_base = gh.uri();
+        cfg.watched_repos = vec!["owner/r".to_string()];
+        cfg.auto_review = Some(AutoReviewConfig {
+            enabled: true,
+            draft_pull_requests: false,
+        });
+        cfg.state_backend = backend.state_backend().to_string();
+        cfg.repo_storage_root = root.join("repos");
+        cfg.git_timeout_seconds = 30;
+        // Documented intent only: the real supervisor builds the
+        // worker env with an empty allowlist (main.rs), so the harness
+        // actually receives FAKE_REVIEW_RESULT via the worker argv
+        // (see `worker_cfg`).
+        cfg.worker_env_allowlist = vec!["FAKE_REVIEW_RESULT".to_string()];
+        cfg.worker_command = worker_command("pass", &harness_py);
+
+        let store = Arc::new(match backend {
+            Backend::Json => ReviewStore::open(&cfg.state_dir).expect("review store opens (json)"),
+            Backend::Sqlite => {
+                ReviewStore::open_sqlite(&cfg.state_dir).expect("review store opens (sqlite)")
+            }
+        });
+
+        let cache = HttpCache::open(&cfg.state_dir).expect("http cache opens");
+        let client = Arc::new(Client::with_cache(&cfg, cache).expect("client builds"));
+
+        let runner = GitRunner::new(&cfg);
+        let pool = Arc::new(
+            Pool::new(
+                cfg.worker_parallelism,
+                DrainConfig::from_seconds_and_ms(
+                    cfg.drain_timeout_seconds,
+                    cfg.backpressure_budget_ms,
+                ),
+            )
+            .with_lease_store_dir(
+                cfg.state_dir.clone(),
+                std::time::Duration::from_secs(cfg.worker_lease_ttl_seconds),
+            ),
+        );
+
+        let self_exe = ReleaseBinary::locate();
+        assert!(
+            self_exe.is_file(),
+            "the real caduceus binary must be built (cargo build --bins) \
+             for the lifecycle test — ReleaseBinary::locate() returned {}",
+            self_exe.display()
+        );
+        let executor = Arc::new(SupervisorExecutor {
+            self_exe,
+            cfg: cfg.clone(),
+        });
+        let services = Services::for_tests(
+            Arc::new(SystemClock),
+            Arc::new(GithubClientAdapter::new(Arc::clone(&client))),
+            Arc::new(GitRunnerAdapter::new(runner.clone())),
+            executor,
+            Arc::clone(&pool),
+        );
+
+        Self {
+            _root: root,
+            gh,
+            cfg,
+            store,
+            client,
+            runner,
+            services,
+            remote_dir,
+            base_sha,
+            mid_sha,
+            tip_sha,
+            harness_py,
+        }
+    }
+
+    /// A config clone whose worker command selects the harness's
+    /// scripted result via the worker argv (`env FAKE_REVIEW_RESULT=<kind>`).
+    pub fn worker_cfg(&self, kind: &str) -> Config {
+        let mut cfg = self.cfg.clone();
+        cfg.worker_command = worker_command(kind, &self.harness_py);
+        cfg
+    }
+
+    /// The `file://` remote URL every resolver returns.
+    pub fn remote_url(&self) -> String {
+        format!("file://{}", self.remote_dir.display())
+    }
+
+    // --- wiremock mounts ---------------------------------------------------
+
+    /// Mount `/repos/owner/r/pulls` to serve one open PR whose head is
+    /// `head_sha` (re-mounting with a new head simulates the force
+    /// push; wiremock serves the most recently mounted match).
+    pub async fn mount_pulls(&self, head_sha: &str) {
+        self.gh
+            .mount(
+                "GET",
+                "/repos/owner/r/pulls",
+                serde_json::json!([pr_wire_row(&self.base_sha, head_sha)]),
+            )
+            .await;
+    }
+
+    /// Re-mount `/pulls` with a NEW head at wiremock priority `1` so
+    /// it beats the original default-priority mount (same matcher;
+    /// wiremock falls back to insertion order only when priorities
+    /// tie).
+    pub async fn mount_pulls_revision(&self, head_sha: &str) {
+        self.gh
+            .mount_status_priority(
+                "GET",
+                "/repos/owner/r/pulls",
+                200,
+                1,
+                serde_json::json!([pr_wire_row(&self.base_sha, head_sha)]),
+            )
+            .await;
+    }
+
+    /// Mount the single-PR fetch (`GET /pulls/7`) + the PR discussion
+    /// page (`GET /issues/7/comments`), both required by
+    /// `run_review_claim`.
+    pub async fn mount_pr_fetch_and_discussion(&self) {
+        self.gh
+            .mount(
+                "GET",
+                &format!("/repos/owner/r/pulls/{PR}"),
+                pr_wire_row(&self.base_sha, &self.mid_sha),
+            )
+            .await;
+        self.gh
+            .mount_paged(
+                &format!("/repos/owner/r/issues/{PR}/comments"),
+                vec![serde_json::json!([])],
+            )
+            .await;
+    }
+
+    /// Mount the sticky-comment create endpoint (`POST
+    /// /issues/{pr}/comments`) with `status` and the returned comment
+    /// id. `500` exercises the publish-failure resume path.
+    pub async fn mount_comment_create(&self, status: u16, id: u64) {
+        self.gh
+            .mount_status(
+                "POST",
+                &format!("/repos/owner/r/issues/{PR}/comments"),
+                status,
+                serde_json::json!({ "id": id, "body": "" }),
+            )
+            .await;
+    }
+
+    /// Re-mount the sticky-comment create endpoint at wiremock
+    /// priority `1` so a recovering endpoint beats an earlier
+    /// default-priority failure mount for the same matcher.
+    pub async fn mount_comment_create_resume(&self, id: u64) {
+        self.gh
+            .mount_status_priority(
+                "POST",
+                &format!("/repos/owner/r/issues/{PR}/comments"),
+                201,
+                1,
+                serde_json::json!({ "id": id, "body": "" }),
+            )
+            .await;
+    }
+
+    /// Mount the sticky-comment update endpoint (`PATCH
+    /// /issues/comments/{id}`).
+    pub async fn mount_comment_patch(&self, id: u64) {
+        self.gh
+            .mount(
+                "PATCH",
+                &format!("/repos/owner/r/issues/comments/{id}"),
+                serde_json::json!({ "id": id, "body": "" }),
+            )
+            .await;
+    }
+
+    /// Mount the idempotency compare (`GET /issues/comments/{id}`)
+    /// with a body different from the PASS render so the PASS
+    /// revision takes the PATCH path.
+    pub async fn mount_comment_get(&self, id: u64) {
+        self.gh
+            .mount(
+                "GET",
+                &format!("/repos/owner/r/issues/comments/{id}"),
+                serde_json::json!({ "id": id, "body": "stale fail body" }),
+            )
+            .await;
+    }
+
+    // --- phase drivers (the D2 seams) ---------------------------------------
+
+    /// Phase 1/4: discovery + admission via `poll_review_step_for_tests`.
+    pub async fn drive_discovery(
+        &self,
+    ) -> caduceus::daemon::tick::review_discovery::ReviewDiscoveryStats {
+        let remote_url = self.remote_url();
+        caduceus::daemon::tick::review_discovery::poll_review_step_for_tests(
+            &["owner/r".to_string()],
+            self.client.as_ref(),
+            &self.cfg,
+            self.store.as_ref(),
+            &self.runner,
+            &move |_owner: &str, _repo: &str| Ok(remote_url.clone()),
+        )
+        .await
+        .expect("discovery step succeeds")
+    }
+
+    /// Phase 2/5: claim + full dispatch through the real supervisor +
+    /// `review_harness.py` subprocess. Returns the tick outcome and
+    /// the run id used for the history-row assertions.
+    pub async fn drive_claim(&self, run_id: &str, kind: &str) -> TickOutcome {
+        let claimed = self
+            .store
+            .acquire_next_review(run_id, std::process::id(), chrono::Utc::now())
+            .expect("acquire succeeds")
+            .expect("an eligible review entry exists");
+        assert_eq!(
+            claimed.entry.target.pull_request, PR,
+            "the claimed entry is PR {PR}"
+        );
+
+        let guard = ReviewRunGuard::new(
+            claimed.claim.clone(),
+            Arc::clone(&self.store),
+            self.cfg.state_dir.join("processor.log"),
+            claimed.entry.target.clone(),
+            self.runner.clone(),
+        );
+        let mut guard = guard;
+
+        let admit = self
+            .services
+            .pool
+            .admit("repo:owner/r", "owner/r")
+            .await
+            .expect("pool admits under cap");
+
+        let remote_url = self.remote_url();
+        let resolve_remote: caduceus::daemon::tick::per_review::RemoteResolver =
+            Arc::new(move |_owner: &str, _repo: &str| Ok(remote_url.clone()));
+
+        let outcome = caduceus::daemon::tick::per_review::run_review_claim_for_tests(
+            self.worker_cfg(kind),
+            &self.services,
+            Arc::clone(&self.client),
+            self.store.as_ref(),
+            claimed,
+            &mut guard,
+            CancellationToken::new(),
+            &mut None,
+            admit,
+            resolve_remote,
+        )
+        .await
+        .expect("claim-side dispatch succeeds");
+        outcome
+    }
+
+    /// Phase 3/6: finalizer poll via `poll_publication_step_for_tests`.
+    pub async fn drive_finalize(
+        &self,
+    ) -> caduceus::daemon::tick::review_finalize_step::PublicationStats {
+        caduceus::daemon::tick::review_finalize_step::poll_publication_step_for_tests(
+            self.client.as_ref(),
+            &self.cfg,
+            self.store.as_ref(),
+        )
+        .await
+        .expect("finalizer poll succeeds")
+    }
+
+    /// The canonical (repo, pr) identity.
+    pub fn repository(&self) -> RepositoryId {
+        RepositoryId {
+            owner: "owner".to_string(),
+            repo: "r".to_string(),
+        }
+    }
+}
+
+/// Build the worker argv that runs the review harness with a scripted
+/// result kind via the `env` utility (survives the supervisor's
+/// `env_clear()` sanitized worker environment).
+fn worker_command(kind: &str, harness_py: &std::path::Path) -> Vec<String> {
+    vec![
+        "env".to_string(),
+        format!("FAKE_REVIEW_RESULT={kind}"),
+        "python3".to_string(),
+        harness_py.display().to_string(),
+    ]
+}
+
+/// Convenience re-export for tests that drive the store directly.
+pub fn review_target(repository: &RepositoryId, head_sha: &str, base_sha: &str) -> ReviewTarget {
+    ReviewTarget {
+        repository: repository.clone(),
+        pull_request: PR,
+        head_sha: head_sha.to_string(),
+        base_sha: base_sha.to_string(),
+        base_ref: "main".to_string(),
+        merge_base: base_sha.to_string(),
+    }
+}
+
+/// Decode a history row's verdict for assertions.
+pub fn verdict_of_row(result_json: &str) -> String {
+    let doc: serde_json::Value = serde_json::from_str(result_json).expect("history row parses");
+    doc["review"]["verdict"]
+        .as_str()
+        .expect("verdict present")
+        .to_string()
+}
+
+/// Assert the store holds exactly the expected history rows
+/// `(run_id, generation, head_sha, verdict)` in order.
+pub fn assert_history(
+    store: &ReviewStore,
+    repository: &RepositoryId,
+    expected: &[(&str, u64, &str, &str)],
+) {
+    let rows = store
+        .history_for_pull_request(repository, PR)
+        .expect("history read");
+    assert_eq!(
+        rows.len(),
+        expected.len(),
+        "history row count — got {:?}",
+        rows.iter()
+            .map(|r| (r.review_run_id.as_str(), r.review_generation))
+            .collect::<Vec<_>>()
+    );
+    for (row, (run_id, generation, head_sha, verdict)) in rows.iter().zip(expected) {
+        assert_eq!(row.review_run_id, *run_id, "run id");
+        assert_eq!(
+            row.review_generation, *generation,
+            "generation for {run_id}"
+        );
+        assert_eq!(row.head_sha, *head_sha, "head sha for {run_id}");
+        assert_eq!(
+            verdict_of_row(&row.result_json),
+            *verdict,
+            "verdict for {run_id}"
+        );
+    }
+}
+
+/// A validator-correct fabricated `ReviewResult` document for the
+/// given verdict (the finalizer is history-driven; the row is the
+/// durable result, DAR §9.1).
+pub fn fabricated_row(
+    repository: &RepositoryId,
+    run_id: &str,
+    head_sha: &str,
+    generation: u64,
+    verdict: &str,
+) -> caduceus::state::review::ReviewHistoryRow {
+    let verdict_enum = if verdict == "fail" {
+        caduceus::review::Verdict::Fail
+    } else {
+        caduceus::review::Verdict::Pass
+    };
+    let findings = match verdict_enum {
+        caduceus::review::Verdict::Fail => vec![caduceus::review::Finding {
+            severity: caduceus::review::Severity::Blocking,
+            title: "Blocking finding".to_string(),
+            body: "Deterministic FAIL finding.".to_string(),
+            path: Some("src/lib.rs".to_string()),
+            line: Some(1),
+            remediation: Some("Fix it.".to_string()),
+        }],
+        caduceus::review::Verdict::Pass => vec![],
+    };
+    let result = caduceus::review::ReviewResult {
+        schema_version: caduceus::review::REVIEW_SCHEMA_VERSION,
+        status: caduceus::review::ExecutionStatus::Success,
+        review: Some(caduceus::review::Review {
+            verdict: verdict_enum,
+            summary: format!("Scripted {verdict} summary."),
+            findings,
+        }),
+    };
+    caduceus::state::review::ReviewHistoryRow {
+        review_run_id: run_id.to_string(),
+        repository: repository.clone(),
+        pull_request: PR,
+        head_sha: head_sha.to_string(),
+        review_generation: generation,
+        completed_at: chrono::Utc::now(),
+        result_json: serde_json::to_string(&result).expect("result serializes"),
+    }
+}

--- a/tests/review/lifecycle_test.rs
+++ b/tests/review/lifecycle_test.rs
@@ -1,0 +1,434 @@
+//! E2E PR lifecycle integration test (issue #322, DAR §15
+//! "End-to-end" row).
+//!
+//! ONE full-lifecycle test, NO STUBS: discovery → queue → review
+//! worker → FAIL published to the sticky comment → head moves → new
+//! revision → PASS replaces the SAME sticky comment — including
+//! out-of-order completion and the two negative paths. Runs on BOTH
+//! state backends (JSON + SQLite).
+//!
+//! Harness (see `lifecycle_harness.rs` and `docs/testing/e2e-lifecycle.md`):
+//! wiremock fake GitHub + real local bare git remote + the REAL daemon
+//! dispatch/finalizer/store code + the REAL `review_harness.py` worker
+//! running as a real subprocess under the REAL `caduceus
+//! __worker-supervisor` supervision protocol (the executor re-execs
+//! the real `caduceus` binary via `ReleaseBinary::locate()`; the plan's
+//! `self_exe = current_exe()` assumption cannot hold inside a test
+//! binary — see the harness module docs for the deviation).
+//!
+//! Acceptance criteria (issue #322):
+//! 1. Lifecycle green end-to-end with no stubs, both backends.
+//! 2. Exactly one sticky comment across both revisions; two history
+//!    rows.
+//! 3. Same-SHA re-poll produces zero new admissions; publish-failure
+//!    resume does not re-run the worker.
+
+use std::fs;
+
+use caduceus::infra::logging::build_test_subscriber;
+use caduceus::meta::TickOutcome;
+use caduceus::review::{
+    finalize_review, DueFinalization, FinalizeOutcome, PublicationState, Verdict,
+};
+use caduceus::state::review::{ReviewPhase, ReviewQueueEntry};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+#[path = "lifecycle_harness.rs"]
+mod harness;
+
+use harness::{Backend, LifecycleHarness, STICKY_COMMENT_ID};
+
+// ---------------------------------------------------------------------------
+// Shared assertion helpers
+// ---------------------------------------------------------------------------
+
+fn state(h: &LifecycleHarness) -> caduceus::review::ReviewState {
+    h.store
+        .review_state(&h.repository(), harness::PR)
+        .expect("state read")
+        .expect("state row exists")
+}
+
+fn queue_entry(h: &LifecycleHarness, head_sha: &str) -> ReviewQueueEntry {
+    h.store
+        .review_queue_snapshot()
+        .expect("queue snapshot")
+        .entries
+        .values()
+        .find(|e| e.target.head_sha == head_sha)
+        .expect("queue entry for head sha")
+        .clone()
+}
+
+fn queue_len(h: &LifecycleHarness) -> usize {
+    h.store
+        .review_queue_snapshot()
+        .expect("queue snapshot")
+        .entries
+        .len()
+}
+
+fn history_len(h: &LifecycleHarness) -> usize {
+    h.store
+        .history_for_pull_request(&h.repository(), harness::PR)
+        .expect("history read")
+        .len()
+}
+
+/// Assert the queue entry for `head_sha` is in `phase` with the given
+/// attempts count.
+fn assert_entry_phase(h: &LifecycleHarness, head_sha: &str, phase: ReviewPhase, attempts: u32) {
+    let entry = queue_entry(h, head_sha);
+    assert_eq!(entry.phase, phase, "phase for head {head_sha}");
+    assert_eq!(entry.attempts, attempts, "attempts for head {head_sha}");
+}
+
+// ---------------------------------------------------------------------------
+// The full lifecycle (AC1 + AC2), parametrized by backend
+// ---------------------------------------------------------------------------
+
+/// Drive the complete FAIL → PASS lifecycle on one backend and return
+/// the finished harness so negative-path tests can continue from it.
+async fn run_lifecycle(backend: Backend) -> LifecycleHarness {
+    let h = LifecycleHarness::start("lifecycle", backend).await;
+    let repo = h.repository();
+    h.mount_pr_fetch_and_discussion().await;
+    h.mount_comment_create(201, STICKY_COMMENT_ID).await;
+    h.mount_comment_get(STICKY_COMMENT_ID).await;
+    h.mount_comment_patch(STICKY_COMMENT_ID).await;
+
+    // Phase 1 — discovery admits gen 1 (head = mid).
+    h.mount_pulls(&h.mid_sha).await;
+    let stats = h.drive_discovery().await;
+    assert_eq!(stats.admitted, 1, "gen 1 admitted on the first poll");
+    assert_eq!(stats.stale_observed, 0);
+    let entry = queue_entry(&h, &h.mid_sha);
+    assert_eq!(entry.review_generation, 1, "first generation");
+    assert_eq!(entry.phase, ReviewPhase::Queued);
+    assert_eq!(
+        entry.target.merge_base, h.base_sha,
+        "DAR §2.2 merge base persisted at admission"
+    );
+
+    // Phase 2 — claim + real worker run → FAIL verdict.
+    let outcome = h.drive_claim("run-1", "fail").await;
+    assert_eq!(outcome, TickOutcome::Processed, "FAIL run processes");
+    harness::assert_history(&h.store, &repo, &[("run-1", 1, &h.mid_sha, "fail")]);
+    assert_eq!(state(&h).review_generation, 1);
+    assert_eq!(
+        state(&h).publication_state,
+        PublicationState::Pending,
+        "history appended; not yet published"
+    );
+    assert_entry_phase(&h, &h.mid_sha, ReviewPhase::Done, 0);
+
+    // Phase 3 — finalizer publishes the FAIL sticky comment.
+    let fstats = h.drive_finalize().await;
+    assert_eq!(fstats.published, 1, "FAIL publication succeeds");
+    let s = state(&h);
+    assert_eq!(s.publication_state, PublicationState::Published);
+    assert_eq!(s.sticky_comment_id, Some(STICKY_COMMENT_ID));
+    assert_eq!(s.last_verdict, Some(Verdict::Fail));
+    assert_eq!(
+        s.last_reviewed_head_sha.as_deref(),
+        Some(h.mid_sha.as_str())
+    );
+    assert_eq!(h.gh.counts().post, 1, "one comment created for FAIL");
+    assert_eq!(h.gh.counts().patch, 0, "no update yet");
+
+    // Phase 4 — head moves → re-discovery admits gen 2 (head = tip).
+    h.mount_pulls_revision(&h.tip_sha).await;
+    let stats = h.drive_discovery().await;
+    assert_eq!(stats.admitted, 1, "new SHA re-admits");
+    assert_eq!(stats.stale_observed, 1, "B → C stale observation");
+    assert_eq!(queue_len(&h), 2, "both revisions present in the queue");
+    let fresh = queue_entry(&h, &h.tip_sha);
+    assert_eq!(fresh.review_generation, 2, "generation advanced");
+    assert_eq!(fresh.phase, ReviewPhase::Queued);
+    assert_entry_phase(&h, &h.mid_sha, ReviewPhase::Done, 0);
+
+    // Phase 5 — re-review → PASS verdict.
+    let outcome = h.drive_claim("run-2", "pass").await;
+    assert_eq!(outcome, TickOutcome::Processed, "PASS run processes");
+    harness::assert_history(
+        &h.store,
+        &repo,
+        &[
+            ("run-1", 1, &h.mid_sha, "fail"),
+            ("run-2", 2, &h.tip_sha, "pass"),
+        ],
+    );
+    assert_eq!(state(&h).review_generation, 2);
+
+    // Phase 6 — finalizer updates the SAME sticky comment with PASS.
+    let fstats = h.drive_finalize().await;
+    assert_eq!(fstats.published, 1, "PASS publication succeeds");
+    let s = state(&h);
+    assert_eq!(s.publication_state, PublicationState::Published);
+    assert_eq!(s.last_verdict, Some(Verdict::Pass));
+    assert_eq!(
+        s.last_reviewed_head_sha.as_deref(),
+        Some(h.tip_sha.as_str())
+    );
+
+    // AC2 — exactly one sticky comment across both revisions; two
+    // history rows with distinct run ids.
+    assert_eq!(
+        state(&h).sticky_comment_id,
+        Some(STICKY_COMMENT_ID),
+        "PASS updates the same comment — id unchanged"
+    );
+    assert_eq!(h.gh.counts().post, 1, "exactly one comment created");
+    assert_eq!(h.gh.counts().patch, 1, "PASS replaced via one PATCH");
+    assert_eq!(history_len(&h), 2, "two history rows");
+
+    h
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn lifecycle_json() {
+    let h = run_lifecycle(Backend::Json).await;
+    drop(h);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn lifecycle_sqlite() {
+    let h = run_lifecycle(Backend::Sqlite).await;
+    drop(h);
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-order completion (DAR §9.4): B completes before A
+// ---------------------------------------------------------------------------
+
+/// B (gen 2) completes before A (gen 1): the sticky comment shows B;
+/// A persists to history only, and A's publication is suppressed with
+/// `review_publication_suppressed_stale_generation`. Both backends.
+#[tokio::test]
+#[serial_test::serial]
+async fn lifecycle_out_of_order() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let h = LifecycleHarness::start("ooo", backend).await;
+        let repo = h.repository();
+        h.mount_pr_fetch_and_discussion().await;
+        h.mount_comment_create(201, STICKY_COMMENT_ID).await;
+
+        // Admit A (gen 1, head = mid) and B (gen 2, head = tip).
+        h.store
+            .enqueue_review(&harness::review_target(&repo, &h.mid_sha, &h.base_sha))
+            .expect("admit A (gen 1)");
+        h.store
+            .enqueue_review(&harness::review_target(&repo, &h.tip_sha, &h.base_sha))
+            .expect("admit B (gen 2)");
+        assert_eq!(
+            state(&h).review_generation,
+            2,
+            "state tracks the newest generation"
+        );
+
+        // Claim both (FIFO: A first, then B), then complete B BEFORE A
+        // — the durable rows are the finalizer's only input (DAR §9.1).
+        let claimed_a = h
+            .store
+            .acquire_next_review("run-a", std::process::id(), chrono::Utc::now())
+            .expect("acquire A")
+            .expect("A claimable");
+        assert_eq!(claimed_a.entry.review_generation, 1);
+        let claimed_b = h
+            .store
+            .acquire_next_review("run-b", std::process::id(), chrono::Utc::now())
+            .expect("acquire B")
+            .expect("B claimable");
+        assert_eq!(claimed_b.entry.review_generation, 2);
+
+        // B's PASS result lands first; A's FAIL result persists to
+        // history afterwards.
+        h.store
+            .append_history(harness::fabricated_row(
+                &repo, "run-b", &h.tip_sha, 2, "pass",
+            ))
+            .expect("B history row");
+        h.store
+            .complete_review(claimed_b.claim)
+            .expect("B completes");
+        h.store
+            .append_history(harness::fabricated_row(
+                &repo, "run-a", &h.mid_sha, 1, "fail",
+            ))
+            .expect("A history row");
+        h.store
+            .complete_review(claimed_a.claim)
+            .expect("A completes");
+
+        // The history-driven poll routes ONLY B: A's generation is
+        // superseded at the query (state.rs due_finalizations).
+        let fstats = h.drive_finalize().await;
+        assert_eq!(fstats.published, 1, "B publishes");
+        assert_eq!(fstats.suppressed, 0, "A is filtered before finalize");
+        let s = state(&h);
+        assert_eq!(s.publication_state, PublicationState::Published);
+        assert_eq!(s.sticky_comment_id, Some(STICKY_COMMENT_ID));
+        assert_eq!(s.last_verdict, Some(Verdict::Pass), "sticky shows B's PASS");
+        assert_eq!(
+            s.last_reviewed_head_sha.as_deref(),
+            Some(h.tip_sha.as_str()),
+            "current pointer shows B, not A"
+        );
+        assert_eq!(h.gh.counts().post, 1, "exactly one comment — for B");
+        assert_eq!(h.gh.counts().patch, 0);
+
+        // Direct guard test: a stale DueFinalization (gen 1 while the
+        // state is gen 2) is suppressed and emits the §9.4 event.
+        let capture = h.cfg.state_dir.join("events.log");
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&capture)
+            .expect("open capture file");
+        let (writer, appender_guard) = tracing_appender::non_blocking(file);
+        let subscriber = build_test_subscriber(writer);
+        let out_a = {
+            let _guard = tracing::subscriber::set_default(subscriber);
+            finalize_review(
+                h.client.as_ref(),
+                &h.cfg,
+                h.store.as_ref(),
+                &DueFinalization {
+                    repository: repo.clone(),
+                    pull_request: harness::PR,
+                    run_generation: 1,
+                    head_sha: h.mid_sha.clone(),
+                },
+                chrono::Utc::now(),
+            )
+            .await
+            .expect("A finalizes")
+        };
+        drop(appender_guard);
+        assert_eq!(
+            out_a,
+            FinalizeOutcome::SuppressedStaleGeneration,
+            "A suppressed — got {out_a:?}"
+        );
+        let body = fs::read_to_string(&capture).expect("read capture file");
+        assert!(
+            body.contains("review_publication_suppressed_stale_generation"),
+            "suppression event missing: {body}"
+        );
+
+        // A never touched the presentation; both rows are in history.
+        assert_eq!(h.gh.counts().post, 1, "no second comment for A");
+        assert_eq!(history_len(&h), 2, "A and B both in history");
+        harness::assert_history(
+            &h.store,
+            &repo,
+            &[
+                ("run-b", 2, &h.tip_sha, "pass"),
+                ("run-a", 1, &h.mid_sha, "fail"),
+            ],
+        );
+        assert!(
+            h.store.due_finalizations().expect("due scan").is_empty(),
+            "nothing re-due after suppression"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative paths (AC3)
+// ---------------------------------------------------------------------------
+
+/// Same-SHA re-poll after the full lifecycle: zero new admissions,
+/// the queue and history are untouched. Both backends.
+#[tokio::test]
+#[serial_test::serial]
+async fn lifecycle_same_sha_repoll() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let h = run_lifecycle(backend).await;
+        let queue_before = queue_len(&h);
+        let history_before = history_len(&h);
+
+        // Re-mount the SAME head (tip) and re-poll.
+        h.mount_pulls_revision(&h.tip_sha).await;
+        let stats = h.drive_discovery().await;
+        assert_eq!(stats.admitted, 0, "AC3: no new admissions on same SHA");
+        assert_eq!(stats.skipped_already_complete, 1);
+        assert_eq!(queue_len(&h), queue_before, "queue unchanged");
+        assert_eq!(history_len(&h), history_before, "no new history row");
+        assert_eq!(h.gh.counts().post, 1, "no extra comment on the re-poll");
+        assert_eq!(h.gh.counts().patch, 1);
+    }
+}
+
+/// Publish-failure resume: a GitHub 500 during publication leaves the
+/// row at `FailedRetryable` with persisted backoff; the resume
+/// publishes WITHOUT re-running the worker. Both backends.
+#[tokio::test]
+#[serial_test::serial]
+async fn lifecycle_publish_failure_resume() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let h = LifecycleHarness::start("publish-fail", backend).await;
+        let repo = h.repository();
+        h.mount_pr_fetch_and_discussion().await;
+
+        // Seed one completed FAIL run (history row; nothing published).
+        h.store
+            .enqueue_review(&harness::review_target(&repo, &h.mid_sha, &h.base_sha))
+            .expect("admit");
+        let claimed = h
+            .store
+            .acquire_next_review("run-1", std::process::id(), chrono::Utc::now())
+            .expect("acquire")
+            .expect("claimable");
+        assert_eq!(claimed.entry.review_generation, 1);
+        h.store
+            .append_history(harness::fabricated_row(
+                &repo, "run-1", &h.mid_sha, 1, "fail",
+            ))
+            .expect("history row");
+        h.store.complete_review(claimed.claim).expect("complete");
+
+        // Publication fails retryably (POST → 500).
+        h.mount_comment_create(500, STICKY_COMMENT_ID).await;
+        let stats = h.drive_finalize().await;
+        assert_eq!(stats.failed_retryable, 1, "AC3: retryable failure");
+        let s = state(&h);
+        assert_eq!(s.publication_state, PublicationState::FailedRetryable);
+        assert_eq!(s.publication_attempt_count, 1);
+        assert!(s.next_publish_at.is_some(), "backoff persisted");
+        assert!(s.last_publish_error.is_some());
+        assert_eq!(
+            h.gh.counts().post,
+            1,
+            "the failed create was attempted once"
+        );
+
+        // Resume: the endpoint recovers, the backoff elapsed, and the
+        // finalizer publishes the SAME durable result — the worker is
+        // NEVER re-run (DAR §9.1: publication is presentation only).
+        h.mount_comment_create_resume(STICKY_COMMENT_ID).await;
+        let next_attempt_at = s.next_publish_at.expect("next publish at");
+        let now = next_attempt_at + chrono::Duration::seconds(1);
+        let due = h.store.due_finalizations().expect("due scan");
+        assert_eq!(due.len(), 1, "the FailedRetryable row is due again");
+        let outcome = finalize_review(h.client.as_ref(), &h.cfg, h.store.as_ref(), &due[0], now)
+            .await
+            .expect("resume finalizes");
+        assert_eq!(outcome, FinalizeOutcome::Published);
+
+        let s = state(&h);
+        assert_eq!(s.publication_state, PublicationState::Published);
+        assert_eq!(s.sticky_comment_id, Some(STICKY_COMMENT_ID));
+        assert_eq!(s.publication_attempt_count, 2);
+        assert_eq!(s.last_verdict, Some(Verdict::Fail));
+        assert_eq!(h.gh.counts().post, 2, "failed create + successful create");
+
+        // AC3 part 2 — the worker was NOT re-run: still exactly one
+        // history row, the queue entry is Done with zero attempts.
+        harness::assert_history(&h.store, &repo, &[("run-1", 1, &h.mid_sha, "fail")]);
+        assert_entry_phase(&h, &h.mid_sha, ReviewPhase::Done, 0);
+    }
+}


### PR DESCRIPTION
## E2E PR review lifecycle integration test (closes #322)

Implements DAR §15 "End-to-end" row: ONE full PR review lifecycle test with **no stubs** — wiremock fake GitHub API, real local bare git remote with real commits, the real daemon dispatch (`run_review_claim_for_tests`), the REAL `caduceus __worker-supervisor` subprocess via the real `supervise()` production executor, the real `tests/fixtures/review_harness.py` worker, the real finalizer, and both state backends (JSON + SQLite).

### Coverage

- `lifecycle_json` / `lifecycle_sqlite`: full FAIL → PASS lifecycle (discovery → queue → worker → sticky comment publish → head move → re-review → comment update). Asserts exactly one sticky comment across revisions; two history rows with distinct run ids.
- `lifecycle_out_of_order`: generation 2 completes before generation 1 (DAR §9.4); newer result wins the sticky comment, stale `DueFinalization` suppressed with `review_publication_suppressed_stale_generation`.
- `lifecycle_same_sha_repoll`: re-poll of an already-complete head yields zero new admissions (`review_skipped_already_complete`).
- `lifecycle_publish_failure_resume`: GitHub 500 on comment create leaves `FailedRetryable` with persisted backoff; the resume publishes the SAME durable result WITHOUT re-running the model (one history row, zero re-claims).

### Harness notes

- The supervisor re-execs `current_exe()`; inside a test binary that is libtest, so the harness's executor pins `ReleaseBinary::locate()` (the same binary production re-execs) as `self_exe` with the `TrustedHostExecutor` body — the supervisor subprocess, framed control protocol, sanitized env, and worker subprocess are all real production machinery.
- `FAKE_REVIEW_RESULT` is delivered via the worker argv (`env FAKE_REVIEW_RESULT=… python3 tests/fixtures/review_harness.py`) because the production supervisor builds the worker env with an empty allowlist.
- #327 wire fixtures carry literal SHAs; the harness builds the real bare remote first and injects the real commit SHAs into the wire rows so SHA-anchored fetches and `git merge-base` work.
- Force-push re-mounts use wiremock priority `1` (`mount_status_priority`, added to `tests/fixtures/github.rs`) because wiremock serves the first matching mount when priorities tie.

### Verification

- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --all-targets` — pass (193 test binaries ok; one pre-existing OCI timing flake observed once under full-suite parallel load, passes in isolation and on re-run)
- Python gate (pytest) — 200 passed

Closes #322