### PR TITLE
fix(config): surface circuit-breaker validation errors

### DIFF
--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -997,6 +997,34 @@ impl Config {
             .max_reviews_per_tick
             .unwrap_or(worker_parallelism.saturating_mul(DEFAULT_MAX_REVIEWS_PER_TICK_MULTIPLIER));
 
+        // Circuit breaker config. Resolved and validated here so a
+        // zero/empty value fails config load instead of loading
+        // silently (issue #357).
+        let circuit_failure_threshold = raw
+            .circuit_failure_threshold
+            .unwrap_or(DEFAULT_CIRCUIT_FAILURE_THRESHOLD);
+        if circuit_failure_threshold == 0 {
+            errors.push("circuit_failure_threshold must be > 0".to_string());
+        }
+        let circuit_backoff_seconds = raw
+            .circuit_backoff_seconds
+            .unwrap_or_else(|| DEFAULT_CIRCUIT_BACKOFF_SECONDS.to_vec());
+        if circuit_backoff_seconds.is_empty() {
+            errors.push("circuit_backoff_seconds must not be empty".to_string());
+        }
+        let circuit_open_interval_seconds = raw
+            .circuit_open_interval_seconds
+            .unwrap_or(DEFAULT_CIRCUIT_OPEN_INTERVAL_SECONDS);
+        if circuit_open_interval_seconds == 0 {
+            errors.push("circuit_open_interval_seconds must be > 0".to_string());
+        }
+        let circuit_max_degraded_seconds = raw
+            .circuit_max_degraded_seconds
+            .unwrap_or(DEFAULT_CIRCUIT_MAX_DEGRADED_SECONDS);
+        if circuit_max_degraded_seconds == 0 {
+            errors.push("circuit_max_degraded_seconds must be > 0".to_string());
+        }
+
         if !errors.is_empty() {
             return Err(CaduceusError::Config(errors.join("; ")));
         }
@@ -1073,43 +1101,10 @@ impl Config {
                 .backpressure_budget_ms
                 .unwrap_or(DEFAULT_BACKPRESSURE_BUDGET_MS),
 
-            // Circuit breaker config
-            circuit_failure_threshold: {
-                let v = raw
-                    .circuit_failure_threshold
-                    .unwrap_or(DEFAULT_CIRCUIT_FAILURE_THRESHOLD);
-                if v == 0 {
-                    errors.push("circuit_failure_threshold must be > 0".to_string());
-                }
-                v
-            },
-            circuit_backoff_seconds: {
-                let v = raw
-                    .circuit_backoff_seconds
-                    .unwrap_or_else(|| DEFAULT_CIRCUIT_BACKOFF_SECONDS.to_vec());
-                if v.is_empty() {
-                    errors.push("circuit_backoff_seconds must not be empty".to_string());
-                }
-                v
-            },
-            circuit_open_interval_seconds: {
-                let v = raw
-                    .circuit_open_interval_seconds
-                    .unwrap_or(DEFAULT_CIRCUIT_OPEN_INTERVAL_SECONDS);
-                if v == 0 {
-                    errors.push("circuit_open_interval_seconds must be > 0".to_string());
-                }
-                v
-            },
-            circuit_max_degraded_seconds: {
-                let v = raw
-                    .circuit_max_degraded_seconds
-                    .unwrap_or(DEFAULT_CIRCUIT_MAX_DEGRADED_SECONDS);
-                if v == 0 {
-                    errors.push("circuit_max_degraded_seconds must be > 0".to_string());
-                }
-                v
-            },
+            circuit_failure_threshold,
+            circuit_backoff_seconds,
+            circuit_open_interval_seconds,
+            circuit_max_degraded_seconds,
             repo_storage_root,
             executor_mode,
             reduced_containment_acknowledged,

--- a/tests/infra/config_test.rs
+++ b/tests/infra/config_test.rs
@@ -110,3 +110,97 @@ fn git_author_config_trims_values_and_treats_empty_as_absent() {
     assert_eq!(cfg.git_author_name.as_deref(), Some("Ops Bot"));
     assert_eq!(cfg.git_author_email, None);
 }
+
+#[test]
+fn circuit_zero_failure_threshold_is_rejected() {
+    let raw = RawConfig {
+        circuit_failure_threshold: Some(0),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let err = Config::from_raw(raw, &LoadContext::default()).expect_err("zero must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("circuit_failure_threshold must be > 0"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn circuit_empty_backoff_seconds_is_rejected() {
+    let raw = RawConfig {
+        circuit_backoff_seconds: Some(vec![]),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let err = Config::from_raw(raw, &LoadContext::default()).expect_err("empty must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("circuit_backoff_seconds must not be empty"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn circuit_zero_open_interval_is_rejected() {
+    let raw = RawConfig {
+        circuit_open_interval_seconds: Some(0),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let err = Config::from_raw(raw, &LoadContext::default()).expect_err("zero must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("circuit_open_interval_seconds must be > 0"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn circuit_zero_max_degraded_is_rejected() {
+    let raw = RawConfig {
+        circuit_max_degraded_seconds: Some(0),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let err = Config::from_raw(raw, &LoadContext::default()).expect_err("zero must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("circuit_max_degraded_seconds must be > 0"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn circuit_explicit_values_resolve_and_defaults_load() {
+    let raw = RawConfig {
+        circuit_failure_threshold: Some(5),
+        circuit_backoff_seconds: Some(vec![10, 20]),
+        circuit_open_interval_seconds: Some(60),
+        circuit_max_degraded_seconds: Some(120),
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let cfg = Config::from_raw(raw, &LoadContext::default()).expect("config");
+    assert_eq!(cfg.circuit_failure_threshold, 5);
+    assert_eq!(cfg.circuit_backoff_seconds, vec![10, 20]);
+    assert_eq!(cfg.circuit_open_interval_seconds, 60);
+    assert_eq!(cfg.circuit_max_degraded_seconds, 120);
+
+    // Absent fields fall back to the documented defaults and still load.
+    let raw_defaults = RawConfig {
+        worker_command: Some(vec!["/bin/true".to_string()]),
+        reduced_containment_acknowledged: Some(true),
+        ..Default::default()
+    };
+    let defaults = Config::from_raw(raw_defaults, &LoadContext::default()).expect("config");
+    assert_eq!(defaults.circuit_failure_threshold, 3);
+    assert_eq!(defaults.circuit_backoff_seconds, vec![30, 120, 600]);
+    assert_eq!(defaults.circuit_open_interval_seconds, 1800);
+    assert_eq!(defaults.circuit_max_degraded_seconds, 86400);
+}


### PR DESCRIPTION
## What

The circuit-breaker field validations in `Config::from_raw` were dead code: they pushed into the shared `errors` vec INSIDE the `Ok(Config { ... })` literal, after the `if !errors.is_empty()` early return. Invalid values loaded silently:

- `circuit_failure_threshold: 0` loaded silently (should error "must be > 0")
- `circuit_backoff_seconds: []` loaded silently (should error "must not be empty")
- `circuit_open_interval_seconds: 0` loaded silently
- `circuit_max_degraded_seconds: 0` loaded silently

## Fix

Moved the four circuit-breaker resolutions + validations into the pre-early-return section of `Config::from_raw`, matching every other validation's pattern. The `Ok` literal now references the resolved bindings. `saturating`/default semantics are unchanged.

## Tests

Added regression tests in `tests/infra/config_test.rs` (existing `infra_config_test` binary): one rejection test per invalid value plus a positive test asserting explicit values resolve and absent fields fall back to the documented defaults.

Gates run serially: `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked --all-targets` (201 binaries, 2994 passed, 0 failed), `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` (200 passed).

Closes #357