### PR TITLE
fix(test): redact sensitive values from assertion messages

### DIFF
--- a/tests/github/context_test.rs
+++ b/tests/github/context_test.rs
@@ -149,7 +149,10 @@ fn trusted_comments_subset_of_comments() {
         .map(|c| (c.author.clone(), c.body.clone()))
         .collect();
     for k in &trusted_keys {
-        assert!(all_keys.contains(k), "trusted key {:?} not in comments", k);
+        assert!(
+            all_keys.contains(k),
+            "a trusted comment key is missing from the full comment set"
+        );
     }
 }
 

--- a/tests/integration/failure_matrix_test.rs
+++ b/tests/integration/failure_matrix_test.rs
@@ -528,7 +528,7 @@ async fn test_git_failures_bounded_secret_free() {
         let scrubbed = scrub(payload);
         assert!(
             !scrubbed.contains("ghp_leaked_secret"),
-            "scrub() must redact {payload}, got: {scrubbed}"
+            "scrub() failed to redact a secret payload"
         );
     }
 


### PR DESCRIPTION
Closes CodeQL rust/cleartext-logging alerts #5 and #6 (test sinks).

Both alerts fired on test-assertion messages that interpolated
untrusted comment bodies (#5, tests/github/context_test.rs) and
fake secret values (#6, tests/integration/failure_matrix_test.rs)
into the panic string, which surfaces in CI logs on failure. The
assertion logic is unchanged; only the failure-message interpolation
is removed, matching the precedent set by 711619d for alert #2.

Local gates green: cargo fmt --check, cargo clippy --locked
--all-targets -- -D warnings, cargo test --locked --all-targets
(with hermetic skips), uv run pytest -q tests/plugin/
tests/integration/bridge_test.py (200 passed).