### PR TITLE
feat(config): drop legacy ticket_label_investigation key

### DIFF
--- a/docs/architecture/auto-review.md
+++ b/docs/architecture/auto-review.md
@@ -593,8 +593,9 @@ PAT-scope statement implied by listing a repo in `allow_fork_prs`
   non-terminal Investigation rows from pre-N or N-era stores are terminated,
   archived, and audited (`review_migration_terminated_investigation`) with
   operator-visible outcomes.
-- `ticket_label_investigation` config field removed with an explicit,
-  documented `from_raw` error naming the replacement.
+- `ticket_label_investigation` config field removed; a config carrying
+  it fails at parse time with serde's generic `unknown field` error
+  (no special-casing). `auto_review:` is the supported replacement.
 - `autofix-investigate` label removed with the feature.
 - Release notes must call out the direct-upgrade safety property for skip-N
   upgraders.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -54,8 +54,8 @@ supported starting point.
    rows the upgrade will terminate and archive (below).
 3. **Remove the config key.** If your `config.yaml` still sets
    `ticket_label_investigation`, delete the key (not the whole file).
-   The load now fails deliberately when it is present — see the
-   release notes for the exact error text.
+   A config carrying it now fails to load with serde's generic
+   `unknown field` error. `auto_review:` is the supported replacement.
 
 ### What happens at first open
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -49,13 +49,10 @@ admit work.
 ### Config key removed
 
 `ticket_label_investigation` was removed. A config that still carries
-the key **fails to load** with this deliberate error:
-
-```text
-ticket_label_investigation was removed in release N+1; investigations
-were replaced by auto_review — remove the key
-(docs/architecture/auto-review.md §12)
-```
+the key **fails to load** with serde's generic `unknown field` error
+(the same error any other unrecognized config key produces). Remove
+the key; `auto_review:` is the supported replacement — see
+`docs/architecture/auto-review.md`.
 
 Remove the key from your config file. There is no replacement value to
 set; investigation work is replaced by

--- a/src/infra/config/mod.rs
+++ b/src/infra/config/mod.rs
@@ -61,8 +61,6 @@ pub const DEFAULT_TICKET_LABEL_CODE: &str = "autofix";
 /// Exact match only; no trimming, no case-folding. A value in this map
 /// is translated to its canonical replacement and a one-time notice is
 /// emitted. See docs/architecture/auto-review.md §12.
-/// (The investigation entries were removed in N+1, issue #331 — that
-/// key now produces the deliberate `from_raw` error below.)
 pub const LEGACY_TICKET_LABEL_TRANSLATIONS: &[(&str, &str)] = &[("🤖 auto-fix", "autofix")];
 
 /// Translate explicitly-configured legacy emoji trigger labels to the
@@ -437,14 +435,6 @@ pub struct RawConfig {
     pub max_retries_per_issue: Option<u32>,
     pub retry_backoff_seconds: Option<u64>,
     pub ticket_label_code: Option<String>,
-    /// RETAINED after the N+1 key removal (issue #331) so a config
-    /// that still carries `ticket_label_investigation` is
-    /// serde-recognized and produces the DELIBERATE `from_raw` error
-    /// naming the replacement — not a raw `deny_unknown_fields` dump.
-    /// Never read for a value; presence alone is the error trigger.
-    /// See the removal checklist in
-    /// `src/state/queue/legacy_investigation.rs`.
-    pub ticket_label_investigation: Option<String>,
     pub remove_label_on_completion: Option<bool>,
     pub feedback_author_allowlist: Option<Vec<String>>,
     pub comment_ignore_patterns: Option<Vec<String>>,
@@ -829,19 +819,6 @@ impl Config {
             .unwrap_or_else(|| DEFAULT_TICKET_LABEL_CODE.to_string());
         if ticket_label_code.trim().is_empty() {
             errors.push("ticket_label_code must not be empty".to_string());
-        }
-        // `ticket_label_investigation` was REMOVED in release N+1
-        // (issue #331, DAR §12). The RawConfig key is retained
-        // (serde-known) so an operator config that still carries it
-        // gets this deliberate, documented error naming the
-        // replacement — not a raw unknown-field serde dump.
-        if raw.ticket_label_investigation.is_some() {
-            errors.push(
-                "ticket_label_investigation was removed in release N+1; investigations \
-                 were replaced by auto_review — remove the key (docs/architecture/\
-                 auto-review.md §12)"
-                    .to_string(),
-            );
         }
         // Translate legacy emoji trigger labels to canonical values at
         // read time (DAR §12). Exact match only; non-legacy values pass

--- a/src/state/queue/legacy_investigation.rs
+++ b/src/state/queue/legacy_investigation.rs
@@ -15,8 +15,7 @@
 //! a pre-N or N-era store remains (i.e. once direct pre-N→N+1 upgrades
 //! are out of support). Deleting it requires deleting
 //! `TicketType::Investigation`, the investigation `FinalizationStage`
-//! variants, the `WorkerResult::investigation` field, the retained
-//! `RawConfig::ticket_label_investigation` key, and the
+//! variants, the `WorkerResult::investigation` field, and the
 //! `PreviewReport::proposed_investigation_comment` field in the same
 //! change. Until then: frozen pre-N fixture tests in CI exercise every
 //! parse path (tests/state/investigation_removal_test.rs).
@@ -29,8 +28,6 @@
 //! * the `FinalizationStage` investigation string forms
 //!   (`investigation_ready` / `investigation_commented`) retained in
 //!   `queue::mod`'s `as_str`/`from_str` mappings (documented here),
-//! * the `RawConfig::ticket_label_investigation` sentinel key that
-//!   produces the deliberate `from_raw` error (documented here),
 //! * the `WorkerResult::investigation` serde default (documented on
 //!   the field).
 //!
@@ -49,10 +46,3 @@ pub const LEGACY_TICKET_TYPE_STRING: &str = "investigation";
 /// written by release N. Never produced by N+1 finalization paths.
 pub const LEGACY_STAGE_INVESTIGATION_READY: &str = "investigation_ready";
 pub const LEGACY_STAGE_INVESTIGATION_COMMENTED: &str = "investigation_commented";
-
-/// The config key removed in N+1. RETAINED on `RawConfig` so a config
-/// that still carries it produces the deliberate `from_raw` error
-/// naming the `auto_review` replacement, instead of a raw
-/// `deny_unknown_fields` serde dump. Presence alone is the trigger —
-/// the value is never read.
-pub const REMOVED_CONFIG_KEY: &str = "ticket_label_investigation";

--- a/src/state/queue/store.rs
+++ b/src/state/queue/store.rs
@@ -260,13 +260,13 @@ impl StateStore {
                 event = INVESTIGATION_ADMISSION_REJECTED_EVENT,
                 repo = %key.repo,
                 issue = key.number,
-                "investigation admission rejected: the ticket type was removed \
-                 in release N+1 (#331); use auto_review or a code ticket"
+                "investigation admission rejected: the ticket type was removed; \
+                 use auto_review or a code ticket"
             );
             return Err(CaduceusError::Queue {
                 context: "investigation-admission-rejected",
                 stderr: format!(
-                    "investigation tickets were removed in release N+1 (#331); \
+                    "investigation tickets were removed; \
                      admission rejected for {key} — re-file as auto_review or code"
                 ),
             });

--- a/tests/infra/config/auto_review_config_test.rs
+++ b/tests/infra/config/auto_review_config_test.rs
@@ -1,7 +1,7 @@
 //! Config-loader tests for the `auto_review:` block, the
 //! OCI-required validation (DAR §6.3), `max_reviews_per_tick`, and
-//! the N+1 `ticket_label_investigation` removal error (issue #331,
-//! DAR §12). Mirrors sandbox_config_test.rs: load through the
+//! the `ticket_label_investigation` removal (issue #382, DAR §12).
+//! Mirrors sandbox_config_test.rs: load through the
 //! canonical `Config::load_from` chain, assert on message content.
 
 use caduceus::infra::config::Config;
@@ -162,36 +162,27 @@ fn unknown_auto_review_key_is_rejected() {
     assert!(err.is_err(), "Phase-2 keys must fail at parse time");
 }
 
-// --- `ticket_label_investigation` removal error (issue #331, AC5) ---
+// --- `ticket_label_investigation` removal (issue #382) ---
 //
-// The release-N deprecation warning became the N+1 deliberate load
-// error. The RawConfig key stays serde-known so an operator config
-// that still carries it produces the GUIDED error naming the
-// auto_review replacement — never a raw deny_unknown_fields dump.
+// The legacy key was removed; a config carrying it fails at parse time
+// with serde's generic unknown-field error — no special-casing, no
+// guided message.
 
 #[test]
-fn ticket_label_investigation_removed_is_a_deliberate_error() {
+fn ticket_label_investigation_fails_at_parse_as_unknown_field() {
     let err = load(&format!(
         "{}ticket_label_investigation: \"autofix-investigate\"\n",
         trusted_host_base()
     ))
-    .expect_err("the removed key must fail the load in N+1");
+    .expect_err("the removed key must fail at parse time");
     let msg = format!("{err}");
     assert!(
+        msg.contains("unknown field"),
+        "expected serde unknown-field error, got: {msg}"
+    );
+    assert!(
         msg.contains("ticket_label_investigation"),
-        "error must name the key: {msg}"
-    );
-    assert!(
-        msg.contains("removed in release N+1"),
-        "error must state the removal: {msg}"
-    );
-    assert!(
-        msg.contains("auto_review"),
-        "error must name the replacement: {msg}"
-    );
-    assert!(
-        msg.contains("auto-review.md"),
-        "error must cite the spec: {msg}"
+        "error must name the unknown field: {msg}"
     );
 }
 

--- a/tests/integration/release_canary_test.rs
+++ b/tests/integration/release_canary_test.rs
@@ -347,8 +347,8 @@ fn write_config(
     ));
     yaml.push_str(&format!("  ticket_label_code: \"{}\"\n", CODE_LABEL));
     // `ticket_label_investigation` is intentionally NOT set: the key
-    // was removed in N+1 (#331) and a config carrying it now fails
-    // the load with the deliberate removal error.
+    // was removed (#382) and a config carrying it now fails at parse
+    // time with serde's generic unknown-field error.
     yaml.push_str(&format!("  dry_run: {}\n", dry_run));
     yaml.push_str("  reduced_containment_acknowledged: true\n");
     fs::write(config_path, yaml).expect("write canary config");

--- a/tests/state/config_test.rs
+++ b/tests/state/config_test.rs
@@ -481,23 +481,31 @@ fn state_backend_invalid_value_is_rejected() {
     assert!(msg.contains("json") && msg.contains("sqlite"), "got: {msg}");
 }
 
-// N+1 key removal (issue #331)
+// Legacy key removal (issue #382)
+
+// Legacy `ticket_label_investigation` key removed (issue #382).
+// A config carrying it now fails at PARSE time with serde's generic
+// unknown-field error — no special-casing, no guided message.
 
 #[test]
-fn removed_investigation_key_produces_deliberate_error() {
-    let root = tempdir("removed-inv-key");
+fn removed_investigation_key_fails_at_parse_as_unknown_field() {
     let yaml = r#"
         ticket_label_code: "autofix"
         ticket_label_investigation: "auto-fix"
         worker_command: ["python3", "bridge.py"]
         reduced_containment_acknowledged: true
         "#;
-    let raw: RawConfig = serde_yaml::from_str(yaml).expect("yaml parses");
-    let err = Config::from_raw(raw, &ctx(&root)).expect_err("removed key must fail the load");
-    let msg = format!("{err:?}");
-    assert!(msg.contains("ticket_label_investigation"), "got: {msg}");
-    assert!(msg.contains("removed in release N+1"), "got: {msg}");
-    assert!(msg.contains("auto_review"), "got: {msg}");
+    let err = serde_yaml::from_str::<RawConfig>(yaml)
+        .expect_err("the removed key must fail at parse time");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("unknown field"),
+        "expected serde unknown-field error, got: {msg}"
+    );
+    assert!(
+        msg.contains("ticket_label_investigation"),
+        "error must name the unknown field: {msg}"
+    );
 }
 
 // Legacy emoji label translation (DAR §12)

--- a/tests/state/investigation_removal_test.rs
+++ b/tests/state/investigation_removal_test.rs
@@ -429,8 +429,12 @@ fn admission_rejected() {
                 "error context must name the rejection: {text}"
             );
             assert!(
-                text.contains("#331"),
-                "error must cite the removal issue: {text}"
+                text.contains("auto_review"),
+                "error must name the replacement: {text}"
+            );
+            assert!(
+                !text.contains("#331"),
+                "error must not cite the internal removal issue: {text}"
             );
         },
         &capture_path,


### PR DESCRIPTION
Closes #382

## What

Remove the legacy `ticket_label_investigation` config key and all
special-casing around it, per the operator directive on #382: the key is
now treated exactly like any other unknown config key — a config that
still carries it fails at parse time with serde's generic `unknown field`
error (`deny_unknown_fields` on `RawConfig`). No guided message, no
"release N+1" jargon in operator-facing errors. `auto_review:` is the
only supported review config surface.

## Changes

- `src/infra/config/mod.rs` — delete the `RawConfig` field, the
  `from_raw` deliberate-error block, and the stale doc-comment tail on
  `LEGACY_TICKET_LABEL_TRANSLATIONS`.
- `src/state/queue/legacy_investigation.rs` — delete the orphaned
  `REMOVED_CONFIG_KEY` const and the two config-key module-doc bullets.
  The module itself stays (persisted-store parse-compat surface).
- `src/state/queue/store.rs` — reword the investigation admission-rejection
  warn/stderr strings to drop the internal issue citation; the guard stays
  as defense-in-depth.
- Tests: rework `config_test.rs` + `auto_review_config_test.rs` to pin the
  new parse-time unknown-field failure; keep the absent-key clean-load
  test; update the canary comment and the `admission_rejected` assertion
  (the latter previously pinned the removed `(#331)` citation).
- Docs: `release-notes.md`, `architecture/auto-review.md`, `migration.md`
  describe the unknown-field behavior instead of quoting the old error.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --all-targets` (hermetic skips) — 201 binaries, 0 failed
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` — 200 passed
- `bash scripts/check-commits.sh c635630..HEAD` — pass

One CI-style flake hit during the gate (oci_provenance_test
ETXTBSY race, pre-existing and documented in the test itself) was
confirmed to pass in isolation; unrelated to this change.
