### PR TITLE
fix(state): cadence skip must not advance the poll gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **Cadence-skipped ticks no longer slide the poll gate.** A tick
+  skipped by the cadence gate recorded its own timestamp as
+  `last_tick_finished`, re-arming the window from the skip: with the
+  default `poll_interval_seconds: 120` and a 2-minute cron, every
+  invocation landed inside the freshly-slid window and skipped again —
+  a silent, permanent poll loop. A `SkippedCadence` outcome now
+  records only its outcome for `caduceus status`; `last_tick_finished`
+  and `next_allowed_poll_at` keep the last completed tick's values, so
+  the gate measures from real work. Closes #384.
 - **Live OCI certification suite: image precedence and exit-code
   readback (issue #252).** The shared live-test fixture now applies
   `CADUCEUS_LIVE_TEST_IMAGE` (the reference image) to every test;

--- a/src/state/meta.rs
+++ b/src/state/meta.rs
@@ -557,6 +557,15 @@ impl CadenceGate {
     /// atomically and `next_allowed_poll_at` is set to the
     /// observation's `reset_at`; otherwise the next-allowed time
     /// is `now + poll_interval_seconds`.
+    ///
+    /// `SkippedCadence` is the one outcome that did no work, so it
+    /// must not re-arm the cadence window: it persists only
+    /// `last_outcome` (and `last_error` when present) and leaves
+    /// `last_tick_finished` and `next_allowed_poll_at` at the last
+    /// completed tick's values. Advancing either from the skip's own
+    /// timestamp makes the next invocation land inside the freshly
+    /// slid window too — a self-perpetuating skip loop whenever the
+    /// cron period is at or below `poll_interval_seconds` (#384).
     pub fn record_tick_finished(
         &self,
         now: DateTime<Utc>,
@@ -578,10 +587,20 @@ impl CadenceGate {
                 .as_ref()
                 .map(|r| r.reset_at)
                 .or_else(|| self.store.snapshot().rate_limit.map(|r| r.reset_at)),
+            // A cadence-skipped tick did no work: the next allowed
+            // poll is still whatever the last completed tick
+            // computed. Sliding this (or `last_tick_finished`)
+            // forward re-arms the gate from the skip itself and
+            // turns cron jitter into a permanent skip loop (#384).
+            TickOutcome::SkippedCadence => None,
             _ => Some(now + chrono::Duration::seconds(poll_interval_seconds as i64)),
         };
         self.store.update(|meta| {
-            meta.last_tick_finished = Some(now);
+            // Same invariant for the gate base: only a tick that did
+            // work may move `last_tick_finished` (#384).
+            if outcome != TickOutcome::SkippedCadence {
+                meta.last_tick_finished = Some(now);
+            }
             meta.last_outcome = Some(outcome);
             meta.last_http_status = http_status;
             if let Some(next) = next_allowed_poll_at {

--- a/tests/daemon/tick_test.rs
+++ b/tests/daemon/tick_test.rs
@@ -585,3 +585,51 @@ async fn auto_gc_error_path_returns_normal_tick_outcome() {
     assert_eq!(outcome, TickOutcome::IdleEmpty);
     assert!(wt.path.exists(), "GC error must not remove worktree");
 }
+
+fn read_state_meta(state_dir: &std::path::Path) -> caduceus::meta::StateMeta {
+    caduceus::meta::load(state_dir).expect("state meta loads")
+}
+
+// Issue #384, tick-level companion to the gate-level arbiter in
+// cadence_test.rs: a real cadence-skipped tick must keep the
+// last completed tick's window in state_meta.json.
+#[tokio::test]
+async fn cadence_skipped_tick_keeps_last_tick_finished() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-test-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    let server = MockServer::start().await;
+
+    // First tick completes and records last_tick_finished.
+    let outcome = run_tick(cfg.clone(), &server).await.expect("first tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+    let meta_after_first = read_state_meta(&cfg.state_dir);
+
+    // Second tick fires immediately → cadence skip (default
+    // poll_interval_seconds is 120; the two ticks are ms apart).
+    let outcome = run_tick(cfg.clone(), &server).await.expect("second tick");
+    assert_eq!(outcome, TickOutcome::SkippedCadence);
+    let meta_after_skip = read_state_meta(&cfg.state_dir);
+
+    // The skip must not have advanced the window or slid
+    // next_allowed_poll_at, but must record its outcome.
+    assert_eq!(
+        meta_after_skip.last_tick_finished, meta_after_first.last_tick_finished,
+        "skipped tick must not advance last_tick_finished"
+    );
+    assert_eq!(
+        meta_after_skip.next_allowed_poll_at, meta_after_first.next_allowed_poll_at,
+        "skipped tick must not slide next_allowed_poll_at"
+    );
+    assert_eq!(
+        meta_after_skip.last_outcome,
+        Some(TickOutcome::SkippedCadence)
+    );
+}

--- a/tests/state/cadence_test.rs
+++ b/tests/state/cadence_test.rs
@@ -180,3 +180,59 @@ fn configured_poll_interval_is_used_when_servers_silent() {
         other => panic!("expected Cadence, got {other:?}"),
     }
 }
+
+// Issue #384 regression: the cadence window must be anchored to the
+// last COMPLETED tick. On the old behavior the skip path recorded its
+// own timestamp as last_tick_finished, sliding the window forward with
+// every skip — on a cron period at or below poll_interval_seconds the
+// daemon silently stopped polling forever.
+#[test]
+fn cadence_skip_does_not_advance_the_gate_window() {
+    let state_dir = tempdir("skip-window");
+    let gate = CadenceGate::open(&state_dir).expect("gate opens");
+    let now = Utc::now();
+
+    // Completed tick at T (interval 60).
+    gate.record_tick_started(now).expect("record start");
+    gate.record_tick_finished(now, TickOutcome::Processed, Some(200), 60, None, None)
+        .expect("record finish");
+    let after_first = gate.store().snapshot();
+    assert_eq!(after_first.last_tick_finished, Some(now));
+
+    // Early tick at T+30 → the gate says Cadence.
+    let decision = gate.precheck(now + Duration::seconds(30), 60);
+    assert!(matches!(decision, CadenceDecision::Cadence { .. }));
+
+    // The daemon's skip path records exactly this outcome.
+    let skipped_at = now + Duration::seconds(30);
+    gate.record_tick_finished(
+        skipped_at,
+        decision.tick_outcome().expect("skip outcome"),
+        None,
+        60,
+        None,
+        None,
+    )
+    .expect("record skip");
+
+    // The skip did no work: the window must still be anchored at the
+    // completed tick, and next_allowed_poll_at must not slide.
+    let after_skip = gate.store().snapshot();
+    assert_eq!(
+        after_skip.last_tick_finished,
+        Some(now),
+        "skipped tick must not advance last_tick_finished"
+    );
+    assert_eq!(
+        after_skip.next_allowed_poll_at,
+        Some(now + Duration::seconds(60)),
+        "skipped tick must not slide next_allowed_poll_at"
+    );
+    // Observability: the outcome itself IS recorded.
+    assert_eq!(after_skip.last_outcome, Some(TickOutcome::SkippedCadence));
+
+    // The gate opens at T+61 — measured from the completed tick,
+    // not from the skip.
+    let decision = gate.precheck(now + Duration::seconds(61), 60);
+    assert_eq!(decision, CadenceDecision::Proceed);
+}


### PR DESCRIPTION
## Problem

A cadence-skipped tick did no work but still advanced the poll gate.
`record_tick_finished` unconditionally wrote the skip's own timestamp
as `last_tick_finished` and slid `next_allowed_poll_at` forward, so on
a cron period at or below `poll_interval_seconds` every invocation
landed inside the freshly-slid window and skipped again — a silent,
permanent poll loop. With the default `poll_interval_seconds: 120` and
a 2-minute cron, the daemon stops polling forever after one completed
tick. (Issue #384, P1, area/runtime.)

## Fix

Central change in `CadenceGate::record_tick_finished`
(`src/state/meta.rs`): a `SkippedCadence` outcome persists only
`last_outcome` (and `last_error` when present) for `caduceus status`
observability and leaves `last_tick_finished` / `next_allowed_poll_at`
anchored to the last completed tick's values. The daemon skip call
site is unchanged, and `RateLimited` semantics are byte-identical
(the rate-limit gate is `reset_at`-based — a wall-clock bound that
cannot loop). The invariant "a tick that did no work must not re-arm
the cadence window" is now a property of the outcome, enforced for
every caller.

## Regression coverage

- `tests/state/cadence_test.rs::cadence_skip_does_not_advance_the_gate_window`
  (gate-level arbiter): Proceed at T (interval 60) → skipped tick at
  T+30 → `last_tick_finished` still T, `next_allowed_poll_at` not slid
  past T+60 → precheck at T+61 → `Proceed`. Fails on pre-fix code at
  "skipped tick must not advance last_tick_finished".
- `tests/daemon/tick_test.rs::cadence_skipped_tick_keeps_last_tick_finished`
  (tick-level companion): two real `run_tick` invocations back-to-back
  on the default JSON backend; the skip returns `SkippedCadence` (exit
  0) but the persisted window is unchanged.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --all-targets` (hermetic skip list) — 201
  suites, 0 failures; cadence/rate_limit/meta/tick suites all green
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` —
  200 passed

Closes #384