### PR TITLE
fix(tick): record real poll interval on success-path ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **Successful ticks now project the real next-allowed-poll time.**
+  The tick's success path recorded `next_allowed_poll_at` with a
+  hard-coded poll interval of 0, so after every successful tick
+  `caduceus status` showed a "next allowed poll" in the past — the
+  tick's own start time. The configured `poll_interval_seconds` is
+  now threaded through, so the field shows when the cadence gate
+  actually opens next. Display-only: the gate itself reads
+  `last_tick_finished`, never `next_allowed_poll_at`.
 - **Cadence-skipped ticks no longer slide the poll gate.** A tick
   skipped by the cadence gate recorded its own timestamp as
   `last_tick_finished`, re-arming the window from the skip: with the

--- a/src/daemon/tick/awaiting_review.rs
+++ b/src/daemon/tick/awaiting_review.rs
@@ -323,6 +323,7 @@ pub(crate) fn finish_tick_outcome(
     now: DateTime<Utc>,
     outcome: TickOutcome,
     http_status: Option<u16>,
+    poll_interval_seconds: u64,
     last_error: Option<&CaduceusError>,
 ) -> CaduceusResult<()> {
     let _ = _meta;
@@ -350,7 +351,7 @@ pub(crate) fn finish_tick_outcome(
         now,
         outcome,
         http_status,
-        0,
+        poll_interval_seconds,
         rate_limit_info.as_ref(),
         last_error.map(|e| format!("{e}")),
     )
@@ -365,9 +366,18 @@ pub fn finish_tick_outcome_for_tests(
     now: DateTime<Utc>,
     outcome: TickOutcome,
     http_status: Option<u16>,
+    poll_interval_seconds: u64,
     last_error: Option<&CaduceusError>,
 ) -> CaduceusResult<()> {
-    finish_tick_outcome(gate, meta, now, outcome, http_status, last_error)
+    finish_tick_outcome(
+        gate,
+        meta,
+        now,
+        outcome,
+        http_status,
+        poll_interval_seconds,
+        last_error,
+    )
 }
 
 pub(crate) fn finish_tick_failure(

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -488,7 +488,15 @@ pub async fn tick(
         }
     };
     if repos.is_empty() {
-        finish_tick_outcome(&gate, &meta, now, TickOutcome::IdleEmpty, None, None)?;
+        finish_tick_outcome(
+            &gate,
+            &meta,
+            now,
+            TickOutcome::IdleEmpty,
+            None,
+            cfg.poll_interval_seconds,
+            None,
+        )?;
         return Ok(TickOutcome::IdleEmpty);
     }
 
@@ -1198,6 +1206,7 @@ pub async fn tick(
         now,
         outcome,
         http_status,
+        cfg.poll_interval_seconds,
         last_error.as_ref(),
     )?;
     Ok(outcome)

--- a/tests/daemon/awaiting_review_test.rs
+++ b/tests/daemon/awaiting_review_test.rs
@@ -456,3 +456,36 @@ async fn config_off_merged_to_done_skips_delete() {
     assert_eq!(entry.phase, Phase::Done);
     assert_eq!(gh.counts().delete, 0, "no DELETE when config flag is false");
 }
+
+// Regression: the success path used to pass a hard-coded
+// poll_interval_seconds = 0 to record_tick_finished, so every
+// successful tick persisted next_allowed_poll_at = the tick's own
+// timestamp — `caduceus status` showed a "next allowed poll"
+// perpetually in the past. Display-only (the cadence gate reads
+// last_tick_finished, never this field), but misleading for
+// operators reading status as "when will the daemon poll next".
+#[test]
+fn finish_tick_outcome_projects_next_allowed_poll_one_interval_ahead() {
+    let state_dir = tempdir("finish-outcome-interval");
+    let gate = caduceus::state::meta::CadenceGate::open(&state_dir).expect("gate opens");
+    let meta = caduceus::state::meta::MetaStore::open(&state_dir).expect("meta opens");
+    let now = chrono::Utc::now();
+
+    caduceus::daemon::tick::awaiting_review::finish_tick_outcome_for_tests(
+        &gate,
+        &meta,
+        now,
+        TickOutcome::Processed,
+        Some(200),
+        60,
+        None,
+    )
+    .expect("finish succeeds");
+
+    let snap = gate.store().snapshot();
+    assert_eq!(
+        snap.next_allowed_poll_at,
+        Some(now + chrono::Duration::seconds(60)),
+        "success path must project next_allowed_poll_at one interval ahead"
+    );
+}

--- a/tests/daemon/review_discovery_test.rs
+++ b/tests/daemon/review_discovery_test.rs
@@ -1643,6 +1643,7 @@ fn finish_tick_outcome_persists_rate_limit_from_last_error() {
         now,
         TickOutcome::IdleEmpty,
         None,
+        120,
         Some(&err),
     )
     .expect("finish succeeds");

--- a/tests/daemon/tick_test.rs
+++ b/tests/daemon/tick_test.rs
@@ -633,3 +633,36 @@ async fn cadence_skipped_tick_keeps_last_tick_finished() {
         Some(TickOutcome::SkippedCadence)
     );
 }
+
+// Companion to the seam-level arbiter in awaiting_review_test.rs:
+// the real tick must thread cfg.poll_interval_seconds into the
+// success-path recording (it used to pass a hard-coded 0, leaving
+// next_allowed_poll_at at the tick's own start time).
+#[tokio::test]
+async fn successful_tick_projects_next_allowed_poll_one_interval_ahead() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-test-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let bare = base.path().join("owner.git");
+    let clone = base.path().join("owner").join("r");
+    init_bare(&bare);
+    init_clone(&bare, &clone);
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    let server = MockServer::start().await;
+    let before = Utc::now();
+
+    let outcome = run_tick(cfg.clone(), &server).await.expect("tick");
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+
+    let meta = read_state_meta(&cfg.state_dir);
+    let next = meta
+        .next_allowed_poll_at
+        .expect("success path sets next_allowed_poll_at");
+    let delta = (next - before).num_seconds();
+    assert!(
+        (119..=180).contains(&delta),
+        "next_allowed_poll_at should be ~one interval (120s) past the tick start; got {delta}"
+    );
+}


### PR DESCRIPTION
## What

The tick's success path passed a hard-coded poll_interval_seconds = 0 to record_tick_finished, so every successful tick persisted next_allowed_poll_at = the tick's own start time. caduceus status showed a next-allowed-poll perpetually in the past.

## Why display-only

The cadence gate (CadenceGate::precheck) reads last_tick_finished and the persisted rate-limit reset; next_allowed_poll_at is consumed only by the status display (src/daemon/status.rs). No gating, polling, or correctness impact.

## Fix

- finish_tick_outcome gains a poll_interval_seconds: u64 parameter (mirroring finish_tick_failure, which already passed cfg.poll_interval_seconds) and threads it into record_tick_finished.
- Both tick call sites (empty-discovery IdleEmpty and the final post-drain outcome) pass cfg.poll_interval_seconds.
- The D14 test seam caller updated accordingly.

## Tests

- New seam-level arbiter: finish_tick_outcome with interval 60 asserts snapshot().next_allowed_poll_at == now + 60s (RED pre-fix: Some(now)).
- New tick-level companion: a real successful tick asserts state_meta.json next_allowed_poll_at lands ~one configured interval (120s) past the tick start (RED pre-fix: ~0).
- All sibling suites green (awaiting_review_test, tick_test, review_discovery_test, cadence_test, rate_limit_test, meta_test), including the #384 cadence-skip companions.

Found during #384 planning; kept out of PR #391 on blast-radius grounds (signature change + test seam + call sites). No GitHub issue — tracked as a kanban card per the programme's bug policy.