### PR TITLE
fix(github): accept 304 on PR merge-status poll (closes #385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **PR merge-status poll no longer fails on a benign 304.** The
+  GitHub client's ETag cache legitimately answers an unchanged PR
+  with HTTP 304 plus the cached body; the merge-status poll treated
+  any non-200 as a failure, so the Auto Review finalizer classified
+  the poll as a publish failure and retried with exponential backoff
+  forever — the sticky PR comment never appeared. A 304 now parses
+  the cached body exactly like a 200, so merged and closed states
+  survive unchanged. Closes #385.
 - **Successful ticks now project the real next-allowed-poll time.**
   The tick's success path recorded `next_allowed_poll_at` with a
   hard-coded poll interval of 0, so after every successful tick

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -648,6 +648,10 @@ name = "github_client_test"
 path = "tests/github/github_client_test.rs"
 
 [[test]]
+name = "merge_detect_test"
+path = "tests/github/merge_detect_test.rs"
+
+[[test]]
 name = "token_resolution_test"
 path = "tests/github/token_resolution_test.rs"
 

--- a/src/github/merge_detect.rs
+++ b/src/github/merge_detect.rs
@@ -40,7 +40,14 @@ pub async fn poll_pr_merge_status(
         Err(err) => return Err(err),
     };
 
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the poll (issue #385: the finalizer treated this as
+    // a publish failure and the sticky comment never posted).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!("poll pull request failed: {}", resp.status),

--- a/tests/github/merge_detect_test.rs
+++ b/tests/github/merge_detect_test.rs
@@ -1,0 +1,144 @@
+//! PR merge-status poll tests (issue #385).
+//!
+//! Coverage:
+//!
+//! - Fresh 200 polls classify open / merged / closed PRs.
+//! - The ETag-cached second poll (server replies 304, the client
+//!   replays the cached body) must classify identically to the fresh
+//!   poll. A 304 means "unchanged", never a poll failure — the #385
+//!   bug was the finalizer treating it as one and retrying forever.
+//! - The 304 replay must not lose state: a cached merged or closed
+//!   body still maps to `Merged` / `ClosedWithoutMerge`.
+
+use caduceus::config::Config;
+use caduceus::github::{poll_pr_merge_status, Client, HttpCache, MergeStatus};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Mock, Request, ResponseTemplate};
+
+use fixtures::{tempdir, MockGitHub};
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const OWNER: &str = "octocat";
+const REPO: &str = "hello-world";
+const PR_NUMBER: u64 = 42;
+const PR_PATH: &str = "/repos/octocat/hello-world/pulls/42";
+const ETAG: &str = "\"abc\"";
+
+/// Matches requests that do NOT carry the named header. The first
+/// (unconditional) GET has no `If-None-Match`; the second does. This
+/// disambiguates the two mocks on the same path — same pattern as
+/// `tests/github/github_client_test.rs`.
+struct NoHeader(&'static str);
+
+impl Match for NoHeader {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+fn mock_client(gh: &MockGitHub) -> Client {
+    let state_dir = tempdir("merge-detect");
+    let mut cfg = Config::test_defaults(&state_dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&state_dir).expect("cache opens");
+    Client::with_cache(&cfg, cache).expect("client builds")
+}
+
+/// Mount the two-arm conditional-GET sequence on the PR endpoint:
+/// 200 + ETag for the unconditional GET, 304 for the re-GET.
+async fn mount_pulls_two_arm(gh: &MockGitHub, pr_body: &'static str) {
+    Mock::given(method("GET"))
+        .and(path(PR_PATH))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_string(pr_body),
+        )
+        .expect(1)
+        .mount(gh.server())
+        .await;
+    Mock::given(method("GET"))
+        .and(path(PR_PATH))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+}
+
+#[tokio::test]
+async fn fresh_200_then_conditional_304_polls_still_open_pr() {
+    let gh = MockGitHub::start().await;
+    mount_pulls_two_arm(&gh, r#"{"merged": false, "state": "open"}"#).await;
+
+    let client = mock_client(&gh);
+    let first = poll_pr_merge_status(&client, OWNER, REPO, PR_NUMBER)
+        .await
+        .expect("fresh poll classifies");
+    assert_eq!(first, MergeStatus::StillOpen);
+
+    // The arbiter regression for #385: the conditional re-GET 304s
+    // and the client replays the cached body. This poll must NOT
+    // fail (on current main it returns Err(GitHubApi { status: 304 })).
+    let second = poll_pr_merge_status(&client, OWNER, REPO, PR_NUMBER)
+        .await
+        .expect("304 poll must not fail (issue #385)");
+    assert_eq!(second, MergeStatus::StillOpen);
+}
+
+#[tokio::test]
+async fn conditional_304_replay_preserves_merged_state() {
+    let gh = MockGitHub::start().await;
+    mount_pulls_two_arm(
+        &gh,
+        r#"{"merged": true, "state": "closed", "merge_commit_sha": "abc123"}"#,
+    )
+    .await;
+
+    let client = mock_client(&gh);
+    // Pre-warm the cache with the merged representation.
+    let first = poll_pr_merge_status(&client, OWNER, REPO, PR_NUMBER)
+        .await
+        .expect("fresh poll classifies");
+    assert_eq!(
+        first,
+        MergeStatus::Merged {
+            merge_commit_sha: "abc123".to_string()
+        }
+    );
+
+    // The 304 replay must preserve the merged classification — not
+    // collapse it to StillOpen, not fail the poll. Proves Option A
+    // loses no state (the reason Option B was rejected).
+    let second = poll_pr_merge_status(&client, OWNER, REPO, PR_NUMBER)
+        .await
+        .expect("304 replay of a merged PR must not fail (issue #385)");
+    assert_eq!(
+        second,
+        MergeStatus::Merged {
+            merge_commit_sha: "abc123".to_string()
+        },
+        "304 replay must not lose the merged state"
+    );
+}
+
+#[tokio::test]
+async fn conditional_304_replay_preserves_closed_unmerged_state() {
+    let gh = MockGitHub::start().await;
+    mount_pulls_two_arm(&gh, r#"{"merged": false, "state": "closed"}"#).await;
+
+    let client = mock_client(&gh);
+    let first = poll_pr_merge_status(&client, OWNER, REPO, PR_NUMBER)
+        .await
+        .expect("fresh poll classifies");
+    assert_eq!(first, MergeStatus::ClosedWithoutMerge);
+
+    let second = poll_pr_merge_status(&client, OWNER, REPO, PR_NUMBER)
+        .await
+        .expect("304 replay of a closed PR must not fail (issue #385)");
+    assert_eq!(second, MergeStatus::ClosedWithoutMerge);
+}

--- a/tests/review/finalizer_test.rs
+++ b/tests/review/finalizer_test.rs
@@ -15,7 +15,7 @@
 //!   comment (marker adoption / byte-identical idempotency).
 
 use caduceus::config::Config;
-use caduceus::github::{Client, HttpCache};
+use caduceus::github::{poll_pr_merge_status, Client, HttpCache};
 use caduceus::infra::logging::build_test_subscriber;
 use caduceus::review::finalize::{
     EVENT_PUBLISHED, EVENT_PUBLISH_FAILED_RETRYABLE, EVENT_PUBLISH_STARTED,
@@ -28,6 +28,8 @@ use caduceus::review::{
 };
 use caduceus::state::review::{ReviewHistoryRow, ReviewStore};
 use chrono::{DateTime, TimeZone, Utc};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Mock, Request, ResponseTemplate};
 
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
@@ -59,6 +61,17 @@ fn mock_client(gh: &MockGitHub) -> (Client, Config) {
     let cache = HttpCache::open(&state_dir).expect("cache opens");
     let client = Client::with_cache(&cfg, cache).expect("client builds");
     (client, cfg)
+}
+
+/// Matches requests that do NOT carry the named header. Disambiguates
+/// the unconditional first GET (200 + ETag) from the conditional
+/// re-GET (304) on the same path.
+struct NoHeader(&'static str);
+
+impl Match for NoHeader {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
 }
 
 fn sample_review() -> Review {
@@ -409,6 +422,74 @@ async fn github_failure_lands_in_failed_retryable_with_backoff() {
     assert_eq!(state.publication_state, PublicationState::Published);
     assert_eq!(state.sticky_comment_id, Some(778));
     assert_eq!(state.publication_attempt_count, 2, "retried once");
+}
+
+// ---------------------------------------------------------------------------
+// #385: a 304 on the lifecycle poll must publish, not retry forever
+// ---------------------------------------------------------------------------
+
+/// Mount the PR lifecycle endpoint as a two-arm conditional GET:
+/// 200 + ETag for the unconditional request, 304 for the re-GET.
+async fn mount_pulls_etag_then_304(gh: &MockGitHub) {
+    let pulls_path = format!("/repos/{OWNER}/{REPO}/pulls/{PR}");
+    gh.mount_with(|_| {
+        Mock::given(method("GET"))
+            .and(path(pulls_path.as_str()))
+            .and(NoHeader("if-none-match"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"abc\"")
+                    .set_body_string(r#"{"merged": false, "state": "open"}"#),
+            )
+            .expect(1)
+    })
+    .await;
+    gh.mount_with(|_| {
+        Mock::given(method("GET"))
+            .and(path(pulls_path.as_str()))
+            .and(header("if-none-match", "\"abc\""))
+            .respond_with(ResponseTemplate::new(304))
+            .expect(1)
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn lifecycle_poll_304_replay_publishes_instead_of_retrying() {
+    let gh = MockGitHub::start().await;
+    mount_pulls_etag_then_304(&gh).await;
+    // Publish-path endpoints: empty marker-search page + create.
+    gh.mount_paged(
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        vec![serde_json::json!([])],
+    )
+    .await;
+    gh.mount_status(
+        "POST",
+        &format!("/repos/{OWNER}/{REPO}/issues/{PR}/comments"),
+        201,
+        serde_json::json!({ "id": 779, "body": "" }),
+    )
+    .await;
+
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-304", 1, PublicationState::Pending);
+
+    // Pre-warm the ETag cache through the same client the finalizer
+    // will use, so the lifecycle poll below is the conditional GET.
+    let warm = poll_pr_merge_status(&client, OWNER, REPO, PR).await;
+    assert!(warm.is_ok(), "cache pre-warm poll succeeds");
+
+    // The finalizer's first GitHub call now 304s. It must parse the
+    // cached body and publish — NOT land in failed_retryable (the
+    // #385 symptom: publication_state stuck, comment never posts).
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize step completes");
+    assert_eq!(outcome, FinalizeOutcome::Published);
+    let state = load_state(&store);
+    assert_eq!(state.publication_state, PublicationState::Published);
+    assert_eq!(state.sticky_comment_id, Some(779));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`poll_pr_merge_status` treated the ETag cache's benign 304 replay as a
poll failure, so the Auto Review finalizer classified publication as
failed_retryable and retried with exponential backoff forever — the
sticky PR comment never posted (issue #385).

## Change

- `src/github/merge_detect.rs`: accept `200 | 304` and parse the
  cached body. GitHub mints a new ETag on any state change, so a 304
  proves the cached representation is current; merged/closed/open
  classifications are preserved exactly (the issue's simpler
  "return StillOpen on 304" suggestion would silently misclassify a
  cached merged/closed PR).
- `tests/github/merge_detect_test.rs` (new, registered in Cargo.toml):
  304-replay regressions for open / merged / closed PRs. RED on main:
  each second poll failed with `GitHubApi { status: 304, message:
  "poll pull request failed: 304" }`.
- `tests/review/finalizer_test.rs`: a publication whose lifecycle poll
  304s must end `Published`, not `failed_retryable`.
- `CHANGELOG.md`: Fixed bullet.

Out of scope (filed separately, kanban t_d04d9724): seven sibling
strict-200 checks on the same cached GET path in `src/finalize/`.

Closes #385
