### PR TITLE
fix(finalize): accept 304 on cached GET status checks (closes #396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,13 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **Finalize-path GETs no longer fail on a benign 304.** The ETag-cached
+  GitHub client answers an unchanged list/state GET with HTTP 304 plus
+  the cached body; eight status checks (PR-list and comment-list reads
+  across the finalize path, crash-resume reconciliation, and the
+  trigger verifier) treated any non-200 as a failure, so a finalize
+  retry or crash-resume on an unchanged URL failed permanently. All
+  eight now parse the cached body exactly like a 200. Closes #396.
 - **PR merge-status poll no longer fails on a benign 304.** The
   GitHub client's ETag cache legitimately answers an unchanged PR
   with HTTP 304 plus the cached body; the merge-status poll treated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -628,6 +628,10 @@ name = "finalize_commit_test"
 path = "tests/finalize/commit_test.rs"
 
 [[test]]
+name = "finalize_reconcile_test"
+path = "tests/finalize/reconcile_test.rs"
+
+[[test]]
 name = "context_test"
 path = "tests/github/context_test.rs"
 

--- a/src/finalize/comment_close.rs
+++ b/src/finalize/comment_close.rs
@@ -84,7 +84,14 @@ pub async fn post_completion_and_close(
     let resp = client
         .get(&list_path, "application/vnd.github+json")
         .await?;
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the stage (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!("list comments failed: {}", resp.status),
@@ -120,7 +127,14 @@ pub async fn post_completion_and_close(
     let resp = client
         .get(&issue_path, "application/vnd.github+json")
         .await?;
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the stage (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!("get issue failed: {}", resp.status),
@@ -215,7 +229,14 @@ pub async fn post_completion_only(
     let resp = client
         .get(&list_path, "application/vnd.github+json")
         .await?;
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the stage (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!("list comments failed: {}", resp.status),

--- a/src/finalize/failure_investigation.rs
+++ b/src/finalize/failure_investigation.rs
@@ -68,7 +68,14 @@ pub async fn post_failure_comment(
     let resp = client
         .get(&list_path, "application/vnd.github+json")
         .await?;
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the stage (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!("list comments failed: {}", resp.status),

--- a/src/finalize/pr.rs
+++ b/src/finalize/pr.rs
@@ -50,7 +50,14 @@ pub async fn find_or_create_pull_request(
     );
     let list_url = format!("{list_path}?{query}");
     let resp = client.get(&list_url, "application/vnd.github+json").await?;
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the stage (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!("list pull requests failed: {}", resp.status),

--- a/src/finalize/reconcile.rs
+++ b/src/finalize/reconcile.rs
@@ -67,7 +67,14 @@ pub async fn reconcile_pr(
     );
     let list_url = format!("{list_path}?{query}");
     let resp = client.get(&list_url, "application/vnd.github+json").await?;
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the stage (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!(
@@ -125,7 +132,14 @@ pub async fn reconcile_comment(
     let resp = client
         .get(&list_path, "application/vnd.github+json")
         .await?;
-    if !matches!(resp.status, 200) {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200 instead
+    // of failing the stage (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if !matches!(resp.status, 200 | 304) {
         return Err(CaduceusError::GitHubApi {
             status: resp.status,
             message: format!("list comments for reconciliation failed: {}", resp.status),

--- a/src/github/verify.rs
+++ b/src/github/verify.rs
@@ -110,7 +110,14 @@ fn verify_response(
             reason: SkipReason::NotFound,
         });
     }
-    if response.status != 200 && response.status != 201 {
+    // A 304 is the ETag-cached GET path replaying the cached
+    // representation: the client guarantees `body` is the last
+    // cached body (byte-identical to the 200 that stored the ETag),
+    // and GitHub mints a fresh ETag on any state change, so a 304
+    // proves the cached body is current. Parse it like a 200
+    // (issue #396, mirroring the #385 fix in
+    // src/github/merge_detect.rs).
+    if response.status != 200 && response.status != 201 && response.status != 304 {
         // Any other non-success is a transient error.
         return Err(CaduceusError::GitHubApi {
             status: response.status,

--- a/tests/finalize/reconcile_test.rs
+++ b/tests/finalize/reconcile_test.rs
@@ -1,0 +1,163 @@
+//! Reconcile-helper tests (issue #396).
+//!
+//! The ETag-cached GitHub client answers an unchanged GET with
+//! HTTP 304 plus the byte-identical cached body. The reconcile
+//! reads (`reconcile_pr`, `reconcile_comment`) used to treat any
+//! non-200 as a failure, so a crash-resume reconciliation on an
+//! unchanged URL failed permanently. These tests pin the fix: a
+//! 304 replay must parse the cached body exactly like a 200.
+
+use caduceus::config::Config;
+use caduceus::finalize::{reconcile_comment, reconcile_pr, ReconcileResult};
+use caduceus::github::{Client, HttpCache};
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Match, Mock, Request, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::{tempdir, MockGitHub};
+
+const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const OWNER: &str = "owner";
+const REPO: &str = "repo";
+const PR_PATH: &str = "/repos/owner/repo/pulls";
+const COMMENTS_PATH: &str = "/repos/owner/repo/issues/1/comments";
+const ETAG: &str = "\"abc\"";
+
+/// Matches requests that do NOT carry the named header. The first
+/// (unconditional) GET has no `If-None-Match`; the second does. This
+/// disambiguates the two mocks on the same path — same pattern as
+/// `tests/github/merge_detect_test.rs`.
+struct NoHeader(&'static str);
+
+impl Match for NoHeader {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+/// Cache-backed client for the 304-replay tests. The cache must live
+/// in an owned `PathBuf` (`fixtures::tempdir`, no auto-cleanup) so it
+/// survives past the helper's return — a `tempfile::tempdir()` local
+/// binding would drop the cache DB before any HTTP call.
+fn mock_client(gh: &MockGitHub) -> Client {
+    let state_dir = tempdir("reconcile");
+    let mut cfg = Config::test_defaults(&state_dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&state_dir).expect("cache opens");
+    Client::with_cache(&cfg, cache).expect("client builds")
+}
+
+/// Mount the two-arm conditional-GET sequence on the open-PR list
+/// endpoint: 200 + ETag for the unconditional GET, 304 for the
+/// re-GET. Query matching mirrors `pr_test.rs`: path + `state=open`
+/// only, never the percent-encoded head/base params.
+async fn mount_pulls_two_arm(gh: &MockGitHub, pr_body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path(PR_PATH))
+        .and(query_param("state", "open"))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_json(pr_body),
+        )
+        .expect(1)
+        .mount(gh.server())
+        .await;
+    Mock::given(method("GET"))
+        .and(path(PR_PATH))
+        .and(query_param("state", "open"))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+}
+
+/// Same two-arm sequence on the issue-comments endpoint.
+async fn mount_comments_two_arm(gh: &MockGitHub, comments_body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path(COMMENTS_PATH))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_json(comments_body),
+        )
+        .expect(1)
+        .mount(gh.server())
+        .await;
+    Mock::given(method("GET"))
+        .and(path(COMMENTS_PATH))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(gh.server())
+        .await;
+}
+
+#[tokio::test]
+async fn reconcile_pr_304_replay_already_applied() {
+    let gh = MockGitHub::start().await;
+    mount_pulls_two_arm(
+        &gh,
+        serde_json::json!([
+            { "number": 7, "html_url": "https://github.com/owner/repo/pull/7" }
+        ]),
+    )
+    .await;
+
+    let client = mock_client(&gh);
+    let first = reconcile_pr(
+        &client,
+        OWNER,
+        REPO,
+        "automation/issue-1-run-x",
+        "main",
+        Some("7"),
+    )
+    .await
+    .expect("fresh list reconciles as applied");
+    assert_eq!(first, ReconcileResult::AlreadyApplied);
+
+    // The conditional re-GET 304s and the client replays the cached
+    // body. This reconcile must NOT fail (on current main the second
+    // call returns Err(GitHubApi { status: 304 })).
+    let second = reconcile_pr(
+        &client,
+        OWNER,
+        REPO,
+        "automation/issue-1-run-x",
+        "main",
+        Some("7"),
+    )
+    .await
+    .expect("304 replay must not fail (issue #396)");
+    assert_eq!(second, ReconcileResult::AlreadyApplied);
+}
+
+#[tokio::test]
+async fn reconcile_comment_304_replay_already_applied() {
+    let gh = MockGitHub::start().await;
+    mount_comments_two_arm(
+        &gh,
+        serde_json::json!([
+            { "id": 1, "body": "<!-- automation-run:run-x\n\nsummary" }
+        ]),
+    )
+    .await;
+
+    let client = mock_client(&gh);
+    let first = reconcile_comment(&client, OWNER, REPO, 1, "run-x", "<!-- automation-run:")
+        .await
+        .expect("fresh list reconciles as applied");
+    assert_eq!(first, ReconcileResult::AlreadyApplied);
+
+    let second = reconcile_comment(&client, OWNER, REPO, 1, "run-x", "<!-- automation-run:")
+        .await
+        .expect("304 replay must not fail (issue #396)");
+    assert_eq!(second, ReconcileResult::AlreadyApplied);
+}

--- a/tests/github/failure_investigation_test.rs
+++ b/tests/github/failure_investigation_test.rs
@@ -17,17 +17,23 @@ use caduceus::config::{Config, LoadContext, RawConfig};
 use caduceus::finalize::{
     post_failure_comment, render_failure_comment, FinalizeContext, FAILURE_MARKER_PREFIX,
 };
-use caduceus::github::Client;
+use caduceus::github::{Client, HttpCache};
 use caduceus::issue::IssueDetail;
 use caduceus::queue::ClaimToken;
 use caduceus::worker::{WorkerResult, WorkerStatus};
 use caduceus::worktree::Worktree;
 use chrono::Utc;
 use serde_json::json;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const ETAG: &str = "\"abc\"";
 
 /// Inert `Arc<Client>` for tests that build a `FinalizeContext`
 /// but never exercise the GitHub HTTP path.
@@ -122,6 +128,55 @@ fn client_for(server: &MockServer) -> Client {
     cfg.api_base = server.uri();
     cfg.github_token = Some(TEST_TOKEN.to_string());
     Client::with_config(&cfg).expect("client")
+}
+
+/// Cache-backed client for the 304-replay test. The cache must live
+/// in an owned `PathBuf` (`fixtures::tempdir`, no auto-cleanup) so it
+/// survives past the helper's return — the `client_for` helper drops
+/// its `TempDir` (and the cache DB) before any HTTP call.
+fn cached_client_for(server: &MockServer) -> Client {
+    let state_dir = tempdir("fail-304");
+    let mut cfg = empty_config(&state_dir);
+    cfg.api_base = server.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&state_dir).expect("cache opens");
+    Client::with_cache(&cfg, cache).expect("client builds")
+}
+
+/// Matches requests that do NOT carry the named header. The first
+/// (unconditional) GET has no `If-None-Match`; the second does. This
+/// disambiguates the two mocks on the same path — same pattern as
+/// `tests/github/merge_detect_test.rs`.
+struct NoHeader(&'static str);
+
+impl Match for NoHeader {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+/// Mount the two-arm conditional-GET sequence on the issue-comments
+/// endpoint: 200 + ETag for the unconditional GET, 304 for the
+/// re-GET.
+async fn mount_comments_two_arm(server: &MockServer, comments_body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_json(comments_body),
+        )
+        .expect(1)
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(server)
+        .await;
 }
 
 #[tokio::test]
@@ -246,4 +301,35 @@ async fn failure_comment_does_not_claim_local_transcript_is_public() {
     assert!(!body.contains("/state/"));
     assert!(!body.contains(".transcript"));
     assert!(body.contains(FAILURE_MARKER_PREFIX));
+}
+
+#[tokio::test]
+async fn failure_304_replay_skips_post() {
+    // The ETag-cached second list GET replies 304 and the client
+    // replays the cached body, which carries the failure marker —
+    // the marker check must parse it like a 200, so no POST and no
+    // failure. On current main the second call returns
+    // Err(GitHubApi { status: 304 }).
+    let server = MockServer::start().await;
+    let body = format!("{}{}\n\nsummary", FAILURE_MARKER_PREFIX, "run-fail-304");
+    mount_comments_two_arm(&server, serde_json::json!([{ "id": 1, "body": body }])).await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    let client = cached_client_for(&server);
+    let state_dir = tempdir("fail-304-cfg");
+    let cfg = empty_config(&state_dir);
+    let issue = make_issue();
+    let ctx = make_context(&cfg, &issue, "run-fail-304");
+    let wr = make_worker_result();
+    let first = post_failure_comment(&ctx, &client, &wr)
+        .await
+        .expect("fresh call succeeds");
+    assert!(!first.comment_posted);
+    let second = post_failure_comment(&ctx, &client, &wr)
+        .await
+        .expect("304 replay must not fail (issue #396)");
+    assert!(!second.comment_posted);
 }

--- a/tests/github/issue_close_test.rs
+++ b/tests/github/issue_close_test.rs
@@ -17,19 +17,26 @@ use std::sync::Arc;
 
 use caduceus::config::{Config, LoadContext, RawConfig};
 use caduceus::finalize::{
-    post_completion_and_close, render_completion_comment, FinalizeContext, COMPLETION_MARKER_PREFIX,
+    post_completion_and_close, post_completion_only, render_completion_comment, FinalizeAction,
+    FinalizeContext, COMPLETION_MARKER_PREFIX,
 };
-use caduceus::github::Client;
+use caduceus::github::{Client, HttpCache};
 use caduceus::issue::IssueDetail;
 use caduceus::queue::ClaimToken;
 use caduceus::worker::{WorkerResult, WorkerStatus};
 use caduceus::worktree::Worktree;
 use chrono::Utc;
 use serde_json::json;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const ETAG: &str = "\"abc\"";
 
 /// Inert `Arc<Client>` for tests that build a `FinalizeContext`
 /// but never exercise the GitHub HTTP path.
@@ -124,6 +131,77 @@ fn client_for(server: &MockServer) -> Client {
     cfg.api_base = server.uri();
     cfg.github_token = Some(TEST_TOKEN.to_string());
     Client::with_config(&cfg).expect("client")
+}
+
+/// Cache-backed client for the 304-replay tests. The cache must live
+/// in an owned `PathBuf` (`fixtures::tempdir`, no auto-cleanup) so it
+/// survives past the helper's return — the `client_for` helper drops
+/// its `TempDir` (and the cache DB) before any HTTP call.
+fn cached_client_for(server: &MockServer) -> Client {
+    let state_dir = tempdir("close-304");
+    let mut cfg = empty_config(&state_dir);
+    cfg.api_base = server.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&state_dir).expect("cache opens");
+    Client::with_cache(&cfg, cache).expect("client builds")
+}
+
+/// Matches requests that do NOT carry the named header. The first
+/// (unconditional) GET has no `If-None-Match`; the second does. This
+/// disambiguates the two mocks on the same path — same pattern as
+/// `tests/github/merge_detect_test.rs`.
+struct NoHeader(&'static str);
+
+impl Match for NoHeader {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+/// Mount the two-arm conditional-GET sequence on the issue-comments
+/// endpoint: 200 + ETag for the unconditional GET, 304 for the
+/// re-GET.
+async fn mount_comments_two_arm(server: &MockServer, comments_body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_json(comments_body),
+        )
+        .expect(1)
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1/comments"))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+/// Same two-arm sequence on the issue-state endpoint.
+async fn mount_issue_two_arm(server: &MockServer, issue_body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1"))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_json(issue_body),
+        )
+        .expect(1)
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/1"))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(server)
+        .await;
 }
 
 #[tokio::test]
@@ -316,4 +394,82 @@ fn completion_marker_includes_run_id() {
     assert!(body.contains(COMPLETION_MARKER_PREFIX));
     assert!(body.contains("run-marker-001"));
     assert!(body.contains("-->"));
+}
+
+#[tokio::test]
+async fn close_completion_304_replay_parses_cached_list_and_state() {
+    // The ETag-cached second call 304s on both the comment list and
+    // the issue-state GET; the client replays the cached bodies, so
+    // the marker check and the state check must parse them like a
+    // 200. On current main the second call fails at the first
+    // strict-200 check with Err(GitHubApi { status: 304 }).
+    let server = MockServer::start().await;
+    let marker_body = format!("{}{}\nsummary", COMPLETION_MARKER_PREFIX, "run-reuse-304");
+    mount_comments_two_arm(
+        &server,
+        serde_json::json!([{ "id": 1, "body": marker_body }]),
+    )
+    .await;
+    mount_issue_two_arm(&server, serde_json::json!({ "state": "open" })).await;
+    // The marker is pre-seeded in the cached body; a 304 replay must
+    // never POST.
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    let client = cached_client_for(&server);
+    let state_dir = tempdir("close-304-cfg");
+    let cfg = empty_config(&state_dir);
+    let issue = make_issue();
+    let ctx = make_context(&cfg, &issue, "run-reuse-304");
+    let result = make_worker_result();
+    let first = post_completion_and_close(&ctx, &client, &result)
+        .await
+        .expect("fresh call succeeds");
+    assert!(!first.comment_posted);
+    assert!(!first.issue_closed);
+    let second = post_completion_and_close(&ctx, &client, &result)
+        .await
+        .expect("304 replay must not fail (issue #396)");
+    assert!(!second.comment_posted);
+    assert!(!second.issue_closed);
+}
+
+#[tokio::test]
+async fn completion_only_304_replay_skips_post() {
+    // Same contract for the non-terminal comment path: the cached
+    // 304 body carries the marker, so no POST and no failure.
+    let server = MockServer::start().await;
+    let marker_body = format!("{}{}\nsummary", COMPLETION_MARKER_PREFIX, "run-only-304");
+    mount_comments_two_arm(
+        &server,
+        serde_json::json!([{ "id": 1, "body": marker_body }]),
+    )
+    .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    let client = cached_client_for(&server);
+    let state_dir = tempdir("close-304-cfg");
+    let cfg = empty_config(&state_dir);
+    let issue = make_issue();
+    let ctx = make_context(&cfg, &issue, "run-only-304");
+    let result = make_worker_result();
+    let first = post_completion_only(&ctx, &client, &result)
+        .await
+        .expect("fresh call succeeds");
+    assert_eq!(first.action, FinalizeAction::Commented);
+    assert!(first
+        .idempotency_observations
+        .contains(&"comment_posted=false".to_string()));
+    let second = post_completion_only(&ctx, &client, &result)
+        .await
+        .expect("304 replay must not fail (issue #396)");
+    assert_eq!(second.action, FinalizeAction::Commented);
+    assert!(second
+        .idempotency_observations
+        .contains(&"comment_posted=false".to_string()));
 }

--- a/tests/github/pr_test.rs
+++ b/tests/github/pr_test.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use caduceus::config::{Config, LoadContext, RawConfig};
 use caduceus::finalize::find_or_create_pull_request;
-use caduceus::github::Client;
+use caduceus::github::{Client, HttpCache};
 use caduceus::issue::IssueDetail;
 use caduceus::queue::ClaimToken;
 use caduceus::worker::{WorkerResult, WorkerStatus};
@@ -30,14 +30,15 @@ use caduceus::worktree::Worktree;
 use chrono::Utc;
 use serde_json::json;
 use wiremock::matchers::{header, method, path, query_param};
-use wiremock::{Mock, ResponseTemplate};
+use wiremock::{Match, Mock, Request, ResponseTemplate};
 
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
-use fixtures::MockGitHub;
+use fixtures::{tempdir, MockGitHub};
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
+const ETAG: &str = "\"abc\"";
 
 /// Build an inert `Arc<Client>` for tests that construct a
 /// `FinalizeContext` but never call any HTTP method. The base
@@ -134,6 +135,58 @@ fn client_for(gh: &MockGitHub) -> Client {
     cfg.api_base = gh.uri();
     cfg.github_token = Some(TEST_TOKEN.to_string());
     Client::with_config(&cfg).expect("client")
+}
+
+/// Cache-backed client for the 304-replay test. The cache must live
+/// in an owned `PathBuf` (`fixtures::tempdir`, no auto-cleanup) so it
+/// survives past the helper's return — the `client_for` helper drops
+/// its `TempDir` (and the cache DB) before any HTTP call.
+fn cached_client_for(gh: &MockGitHub) -> Client {
+    let state_dir = tempdir("pr-304");
+    let mut cfg = empty_config(&state_dir);
+    cfg.api_base = gh.uri();
+    cfg.github_token = Some(TEST_TOKEN.to_string());
+    let cache = HttpCache::open(&state_dir).expect("cache opens");
+    Client::with_cache(&cfg, cache).expect("client builds")
+}
+
+/// Matches requests that do NOT carry the named header. The first
+/// (unconditional) GET has no `If-None-Match`; the second does. This
+/// disambiguates the two mocks on the same path — same pattern as
+/// `tests/github/merge_detect_test.rs`.
+struct NoHeader(&'static str);
+
+impl Match for NoHeader {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+/// Mount the two-arm conditional-GET sequence on the open-PR list
+/// endpoint: 200 + ETag for the unconditional GET, 304 for the
+/// re-GET. Query matching mirrors the existing list tests: path +
+/// `state=open` only, never the percent-encoded head/base params.
+async fn mount_pulls_two_arm(gh: &MockGitHub, pr_body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls"))
+        .and(query_param("state", "open"))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_json(pr_body),
+        )
+        .expect(1)
+        .mount(gh.server())
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls"))
+        .and(query_param("state", "open"))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(gh.server())
+        .await;
 }
 
 #[tokio::test]
@@ -386,4 +439,42 @@ async fn pr_post_body_carries_exact_title_and_head() {
         .await
         .expect("find or create");
     assert_eq!(pr.number, 8);
+}
+
+#[tokio::test]
+async fn pr_list_304_replay_reuses_cached_pr() {
+    // The ETag-cached second list GET replies 304 and the client
+    // replays the cached body. The list must be parsed like a 200
+    // and the existing PR reused — on current main the second call
+    // returns Err(GitHubApi { status: 304 }).
+    let gh = MockGitHub::start().await;
+    mount_pulls_two_arm(
+        &gh,
+        serde_json::json!([
+            { "number": 7, "html_url": "https://github.com/owner/repo/pull/7" }
+        ]),
+    )
+    .await;
+    // No POST should occur — the cached body already lists the PR.
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(gh.server())
+        .await;
+    let client = cached_client_for(&gh);
+    let state_dir = tempdir("pr-304-cfg");
+    let cfg = empty_config(&state_dir);
+    let issue = make_issue();
+    let ctx = make_context(&cfg, &issue, "run-reuse-304");
+    let result = make_worker_result("summary", "PR title");
+    let first = find_or_create_pull_request(&ctx, &client, &result)
+        .await
+        .expect("fresh list reuses the existing PR");
+    assert_eq!(first.number, 7);
+    assert!(first.reused);
+    let second = find_or_create_pull_request(&ctx, &client, &result)
+        .await
+        .expect("304 replay must not fail (issue #396)");
+    assert_eq!(second.number, 7);
+    assert!(second.reused);
 }

--- a/tests/github/verify_test.rs
+++ b/tests/github/verify_test.rs
@@ -16,8 +16,8 @@ use caduceus::github::{Client, HttpCache};
 use caduceus::issue::IssueKey;
 use caduceus::queue::TicketType;
 use caduceus::verify::{SkipReason, VerifyOutcome};
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
@@ -25,6 +25,7 @@ use fixtures::tempdir;
 
 const TEST_TOKEN: &str = "ghp_testtoken_value_xyz";
 const CODE_LABEL: &str = "autofix";
+const ETAG: &str = "\"abc\"";
 
 fn mock_client_with_repos(server: &MockServer) -> (Client, Config) {
     let state_dir = tempdir("mock");
@@ -53,6 +54,41 @@ fn issue_body(labels: &[&str], state: &str, pull_request: bool) -> serde_json::V
             serde_json::json!({"url": "https://api.github.com/repos/octocat/hello-world/pulls/7"});
     }
     obj
+}
+
+/// Matches requests that do NOT carry the named header. The first
+/// (unconditional) GET has no `If-None-Match`; the second does. This
+/// disambiguates the two mocks on the same path — same pattern as
+/// `tests/github/merge_detect_test.rs`.
+struct NoHeader(&'static str);
+
+impl Match for NoHeader {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+/// Mount the two-arm conditional-GET sequence on the issue endpoint:
+/// 200 + ETag for the unconditional GET, 304 for the re-GET.
+async fn mount_issue_two_arm(server: &MockServer, issue_body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/issues/7"))
+        .and(NoHeader("if-none-match"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("etag", ETAG)
+                .set_body_json(issue_body),
+        )
+        .expect(1)
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/issues/7"))
+        .and(header("if-none-match", ETAG))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(server)
+        .await;
 }
 
 // Both ticket types
@@ -357,4 +393,25 @@ fn skip_reason_as_str_is_stable() {
     assert_eq!(SkipReason::Transferred.as_str(), "transferred");
     assert_eq!(SkipReason::NotFound.as_str(), "not_found");
     assert_eq!(SkipReason::Malformed.as_str(), "malformed");
+}
+
+#[tokio::test]
+async fn verify_304_replay_returns_same_outcome() {
+    // The ETag-cached second GET replies 304 and the client replays
+    // the cached body with the cached final_url. The verifier must
+    // parse it like a 200 and still Proceed — on current main the
+    // second call returns Err(GitHubApi { status: 304 }).
+    let server = MockServer::start().await;
+    mount_issue_two_arm(&server, issue_body(&[CODE_LABEL], "open", false)).await;
+
+    let (client, cfg) = mock_client_with_repos(&server);
+    let key = IssueKey::parse("octocat/hello-world#7").unwrap();
+    let first = caduceus::verify::verify_trigger(&client, &key, TicketType::Code, &cfg)
+        .await
+        .expect("fresh verify proceeds");
+    assert_eq!(first, VerifyOutcome::Proceed);
+    let second = caduceus::verify::verify_trigger(&client, &key, TicketType::Code, &cfg)
+        .await
+        .expect("304 replay must not fail (issue #396)");
+    assert_eq!(second, VerifyOutcome::Proceed);
 }


### PR DESCRIPTION
## Summary

The ETag-cached GitHub client answers an unchanged GET with HTTP 304
plus the byte-identical cached body (`src/github/client/client_core.rs`,
correct and tested — unchanged here). Eight status checks on the
finalize path (PR-list read, completion comment-list / issue-state
reads, failure-comment list read, crash-resume reconciliation reads,
and the trigger verifier) treated any non-200 as a failure, so a
finalize retry or crash-resume on an unchanged URL failed permanently
with `Err(GitHubApi { status: 304 })`.

All eight now accept 304 and parse the cached body exactly like a 200,
mirroring the #385 fix in `src/github/merge_detect.rs`. POST/PATCH
status checks are untouched — writes never receive this cache's 304.

Seven new tests across five binaries (tests-first: RED on main at the
second call, GREEN after the fix):

- `tests/github/pr_test.rs`: `pr_list_304_replay_reuses_cached_pr` (site 1)
- `tests/github/issue_close_test.rs`:
  `close_completion_304_replay_parses_cached_list_and_state` (sites 2+3),
  `completion_only_304_replay_skips_post` (site 4)
- `tests/github/failure_investigation_test.rs`:
  `failure_304_replay_skips_post` (site 5)
- `tests/finalize/reconcile_test.rs` (new binary, registered in
  Cargo.toml): `reconcile_pr_304_replay_already_applied`,
  `reconcile_comment_304_replay_already_applied` (sites 6+7)
- `tests/github/verify_test.rs`: `verify_304_replay_returns_same_outcome`
  (site 8)

Verification: `cargo fmt --check`, `cargo clippy --locked --all-targets
-- -D warnings`, `cargo test --locked --all-targets` (3052 passed,
0 failed, hermetic skips), `uv run pytest -q tests/plugin/
tests/integration/bridge_test.py` (200 passed).

Closes #396