### PR TITLE
fix(runtime): initialise file logging on caduceus run (closes #386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **`caduceus run` now initialises file logging.** The CLI `run`
+  handler — the entry path the cron pulse wrapper and bare `caduceus`
+  invocations actually take — never called `logging::init`, so
+  `<state_dir>/processor.log` was never created: the structured log
+  stream, and even the handler's own git-identity warning, were
+  silently dropped because no tracing subscriber was installed. The
+  handler now initialises logging right after config resolution —
+  mirroring the documented `tick::run` order — and flushes the
+  non-blocking writer before `std::process::exit`. Closes #386.
 - **Finalize-path GETs no longer fail on a benign 304.** The ETag-cached
   GitHub client answers an unchanged list/state GET with HTTP 304 plus
   the cached body; eight status checks (PR-list and comment-list reads

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,6 +520,10 @@ name = "review_cli_test"
 path = "tests/cli/review_cli_test.rs"
 
 [[test]]
+name = "run_logging_test"
+path = "tests/cli/run_logging_test.rs"
+
+[[test]]
 name = "state_store_test"
 path = "tests/state/state_store_test.rs"
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -243,6 +243,13 @@ pub fn run() -> CaduceusResult<()> {
                 Some(path) => Config::load_from(std::path::Path::new(&path))?,
                 None => Config::load()?,
             };
+            // Initialise the structured log stream before any tick work
+            // so every subsequent event — including the git-identity
+            // warning below, which is currently dropped because no
+            // subscriber is installed on this path — lands in
+            // `<state_dir>/processor.log`. Mirrors the documented order
+            // of the no-argument wrapper `tick::run` (issue #386).
+            let _log_guard = caduceus::logging::init(&cfg.log_path)?;
             let (host_name, host_email) = caduceus::finalize::commit::host_git_identity();
             let name_from_tier3 = cfg.git_author_name.is_none() && host_name.is_none();
             let email_from_tier3 = cfg.git_author_email.is_none() && host_email.is_none();
@@ -252,6 +259,10 @@ pub fn run() -> CaduceusResult<()> {
                 tracing::warn!("git_author: no config or host identity resolved — falling back to \"Caduceus Daemon <caduceus@daemon.local>\". Configure git_author_name + git_author_email in the caduceus: config block to silence this warning.");
             }
             let outcome = caduceus::tick::run_blocking(cfg)?;
+            // `std::process::exit` runs no destructors; drop the guard
+            // so the non-blocking writer flushes pending events before
+            // the process terminates.
+            drop(_log_guard);
             // Map the outcome to the documented exit code so
             // the cron model (Processed / Idle / Cancelled →
             // 0; Failed → 1) holds without changing the CLI.

--- a/tests/cli/run_logging_test.rs
+++ b/tests/cli/run_logging_test.rs
@@ -1,0 +1,151 @@
+//! `caduceus run` initialises file logging (issue #386).
+//!
+//! Regression: the CLI `run` handler — the entry path the cron pulse
+//! wrapper, bare `caduceus`, and explicit `caduceus run` all take —
+//! never called `logging::init`, so `<state_dir>/processor.log` was
+//! never created and every tracing event (including the handler's own
+//! git-identity warning) was silently dropped.
+//!
+//! Hermeticity: each test seeds `state_meta.json` so the cadence gate
+//! returns a gate-skip before any network I/O — the same trick as
+//! `tests/daemon/signal_test.rs::seed_recent_tick`. The spawned binary
+//! must still create the log file, because `logging::init` runs before
+//! the tick even starts.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use caduceus::meta::{StateMeta, TickOutcome, META_VERSION};
+use chrono::Utc;
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use fixtures::tempdir;
+
+/// Write a minimal valid config pointing `state_dir` at *dir* and the
+/// worker at a noop script. `log_path` overrides the default
+/// `<state_dir>/processor.log` when supplied (YAML shape mirrors
+/// `review_cli_test.rs` / `signal_test.rs`).
+fn write_config(state_dir: &Path, log_path: Option<&Path>) -> PathBuf {
+    let hermes_home = state_dir.join("hermes");
+    fs::create_dir_all(&hermes_home).expect("create hermes home");
+    let noop = state_dir.join("noop.py");
+    fs::write(&noop, "#!/usr/bin/env python3\n").expect("write noop worker");
+    let mut yaml = format!(
+        "caduceus:\n  state_dir: \"{}\"\n  poll_interval_seconds: 3600\n",
+        state_dir.display()
+    );
+    if let Some(path) = log_path {
+        yaml.push_str(&format!("  log_path: \"{}\"\n", path.display()));
+    }
+    yaml.push_str(&format!(
+        "  watched_repos:\n    - \"owner/repo\"\n  worker_command:\n    - \"python3\"\n    - \"{}\"\n  reduced_containment_acknowledged: true\n",
+        noop.display()
+    ));
+    let config_path = state_dir.join("config.yaml");
+    fs::write(&config_path, yaml).expect("write config");
+    config_path
+}
+
+/// Seed `state_meta.json` with a fresh `last_tick_finished` and a
+/// future `next_allowed_poll_at` so the cadence gate's precheck fires
+/// and the tick returns a gate-skip without polling GitHub (verbatim
+/// shape of `signal_test.rs::seed_recent_tick`).
+fn seed_recent_tick(state_dir: &Path) {
+    let now = Utc::now();
+    let meta = StateMeta {
+        version: META_VERSION,
+        last_tick_started: Some(now),
+        last_tick_finished: Some(now),
+        last_outcome: Some(TickOutcome::Processed),
+        last_http_status: Some(200),
+        next_allowed_poll_at: Some(now + chrono::Duration::seconds(3600)),
+        last_reap_at: None,
+        last_reaped_count: 0,
+        rate_limit: None,
+        last_error: None,
+        recent_diagnostics: Vec::new(),
+    };
+    let body = serde_json::to_vec(&meta).expect("serialize meta");
+    fs::write(state_dir.join("state_meta.json"), body).expect("write state_meta.json");
+}
+
+/// Run the built `caduceus` binary's `run` subcommand as a subprocess.
+/// `RUST_LOG` is removed so the default `caduceus=info,info` filter is
+/// deterministic regardless of the host environment.
+fn run_binary(config: &Path) -> std::process::Output {
+    let hermes_home = config.parent().expect("config has a parent").join("hermes");
+    Command::new(env!("CARGO_BIN_EXE_caduceus"))
+        .env("CADUCEUS_CONFIG", config)
+        .env("HERMES_HOME", &hermes_home)
+        .env_remove("RUST_LOG")
+        .arg("run")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn caduceus")
+}
+
+fn assert_exit_zero(output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "expected exit 0 (gate-skipped tick); got {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn run_creates_processor_log_in_active_state_dir() {
+    let dir = tempdir("run-logging-default");
+    let config = write_config(&dir, None);
+    seed_recent_tick(&dir);
+
+    let output = run_binary(&config);
+    assert_exit_zero(&output);
+
+    let log = dir.join("processor.log");
+    assert!(
+        log.is_file(),
+        "`caduceus run` must create {} (issue #386); state_dir listing: {:?}",
+        log.display(),
+        fs::read_dir(&dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.file_name())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+    );
+    let body = fs::read_to_string(&log).expect("read processor.log");
+    assert!(
+        body.contains("tick skipped by gate"),
+        "the gate-skip event must be flushed into the log before exit; got: {body}"
+    );
+}
+
+#[test]
+fn run_honours_configured_log_path_over_default() {
+    let dir = tempdir("run-logging-override");
+    let custom = dir.join("logs").join("daemon.log");
+    let config = write_config(&dir, Some(&custom));
+    seed_recent_tick(&dir);
+
+    let output = run_binary(&config);
+    assert_exit_zero(&output);
+
+    assert!(
+        custom.is_file(),
+        "configured log_path {} must be created (issue #386)",
+        custom.display(),
+    );
+    assert!(
+        !dir.join("processor.log").exists(),
+        "default processor.log must NOT be created when log_path is overridden",
+    );
+}

--- a/tests/daemon/signal_test.rs
+++ b/tests/daemon/signal_test.rs
@@ -399,12 +399,14 @@ fn idle_cancellation_does_not_mutate_state() {
         .map(|e| e.file_name())
         .collect::<BTreeSet<_>>();
     // The daemon may legitimately create the daemon lock file,
-    // the scheduler lock file, and the GitHub HTTP cache
-    // directory during its first tick — those are not state
-    // mutations attributable to the cancellation. The contract
-    // is: the queued entry is not mutated. We assert that
-    // explicitly by checking the absence of state.json (no
-    // enqueue happened).
+    // the scheduler lock file, the GitHub HTTP cache directory,
+    // and (since issue #386) the structured log file — the `run`
+    // handler now calls `logging::init` right after config
+    // resolution, before any tick work — during its first tick;
+    // those are not state mutations attributable to the
+    // cancellation. The contract is: the queued entry is not
+    // mutated. We assert that explicitly by checking the absence
+    // of state.json (no enqueue happened).
     let extras: Vec<_> = state_dir_after.difference(&state_dir_before).collect();
     for extra in &extras {
         let name = extra.to_string_lossy();
@@ -413,6 +415,7 @@ fn idle_cancellation_does_not_mutate_state() {
                 || name == "scheduler.lock"
                 || name == "cache"
                 || name == "repos"
+                || name == "processor.log"
                 || name.starts_with("cache."),
             "unexpected state-file created by idle SIGINT: {name}"
         );


### PR DESCRIPTION
## Summary

The CLI `run` handler — the entry path the cron pulse wrapper, bare
`caduceus`, and explicit `caduceus run` all take — never called
`logging::init`, so `<state_dir>/processor.log` was never created and
every tracing event (including the handler's own git-identity warning)
was silently dropped because no tracing subscriber was installed.

This PR initialises logging right after config resolution (mirroring the
documented `tick::run` order) and explicitly drops the log guard before
`std::process::exit`, since exit runs no destructors and would lose the
non-blocking writer's buffered tail.

Two new hermetic regression tests spawn the built binary with a
cadence-gate seed (zero network): one asserts `processor.log` exists in
the active state dir and carries the gate-skip event, the other asserts
a configured `log_path` override is honoured. The signal_test idle
no-mutate allowlist now includes `processor.log` as a legitimate startup
artifact.

Closes #386