### PR TITLE
test(fixtures): reap orphaned git daemons from interrupted runs (closes #383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **E2E fixtures no longer orphan `git daemon` processes on interrupted
+  runs.** `GitDaemon::start` now holds an exclusive `flock` on
+  `<fixture-root>/git-daemon.lock` for the daemon's lifetime and writes
+  `<fixture-root>/git-daemon.pid` right after spawn. Every start first
+  reaps leftovers from previous runs that died hard (SIGKILL, abort,
+  crash): for ownerless stale roots (lock free) whose pidfile points at
+  a live `git daemon` serving exactly that root's base-path, the daemon
+  is killed and the root removed. Identity is checked via
+  `/proc/<pid>/cmdline` (Linux) or `ps -ww` (macOS), so an unrelated
+  process is never signalled and a live test's root is never touched.
+  Closes #383.
 - **`caduceus run` now initialises file logging.** The CLI `run`
   handler — the entry path the cron pulse wrapper and bare `caduceus`
   invocations actually take — never called `logging::init`, so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -756,6 +756,10 @@ name = "fixtures_self_test"
 path = "tests/architecture/fixtures_self_test.rs"
 
 [[test]]
+name = "git_daemon_reap_test"
+path = "tests/architecture/git_daemon_reap_test.rs"
+
+[[test]]
 name = "oci_fixture_parity_test"
 path = "tests/architecture/oci_fixture_parity_test.rs"
 

--- a/tests/architecture/git_daemon_reap_test.rs
+++ b/tests/architecture/git_daemon_reap_test.rs
@@ -1,0 +1,287 @@
+//! Regression tests for the `GitDaemon` fixture's stale-daemon reaper
+//! (issue #383).
+//!
+//! A hard parent death — SIGKILL, `panic=abort`, or a crash — skips
+//! every destructor, so a `git daemon` spawned by the fixture is
+//! reparented and keeps listening forever and its
+//! `/tmp/caduceus-origin-*` root persists. `GitDaemon::start` now
+//! writes `<root>/git-daemon.pid`, holds an exclusive `flock` on
+//! `<root>/git-daemon.lock` for the daemon's lifetime, and first
+//! reaps provably-ownerless leftovers (`reap_stale_git_daemons`).
+//! These tests prove that reap decision tree end to end: the
+//! interrupted-run shape is reaped, unrelated processes are never
+//! signalled, live owners are untouched, and the pidfile lifecycle
+//! holds.
+//!
+//! All tests are serial: they stage fake stale roots in the shared
+//! temp dir, and while the flock guard (I4/I5) makes concurrent
+//! reapers safe, the tests must not race each other.
+
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+use std::fs;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use nix::fcntl::{Flock, FlockArg};
+use nix::sys::signal::kill;
+use nix::unistd::Pid;
+use tempfile::TempDir;
+
+use fixtures::{free_port_127, reap_stale_git_daemons, wait_for_port_127, GitDaemon};
+
+/// AC1 — the interrupted-run regression: a stale orphan (leaked root +
+/// pidfile + unheld owner lock + live `git daemon`) is reaped; the
+/// daemon is dead and the root is gone.
+#[test]
+#[serial_test::serial]
+fn reaps_orphaned_daemon_from_dead_run() {
+    // Leak the root on purpose: nobody owns it — the faithful
+    // interrupted-run shape.
+    let root = TempDir::with_prefix("caduceus-origin-reap-")
+        .expect("stale root")
+        .keep();
+    let gitroot = root.join("gitroot");
+    fs::create_dir_all(&gitroot).expect("mkdir gitroot");
+
+    // Lock file + owner guard, exactly like `GitDaemon::start`, then
+    // simulate the owner's death: dropping the guard releases the
+    // flock (kernel semantics) while the file itself remains.
+    fs::File::create(root.join("git-daemon.lock")).expect("create lock");
+    let lock_file = fs::File::open(root.join("git-daemon.lock")).expect("open lock");
+    let guard = Flock::lock(lock_file, FlockArg::LockExclusiveNonblock).expect("owner lock");
+
+    let port = free_port_127();
+    let log_path = root.join("git-daemon.log");
+    let log = fs::File::create(&log_path).expect("create log");
+    // Guard the child so a failure inside this test (readiness panic,
+    // broken reaper) cannot leak a real daemon.
+    let mut child = {
+        struct KillOnDrop(Option<Child>);
+        impl Drop for KillOnDrop {
+            fn drop(&mut self) {
+                if let Some(mut c) = self.0.take() {
+                    let _ = c.kill();
+                    let _ = c.wait();
+                }
+            }
+        }
+        KillOnDrop(Some(
+            Command::new("git")
+                .args([
+                    "daemon",
+                    "--reuseaddr",
+                    "--listen=127.0.0.1",
+                    &format!("--port={port}"),
+                    &format!("--base-path={}", gitroot.display()),
+                    "--export-all",
+                ])
+                .stdin(Stdio::null())
+                .stdout(Stdio::from(log.try_clone().expect("clone log")))
+                .stderr(Stdio::from(log))
+                .spawn()
+                .expect("spawn git daemon"),
+        ))
+    };
+    wait_for_port_127(port, Duration::from_secs(5));
+
+    let pid = child.0.as_ref().expect("child present").id();
+    fs::write(root.join("git-daemon.pid"), format!("{pid}\n")).expect("write pidfile");
+
+    // Owner death: the flock is released when the guard and its file
+    // are dropped. The daemon keeps running, reparented like a real
+    // orphan.
+    drop(guard);
+
+    let pid = Pid::from_raw(pid as i32);
+    assert!(
+        kill(pid, None).is_ok(),
+        "pre-reap sanity: the orphaned daemon must still be alive"
+    );
+
+    let mut child = child.0.take().expect("child present after readiness");
+    let summary = reap_stale_git_daemons();
+
+    // Outcome-based (not `daemons_killed == 1`): under the full
+    // parallel gate a sibling binary's own start()-reap may legally
+    // perform the kill first; the outcome is identical either way.
+    // `try_wait` (not kill(pid, 0)) asserts death because the daemon
+    // is our own child and must be reaped by this test.
+    let deadline = std::time::SystemTime::now() + Duration::from_secs(5);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(s)) => break s,
+            Ok(None) if std::time::SystemTime::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("reaped daemon did not die within 5s; summary {summary:?}");
+            }
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("try_wait after reap: {e}");
+            }
+        }
+    };
+    assert_eq!(
+        status.signal(),
+        Some(9),
+        "daemon must be SIGKILLed (summary {summary:?})"
+    );
+    assert!(
+        !root.exists(),
+        "stale root must be removed by the reap (summary {summary:?})"
+    );
+}
+
+/// AC2a — a stale root whose pidfile names a DEAD pid: nothing is
+/// killed; the ownerless root (and its pidfile) is removed.
+#[test]
+#[serial_test::serial]
+fn stale_pidfile_with_dead_pid_kills_nothing() {
+    let root = TempDir::with_prefix("caduceus-origin-reap-dead-")
+        .expect("stale root")
+        .keep();
+    fs::create_dir_all(root.join("gitroot")).expect("mkdir gitroot");
+
+    // Lock file present but NEVER held: the owner died without ever
+    // acquiring (or acquired and the kernel released the flock).
+    fs::File::create(root.join("git-daemon.lock")).expect("create lock");
+
+    // A pid that is definitely dead: spawn a child, reap it, use its
+    // pid.
+    let mut sleeper = Command::new("sleep").arg("1").spawn().expect("spawn sleep");
+    let dead_pid = sleeper.id();
+    let _ = sleeper.wait().expect("wait sleep");
+
+    fs::write(root.join("git-daemon.pid"), format!("{dead_pid}\n")).expect("write pidfile");
+
+    let summary = reap_stale_git_daemons();
+
+    assert_eq!(
+        summary.daemons_killed, 0,
+        "a dead pid must never be counted as killed"
+    );
+    assert!(
+        !root.join("git-daemon.pid").exists(),
+        "stale pidfile must be removed"
+    );
+    assert!(
+        !root.exists(),
+        "ownerless root with a dead pid must be removed"
+    );
+}
+
+/// AC2b — the critical safety negative: a pidfile pointing at a LIVE
+/// process that is NOT a git daemon. The reaper must never signal it;
+/// it drops the pidfile and leaves the root.
+#[test]
+#[serial_test::serial]
+fn pidfile_with_unrelated_live_pid_never_kills() {
+    let root = TempDir::with_prefix("caduceus-origin-reap-unrelated-")
+        .expect("stale root")
+        .keep();
+    fs::create_dir_all(root.join("gitroot")).expect("mkdir gitroot");
+    fs::File::create(root.join("git-daemon.lock")).expect("create lock");
+
+    let mut sleeper = Command::new("sleep")
+        .arg("300")
+        .spawn()
+        .expect("spawn sleep");
+    let sleep_pid = sleeper.id();
+    fs::write(root.join("git-daemon.pid"), format!("{sleep_pid}\n")).expect("write pidfile");
+
+    let summary = reap_stale_git_daemons();
+
+    assert_eq!(
+        summary.daemons_killed, 0,
+        "an unrelated live process must never be killed"
+    );
+    assert!(
+        kill(Pid::from_raw(sleep_pid as i32), None).is_ok(),
+        "the unrelated process must still be alive"
+    );
+    assert!(
+        !root.join("git-daemon.pid").exists(),
+        "the stale pidfile must be removed"
+    );
+    assert!(
+        root.exists(),
+        "an identity-mismatch root is left for forensics, not deleted"
+    );
+    assert!(
+        sleeper.try_wait().expect("try_wait sleep").is_none(),
+        "the sleep child must still be running"
+    );
+
+    // The reaper deliberately left the root, so the TEST must remove
+    // it or it litters the shared temp dir (a later run's reap would
+    // see a no-pidfile root: harmless, but dirty).
+    let _ = sleeper.kill();
+    let _ = sleeper.wait();
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// AC2c — a LIVE test's root (lock held) is invisible to every
+/// reaper: the daemon survives, its port still accepts, and the root
+/// survives.
+#[test]
+#[serial_test::serial]
+fn live_owned_root_is_never_reaped() {
+    let daemon = GitDaemon::start("reap-live", "owner", "repo");
+
+    let summary = reap_stale_git_daemons();
+    assert_eq!(
+        summary.daemons_killed, 0,
+        "a live owner's daemon must never be killed"
+    );
+
+    let root = daemon.root().to_path_buf();
+    assert!(root.exists(), "a live root must survive the reap");
+
+    // The daemon's port still accepts connections (flock guard I5).
+    let port: u16 = daemon
+        .uri()
+        .split(':')
+        .nth(2)
+        .and_then(|s| s.split('/').next())
+        .expect("uri port")
+        .parse()
+        .expect("uri port parses");
+    wait_for_port_127(port, Duration::from_secs(5));
+
+    drop(daemon);
+    assert!(!root.exists(), "normal Drop must still remove the root");
+}
+
+/// AC3 — pidfile lifecycle: written on start and removed on Drop
+/// (with the root).
+#[test]
+#[serial_test::serial]
+fn pidfile_written_on_start_removed_on_drop() {
+    let daemon = GitDaemon::start("reap-lifecycle", "owner", "repo");
+
+    let root = daemon.root().to_path_buf();
+    let pidfile = root.join("git-daemon.pid");
+    assert!(pidfile.exists(), "pidfile must exist after start");
+    let pid: u32 = fs::read_to_string(&pidfile)
+        .expect("read pidfile")
+        .trim()
+        .parse()
+        .expect("pidfile parses");
+    assert!(
+        kill(Pid::from_raw(pid as i32), None).is_ok(),
+        "the recorded pid must be a live process"
+    );
+
+    drop(daemon);
+    assert!(
+        !root.exists(),
+        "drop must remove the root (pidfile with it)"
+    );
+}

--- a/tests/fixtures/git_daemon.rs
+++ b/tests/fixtures/git_daemon.rs
@@ -13,6 +13,19 @@
 //! and imports what it uses. The `#![allow(dead_code)]` covers
 //! methods only one consumer binary exercises — same rationale as
 //! `github.rs` and `git_origin.rs`.
+//!
+//! Ownership protocol (issue #383): a hard parent death — SIGKILL,
+//! `panic=abort`, or a crash — skips every destructor, so the daemon
+//! would be reparented and keep listening forever and the fixture
+//! root would persist. `start()` therefore (1) first reaps leftovers
+//! from dead runs (`reap_stale_git_daemons`), (2) acquires an
+//! exclusive `flock` on `<root>/git-daemon.lock` for the daemon's
+//! lifetime — the kernel releases it automatically when this process
+//! dies — and (3) writes the child pid to `<root>/git-daemon.pid`
+//! right after spawn. The lock is acquired BEFORE the pidfile
+//! exists, so a pidfile present in the temp dir always means "a live
+//! owner holds the lock, or that owner is dead"; the reaper only
+//! ever acts on roots whose lock is provably free.
 
 #![allow(dead_code)]
 
@@ -22,6 +35,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime};
 
+use nix::errno::Errno;
+use nix::fcntl::{Flock, FlockArg};
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
 use tempfile::TempDir;
 
 /// Owns a `git daemon` subprocess serving a bare repo at
@@ -34,6 +51,11 @@ pub struct GitDaemon {
     child: std::process::Child,
     owner: String,
     repo: String,
+    pidfile: PathBuf,
+    // Declared LAST so it drops after `_root` (struct fields drop in
+    // declaration order): unlocking a lock file that was just unlinked
+    // with the tempdir is harmless.
+    _lock: Flock<std::fs::File>,
 }
 
 impl GitDaemon {
@@ -44,6 +66,10 @@ impl GitDaemon {
     /// If the daemon fails to become ready, the spawned child is killed
     /// before this function panics, so no orphan `git daemon` leaks.
     pub fn start(label: &str, owner: &str, repo: &str) -> Self {
+        // Self-heal: first reap daemons left behind by previous runs
+        // that died hard (SIGKILL, abort, crash) and skipped Drop.
+        reap_stale_git_daemons();
+
         let root = TempDir::with_prefix(format!("caduceus-origin-{label}-")).expect("origin");
         let gitroot = root.path().join("gitroot");
         let bare = gitroot.join(owner).join(repo);
@@ -53,6 +79,17 @@ impl GitDaemon {
         // Enable push over the git protocol.
         git_in(&bare, &["config", "daemon.receivepack", "true"]);
         git_in(&bare, &["config", "daemon.uploadarch", "true"]);
+
+        // Owner guard: the kernel releases this flock automatically if
+        // this process dies hard, so a later run can distinguish "live
+        // owner" from "dead run" without heuristics. Acquired BEFORE
+        // the pidfile exists — that ordering is what makes a pidfile
+        // in the temp dir imply "lock held OR owner dead".
+        let lock_path = root.path().join("git-daemon.lock");
+        fs::File::create(&lock_path).expect("create daemon lock");
+        let lock_file = fs::File::open(&lock_path).expect("open daemon lock");
+        let lock = Flock::lock(lock_file, FlockArg::LockExclusiveNonblock)
+            .unwrap_or_else(|(_, errno)| panic!("git-daemon.lock acquire: {errno}"));
 
         let port = free_port_127();
         let log_path = root.path().join("git-daemon.log");
@@ -87,6 +124,14 @@ impl GitDaemon {
             ))
         };
 
+        // Record the child pid BEFORE the readiness wait so a hard
+        // death inside the readiness window still leaves a pidfile for
+        // the next run's reaper. A half-ready daemon in the pidfile is
+        // harmless: the reap only acts on roots whose lock is free.
+        let pidfile = root.path().join("git-daemon.pid");
+        let pid = child.0.as_ref().expect("child present after spawn").id();
+        fs::write(&pidfile, format!("{pid}\n")).expect("write daemon pidfile");
+
         // Wait for the daemon to accept a connection so the clone below
         // does not race the bind. Also confirm the child has not already
         // exited (a bind error would make it die before readiness).
@@ -108,6 +153,8 @@ impl GitDaemon {
             child,
             owner: owner.to_string(),
             repo: repo.to_string(),
+            pidfile,
+            _lock: lock,
         }
     }
 
@@ -120,6 +167,12 @@ impl GitDaemon {
     /// Path to the bare repository directory on disk.
     pub fn path(&self) -> &Path {
         &self.bare
+    }
+
+    /// Path to the fixture root directory, which holds
+    /// `git-daemon.log`, `git-daemon.lock`, and `git-daemon.pid`.
+    pub fn root(&self) -> &Path {
+        self._root.path()
     }
 
     /// Number of refs under `refs/heads/` in the bare repo. Used to
@@ -160,7 +213,153 @@ impl Drop for GitDaemon {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+        // Best-effort: the tempdir removal that follows takes the file
+        // with it if this removal fails.
+        let _ = fs::remove_file(&self.pidfile);
     }
+}
+
+/// Outcome of a stale-daemon sweep: how many daemons were killed and
+/// how many fixture roots were removed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ReapSummary {
+    pub daemons_killed: usize,
+    pub roots_removed: usize,
+}
+
+/// Kill `git daemon` processes left behind by interrupted test runs
+/// and remove their fixture roots.
+///
+/// Scans `std::env::temp_dir()` for `caduceus-origin-*` roots. A root
+/// is only touched when ALL of these hold: it has a `git-daemon.pid`,
+/// its `git-daemon.lock` is FREE (kernel-verified: no live owner), the
+/// recorded pid is alive, and that process's argv identifies it as a
+/// `git daemon` serving exactly this root's `gitroot` base path. Any
+/// unprovable step fails safe (skip, never signal). Never panics and
+/// never blocks: every fallible step is best-effort and the lock probe
+/// is non-blocking, so a reap failure cannot break a test run.
+pub fn reap_stale_git_daemons() -> ReapSummary {
+    let mut summary = ReapSummary::default();
+    let temp_dir = std::env::temp_dir();
+    let Ok(entries) = fs::read_dir(&temp_dir) else {
+        return summary;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if !name.starts_with("caduceus-origin-") {
+            continue;
+        }
+        let root = entry.path();
+        let pidfile = root.join("git-daemon.pid");
+        if !pidfile.exists() {
+            // LocalOrigin root, pre-fix legacy root, or a live root
+            // mid-setup: never act without a pidfile.
+            continue;
+        }
+        // Open the lock file read-only and probe it non-blocking.
+        // EWOULDBLOCK means a LIVE owner: never touch that root.
+        let Ok(lock_file) = fs::File::open(root.join("git-daemon.lock")) else {
+            continue;
+        };
+        let Ok(_guard) = Flock::lock(lock_file, FlockArg::LockExclusiveNonblock) else {
+            continue;
+        };
+        // The lock is free: the owning run is dead. `_guard` is held
+        // for the rest of this iteration so a concurrent reaper cannot
+        // double-act; it unlocks when it drops at the iteration end.
+        let Ok(pid_text) = fs::read_to_string(&pidfile) else {
+            continue;
+        };
+        let Ok(pid_num) = pid_text.trim().parse::<u32>() else {
+            let _ = fs::remove_file(&pidfile);
+            continue;
+        };
+        let pid = Pid::from_raw(pid_num as i32);
+        match kill(pid, None) {
+            Err(Errno::ESRCH) => {
+                // Ownerless root whose pid is already gone: garbage.
+                let _ = fs::remove_file(&pidfile);
+                let _ = fs::remove_dir_all(&root);
+                summary.roots_removed += 1;
+                continue;
+            }
+            Ok(_) | Err(Errno::EPERM) => {}
+            Err(_) => continue,
+        }
+        let expected_gitroot = root.join("gitroot");
+        if !daemon_serves_base_path(pid, &expected_gitroot) {
+            // Identity unprovable or wrong: NEVER kill. Drop the stale
+            // pidfile, leave the root for forensics.
+            let _ = fs::remove_file(&pidfile);
+            continue;
+        }
+        // Re-validate immediately before the kill to shrink the
+        // pid-recycle TOCTOU window to microseconds.
+        if !daemon_serves_base_path(pid, &expected_gitroot) {
+            let _ = fs::remove_file(&pidfile);
+            continue;
+        }
+        let _ = kill(pid, Signal::SIGKILL); // ignore a raced death (ESRCH)
+        summary.daemons_killed += 1;
+        let _ = fs::remove_file(&pidfile);
+        let _ = fs::remove_dir_all(&root);
+        summary.roots_removed += 1;
+        // `_guard` drops here, after the root is gone (unlocking an
+        // unlinked file is harmless).
+    }
+    summary
+}
+
+/// True when process `pid`'s argv identifies it as a `git daemon`
+/// serving exactly `expected_gitroot` as its base path.
+///
+/// Linux: read `/proc/<pid>/cmdline`. macOS: `ps -ww -p <pid> -o
+/// command=`. Any read/spawn/parse failure is `false` (fail-safe:
+/// unverifiable is never a kill reason).
+#[cfg(target_os = "linux")]
+fn daemon_serves_base_path(pid: Pid, expected_gitroot: &Path) -> bool {
+    let Ok(cmdline) = fs::read_to_string(format!("/proc/{}/cmdline", pid.as_raw())) else {
+        return false;
+    };
+    let argv: Vec<&str> = cmdline.split('\0').filter(|s| !s.is_empty()).collect();
+    let Some(argv0) = argv.first() else {
+        return false; // zombie with empty argv: identity unprovable
+    };
+    let basename = argv0.rsplit('/').next().unwrap_or(argv0);
+    // `git daemon` is the git multi-call binary (argv[0]="git",
+    // argv[1]="daemon"); some setups exec the dashed `git-daemon`
+    // form. Accept both — the base-path match is the real guard.
+    let is_git_daemon = basename.ends_with("git-daemon")
+        || (basename == "git" && argv.get(1).is_some_and(|a| *a == "daemon"));
+    if !is_git_daemon {
+        return false;
+    }
+    let base_path_arg = format!("--base-path={}", expected_gitroot.display());
+    argv.iter().any(|arg| *arg == base_path_arg)
+}
+
+#[cfg(target_os = "macos")]
+fn daemon_serves_base_path(pid: Pid, expected_gitroot: &Path) -> bool {
+    let Ok(out) = Command::new("ps")
+        .args(["-ww", "-p", &pid.as_raw().to_string(), "-o", "command="])
+        .output()
+    else {
+        return false;
+    };
+    if !out.status.success() {
+        return false;
+    }
+    let cmdline = String::from_utf8_lossy(&out.stdout);
+    (cmdline.contains("git-daemon") || cmdline.contains("git daemon"))
+        && cmdline.contains(&format!("--base-path={}", expected_gitroot.display()))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn daemon_serves_base_path(_pid: Pid, _expected_gitroot: &Path) -> bool {
+    false
 }
 
 fn rev_list_count(bare: &Path, refspec: &str) -> usize {

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -41,8 +41,8 @@ pub use doctor_report::{classify_doctor, DoctorVerdict};
 #[cfg(test)]
 #[allow(unused_imports)]
 pub use git_daemon::{
-    clone_main, free_port_127, git_in, init_bare_with_empty_main, run_with_timeout,
-    wait_for_port_127, GitDaemon,
+    clone_main, free_port_127, git_in, init_bare_with_empty_main, reap_stale_git_daemons,
+    run_with_timeout, wait_for_port_127, GitDaemon, ReapSummary,
 };
 #[cfg(test)]
 #[allow(unused_imports)]


### PR DESCRIPTION
Closes #383.

## Problem

Interrupted E2E runs (SIGKILL, `panic=abort`, hard crash) skip every
destructor, so the `git daemon` child spawned by the `GitDaemon` fixture
was reparented and kept listening forever, and its
`/tmp/caduceus-origin-*` root persisted (28 stale roots + 15+ live
orphan daemons observed on this host). A stale daemon holding a fixture
port can make a later run bind-fail.

## Fix (test-fixture surface only — zero production changes)

- `GitDaemon::start` now first calls `reap_stale_git_daemons()`
  (self-heal), then acquires an exclusive non-blocking `flock` on
  `<root>/git-daemon.lock` for the daemon's lifetime — the kernel
  auto-releases it on hard owner death, which is what makes "live test
  root" vs "dead-run root" race-free — and writes `<root>/git-daemon.pid`
  right after spawn (before the readiness wait). `Drop` keeps the
  kill+wait verbatim and additionally removes the pidfile.
- The reaper scans `std::env::temp_dir()` for `caduceus-origin-*`
  roots and kills only when FIVE facts all hold: root name matches,
  pidfile exists, the lock is FREE (kernel-verified dead owner), the
  pid is alive, and the argv identifies a `git daemon` serving exactly
  that root's `gitroot` base path (Linux `/proc/<pid>/cmdline`, macOS
  `ps -ww`). It removes the provably-ownerless root afterwards. Any
  unprovable step fails safe — never signals an unrelated process,
  never touches a live owner's root.

## RED protocol

The new API cannot exist pre-fix, so the RED is a compile-failure shape
(not a behavioural failure): with the fixture files stashed,
`cargo test --locked --test git_daemon_reap_test` fails to compile
(missing `reap_stale_git_daemons` / `ReapSummary` / `root()`). Observed
before the fix was implemented.

## Regression coverage (5 serial tests)

1. `reaps_orphaned_daemon_from_dead_run` — interrupted-run simulation:
   leaked root + pidfile + released owner lock + live `git daemon` →
   daemon dead (try_wait, signal 9) and root gone. Outcome-based per
   plan §7.1 (a sibling binary's start()-reap may legally perform the
   kill first under the parallel gate).
2. `stale_pidfile_with_dead_pid_kills_nothing` — dead pid never
   signalled; ownerless root removed.
3. `pidfile_with_unrelated_live_pid_never_kills` — a live non-daemon
   process is never signalled; pidfile removed, root left.
4. `live_owned_root_is_never_reaped` — a live test's flock-guarded root
   is untouched; port still accepts; Drop still removes the root.
5. `pidfile_written_on_start_removed_on_drop` — pidfile lifecycle.

## Gate evidence (Linux host, HOME=/home/agent)

- `cargo fmt --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --all-targets --no-fail-fast` (hermetic
  `--skip` list: ac04/ac06/ac07/ac08/release_binary_canary) — 205 test
  binaries, 0 failures
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` —
  200 passed

Notes:
- The 15 pre-fix orphans on this host have NO pidfile and are
  deliberately NOT cleaned by the reap (plan §9.3); they still need the
  manual `pkill` ops note from the issue.
- Deviation from plan §5, required for correctness: a fixture-spawned
  `git daemon` runs as the git multi-call binary (argv[0]="git",
  argv[1]="daemon"), not argv[0]="git-daemon"; the identity check
  accepts both forms, and the `--base-path=<root>/gitroot` exact match
  remains the kill guard.
