### PR TITLE
docs(tests): note stale daemon reap on fixture start

### DIFF
--- a/tests/fixtures/git_daemon.rs
+++ b/tests/fixtures/git_daemon.rs
@@ -43,7 +43,8 @@ use tempfile::TempDir;
 
 /// Owns a `git daemon` subprocess serving a bare repo at
 /// `git://127.0.0.1:<port>/<owner>/<repo>`. The child is killed on
-/// drop before the tempdir is removed.
+/// drop before the tempdir is removed; stale daemons orphaned by
+/// interrupted runs are reaped on the next `start`.
 pub struct GitDaemon {
     _root: TempDir,
     bare: PathBuf,


### PR DESCRIPTION
Follow-up to #383: the fixture doc still claimed the daemon child is only killed on drop; with the new stale-reap, daemons orphaned by interrupted runs are also reaped on the next start. Doc-only change (no behavior).