### PR TITLE
fix(cli): show per-SHA verdict in review list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **`review list` and `review status` now show each entry's own
+  verdict.** The verdict column is derived from the entry's latest
+  same-generation history row's `ReviewResult` document (mirroring the
+  derived execution status), so superseded SHA entries no longer
+  display the PR's current verdict — historical FAIL reviews render as
+  `fail`. Entries with no completed run fall back to the PR's last
+  verdict; unreadable (old-schema or malformed) result documents
+  surface as `-`/null per the defensive-parse contract. Closes #387.
 - **E2E fixtures no longer orphan `git daemon` processes on interrupted
   runs.** `GitDaemon::start` now holds an exclusive `flock` on
   `<fixture-root>/git-daemon.lock` for the daemon's lifetime and writes

--- a/skills/caduceus/SKILL.md
+++ b/skills/caduceus/SKILL.md
@@ -196,6 +196,12 @@ All three read BOTH state backends (they branch on
 latest same-generation history row's `ReviewResult.status` — it
 describes execution, not outcome (`verdict` holds the outcome; a
 failed-verdict run is still `execution status: success`).
+`verdict` is per-entry too: parsed from the SAME latest
+same-generation history row's `ReviewResult.review.verdict`, so
+superseded SHA entries show their own outcome; only entries with no
+completed run fall back to the PR-level last verdict (#387).
+Unparsable result documents surface `-`/null, never the PR-level
+verdict.
 
 ## State Recovery Procedure
 

--- a/src/cli/review.rs
+++ b/src/cli/review.rs
@@ -66,7 +66,9 @@ pub enum ReviewAction {
 
 /// One §13 per-row view: the queue entry joined with its `(repo, pr)`
 /// state row and, for terminal rows, the latest same-generation
-/// history row's execution status. The same field set is rendered by
+/// history row's execution status and verdict (the entry's own run
+/// outcome — the per-PR last verdict is only a fallback for entries
+/// with no run, issue #387). The same field set is rendered by
 /// the human and JSON paths (`--json` only changes the rendering).
 #[derive(Serialize)]
 struct ReviewRow {
@@ -80,6 +82,9 @@ struct ReviewRow {
     review_generation: u64,
     execution_attempts: u32,
     execution_status: Option<String>,
+    /// Entry's own run verdict (latest same-generation history row);
+    /// falls back to the PR's last verdict only when the entry has
+    /// no completed run (issue #387).
     verdict: Option<String>,
     last_error: Option<String>,
     reviewed_at: Option<String>,
@@ -302,9 +307,7 @@ fn row_for(
         review_generation: entry.review_generation,
         execution_attempts: entry.attempts,
         execution_status: derive_execution_status(entry, history),
-        verdict: state
-            .and_then(|s| s.last_verdict)
-            .map(|v| verdict_label(v).to_string()),
+        verdict: derive_verdict(entry, history, state),
         last_error: entry.last_error.clone(),
         reviewed_at: state
             .and_then(|s| s.last_reviewed_at)
@@ -330,10 +333,46 @@ fn derive_execution_status(
     entry: &ReviewQueueEntry,
     history: &[ReviewHistoryRow],
 ) -> Option<String> {
+    latest_same_generation_row(entry, history)
+        .and_then(|row| parse_result_document(&row.result_json).0)
+}
+
+/// The history row that owns this entry's outcome: the latest (append
+/// order) row for the entry's own generation, or `None` while the
+/// entry has no completed run. Generation matching implies head-SHA
+/// matching: every admission bumps the per-PR generation (a same-SHA
+/// re-review replaces the entry under a new one), and a run completes
+/// under the claimed entry's own target (DAR §9.4).
+fn latest_same_generation_row<'a>(
+    entry: &ReviewQueueEntry,
+    history: &'a [ReviewHistoryRow],
+) -> Option<&'a ReviewHistoryRow> {
     history
         .iter()
         .rfind(|row| row.review_generation == entry.review_generation)
-        .and_then(|row| parse_result_document(&row.result_json).0)
+}
+
+/// Per-entry verdict (issue #387): an entry that HAS a completed run
+/// shows that run's verdict — the latest same-generation history
+/// row's `ReviewResult.review.verdict` — never the PR's current
+/// verdict, so a superseded FAIL review no longer displays as PASS.
+/// When the row's document cannot be read (old schema version,
+/// malformed document, or an execution failure with no review
+/// payload) the defensive-parse contract (DAR §4.3) surfaces `None`;
+/// the PR-level verdict is NOT substituted for a run that exists.
+/// Only entries with no same-generation run (queued, in-progress)
+/// fall back to the PR-level `ReviewState.last_verdict`.
+fn derive_verdict(
+    entry: &ReviewQueueEntry,
+    history: &[ReviewHistoryRow],
+    state: Option<&ReviewState>,
+) -> Option<String> {
+    match latest_same_generation_row(entry, history) {
+        Some(row) => parse_result_document(&row.result_json).1,
+        None => state
+            .and_then(|s| s.last_verdict)
+            .map(|v| verdict_label(v).to_string()),
+    }
 }
 
 /// Render one history row's `result_json` into the defensively parsed

--- a/tests/cli/review_cli_test.rs
+++ b/tests/cli/review_cli_test.rs
@@ -42,6 +42,9 @@ const OWNER_C: &str = "New";
 const REPO_C: &str = "Repo";
 const PR_C: u64 = 3;
 const SHA_C: &str = "cccccccccccccccccccccccccccccccccccccccc";
+const SHA_OLD: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_NEW: &str = "dddddddddddddddddddddddddddddddddddddddd";
+const SHA_PENDING: &str = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum Backend {
@@ -203,6 +206,38 @@ fn seed_old_history(dir: &Path, backend: Backend) -> ReviewStore {
     store
 }
 
+/// One PR with three SHA entries (the #387 shape): OLD completed
+/// FAIL (generation 1), NEW completed PASS (generation 2), PENDING
+/// queued with no run (generation 3). The PR-level state ends with
+/// `last_verdict = pass` (written by NEW's completion), so OLD's
+/// own verdict (fail) disagrees with the PR's current verdict.
+fn seed_multi_sha_pr(dir: &Path, backend: Backend) -> ReviewStore {
+    let store = open_store(dir, backend);
+    let repository = repo(OWNER_A, REPO_A);
+    seed_completed_run(
+        &store,
+        &repository,
+        PR_A,
+        SHA_OLD,
+        "RUN-OLD",
+        Verdict::Fail,
+        result_doc(Verdict::Fail),
+    );
+    seed_completed_run(
+        &store,
+        &repository,
+        PR_A,
+        SHA_NEW,
+        "RUN-NEW",
+        Verdict::Pass,
+        result_doc(Verdict::Pass),
+    );
+    store
+        .enqueue_review(&target(&repository, PR_A, SHA_PENDING))
+        .unwrap();
+    store
+}
+
 /// Run the CLI binary as a subprocess against `dir` with a
 /// `$CADUCEUS_CONFIG` whose `state_dir` is `dir` (and
 /// `state_backend: sqlite` for the SQLite backend).
@@ -253,6 +288,16 @@ fn row_by_pr(entries: &serde_json::Value, pr: u64) -> serde_json::Value {
         .iter()
         .find(|row| row["pr"].as_u64() == Some(pr))
         .unwrap_or_else(|| panic!("no row for pr {pr} in {entries}"))
+        .clone()
+}
+
+fn row_by_head_sha(entries: &serde_json::Value, head_sha: &str) -> serde_json::Value {
+    entries
+        .as_array()
+        .expect("entries must be an array")
+        .iter()
+        .find(|row| row["head_sha"].as_str() == Some(head_sha))
+        .unwrap_or_else(|| panic!("no row for head {head_sha} in {entries}"))
         .clone()
 }
 
@@ -452,6 +497,106 @@ fn empty_store_lists_placeholder() {
 }
 
 // ---------------------------------------------------------------------------
+// per-SHA verdict (issue #387)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_and_status_render_each_entrys_own_verdict() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-per-sha-verdict-{backend:?}"));
+        seed_multi_sha_pr(&dir, backend);
+
+        // JSON rows (list and status render the same ReviewRow).
+        for subcommand in ["list", "status"] {
+            let output = run_cli(&dir, backend, &["review", subcommand, "--json"]);
+            assert_success(&output);
+            let envelope = parse_json(&output);
+            let entries = &envelope["payload"]["entries"];
+
+            // OLD: its own run says FAIL even though the PR's current
+            // verdict is pass — the #387 regression.
+            let old = row_by_head_sha(entries, SHA_OLD);
+            assert_eq!(old["review_generation"], 1);
+            assert_eq!(old["execution_status"], "success");
+            assert_eq!(
+                old["verdict"], "fail",
+                "superseded FAIL entry must render its own verdict, not the PR's current pass"
+            );
+
+            // NEW: the current run — pass, same as before.
+            let new = row_by_head_sha(entries, SHA_NEW);
+            assert_eq!(new["verdict"], "pass");
+
+            // PENDING: no completed run, so it falls back to the
+            // PR-level last verdict (issue-Expected fallback).
+            let pending = row_by_head_sha(entries, SHA_PENDING);
+            assert_eq!(pending["execution_status"], serde_json::Value::Null);
+            assert_eq!(
+                pending["verdict"], "pass",
+                "entry with no run falls back to the PR last verdict"
+            );
+        }
+
+        // Human renderers carry the same columns.
+        let output = run_cli(&dir, backend, &["review", "list"]);
+        assert_success(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("owner/repo#42@aaaaaaaaaaaa\tdone\t0\t1\tfail\t"),
+            "OLD list row must show its own fail verdict: {stdout}"
+        );
+        assert!(
+            stdout.contains("owner/repo#42@eeeeeeeeeeee\tqueued\t0\t3\tpass\t"),
+            "PENDING list row must fall back to the PR verdict: {stdout}"
+        );
+
+        let output = run_cli(&dir, backend, &["review", "status"]);
+        assert_success(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("owner/repo#42@aaaaaaaaaaaa  phase=done attempts=0 gen=1 verdict=fail"),
+            "OLD status line must show its own fail verdict: {stdout}"
+        );
+        assert!(
+            stdout
+                .contains("owner/repo#42@eeeeeeeeeeee  phase=queued attempts=0 gen=3 verdict=pass"),
+            "PENDING status line must fall back to the PR verdict: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn list_and_status_surface_unparsable_result_as_null_verdict() {
+    for backend in [Backend::Json, Backend::Sqlite] {
+        let dir = tempdir(&format!("review-old-doc-verdict-{backend:?}"));
+        seed_old_history(&dir, backend);
+
+        for subcommand in ["list", "status"] {
+            let output = run_cli(&dir, backend, &["review", subcommand, "--json"]);
+            // No panic, exit 0 — the defensive-parse contract.
+            assert_success(&output);
+            let envelope = parse_json(&output);
+            let entries = &envelope["payload"]["entries"];
+            let row = row_by_head_sha(entries, &"d".repeat(40));
+            // The entry HAS a run (an old-schema one): the verdict
+            // surfaces the defensive-parse null — DAR §4.3, never
+            // back-migrated, never the PR-level substitution (#387).
+            assert_eq!(row["verdict"], serde_json::Value::Null);
+            assert_eq!(row["execution_status"], serde_json::Value::Null);
+        }
+
+        // Human render: "-" in the verdict column, no crash.
+        let output = run_cli(&dir, backend, &["review", "list"]);
+        assert_success(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("legacy/repo#5@dddddddddddd\tdone\t0\t1\t-\t"),
+            "old-schema entry must render '-' for the verdict: {stdout}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // show
 // ---------------------------------------------------------------------------
 
@@ -543,8 +688,14 @@ fn show_surfaces_old_schema_result_json_defensively() {
         let raw_doc: serde_json::Value =
             serde_json::from_str(row["result_json"].as_str().unwrap()).unwrap();
         assert_eq!(raw_doc["schema_version"], 99, "raw doc kept: {row}");
-        // The entry row itself still works (state-joined fields).
-        assert_eq!(envelope["payload"]["entry"]["verdict"], "pass");
+        // The entry row itself still works (queue + state-joined
+        // fields). The verdict column surfaces the defensive-parse
+        // null because this entry HAS a run (an old-schema one) —
+        // no PR-level substitution (issue #387).
+        assert_eq!(
+            envelope["payload"]["entry"]["verdict"],
+            serde_json::Value::Null
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

`caduceus review list` / `review status` showed the PR's current
verdict (`ReviewState.last_verdict`) for every SHA entry, so a
historical FAIL review displayed as PASS once the PR's latest review
passed. The verdict column is now derived per entry from the entry's
own run outcome — the latest same-generation history row's
`ReviewResult` document — mirroring the already-derived execution
status (they read the SAME history row via a shared
`latest_same_generation_row` helper). Only entries with no completed
run fall back to the PR-level last verdict; unparsable or old-schema
result documents surface `-`/null per the defensive-parse contract
(DAR §4.3), never the PR-level substitution.

`review show`'s entry row shares the same `ReviewRow` and gets the
same corrected derivation. Read-side only — no store/schema/
persistence changes (review history is never pruned).

## Tests

- `list_and_status_render_each_entrys_own_verdict`: one PR with three
  SHA entries — OLD completed FAIL (gen 1), NEW completed PASS
  (gen 2), PENDING queued (gen 3) — asserts OLD renders `fail` (not
  the PR's current `pass`), NEW renders `pass`, PENDING falls back to
  `pass`, on both backends, JSON and human paths.
- `list_and_status_surface_unparsable_result_as_null_verdict`:
  old-schema v99 doc surfaces null/`-`, exit 0, no panic.
- One existing assertion churned: `show` on an old-schema entry now
  expects the defensive-parse null verdict instead of the PR-level
  `pass` (the entry HAS a run; no substitution).

Verified: RED on main (the two new tests + churned assertion failed
exactly at the expected assertions), GREEN after the source edit.
Gates: fmt, clippy `-D warnings`, full cargo test suite, pytest
(plugin + bridge) all green.

Closes #387.