### PR TITLE
fix(plugin): expose run and review passthroughs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **`hermes caduceus` now exposes the binary's full command set.**
+  The wrapper registers `run` and `review` REMAINDER passthroughs
+  (previously argparse `invalid choice` errors for operators), with a
+  dedicated 2h subprocess bound for `run` (a tick supervises workers
+  for minutes; the 15s passthrough default would kill a live run).
+  A new drift-guard test parses the clap `Command` enum from
+  `src/cli/mod.rs` and asserts the wrapper's subcommand tree covers it
+  exactly, so a future binary subcommand fails CI instead of breaking
+  operators. Closes #389.
 - **`review list` and `review status` now show each entry's own
   verdict.** The verdict column is derived from the entry's latest
   same-generation history row's `ReviewResult` document (mirroring the

--- a/__init__.py
+++ b/__init__.py
@@ -23,9 +23,10 @@ plugin compatibility contract:
    chat-safe diagnostic explaining how to run ``hermes caduceus setup``.
 3. ``ctx.register_cli_command(name="caduceus", ...)`` for the
    ``hermes caduceus <subcommand>`` family, with subcommands
-   ``setup``, ``doctor``, ``status``, ``cron-install``, ``cron-remove``,
-   and the pass-through ``queue``, ``worktree-gc``, and ``migrate-state``
-   (trailing args are forwarded verbatim to the ``caduceus`` binary).
+   ``setup``, ``doctor``, ``status``, ``cron-install``,
+   ``cron-remove``, and the pass-through ``run``, ``review``,
+   ``queue``, ``worktree-gc``, and ``migrate-state`` (trailing args
+   are forwarded verbatim to the ``caduceus`` binary).
 """
 
 from __future__ import annotations
@@ -58,6 +59,13 @@ SKILL_QUALIFIED_NAME = f"{PLUGIN_NAME}:{SKILL_BARE_NAME}"
 SUBPROCESS_TIMEOUT_SECONDS = 15
 SUBPROCESS_OUTPUT_BYTES = 32 * 1024
 SUBPROCESS_BUILD_TIMEOUT_SECONDS = 600
+
+# `caduceus run` executes a full daemon tick: worker supervision alone
+# defaults to worker_timeout_seconds = 3600
+# (src/infra/config/mod.rs DEFAULT_WORKER_TIMEOUT_SECONDS). The 2h
+# bound leaves headroom for git/finalize overhead while still surfacing
+# a hung binary to the operator instead of blocking the shell forever.
+SUBPROCESS_RUN_TIMEOUT_SECONDS = 7200
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +287,7 @@ def register(ctx: Any) -> None:
     )
     ctx.register_cli_command(
         name=PLUGIN_NAME,
-        help="Caduceus v1.0.0 lifecycle (setup, doctor, status, cron).",
+        help="Caduceus v1.0.0 lifecycle, cron, and daemon subcommands.",
         setup_fn=_register_caduceus_cli,
         handler_fn=_caduceus_cli_command,
         description=(
@@ -373,7 +381,8 @@ def _format_status_for_chat(payload: Dict[str, Any]) -> str:
 
 # ---------------------------------------------------------------------------
 # CLI command: hermes caduceus
-#   <setup|doctor|status|cron-install|cron-remove|queue|worktree-gc|migrate-state>
+#   <setup|doctor|status|cron-install|cron-remove|run|review|queue|
+#    worktree-gc|migrate-state>
 # ---------------------------------------------------------------------------
 
 
@@ -465,6 +474,32 @@ def _register_caduceus_cli(subparser: Any) -> None:
         help="Subcommand and flags forwarded to the caduceus binary.",
     )
 
+    run = subs.add_parser(
+        "run",
+        help="Run one daemon tick (args forwarded to the binary).",
+        passthrough_attr="run_args",
+    )
+    # Pass-through: every trailing token is forwarded verbatim to the
+    # binary; clap is the single source of truth for the flag contract.
+    # `run` takes no flags today (src/cli/mod.rs Command::Run) — the
+    # REMAINDER keeps that true without re-encoding it here.
+    run.add_argument(
+        "run_args",
+        nargs=argparse.REMAINDER,
+        help="Flags forwarded to the caduceus binary.",
+    )
+
+    review = subs.add_parser(
+        "review",
+        help="Inspect review state (status, list, show).",
+        passthrough_attr="review_args",
+    )
+    review.add_argument(
+        "review_args",
+        nargs=argparse.REMAINDER,
+        help="Subcommand and flags forwarded to the caduceus binary.",
+    )
+
     subs.add_parser(
         "worktree-gc",
         help="Garbage-collect stale worktrees (flags forwarded to the binary).",
@@ -523,6 +558,14 @@ def _caduceus_cli_command(args: Any) -> int:
         return _cli_status(json=getattr(args, "json", False))
     if sub == "queue":
         return _cli_passthrough("queue", getattr(args, "queue_args", []))
+    if sub == "run":
+        return _cli_passthrough(
+            "run",
+            getattr(args, "run_args", []),
+            timeout=SUBPROCESS_RUN_TIMEOUT_SECONDS,
+        )
+    if sub == "review":
+        return _cli_passthrough("review", getattr(args, "review_args", []))
     if sub == "worktree-gc":
         return _cli_passthrough("worktree-gc", getattr(args, "worktree_gc_args", []))
     if sub == "migrate-state":
@@ -1094,12 +1137,20 @@ def _cli_status(*, json: bool = False) -> int:
     return proc.returncode
 
 
-def _cli_passthrough(subcommand: str, forwarded: List[str]) -> int:
+def _cli_passthrough(
+    subcommand: str,
+    forwarded: List[str],
+    *,
+    timeout: int = SUBPROCESS_TIMEOUT_SECONDS,
+) -> int:
     """Run ``caduceus <subcommand> [forwarded...]`` and propagate the exit code.
 
     *forwarded* is the verbatim trailing argv the operator typed after
     the subcommand keyword; the wrapper never re-encodes flags — the
     clap parser in the binary is the single source of truth.
+    ``timeout`` defaults to the short subprocess bound; ``run`` passes
+    a dedicated long bound because a tick supervises workers for
+    minutes.
     """
     binary = _binary_path()
     if not binary.is_file():
@@ -1111,7 +1162,7 @@ def _cli_passthrough(subcommand: str, forwarded: List[str]) -> int:
     proc = _run(
         [str(binary), subcommand, *forwarded],
         cwd=_plugin_root(),
-        timeout=SUBPROCESS_TIMEOUT_SECONDS,
+        timeout=timeout,
     )
     if proc.stdout:
         sys.stdout.write(proc.stdout)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -186,20 +186,31 @@ directories) is `hermes caduceus setup`.
 
 ## The `hermes caduceus` wrapper
 
-The Hermes plugin exposes eight subcommands. `queue`, `worktree-gc`,
-and `migrate-state` forward every trailing token verbatim to the
-binary — clap is the single source of truth for their flags.
+The Hermes plugin exposes ten subcommands. `run`, `review`, `queue`,
+`worktree-gc`, and `migrate-state` forward every trailing token
+verbatim to the binary — clap is the single source of truth for their
+flags. A CI drift guard (`tests/plugin/cli_parity_test.py`) parses the
+binary's `Command` enum from `src/cli/mod.rs` and fails when the
+wrapper set diverges, so a new binary subcommand breaks CI instead of
+operators.
 
 ```text
 hermes caduceus setup [--dry-run]
 hermes caduceus doctor [--verbose]
 hermes caduceus status [--json]
+hermes caduceus run [flags...]
+hermes caduceus review <action> [flags...]
 hermes caduceus queue <action> [flags...]
 hermes caduceus worktree-gc [flags...]
 hermes caduceus migrate-state [flags...]
 hermes caduceus cron-install [--dry-run] [--verbose]
 hermes caduceus cron-remove [--verbose]
 ```
+
+`hermes caduceus run` blocks for the whole tick: worker supervision
+alone defaults to a one-hour timeout, so the wrapper allows up to two
+hours before killing the passthrough. For longer-running ticks, run
+the binary directly (or via the cron pulse wrapper).
 
 Note the two different doctors: the wrapper's `hermes caduceus doctor`
 checks plugin health (binary present, bridge seeded, cron job

--- a/tests/plugin/cli_parity_test.py
+++ b/tests/plugin/cli_parity_test.py
@@ -1,0 +1,97 @@
+"""Drift guard: the wrapper must cover the binary's full command set.
+
+Issue #389: the wrapper registered only a subset of the binary's clap
+subcommands, so operators hit argparse ``invalid choice`` errors. This
+guard parses the clap ``Command`` enum straight from ``src/cli/mod.rs``
+(hermetic: the CI python job has no Rust toolchain, so shelling out to
+a built binary would silently never run) and asserts the wrapper's
+argparse subcommand tree covers it exactly. A future binary subcommand
+fails HERE instead of breaking operators at runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from tests.fixtures.fake_ctx import FakePluginContext
+
+# Subcommands that exist only in the Hermes wrapper, never in the
+# binary. The coverage test ignores them on the wrapper side.
+WRAPPER_ONLY = {"cron-install", "cron-remove"}
+
+# Binary subcommands the wrapper intercepts with its own rich
+# implementation instead of pass-through. Kept explicit so a variant
+# moving between the two classes requires touching this file — the
+# passthrough-set test fails otherwise.
+INTERCEPTED = {"setup", "doctor", "status"}
+
+
+def _binary_commands(repo_root: Path) -> set:
+    """Return the binary's subcommand names from the clap source.
+
+    clap's derive converts variant names to kebab-case subcommand
+    names (``WorktreeGc`` -> ``worktree-gc``). The clap-internal
+    ``help`` subcommand is deliberately not part of the enum and not
+    part of the parity set: the wrapper's argparse provides its own
+    ``--help`` surface.
+    """
+    src = (repo_root / "src" / "cli" / "mod.rs").read_text(encoding="utf-8")
+    match = re.search(r"pub enum Command \{(.*?)\n\}", src, re.DOTALL)
+    assert match is not None, "pub enum Command block not found in src/cli/mod.rs"
+    variants = re.findall(r"^    ([A-Z][A-Za-z0-9]*)\b", match.group(1), re.MULTILINE)
+    assert variants, "no Command variants parsed from src/cli/mod.rs"
+    return {re.sub(r"(?<!^)(?=[A-Z])", "-", v).lower() for v in variants}
+
+
+def _subparsers_action(adapter, fake_ctx: FakePluginContext):
+    """Register the CLI and return the argparse subparsers action."""
+    adapter.register(fake_ctx)
+    parser = fake_ctx.cli_commands["caduceus"].parser
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    raise AssertionError("caduceus parser has no subparsers action")
+
+
+def test_wrapper_covers_full_binary_command_set(
+    adapter, fake_ctx: FakePluginContext, repo_root: Path
+) -> None:
+    """Every binary subcommand is registered by the wrapper (issue #389)."""
+    binary = _binary_commands(repo_root)
+    wrapper = set(_subparsers_action(adapter, fake_ctx).choices)
+    missing = binary - wrapper
+    extra = wrapper - binary - WRAPPER_ONLY
+    assert not missing, (
+        f"hermes caduceus is missing binary subcommands: {sorted(missing)}. "
+        "Add a parser for it in _register_caduceus_cli (__init__.py) "
+        "so operators do not hit argparse 'invalid choice'."
+    )
+    assert not extra, (
+        f"hermes caduceus registers unknown subcommands: {sorted(extra)}. "
+        "Binary commands must map 1:1; cron-install/cron-remove are the "
+        "only wrapper-owned additions."
+    )
+
+
+def test_passthrough_set_equals_binary_minus_intercepted(
+    adapter, fake_ctx: FakePluginContext, repo_root: Path
+) -> None:
+    """Every non-intercepted binary command is a REMAINDER passthrough.
+
+    The guard compares ONLY the passthrough set: wrapper-owned
+    (cron-*) and intercepted (setup/doctor/status) subcommands are
+    excluded here and pinned by WRAPPER_ONLY / INTERCEPTED above.
+    """
+    subs = _subparsers_action(adapter, fake_ctx)
+    passthrough = {
+        name
+        for name, sub in subs.choices.items()
+        if isinstance(sub, adapter._PassthroughParser) and sub._passthrough_attr
+    }
+    expected = _binary_commands(repo_root) - INTERCEPTED
+    assert passthrough == expected, (
+        f"passthrough set drifted: missing={sorted(expected - passthrough)} "
+        f"unexpected={sorted(passthrough - expected)}"
+    )

--- a/tests/plugin/cli_passthrough_test.py
+++ b/tests/plugin/cli_passthrough_test.py
@@ -1,8 +1,9 @@
 """Hermes wrapper pass-through CLI tests.
 
-``hermes caduceus`` forwards ``queue``, ``worktree-gc``, and
-``migrate-state`` verbatim to the ``caduceus`` binary, and forwards
-``status --json``. The wrapper never re-encodes the flag contract —
+``hermes caduceus`` forwards ``run``, ``review``, ``queue``,
+``worktree-gc``, and ``migrate-state`` verbatim to the ``caduceus``
+binary, and forwards ``status --json``. The wrapper never re-encodes
+the flag contract —
 the clap parser in the binary is the single source of truth. The
 pass-through subparsers use a custom argparse parser so a
 flags-first invocation (e.g. ``worktree-gc --older-than-days 7``)
@@ -50,6 +51,8 @@ def test_cli_help_lists_full_command_set(adapter, fake_ctx: FakePluginContext) -
         "status",
         "cron-install",
         "cron-remove",
+        "run",
+        "review",
         "queue",
         "worktree-gc",
         "migrate-state",
@@ -168,3 +171,85 @@ def test_passthrough_missing_binary_returns_diagnostic(
     captured = capsys.readouterr()
     assert rc == 1
     assert "hermes caduceus setup" in captured.err
+
+
+def test_run_passthrough_forwards_bare_tick(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    """``hermes caduceus run`` forwards a bare tick invocation verbatim.
+
+    `caduceus run` takes no flags on current main (src/cli/mod.rs
+    `Command::Run`); REMAINDER passthrough still forwards any trailing
+    tokens so clap stays the single source of truth.
+    """
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "run")
+    assert rc == 0
+    assert calls == [[str(install_with_fake_binary), "run"]]
+
+
+def test_run_passthrough_uses_long_timeout(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    """A tick supervises workers for minutes — never the 15s default.
+
+    Regression shape for issue #389: a naive mirror of the queue parser
+    would reuse SUBPROCESS_TIMEOUT_SECONDS (15s) and SIGKILL a live
+    tick mid-worker (worker_timeout_seconds defaults to 3600).
+    """
+    seen: List[Dict[str, Any]] = []
+
+    def fake_run(argv: list, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        seen.append(dict(kwargs))
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(adapter, "_run", fake_run)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "run")
+    assert rc == 0
+    assert len(seen) == 1
+    assert seen[0].get("timeout") == adapter.SUBPROCESS_RUN_TIMEOUT_SECONDS
+    assert seen[0]["timeout"] > 3600
+
+
+def test_review_status_passthrough_forwards_args(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "review", "status")
+    assert rc == 0
+    assert calls == [[str(install_with_fake_binary), "review", "status"]]
+
+
+def test_review_list_passthrough_forwards_json_flag(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "review", "list", "--json")
+    assert rc == 0
+    assert calls == [[str(install_with_fake_binary), "review", "list", "--json"]]
+
+
+def test_review_show_passthrough_forwards_positionals(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    """``review show OWNER/REPO PR`` forwards both positionals verbatim."""
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(
+        adapter, fake_ctx, "review", "show", "owner/repo", "123", "--json"
+    )
+    assert rc == 0
+    assert calls == [
+        [str(install_with_fake_binary), "review", "show", "owner/repo", "123", "--json"]
+    ]
+
+
+def test_review_status_repo_filter_passthrough(
+    adapter, fake_ctx: FakePluginContext, install_with_fake_binary, monkeypatch
+) -> None:
+    """Flags-first tokens are swallowed by the pass-through parser."""
+    calls = _record_run(adapter, monkeypatch)
+    rc = _parse_and_dispatch(adapter, fake_ctx, "review", "--json", "status")
+    assert rc == 0
+    assert calls == [
+        [str(install_with_fake_binary), "review", "--json", "status"]
+    ]

--- a/tests/plugin/test_cli.py
+++ b/tests/plugin/test_cli.py
@@ -40,6 +40,8 @@ def test_cli_command_is_registered(adapter, fake_ctx: FakePluginContext) -> None
         "status",
         "cron-install",
         "cron-remove",
+        "run",
+        "review",
         "queue",
         "worktree-gc",
         "migrate-state",


### PR DESCRIPTION
## What changed

The `hermes caduceus` wrapper now exposes the binary's full command
set. `run` and `review` were missing from `_register_caduceus_cli`
(argparse `invalid choice: 'review'` for operators); both are now
REMAINDER passthrough parsers mirroring the existing `queue` parser,
so every trailing token forwards verbatim to the binary and clap stays
the single source of truth for the flag contract.

- `__init__.py`: added `run` + `review` passthrough parsers and
  dispatch arms; added `SUBPROCESS_RUN_TIMEOUT_SECONDS = 7200` for
  `run` (a tick supervises workers for minutes — the 15s passthrough
  default would SIGKILL a live tick; `worker_timeout_seconds` defaults
  to 3600). `review` keeps the 15s default (read-only store access,
  same class as `queue`).
- `tests/plugin/cli_parity_test.py` (new): drift guard that parses the
  clap `Command` enum from `src/cli/mod.rs` (hermetic — the CI python
  job has no Rust toolchain) and asserts the wrapper's subcommand tree
  covers it exactly. Two tests: full coverage (wrapper ⊇ binary, no
  unknowns) and exact passthrough classification
  (passthrough == binary − intercepted). Wrapper-owned
  `cron-install`/`cron-remove` stay wired and are pinned in
  `WRAPPER_ONLY`.
- `tests/plugin/cli_passthrough_test.py` + `tests/plugin/test_cli.py`:
  help-text enumeration extended; 6 new smoke tests covering
  `review status`, `review list --json`,
  `review show owner/repo 123 --json`, flags-first `review --json
  status`, bare `run`, and the dedicated 2h run timeout.
- `docs/cli.md` + `CHANGELOG.md`: wrapper surface updated from eight to
  ten subcommands; run-timeout behavior documented.

## RED → GREEN evidence

Drift guard on current main (before this fix):

- `hermes caduceus is missing binary subcommands: ['review', 'run']`
- `passthrough set drifted: missing=['review', 'run']`

Both guard tests and the 6 new behavior tests failed on main; all 21
tests in the three touched files pass after the fix. Full
`tests/plugin/` + `tests/integration/bridge_test.py`: 208 passed.

## Gates

Serialized per AGENTS.md (cargo before pytest — OOM host):

- `cargo fmt --check` — OK
- `cargo clippy --locked --all-targets -- -D warnings` — OK
- `cargo test --locked --all-targets` — 204 test-result blocks OK; one
  pre-existing host-race failure: `readiness_test
  ::live_probe_reports_missing_cgroup_controller` failed only in the
  parallel full run and passes when re-run alone. This PR changes zero
  Rust files, so it is not a regression from this change.
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` —
  208 passed

Closes #389.