### PR TITLE
test(fixtures): preflight script exec to close ETXTBSY flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
   with no sticky comment ever published. Dedup now holds from completion
   onward and the next tick publishes the run it was built for. Closes
   #333.
+- **Executable-script fixtures no longer flake with `Text file busy`.**
+  `tests/fixtures/script.rs::write_executable_script` writes the fake
+  engine/stub script and pre-flights one exec before returning, retrying
+  the transient `ExecutableFileBusy` (ETXTBSY) that Linux `execve()`
+  reports for a file whose write fd was just closed under parallel test
+  threads. `oci_provenance_test` flaked with shuffled failure names
+  (failing ~1/3 of isolated runs) despite its fsync workaround; the
+  shared helper now backs the OCI adapter, readiness, lifecycle-stub,
+  and env-file fixtures.
 
 ## [1.0.0] - 2026-08-08
 

--- a/tests/executor/oci_engine_seam_test.rs
+++ b/tests/executor/oci_engine_seam_test.rs
@@ -1,4 +1,6 @@
-use std::os::unix::fs::PermissionsExt;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
 use std::path::Path;
 
 use caduceus::executor::oci_engine::OciImageAdapter;
@@ -6,6 +8,7 @@ use caduceus::executor::oci_image::ensure_image_with_adapter;
 use caduceus::executor::oci_platform::HostPlatform;
 use caduceus::executor::SandboxEngine;
 use caduceus::infra::config::OciPullPolicy;
+use fixtures::write_executable_script;
 
 const DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 const IMAGE_REF: &str = "registry.example/worker@sha256:0000000000000000000000000000000000000000000000000000000000000000";
@@ -17,9 +20,7 @@ fn fake_engine(root: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
         "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"pull\" ]; then\n  printf 'pull must not be called on a warm cache\\n' >&2\n  exit 91\nfi\nif [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"--format\" ]; then\n  printf '%s' '{{\"Id\":\"sha256:{DIGEST}\",\"RepoDigests\":[\"{IMAGE_REF}\"],\"Architecture\":\"amd64\"}}'\nfi\nexit 0\n",
         calls.display()
     );
-    std::fs::write(&binary, script).expect("write fake OCI executable");
-    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
-        .expect("make fake OCI executable");
+    write_executable_script(root, "fake-oci", &script);
     (binary, calls)
 }
 

--- a/tests/executor/oci_ensure_image_test.rs
+++ b/tests/executor/oci_ensure_image_test.rs
@@ -1,4 +1,6 @@
-use std::os::unix::fs::PermissionsExt;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::oci_engine::OciImageAdapter;
@@ -7,6 +9,7 @@ use caduceus::executor::oci_platform::HostPlatform;
 use caduceus::executor::SandboxEngine;
 use caduceus::infra::config::OciPullPolicy;
 use caduceus::infra::error::CaduceusError;
+use fixtures::write_executable_script;
 
 const DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const IMAGE_REF: &str = "registry.example/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -19,9 +22,7 @@ fn fake_engine(root: &Path, inspect_json: &str) -> (PathBuf, PathBuf) {
         calls.display(),
         inspect_json
     );
-    std::fs::write(&binary, script).expect("write fake OCI executable");
-    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
-        .expect("make fake OCI executable");
+    write_executable_script(root, "fake-oci", &script);
     (binary, calls)
 }
 

--- a/tests/executor/oci_env_file_test.rs
+++ b/tests/executor/oci_env_file_test.rs
@@ -24,6 +24,9 @@ use std::time::Duration;
 use serial_test::serial;
 use tokio_util::sync::CancellationToken;
 
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
 use caduceus::executor::oci_env_file::OciEnvFile;
 use caduceus::executor::oci_lifecycle;
 use caduceus::executor::sandbox_spec::{resolve, SandboxEngine};
@@ -32,6 +35,7 @@ use caduceus::github::issue::IssueKey;
 use caduceus::infra::config::Config;
 use caduceus::infra::error::{CaduceusError, CaduceusResult};
 use caduceus::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
+use fixtures::write_executable_script;
 
 mod support;
 
@@ -327,9 +331,7 @@ esac
 async fn create_failure_leaves_no_env_file() {
     let tmp = tempfile::tempdir().expect("tmp");
     let stub_dir = tempfile::tempdir().expect("stub tmp");
-    let script = stub_dir.path().join("docker");
-    std::fs::write(&script, FAILING_CREATE_STUB).expect("write stub");
-    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod stub");
+    write_executable_script(stub_dir.path(), "docker", FAILING_CREATE_STUB);
 
     let run_dir = tmp.path().join("oci-runs").join("run-guard");
     let env_file = OciEnvFile::create(&run_dir, &env_map(&[("CADUCEUS_RUN_ID", "run-guard")]))

--- a/tests/executor/oci_lifecycle_stub_test.rs
+++ b/tests/executor/oci_lifecycle_stub_test.rs
@@ -35,6 +35,10 @@ use caduceus::infra::config::Config;
 use caduceus::infra::error::CaduceusResult;
 use caduceus::state::oci_run::{ContainerRunRow, OciLifecycleState, OciRunState};
 
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+use fixtures::write_executable_script;
+
 #[allow(dead_code)]
 mod support;
 
@@ -299,11 +303,7 @@ struct StubEngine {
 impl StubEngine {
     fn new() -> Self {
         let dir = tempfile::tempdir().expect("stub tempdir");
-        let script = dir.path().join("docker");
-        std::fs::write(&script, STUB_SCRIPT).expect("write stub script");
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
-            .expect("chmod stub script");
+        write_executable_script(dir.path(), "docker", STUB_SCRIPT);
         let path = std::env::var("PATH").unwrap_or_default();
         std::env::set_var("PATH", format!("{}:{path}", dir.path().display()));
         Self {

--- a/tests/executor/oci_provenance_test.rs
+++ b/tests/executor/oci_provenance_test.rs
@@ -1,5 +1,6 @@
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
 use std::path::{Path, PathBuf};
 
 use caduceus::executor::oci_engine::OciImageAdapter;
@@ -8,6 +9,7 @@ use caduceus::executor::oci_platform::HostPlatform;
 use caduceus::executor::SandboxEngine;
 use caduceus::infra::config::OciPullPolicy;
 use caduceus::infra::error::CaduceusError;
+use fixtures::write_executable_script;
 use serde_json::Value;
 
 const DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -21,7 +23,6 @@ fn host() -> HostPlatform {
 }
 
 fn fake_engine(root: &Path, local_present: bool, inspect_json: &str, pull_fails: bool) -> PathBuf {
-    let binary = root.join("fake-oci");
     let present_exit = if local_present { "0" } else { "1" };
     let pull_body = if pull_fails {
         "printf 'registry offline\\n' >&2\n  exit 42"
@@ -35,18 +36,10 @@ fn fake_engine(root: &Path, local_present: bool, inspect_json: &str, pull_fails:
         pull_body = pull_body,
         inspect_json = inspect_json,
     );
-    let mut file = std::fs::File::create(&binary).expect("create fake OCI executable");
-    file.write_all(script.as_bytes())
-        .expect("write fake OCI executable");
-    // Flush the script to disk before returning: the adapter execs the
-    // binary immediately after this helper returns, and a write that is
-    // still in flight can make the exec fail with ETXTBSY ("text file
-    // busy") on some filesystems. fsync closes the write->exec window.
-    file.sync_all().expect("fsync fake OCI executable");
-    drop(file);
-    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
-        .expect("make fake OCI executable");
-    binary
+    // write_executable_script flushes the script to disk and pre-flights
+    // one exec before returning, closing the write->exec ETXTBSY race
+    // (see tests/fixtures/script.rs).
+    write_executable_script(root, "fake-oci", &script)
 }
 
 fn read_record(run_dir: &Path) -> Value {

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -30,6 +30,8 @@ mod process_tree;
 #[cfg(test)]
 mod release_binary;
 #[cfg(test)]
+mod script;
+#[cfg(test)]
 mod tempdir;
 
 #[cfg(test)]
@@ -56,6 +58,9 @@ pub use process_tree::{assert_no_survivors, snapshot_subtree, ProcessTree};
 #[cfg(test)]
 #[allow(unused_imports)]
 pub use release_binary::{ReleaseBinary, RunSupervisorArgs};
+#[cfg(test)]
+#[allow(unused_imports)]
+pub use script::write_executable_script;
 #[cfg(test)]
 #[allow(unused_imports)]
 pub use tempdir::{tempdir, tempdir_owned};

--- a/tests/fixtures/script.rs
+++ b/tests/fixtures/script.rs
@@ -1,0 +1,88 @@
+//! Executable-script fixture helper.
+//!
+//! Tests that drive the engine adapter (or a PATH stub) need an
+//! executable script written moments before the code-under-test execs
+//! it. On Linux that write->exec sequence races the kernel's
+//! `deny_write_access()` check inside `execve()`: the inode's writer
+//! refcount (`i_writecount`) is dropped late in the close path
+//! (`__fput`), so a concurrent `fork()`+`execve()` in another test
+//! thread can transiently observe the freshly-closed file as
+//! still-open-for-writing and fail the exec with `ETXTBSY` ("Text file
+//! busy"). `fsync()` does NOT close the window — verified 2026-09-12
+//! on `oci_provenance_test`: the fixture's `sync_all()` workaround
+//! still flaked 20/60 isolated runs under 4 test threads. Retrying the
+//! first exec until one succeeds closes it: a successful exec proves
+//! the writer refcount has been released, and that one-time close
+//! window never reopens for the file.
+
+// Not every test binary that includes `fixtures/mod.rs` uses the helper;
+// dead-code allowances match the other fixture modules.
+#![allow(dead_code)]
+
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// Marker argument the pre-flight exec passes so scripts that log
+/// invocations (`$*`) can be identified in call logs.
+const PREFLIGHT_ARG: &str = "__caduceus_fixture_preflight__";
+
+/// Bounded retry: the transient ETXTBSY window clears in
+/// microseconds-to-milliseconds; 20 attempts x 10ms far exceeds the
+/// observed worst case while keeping the failure path diagnostic.
+const MAX_PREFLIGHT_ATTEMPTS: usize = 20;
+const PREFLIGHT_RETRY_DELAY_MS: u64 = 10;
+
+/// Write an executable POSIX shell script under `dir` and prove it can
+/// be exec'd before returning.
+///
+/// The caller's code execs the returned path immediately; the pre-flight
+/// exec guarantees no subsequent exec of this file can hit the
+/// transient `ExecutableFileBusy` (ETXTBSY) race described above.
+pub fn write_executable_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    let mut file = std::fs::File::create(&path).expect("create script");
+    file.write_all(body.as_bytes()).expect("write script");
+    // Flush + close before chmod/exec so the write fd is fully released
+    // (the fsync is not sufficient on its own — see module docs — but
+    // keeps the file durable for hosts that do report in-flight-write
+    // exec failures).
+    file.sync_all().expect("sync script");
+    drop(file);
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod script");
+    preflight_exec(&path, name);
+    path
+}
+
+/// Retry a single exec of the freshly-written script until it succeeds.
+///
+/// Exit status is irrelevant (scripts fall through to their default
+/// branch for the marker arg); only a successful spawn matters, because
+/// it proves the kernel's writer-refcount close-window has closed.
+fn preflight_exec(path: &Path, name: &str) {
+    let mut attempts = 0usize;
+    loop {
+        match Command::new(path)
+            .arg(PREFLIGHT_ARG)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+        {
+            Ok(_) => return,
+            Err(err) if err.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                attempts += 1;
+                if attempts >= MAX_PREFLIGHT_ATTEMPTS {
+                    panic!(
+                        "spawn fixture script {name}: still ExecutableFileBusy \
+                         after {MAX_PREFLIGHT_ATTEMPTS} attempts"
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(PREFLIGHT_RETRY_DELAY_MS));
+            }
+            Err(err) => panic!("spawn fixture script {name}: {err}"),
+        }
+    }
+}

--- a/tests/readiness_test.rs
+++ b/tests/readiness_test.rs
@@ -4,6 +4,9 @@ use caduceus::readiness::{
     assemble_report, render_human, run_live_with_options, CheckId, CheckResult, CheckStatus,
     DiagnosticCanary, DiagnosticStatus, ProbeOptions, ReadinessVerdict,
 };
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+use fixtures::write_executable_script;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -106,11 +109,7 @@ fn fake_engine(dir: &Path, image_present: bool, userns_remap: bool) -> PathBuf {
         if image_present { "exit 0" } else { "exit 1" },
     )
     .replace("__IMAGE__", &image);
-    let path = dir.join("fake-engine");
-    std::fs::write(&path, script).expect("write fake engine");
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
-        .expect("make fake engine executable");
-    path
+    write_executable_script(dir, "fake-engine", &script)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Closes the oci_provenance_test flake found during the #389 review gate (shuffled failure names under load). The fixture fsync'd the fake-oci script but still raced on exec under parallel-suite load; preflighting the exec closes the ETXTBSY window. No production code touched.