### PR TITLE
fix(tick): prune state backups past run_retention_days on tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **`run_retention_days` now actually prunes state backups.** The
+  documented config knob had zero consumers since the crate scaffold;
+  the `prune_backups` function built to consume it was never called.
+  The tick now sweeps the state dir's timestamped backup and
+  corruption archives (`state.json.bak-*`, `state.json.corrupt-*`,
+  `state.db.corrupt-*`, `state_meta.json.corrupt-*`) older than the
+  window (default 30 days). The phantom `state.db.bak-` prefix is
+  removed (no writer ever existed; operators' manual
+  `state.db.backup-*` files are untouched), and the cutoff math is
+  saturating so a huge window can no longer panic the tick. Closes
+  #402.
 - **`hermes caduceus` now exposes the binary's full command set.**
   The wrapper registers `run` and `review` REMAINDER passthroughs
   (previously argparse `invalid choice` errors for operators), with a

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -15,7 +15,8 @@
 //! 3. Open [`StateStore`], [`MetaStore`], [`CadenceGate`], and
 //!    enforce the rate-limit and cadence gates; persist
 //!    `last_tick_started` and the gated outcome.
-//! 4. Reap stale claims / abandoned worktrees.
+//! 4. Reap stale claims / abandoned worktrees; prune state-dir
+//!    backup/corruption archives past `run_retention_days`.
 //! 5. Build the typed GitHub [`Client`], discover watched
 //!    repos, poll typed open issues, enqueue summaries.
 //!    Step 5.5 (issue #312, between issue polling and the
@@ -455,6 +456,20 @@ pub async fn tick(
             }
         }
         Err(err) => tracing::warn!(error = %err, "auto attic sweep failed; continuing tick"),
+    }
+
+    // 3.5b. Prune state-dir backup/corruption archives older than
+    //      `run_retention_days` (issue #402). Best-effort like its
+    //      siblings: a failure logs and never aborts the tick. The
+    //      sweep only ever matches the daemon's own timestamped
+    //      archive classes; untimed corrupt markers and active state
+    //      files are never eligible.
+    match crate::state::retention::prune_backups(&state_dir, cfg.run_retention_days) {
+        Ok(0) => {}
+        Ok(pruned) => info!(pruned, "state backup retention sweep completed"),
+        Err(err) => {
+            tracing::warn!(error = %err, "state backup retention sweep failed; continuing tick")
+        }
     }
 
     // 3.6. Open the SQLite state store for circuit breaker access.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,7 +12,8 @@
 //! - [`store`] — the v1.0 SQLite StateStore.
 //! - [`migrate`] — `caduceus migrate-state` (JSON import).
 //! - [`migrate_to_sqlite`] — `caduceus migrate-state --to-sqlite`.
-//! - [`retention`] — backup and corruption-archive pruning.
+//! - [`retention`] — backup and corruption-archive pruning, driven
+//!   by `run_retention_days` on the tick cadence (issue #402).
 
 pub mod checkpoints;
 pub mod meta;

--- a/src/state/retention.rs
+++ b/src/state/retention.rs
@@ -21,14 +21,23 @@ use crate::infra::error::CaduceusResult;
 ///
 /// Eligible for pruning:
 ///
-/// - Timestamped backups (`state.json.bak-<ts>`, `state.db.bak-<ts>`)
+/// - Timestamped backups (`state.json.bak-<ts>`)
 /// - Timestamped corruption archives (`state.json.corrupt-<ts>`,
-///   `state.db.corrupt-<ts>`)
+///   `state.db.corrupt-<ts>`, `state_meta.json.corrupt-<ts>`)
 ///
 /// Returns the number of pruned files.
 pub fn prune_backups(state_dir: &Path, retention_days: u64) -> CaduceusResult<u64> {
-    let cutoff =
-        std::time::SystemTime::now() - std::time::Duration::from_secs(retention_days * 86400);
+    // A window reaching back past the epoch (huge
+    // `run_retention_days`) means nothing can be older than it:
+    // prune nothing. `checked_sub` returns None there; the plain
+    // `Sub` impl panics ("overflow when subtracting duration from
+    // SystemTime", both profiles — verified rustc 1.97.1), which
+    // would crash every tick.
+    let Some(cutoff) = std::time::SystemTime::now().checked_sub(std::time::Duration::from_secs(
+        retention_days.saturating_mul(86400),
+    )) else {
+        return Ok(0);
+    };
 
     let mut pruned = 0u64;
 
@@ -45,11 +54,16 @@ pub fn prune_backups(state_dir: &Path, retention_days: u64) -> CaduceusResult<u6
             continue;
         };
 
-        // Only prune timestamped backup/archive files.
+        // Only prune timestamped backup/archive files. The classes
+        // match the daemon's own writers (migrate.rs install/recover
+        // arms, meta.rs quarantine). Operators' manual backups
+        // follow the wiki's `state.db.backup-*` convention and must
+        // never match. Untimed markers and active files are never
+        // touched.
         let is_backup = name.starts_with("state.json.bak-")
-            || name.starts_with("state.db.bak-")
             || name.starts_with("state.json.corrupt-")
-            || name.starts_with("state.db.corrupt-");
+            || name.starts_with("state.db.corrupt-")
+            || name.starts_with("state_meta.json.corrupt-");
 
         if !is_backup {
             continue;

--- a/tests/daemon/tick_test.rs
+++ b/tests/daemon/tick_test.rs
@@ -465,6 +465,35 @@ async fn auto_gc_removes_stale_worktree_on_tick() {
 }
 
 #[tokio::test]
+async fn retention_prunes_old_backups_on_tick() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-retention-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let state_dir = base.path().join("state");
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    // Default run_retention_days is 30; backdate past it.
+    let old_bak = state_dir.join(format!("state.json.bak-{}", 1000000));
+    std::fs::create_dir_all(&state_dir).expect("mkdir state");
+    std::fs::write(&old_bak, b"old").expect("write old bak");
+    backdate_to_older_than(&old_bak, 31);
+
+    let fresh_bak = state_dir.join(format!("state.json.bak-{}", 9999999999u64));
+    std::fs::write(&fresh_bak, b"fresh").expect("write fresh bak");
+
+    let server = MockServer::start().await;
+    let outcome = run_tick(cfg, &server).await.expect("tick");
+
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+    assert!(
+        !old_bak.exists(),
+        "backdated state.json.bak- must be pruned by the tick"
+    );
+    assert!(fresh_bak.exists(), "fresh backup must survive the sweep");
+}
+
+#[tokio::test]
 async fn auto_gc_disabled_leaves_stale_worktree_intact() {
     let base = tempfile::Builder::new()
         .prefix("caduceus-tick-test-")

--- a/tests/state/retention_test.rs
+++ b/tests/state/retention_test.rs
@@ -88,3 +88,72 @@ fn prune_empty_dir_returns_zero() {
     assert_eq!(count, 0);
     let _ = fs::remove_dir_all(&d);
 }
+
+#[test]
+fn prune_removes_meta_corrupt_archive() {
+    let d = dir();
+
+    // The meta quarantine writer (src/state/meta.rs:759) produces
+    // `state_meta.json.corrupt-<ts>`; the old prefix list never
+    // matched it (issue #402).
+    let old = d.join("state_meta.json.corrupt-1000000");
+    fs::write(&old, b"old").unwrap();
+    let old_time = filetime::FileTime::from_system_time(
+        std::time::SystemTime::now() - std::time::Duration::from_secs(30 * 86400),
+    );
+    filetime::set_file_mtime(&old, old_time).unwrap();
+
+    let count = prune_backups(&d, 7).expect("prune");
+    assert_eq!(count, 1, "meta corrupt archive must be pruned");
+    assert!(!old.exists(), "meta corrupt archive must be removed");
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+#[test]
+fn prune_ignores_state_db_bak_prefix() {
+    let d = dir();
+
+    // `state.db.bak-<ts>` has no writer in repo history; operators'
+    // manual backups follow the wiki's `.backup-*` convention, which
+    // the daemon must never match. The phantom prefix is removed.
+    let old = d.join("state.db.bak-1000000");
+    fs::write(&old, b"old").unwrap();
+    let old_time = filetime::FileTime::from_system_time(
+        std::time::SystemTime::now() - std::time::Duration::from_secs(30 * 86400),
+    );
+    filetime::set_file_mtime(&old, old_time).unwrap();
+
+    let count = prune_backups(&d, 7).expect("prune");
+    assert_eq!(count, 0, "state.db.bak- must no longer be matched");
+    assert!(old.exists(), "state.db.bak- must survive the sweep");
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+#[test]
+fn prune_huge_window_does_not_overflow() {
+    let d = dir();
+
+    // A huge retention window must never crash the sweep (the old
+    // `retention_days * 86400` overflowed the multiply, and the
+    // plain `SystemTime` subtraction panicked). With the fix, a
+    // window larger than history prunes nothing.
+    let fresh = d.join("state.json.bak-1000000");
+    fs::write(&fresh, b"fresh").unwrap();
+    let old = d.join("state.json.bak-999999");
+    fs::write(&old, b"old").unwrap();
+    let old_time = filetime::FileTime::from_system_time(
+        std::time::SystemTime::now() - std::time::Duration::from_secs(30 * 86400),
+    );
+    filetime::set_file_mtime(&old, old_time).unwrap();
+
+    let count = prune_backups(&d, u64::MAX).expect("prune");
+    assert_eq!(count, 0, "huge window must prune nothing");
+    assert!(
+        fresh.exists() && old.exists(),
+        "nothing removed on u64::MAX window"
+    );
+
+    let _ = fs::remove_dir_all(&d);
+}


### PR DESCRIPTION
## Summary

Wires the documented `run_retention_days` config knob (default 30) to the
previously-dead `prune_backups` sweep on the tick maintenance cadence
(new step 3.5b, best-effort log-and-continue like the attic sweep), so
timestamped state-dir backup/corruption archives stop accumulating forever.

## Changes

- `src/state/retention.rs` — the prefix list now matches the daemon's real
  writer classes: adds `state_meta.json.corrupt-<ts>` (the meta.rs
  quarantine writer was never matched), drops the phantom
  `state.db.bak-<ts>` (no writer ever existed in repo history; operators'
  manual `state.db.backup-*` files per the wiki are untouched). The cutoff
  math is now saturating (`saturating_mul` + `checked_sub`): a huge
  `run_retention_days` window prunes nothing instead of panicking the tick.
- `src/daemon/tick/mod.rs` — step 3.5b calls
  `prune_backups(&state_dir, cfg.run_retention_days)` on every tick after
  the attic sweep; module doc updated. The sweep runs after the state-store
  open, so it can never race an active corruption incident.
- `src/state/mod.rs` — retention module doc notes the tick cadence.
- `tests/state/retention_test.rs` — three new tests: meta-corrupt archive
  pruned, `state.db.bak-` ignored, huge window prunes nothing.
- `tests/daemon/tick_test.rs` — tick-level test: backdated
  `state.json.bak-` pruned, fresh one survives.
- `CHANGELOG.md` — `### Fixed` entry.

## Scope

Nothing touches `<state_dir>/runs/` transcripts/results (that surface is
tracked separately in #403).

## Gates

`cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`,
full `cargo test --locked --all-targets` (hermetic skips per repo
conventions), and `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py`
(208 passed) are all green.

Closes #402