### PR TITLE
fix(state): prune finished runs/ artifacts on the retention sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **Finished-run artifacts are now retained, not kept forever.**
+  `<state_dir>/runs/` (worker transcripts, archived results,
+  dry-run previews, heartbeats) had no retention at all — files
+  accumulated for the install's lifetime. The same
+  `run_retention_days` window (default 30 days) that sweeps
+  state-dir backup archives now also prunes finished-run
+  artifacts. A heartbeat-freshness guard (skip anything whose
+  mtime is within the last hour, mirroring the worktree-GC
+  liveness rule) makes it impossible for the sweep to delete an
+  in-flight run's heartbeat and let GC reap a live worktree.
+  Closes #403.
 - **`run_retention_days` now actually prunes state backups.** The
   documented config knob had zero consumers since the crate scaffold;
   the `prune_backups` function built to consume it was never called.

--- a/src/daemon/tick/mod.rs
+++ b/src/daemon/tick/mod.rs
@@ -16,7 +16,9 @@
 //!    enforce the rate-limit and cadence gates; persist
 //!    `last_tick_started` and the gated outcome.
 //! 4. Reap stale claims / abandoned worktrees; prune state-dir
-//!    backup/corruption archives past `run_retention_days`.
+//!    backup/corruption archives and finished-run artifacts
+//!    (transcripts, results, previews, stale heartbeats) past
+//!    `run_retention_days`.
 //! 5. Build the typed GitHub [`Client`], discover watched
 //!    repos, poll typed open issues, enqueue summaries.
 //!    Step 5.5 (issue #312, between issue polling and the
@@ -469,6 +471,22 @@ pub async fn tick(
         Ok(pruned) => info!(pruned, "state backup retention sweep completed"),
         Err(err) => {
             tracing::warn!(error = %err, "state backup retention sweep failed; continuing tick")
+        }
+    }
+
+    // 3.5c. Prune finished-run artifacts in `<state_dir>/runs/`
+    //      older than `run_retention_days` (issue #403): worker
+    //      transcripts, archived results, dry-run previews, and
+    //      stale heartbeats. Best-effort like its siblings: a
+    //      failure logs and never aborts the tick. The
+    //      heartbeat-freshness guard inside the sweep mirrors the
+    //      worktree-GC liveness rule, so an in-flight run's files
+    //      are never touched.
+    match crate::state::retention::prune_run_artifacts(&state_dir, cfg.run_retention_days) {
+        Ok(0) => {}
+        Ok(pruned) => info!(pruned, "run artifact retention sweep completed"),
+        Err(err) => {
+            tracing::warn!(error = %err, "run artifact retention sweep failed; continuing tick")
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,8 +12,9 @@
 //! - [`store`] — the v1.0 SQLite StateStore.
 //! - [`migrate`] — `caduceus migrate-state` (JSON import).
 //! - [`migrate_to_sqlite`] — `caduceus migrate-state --to-sqlite`.
-//! - [`retention`] — backup and corruption-archive pruning, driven
-//!   by `run_retention_days` on the tick cadence (issue #402).
+//! - [`retention`] — backup, corruption-archive, and finished-run
+//!   artifact pruning, driven by `run_retention_days` on the tick
+//!   cadence (issues #402, #403).
 
 pub mod checkpoints;
 pub mod meta;

--- a/src/state/retention.rs
+++ b/src/state/retention.rs
@@ -3,7 +3,11 @@
 //! Prune old backup and corruption-archive files from the state
 //! directory, keeping only files within the configured retention
 //! window plus active state, claims, checkpoints, and corruption
-//! evidence.
+//! evidence. Also prunes finished-run artifacts (transcripts,
+//! archived results, dry-run previews, stale heartbeats) from
+//! `<state_dir>/runs/`, with a heartbeat-freshness guard that
+//! mirrors the worktree-GC liveness rule so in-flight runs are
+//! never touched.
 
 use std::fs;
 use std::path::Path;
@@ -76,6 +80,110 @@ pub fn prune_backups(state_dir: &Path, retention_days: u64) -> CaduceusResult<u6
         let Ok(modified) = meta.modified() else {
             continue;
         };
+
+        if modified < cutoff {
+            let _ = fs::remove_file(&path);
+            pruned += 1;
+        }
+    }
+
+    Ok(pruned)
+}
+
+/// Prune finished-run artifacts from `<state_dir>/runs/` older
+/// than `retention_days` (issue #403). Eligible classes, by
+/// suffix — the run-id prefix is an opaque ULID:
+///
+/// - Worker transcripts (`<run_id>.log`)
+/// - Archived results (`<run_id>.result.json`)
+/// - Dry-run previews (`<run_id>.preview.json`,
+///   `<run_id>.dry-run.md`)
+/// - Heartbeats (`<run_id>.heartbeat`) — only stale ones; see
+///   the freshness guard below.
+///
+/// Safety (mirrors the `worktree/gc.rs` liveness rule): a live
+/// run's supervisor rewrites its heartbeat at most once per
+/// second and appends to its transcript continuously, so both
+/// always carry a fresh mtime. Any file whose mtime is within
+/// the last hour is skipped unconditionally — the sweep can
+/// never delete an in-flight run's heartbeat and make the
+/// worktree GC reap a live worktree (the #177 bug class). A
+/// heartbeat older than the cutoff is already inert for GC
+/// (it skips stale heartbeats), so pruning it changes no GC
+/// decision.
+///
+/// Preserves: anything not matching the five suffixes (operator
+/// drops, foreign files), directories, symlinks, and atomic-write
+/// temporaries (they end in `.tmp.<pid>.<nanos>`, never in a
+/// matched suffix).
+///
+/// Returns the number of pruned files. `Ok(0)` when the `runs/`
+/// directory is missing.
+pub fn prune_run_artifacts(state_dir: &Path, retention_days: u64) -> CaduceusResult<u64> {
+    let now = std::time::SystemTime::now();
+    // Same huge-window rule as `prune_backups`: a window reaching
+    // back past the epoch means nothing can be older than it —
+    // prune nothing rather than panicking.
+    let Some(cutoff) = now.checked_sub(std::time::Duration::from_secs(
+        retention_days.saturating_mul(86400),
+    )) else {
+        return Ok(0);
+    };
+    // Heartbeat-freshness floor mirroring `worktree/gc.rs` (1h):
+    // files modified within the last hour are never eligible,
+    // regardless of the retention window. `checked_sub` again so
+    // a broken pre-epoch clock prunes nothing instead of
+    // panicking.
+    let Some(fresh_floor) = now.checked_sub(std::time::Duration::from_secs(3600)) else {
+        return Ok(0);
+    };
+
+    let runs_dir = state_dir.join("runs");
+    let Ok(entries) = fs::read_dir(&runs_dir) else {
+        return Ok(0);
+    };
+
+    let mut pruned = 0u64;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // `entry.file_type()` stats the link itself (no follow):
+        // a symlinked artifact is never removed, matching the
+        // status reader's symlink rejection. Directories are
+        // skipped the same way.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        let is_run_artifact = name.ends_with(".log")
+            || name.ends_with(".result.json")
+            || name.ends_with(".heartbeat")
+            || name.ends_with(".preview.json")
+            || name.ends_with(".dry-run.md");
+
+        if !is_run_artifact {
+            continue;
+        }
+
+        // Check file age.
+        let Ok(meta) = fs::metadata(&path) else {
+            continue;
+        };
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+
+        // In-flight guard: never touch anything a live run may
+        // still be writing, regardless of the window.
+        if modified >= fresh_floor {
+            continue;
+        }
 
         if modified < cutoff {
             let _ = fs::remove_file(&path);

--- a/tests/daemon/tick_test.rs
+++ b/tests/daemon/tick_test.rs
@@ -494,6 +494,49 @@ async fn retention_prunes_old_backups_on_tick() {
 }
 
 #[tokio::test]
+async fn run_artifact_retention_sweep_on_tick() {
+    let base = tempfile::Builder::new()
+        .prefix("caduceus-tick-runs-retention-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .expect("base");
+    let state_dir = base.path().join("state");
+    let runs_dir = state_dir.join("runs");
+
+    let cfg = tick_config(base.path(), vec!["owner/r".to_string()], None, None);
+    // Default run_retention_days is 30; backdate past it.
+    std::fs::create_dir_all(&runs_dir).expect("mkdir runs");
+    let old_log = runs_dir.join("old-run.log");
+    std::fs::write(&old_log, b"old transcript").expect("write old log");
+    let old_result = runs_dir.join("old-run.result.json");
+    std::fs::write(&old_result, b"{}").expect("write old result");
+    backdate_to_older_than(&old_log, 31);
+    backdate_to_older_than(&old_result, 31);
+
+    let fresh_log = runs_dir.join("fresh-run.log");
+    std::fs::write(&fresh_log, b"fresh transcript").expect("write fresh log");
+    let fresh_result = runs_dir.join("fresh-run.result.json");
+    std::fs::write(&fresh_result, b"{}").expect("write fresh result");
+
+    let server = MockServer::start().await;
+    let outcome = run_tick(cfg, &server).await.expect("tick");
+
+    assert_eq!(outcome, TickOutcome::IdleEmpty);
+    assert!(
+        !old_log.exists(),
+        "old transcript must be pruned by the tick"
+    );
+    assert!(
+        !old_result.exists(),
+        "old result must be pruned by the tick"
+    );
+    assert!(
+        fresh_log.exists(),
+        "fresh transcript must survive the sweep"
+    );
+    assert!(fresh_result.exists(), "fresh result must survive the sweep");
+}
+
+#[tokio::test]
 async fn auto_gc_disabled_leaves_stale_worktree_intact() {
     let base = tempfile::Builder::new()
         .prefix("caduceus-tick-test-")

--- a/tests/state/retention_test.rs
+++ b/tests/state/retention_test.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use caduceus::retention::prune_backups;
+use caduceus::retention::{prune_backups, prune_run_artifacts};
 
 fn dir() -> PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -154,6 +154,164 @@ fn prune_huge_window_does_not_overflow() {
         fresh.exists() && old.exists(),
         "nothing removed on u64::MAX window"
     );
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+fn runs_dir(d: &std::path::Path) -> std::path::PathBuf {
+    let r = d.join("runs");
+    fs::create_dir_all(&r).unwrap();
+    r
+}
+
+fn backdate(path: &std::path::Path, days: u64) {
+    let t = filetime::FileTime::from_system_time(
+        std::time::SystemTime::now() - std::time::Duration::from_secs(days * 86400),
+    );
+    filetime::set_file_mtime(path, t).unwrap();
+}
+
+#[test]
+fn run_sweep_prunes_old_artifacts_of_all_classes() {
+    let d = dir();
+    let runs = runs_dir(&d);
+
+    let log = runs.join("old-run.log");
+    fs::write(&log, b"old transcript").unwrap();
+    backdate(&log, 31);
+    let result = runs.join("old-run.result.json");
+    fs::write(&result, b"{}").unwrap();
+    backdate(&result, 31);
+    let preview = runs.join("old-run.preview.json");
+    fs::write(&preview, b"{}").unwrap();
+    backdate(&preview, 31);
+    let dry = runs.join("old-run.dry-run.md");
+    fs::write(&dry, b"# old").unwrap();
+    backdate(&dry, 31);
+    let fresh_log = runs.join("new-run.log");
+    fs::write(&fresh_log, b"fresh").unwrap();
+
+    let count = prune_run_artifacts(&d, 7).expect("sweep");
+    assert_eq!(count, 4, "one pruned file per artifact class");
+    assert!(!log.exists() && !result.exists() && !preview.exists() && !dry.exists());
+    assert!(fresh_log.exists(), "fresh transcript must survive");
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+#[test]
+fn run_sweep_never_prunes_fresh_heartbeat_of_run_with_old_files() {
+    let d = dir();
+    let runs = runs_dir(&d);
+
+    // The issue's safety pin: the run's OTHER files are old, but
+    // the heartbeat is fresh (mtime now) — the in-flight signal
+    // gc.rs:319 reads. The heartbeat must survive even though the
+    // old log and result are pruned.
+    let log = runs.join("live-run.log");
+    fs::write(&log, b"old-looking transcript").unwrap();
+    backdate(&log, 31);
+    let result = runs.join("live-run.result.json");
+    fs::write(&result, b"{}").unwrap();
+    backdate(&result, 31);
+    let heartbeat = runs.join("live-run.heartbeat");
+    fs::write(&heartbeat, b"{\"version\":2}").unwrap();
+
+    let count = prune_run_artifacts(&d, 7).expect("sweep");
+    assert_eq!(count, 2, "only the old log and result go");
+    assert!(heartbeat.exists(), "fresh heartbeat must NEVER be pruned");
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+#[test]
+fn run_sweep_prunes_stale_heartbeat() {
+    let d = dir();
+    let runs = runs_dir(&d);
+
+    // A heartbeat older than the GC freshness cutoff is inert for
+    // gc.rs (it skips stale heartbeats), so the sweep may retire it.
+    let heartbeat = runs.join("dead-run.heartbeat");
+    fs::write(&heartbeat, b"{\"version\":2}").unwrap();
+    backdate(&heartbeat, 31);
+
+    let count = prune_run_artifacts(&d, 7).expect("sweep");
+    assert_eq!(count, 1, "stale heartbeat is pruned");
+    assert!(!heartbeat.exists());
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+#[test]
+fn run_sweep_preserves_foreign_files_dirs_symlinks_and_tmps() {
+    let d = dir();
+    let runs = runs_dir(&d);
+
+    let notes = runs.join("notes.txt");
+    fs::write(&notes, b"operator notes").unwrap();
+    backdate(&notes, 31);
+    let dir_named_log = runs.join("weird.log");
+    fs::create_dir_all(&dir_named_log).unwrap();
+    let link = runs.join("link.log");
+    std::os::unix::fs::symlink("does-not-exist", &link).unwrap();
+    let tmp = runs.join(".crashed-run.log.tmp.123.999");
+    fs::write(&tmp, b"partial").unwrap();
+    backdate(&tmp, 31);
+    let old_log = runs.join("plain-run.log");
+    fs::write(&old_log, b"old").unwrap();
+    backdate(&old_log, 31);
+
+    let count = prune_run_artifacts(&d, 7).expect("sweep");
+    assert_eq!(count, 1, "only the real transcript goes");
+    assert!(notes.exists(), "foreign files are never touched");
+    assert!(dir_named_log.is_dir(), "directories are never touched");
+    assert!(
+        link.symlink_metadata().is_ok(),
+        "symlinks are never removed"
+    );
+    assert!(tmp.exists(), "atomic-write temporaries are left alone");
+    assert!(!old_log.exists());
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+#[test]
+fn run_sweep_huge_window_prunes_nothing() {
+    let d = dir();
+    let runs = runs_dir(&d);
+
+    let old = runs.join("ancient-run.log");
+    fs::write(&old, b"old").unwrap();
+    backdate(&old, 31);
+
+    let count = prune_run_artifacts(&d, u64::MAX).expect("sweep");
+    assert_eq!(count, 0, "window past the epoch prunes nothing");
+    assert!(old.exists());
+
+    let _ = fs::remove_dir_all(&d);
+}
+
+#[test]
+fn run_sweep_zero_window_still_spares_fresh_files() {
+    let d = dir();
+    let runs = runs_dir(&d);
+
+    // The guard pin, independent of the window: config validation
+    // forbids run_retention_days == 0, but the function must be
+    // safe anyway. A zero window makes cutoff == now, which would
+    // prune EVERYTHING older than the call instant — only the
+    // 1-hour freshness floor stands between a just-written
+    // heartbeat and deletion. This test fails if the guard is
+    // removed (mirrors the #177 bug class the issue calls out).
+    let heartbeat = runs.join("guard-run.heartbeat");
+    fs::write(&heartbeat, b"{\"version\":2}").unwrap();
+    let old_log = runs.join("guard-run.log");
+    fs::write(&old_log, b"old").unwrap();
+    backdate(&old_log, 31);
+
+    let count = prune_run_artifacts(&d, 0).expect("sweep");
+    assert_eq!(count, 1, "only the old transcript goes");
+    assert!(heartbeat.exists(), "fresh heartbeat survives a zero window");
 
     let _ = fs::remove_dir_all(&d);
 }


### PR DESCRIPTION
## What

Implements issue #403: `run_retention_days` now also governs
finished-run artifacts in `<state_dir>/runs/` (worker transcripts,
archived results, dry-run previews, stale heartbeats), which had no
retention at all.

- **Task 1** — new `prune_run_artifacts(state_dir, retention_days)`
  sibling sweep in `src/state/retention.rs`: five-suffix eligible set
  (`.log`, `.result.json`, `.heartbeat`, `.preview.json`,
  `.dry-run.md`), with the safety-critical 1-hour mtime freshness
  guard mirroring `worktree/gc.rs` so an in-flight run's heartbeat
  can never be deleted (the #177 bug class). Symlinks, directories,
  foreign files, and atomic-write temporaries are preserved. 6 new
  unit tests (13 total in `retention_test`); all 7 existing tests
  unmodified.
- **Task 2** — tick step 3.5c, immediately after #402's 3.5b
  `prune_backups`, same best-effort log-and-continue shape, same
  `run_retention_days` knob (no config changes). Tick-level test:
  backdated `.log`/`.result.json` pair pruned by the tick, fresh pair
  survives. Module docs updated to name both surfaces.
- **Task 3** — CHANGELOG Fixed entry.

The sweep is a pure directory scan on the tick cadence (microseconds
at current scale); #402's backup/archive sweep semantics are
untouched.

## Gate results (all green)

- `cargo fmt --check` — OK
- `cargo clippy --locked --all-targets -- -D warnings` — OK
- `env -u GITHUB_TOKEN cargo test --locked --all-targets
  --no-fail-fast` (hermetic skips: `test_ac04_cron_install_happy`,
  `test_ac06_doctor_and_status`, `test_ac07_gateway_prerequisite`,
  `test_ac08_update_preserves_state`, `release_binary_canary`) —
  3160 passed, 0 failed
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` —
  208 passed

Closes #403