### PR TITLE
fix(review): banner sticky-comment updates on re-review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Fixed
 
+- **Re-review updates are visible on the PR.** The sticky review
+  comment is edited in place, which made a re-review easy to miss.
+  Every re-publication (review generation > 1) now prepends a
+  `> [!IMPORTANT]` banner naming the reviewed short SHA and the
+  generation; the first publication keeps the current body. Closes
+  #393.
 - **Finished-run artifacts are now retained, not kept forever.**
   `<state_dir>/runs/` (worker transcripts, archived results,
   dry-run previews, heartbeats) had no retention at all — files

--- a/docs/architecture/auto-review.md
+++ b/docs/architecture/auto-review.md
@@ -453,6 +453,11 @@ within severity = persisted order) within the remaining budget. Never
 front-truncate. Byte limit 65,536. Re-publishing the same result is
 **byte-identical** (idempotency requirement, tested).
 
+Re-publication (any generation > 1) prepends a `> [!IMPORTANT]` banner
+— `Updated for commit `<short-sha>` (review generation N)` — above the
+verdict heading, so the in-place edit is visible at a glance; the first
+publication (generation 1) keeps the banner-less body (#393).
+
 Body identifies the exact reviewed SHA (and previous SHA when applicable);
 stale results still publish with the reviewed SHA noted.
 

--- a/docs/auto-review.md
+++ b/docs/auto-review.md
@@ -186,6 +186,10 @@ suppressed by a monotonic publication guard so an older run can never
 overwrite a newer one (DAR §9.4). Re-publishing the same result is
 byte-identical (idempotency requirement).
 
+Re-reviews (generation 2 and later) prepend a `> [!IMPORTANT]` banner
+naming the new reviewed commit and the generation, so the update is
+visible without opening the comment's edit history.
+
 ## Config reference
 
 All keys below are validated at load time; `deny_unknown_fields` is on

--- a/src/review/finalize.rs
+++ b/src/review/finalize.rs
@@ -366,6 +366,10 @@ pub async fn finalize_review(
         review: &review,
         reviewed_head_sha: &due.head_sha,
         current_head_sha: None,
+        // The §9.4 guard above already guarantees
+        // `due.run_generation == state.review_generation` here, so this
+        // reads the completing run's generation (issue #393).
+        review_generation: due.run_generation,
     };
     let sticky = match publish(
         client,

--- a/src/review/sticky_comment.rs
+++ b/src/review/sticky_comment.rs
@@ -9,8 +9,9 @@
 //! The renderer ([`render_sticky_comment`]) is pure and deterministic:
 //! the same [`RenderInput`] always produces byte-identical output. It
 //! reserves the header (marker, verdict heading, reviewed SHA,
-//! stale-revision notice) first and NEVER front-truncates — only
-//! findings are dropped from the tail, inside a hard byte budget.
+//! stale-revision notice, update banner (re-publications)) first and
+//! NEVER front-truncates — only findings are dropped from the tail,
+//! inside a hard byte budget.
 //!
 //! [`publish`] owns the four gone-states (DAR §9.3): a deleted comment
 //! (A) is recovered via marker search; a vanished PR (B) and a
@@ -76,6 +77,12 @@ pub struct RenderInput<'a> {
     /// notice (DAR §9.2: stale results still publish with the reviewed
     /// SHA noted).
     pub current_head_sha: Option<&'a str>,
+    /// The completing run's `review_generation` — 1 on first
+    /// publication. Any generation > 1 renders the update banner
+    /// (issue #393): the sticky comment is edited in place, so the
+    /// banner is the at-a-glance signal that the review was re-run
+    /// for a new commit.
+    pub review_generation: u64,
 }
 
 /// Render the sticky comment body. Pure and deterministic: the same
@@ -86,16 +93,19 @@ pub struct RenderInput<'a> {
 ///
 /// 1. [`REVIEW_MARKER`] (head marker).
 /// 2. Blank line.
-/// 3. PASS/FAIL heading line (derived from `review.verdict`).
-/// 4. Reviewed SHA line.
-/// 5. Stale-revision notice line (only when `current_head_sha` is
+/// 3. Update banner (only when `review_generation > 1`, issue #393): a
+///    `> [!IMPORTANT]` alert panel naming the reviewed short SHA and the
+///    generation, so an in-place edit is visible at a glance.
+/// 4. PASS/FAIL heading line (derived from `review.verdict`).
+/// 5. Reviewed SHA line.
+/// 6. Stale-revision notice line (only when `current_head_sha` is
 ///    `Some` and differs from `reviewed_head_sha`).
-/// 6. Summary.
-/// 7. Findings in severity order (Blocking → Warning → Suggestion,
+/// 7. Summary.
+/// 8. Findings in severity order (Blocking → Warning → Suggestion,
 ///    stable within severity = persisted `findings` order). Consumption
 ///    stops when the next finding would overflow the remaining budget.
-/// 8. Truncation notice (only when at least one finding was dropped).
-/// 9. Blank line, then [`REVIEW_MARKER`] again (tail marker).
+/// 9. Truncation notice (only when at least one finding was dropped).
+/// 10. Blank line, then [`REVIEW_MARKER`] again (tail marker).
 ///
 /// The total is bounded by [`STICKY_COMMENT_MAX_BYTES`]. Only findings
 /// (and, in the pathological over-cap-summary case, the summary tail)
@@ -110,6 +120,18 @@ pub fn render_sticky_comment(input: &RenderInput<'_>) -> String {
     let mut head = String::new();
     head.push_str(REVIEW_MARKER);
     head.push_str("\n\n");
+    // Update banner (issue #393): re-publications edit the comment in
+    // place, so the banner is the at-a-glance signal. Pushed onto
+    // `head` BEFORE the reserve computation below, which makes it
+    // part of the never-front-truncated header with zero budget-math
+    // changes.
+    if input.review_generation > 1 {
+        head.push_str(&format!(
+            "> [!IMPORTANT] Updated for commit `{}` (review generation {})\n\n",
+            short_sha(input.reviewed_head_sha),
+            input.review_generation
+        ));
+    }
     head.push_str(heading);
     head.push('\n');
     head.push_str("Reviewed SHA: ");
@@ -225,6 +247,20 @@ fn push_char_bounded(out: &mut String, text: &str, max_bytes: usize) {
         keep -= 1;
     }
     out.push_str(&text[..keep]);
+}
+
+/// First 12 characters of a SHA, or the whole string when shorter.
+/// Char-boundary safe: head SHAs are bounded, non-empty strings at
+/// the store layer, but a multi-byte value must never panic the
+/// renderer. Mirrors the CLI's display convention
+/// (`src/cli/review.rs::short_sha`); kept private so the renderer
+/// stays self-contained.
+fn short_sha(sha: &str) -> &str {
+    if sha.len() > 12 && sha.is_char_boundary(12) {
+        &sha[..12]
+    } else {
+        sha
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/review/crash_recovery_test.rs
+++ b/tests/review/crash_recovery_test.rs
@@ -218,6 +218,7 @@ async fn restart_mid_publish_emits_no_duplicate_comment_and_reaches_published() 
         review: &sample_review(),
         reviewed_head_sha: SHA,
         current_head_sha: None,
+        review_generation: 1,
     });
     assert!(
         rendered.contains(REVIEW_MARKER),

--- a/tests/review/finalizer_test.rs
+++ b/tests/review/finalizer_test.rs
@@ -145,6 +145,7 @@ fn rendered_body() -> String {
         review: &sample_review(),
         reviewed_head_sha: SHA,
         current_head_sha: None,
+        review_generation: 1,
     })
 }
 
@@ -842,4 +843,63 @@ async fn publish_failed_retryable_emits_on_github_failure() {
         !body.contains(EVENT_PUBLISHED),
         "published leaked into the failed path: {body}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Update banner wiring (issue #393) — finalize passes the generation
+// ---------------------------------------------------------------------------
+
+fn posted_comment_body(gh: &MockGitHub) -> String {
+    let posts: Vec<_> = gh
+        .received_requests()
+        .into_iter()
+        .filter(|r| r.method.as_str() == "POST")
+        .collect();
+    assert_eq!(posts.len(), 1, "exactly one comment POST");
+    let payload: serde_json::Value =
+        serde_json::from_slice(&posts[0].body).expect("POST body is JSON");
+    payload["body"].as_str().expect("body field").to_string()
+}
+
+#[tokio::test]
+async fn generation_two_finalize_publishes_banner_body() {
+    let gh = MockGitHub::start().await;
+    mount_publish_open(&gh, 601).await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-banner", 2, PublicationState::Pending);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(2), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::Published);
+
+    // `SHA` is forty `a`s (finalizer_test.rs:43), so the 12-char
+    // prefix is "aaaaaaaaaaaa". Build the expected fragment from the
+    // const so the assertion tracks it.
+    let body = posted_comment_body(&gh);
+    let expected = format!(
+        "> [!IMPORTANT] Updated for commit `{}` (review generation 2)",
+        &SHA[..12]
+    );
+    assert!(
+        body.contains(&expected),
+        "banner on the wire for gen 2: {body}"
+    );
+}
+
+#[tokio::test]
+async fn generation_one_finalize_publishes_without_banner() {
+    let gh = MockGitHub::start().await;
+    mount_publish_open(&gh, 602).await;
+    let (client, cfg) = mock_client(&gh);
+    let (store, _dir) = seeded_store("fin-banner-one", 1, PublicationState::Pending);
+
+    let outcome = finalize_review(&client, &cfg, &store, &due(1), now())
+        .await
+        .expect("finalize succeeds");
+    assert_eq!(outcome, FinalizeOutcome::Published);
+
+    let body = posted_comment_body(&gh);
+    assert!(!body.contains("[!IMPORTANT]"), "no banner on gen 1: {body}");
+    assert!(body.starts_with(REVIEW_MARKER), "marker still first");
 }

--- a/tests/review/sticky_comment_publish_test.rs
+++ b/tests/review/sticky_comment_publish_test.rs
@@ -72,6 +72,7 @@ fn render_input<'a>(r: &'a Review) -> RenderInput<'a> {
         review: r,
         reviewed_head_sha: "abc123",
         current_head_sha: None,
+        review_generation: 1,
     }
 }
 

--- a/tests/review/sticky_comment_renderer_test.rs
+++ b/tests/review/sticky_comment_renderer_test.rs
@@ -31,6 +31,7 @@ fn pass_input<'a>(r: &'a Review, sha: &'a str) -> RenderInput<'a> {
         review: r,
         reviewed_head_sha: sha,
         current_head_sha: None,
+        review_generation: 1,
     }
 }
 
@@ -102,6 +103,7 @@ fn no_stale_notice_when_head_unchanged_or_unknown() {
         review: &r,
         reviewed_head_sha: "sha1",
         current_head_sha: Some("sha1"),
+        review_generation: 1,
     });
     assert!(!body.contains("Stale"), "no stale notice when equal");
 }
@@ -113,6 +115,7 @@ fn stale_revision_notice_when_head_moved() {
         review: &r,
         reviewed_head_sha: "oldsha",
         current_head_sha: Some("newsha"),
+        review_generation: 1,
     });
     assert!(body.contains("oldsha"));
     assert!(body.contains("newsha"));
@@ -318,5 +321,105 @@ fn empty_findings_render_is_compact_and_deterministic() {
     assert!(
         !body.contains("truncated") && !body.contains("Truncated"),
         "no truncation note when nothing was dropped"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Update banner (issue #393)
+// -----------------------------------------------------------------------
+
+const SHA40: &str = "3b836a2391a4567890abcdef1234567890abcdef"; // 40 hex chars
+
+fn gen_input<'a>(r: &'a Review, sha: &'a str, generation: u64) -> RenderInput<'a> {
+    RenderInput {
+        review: r,
+        reviewed_head_sha: sha,
+        current_head_sha: None,
+        review_generation: generation,
+    }
+}
+
+#[test]
+fn republish_banner_present_from_generation_two() {
+    let r = review(Verdict::Pass, "all good", vec![]);
+    let body = render_sticky_comment(&gen_input(&r, SHA40, 2));
+    let expected = "> [!IMPORTANT] Updated for commit `3b836a2391a4` \
+(review generation 2)";
+    assert!(body.contains(expected), "exact banner line: {body}");
+    // Banner reads as the top of the comment: after the invisible
+    // head marker, before the verdict heading.
+    assert!(body.starts_with(REVIEW_MARKER), "marker still first");
+    let banner_pos = body.find("[!IMPORTANT]").expect("banner present");
+    let heading_pos = body.find("## Auto review").expect("heading present");
+    assert!(banner_pos < heading_pos, "banner above the heading");
+    assert_eq!(
+        body.find("[!IMPORTANT]"),
+        body.rfind("[!IMPORTANT]"),
+        "exactly one banner"
+    );
+}
+
+#[test]
+fn banner_carries_the_generation_number() {
+    let r = review(Verdict::Pass, "ok", vec![]);
+    let body = render_sticky_comment(&gen_input(&r, SHA40, 3));
+    assert!(
+        body.contains("(review generation 3)"),
+        "generation is part of the banner: {body}"
+    );
+}
+
+#[test]
+fn first_publication_generation_one_has_no_banner() {
+    let r = review(Verdict::Pass, "ok", vec![]);
+    let body = render_sticky_comment(&gen_input(&r, SHA40, 1));
+    assert!(!body.contains("[!IMPORTANT]"), "no banner on gen 1");
+    assert!(
+        !body.contains("Updated for commit"),
+        "no banner text on gen 1"
+    );
+}
+
+#[test]
+fn republish_banner_is_byte_identical_across_renders() {
+    let r = review(
+        Verdict::Fail,
+        "problems",
+        vec![finding(Severity::Blocking, "t", "b")],
+    );
+    let input = gen_input(&r, SHA40, 2);
+    assert_eq!(render_sticky_comment(&input), render_sticky_comment(&input));
+}
+
+#[test]
+fn banner_survives_truncation_under_overflow() {
+    // 64 KiB summary alone overflows the budget: the banner is part
+    // of the reserved header and must never be front-truncated.
+    let summary = format!("Z{}", "s".repeat(64 * 1024));
+    let r = review(Verdict::Pass, &summary, vec![]);
+    let body = render_sticky_comment(&gen_input(&r, SHA40, 2));
+    assert!(body.len() <= STICKY_COMMENT_MAX_BYTES, "under cap");
+    assert!(body.starts_with(REVIEW_MARKER), "marker intact");
+    assert!(
+        body.contains("> [!IMPORTANT] Updated for commit `3b836a2391a4` (review generation 2)"),
+        "banner intact despite overflow"
+    );
+    assert!(
+        body.contains("truncated") || body.contains("Truncated"),
+        "truncation note present"
+    );
+}
+
+#[test]
+fn banner_short_sha_is_twelve_chars_and_boundary_safe() {
+    let r = review(Verdict::Pass, "ok", vec![]);
+    // 40-char SHA → first 12 chars in the banner.
+    let body = render_sticky_comment(&gen_input(&r, SHA40, 2));
+    assert!(body.contains("`3b836a2391a4`"), "12-char short sha: {body}");
+    // Short SHA stays whole.
+    let body = render_sticky_comment(&gen_input(&r, "abc123", 2));
+    assert!(
+        body.contains("Updated for commit `abc123`"),
+        "short sha unchanged when already short: {body}"
     );
 }


### PR DESCRIPTION
## What

Re-review updates were invisible on the PR: the sticky comment is
PATCHed in place, so a human reading the PR never registered that the
verdict/findings changed. Every re-publication (review generation > 1)
now prepends a loud, styled GitHub alert-panel banner to the comment
body, above the verdict heading:

```text
> [!IMPORTANT] Updated for commit `<short-sha>` (review generation N)
```

Generation 1 keeps the current banner-less body. The exactly-one-sticky-
comment contract, marker ownership, DAR §9.4 suppression, and the
`publish` machinery are unchanged — the banner lives entirely inside the
pure, deterministic renderer, pushed onto the reserved header before the
truncation-budget computation, so it is never front-truncated and the
body still starts with the invisible `<!-- caduceus-auto-review -->`
marker.

## Design notes

- `(review generation N)` instead of `(generation N of M)`: M is not
  available inside the pure renderer and is semantically wrong when
  generations are skipped (a PR closed mid-flight makes the next
  admission gen 3 with no gen-2 publication).
- Short SHA is the codebase-wide 12-char display convention (mirrors
  `cli/review.rs`), kept as a private renderer helper so the renderer
  stays self-contained.
- The banner is inside the rendered body, so publish's byte-compare
  idempotency works unchanged; a crashed gen-2 publish resumes
  byte-identical (`Unchanged`), no duplicate.

## Tests

- 6 new renderer tests: banner exact line + placement above heading at
  gen 2, generation number carried, no banner at gen 1, byte-identity,
  banner survives 64 KiB overflow, 12-char short-SHA boundary safety.
- 2 new finalizer wiring tests: gen-2 POST body carries the banner on
  the wire (via `MockGitHub.received_requests`), gen-1 does not.
- All 5 pre-existing `RenderInput` test sites pinned to generation 1,
  so every existing byte-replay assertion keeps passing.

## Gates

- `cargo fmt --check` — OK
- `cargo clippy --locked --all-targets -- -D warnings` — OK
- `cargo test --locked --all-targets` (hermetic skips) — 205 binaries,
  0 failed
- `uv run pytest -q tests/plugin/ tests/integration/bridge_test.py` —
  208 passed

Closes #393